### PR TITLE
Add restore functions if HA restarts

### DIFF
--- a/custom_components/ai_thermostat/climate.py
+++ b/custom_components/ai_thermostat/climate.py
@@ -372,7 +372,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		dev_specific = {
 			ATTR_STATE_WINDOW_OPEN  : self.window_open,
 			ATTR_STATE_NIGHT_MODE   : self.night_status,
-			ATTR_STATE_CALL_FOR_HEAT: not self.call_for_heat,
+			ATTR_STATE_CALL_FOR_HEAT: self.call_for_heat,
 			ATTR_STATE_LAST_CHANGE  : self.last_change,
 			ATTR_STATE_DAY_TEMP     : self.daytime_temp,
 		}

--- a/custom_components/ai_thermostat/climate.py
+++ b/custom_components/ai_thermostat/climate.py
@@ -48,7 +48,7 @@ SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
 
 ATTR_STATE_WINDOW_OPEN = "window_open"
 ATTR_STATE_NIGHT_MODE = "night_mode"
-ATTR_STATE_CALL_FOR_HEAT = "winter"
+ATTR_STATE_SUMMER = "summer"
 ATTR_STATE_LAST_CHANGE = "last_change"
 ATTR_STATE_DAY_TEMP = "last_day_temp"
 
@@ -267,6 +267,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 				self.window_open = old_state.attributes.get(ATTR_STATE_WINDOW_OPEN)
 			if old_state.attributes.get(ATTR_STATE_DAY_TEMP) is not None:
 				self.daytime_temp = old_state.attributes.get(ATTR_STATE_DAY_TEMP)
+			if old_state.attributes.get(ATTR_STATE_SUMMER) is not None:
+				self.is_summer = old_state.attributes.get(ATTR_STATE_SUMMER)
 			if old_state.attributes.get(ATTR_STATE_NIGHT_MODE) is not None:
 				self.night_status = old_state.attributes.get(ATTR_STATE_NIGHT_MODE)
 				if self.night_status:
@@ -372,7 +374,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		dev_specific = {
 			ATTR_STATE_WINDOW_OPEN  : self.window_open,
 			ATTR_STATE_NIGHT_MODE   : self.night_status,
-			ATTR_STATE_CALL_FOR_HEAT: self.call_for_heat,
+			ATTR_STATE_SUMMER       : self.is_summer,
 			ATTR_STATE_LAST_CHANGE  : self.last_change,
 			ATTR_STATE_DAY_TEMP     : self.daytime_temp,
 		}
@@ -678,11 +680,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 				elif not self.window_open and self.closed_window_triggered:
 					self._hvac_mode = self.last_change
 
-				# check ifs warm outside
-				if self._hvac_mode != HVAC_MODE_OFF and not self.call_for_heat:
+				# check if's summer
+				if self._hvac_mode != HVAC_MODE_OFF and not self.call_for_heat and not self.is_summer and not self.window_open:
 					self.last_change = self._hvac_mode
 					self._hvac_mode = HVAC_MODE_OFF
-				elif self._hvac_mode != HVAC_MODE_OFF and self.call_for_heat:
+					self.is_summer = True
+				elif self._hvac_mode != HVAC_MODE_OFF and self.call_for_heat and self.is_summer and not self.window_open:
 					self._hvac_mode = self.last_change
 
 				

--- a/custom_components/ai_thermostat/climate.py
+++ b/custom_components/ai_thermostat/climate.py
@@ -4,6 +4,7 @@ Z2M version """
 import asyncio
 import logging
 import math
+import numbers
 from abc import ABC
 from datetime import datetime, timedelta
 from random import randint
@@ -50,7 +51,7 @@ ATTR_STATE_WINDOW_OPEN = "window_open"
 ATTR_STATE_NIGHT_MODE = "night_mode"
 ATTR_STATE_CALL_FOR_HEAT = "call_for_heat"
 ATTR_STATE_LAST_CHANGE = "last_change"
-ATTR_STATE_DAY_TEMP = "last_day_temp"
+ATTR_STATE_DAY_SET_TEMP = "last_day_set_temp"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 		{
@@ -268,14 +269,17 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 				self.last_change = HVAC_MODE_OFF
 			if not old_state.attributes.get(ATTR_STATE_WINDOW_OPEN):
 				self.window_open = old_state.attributes.get(ATTR_STATE_WINDOW_OPEN)
-			if not old_state.attributes.get(ATTR_STATE_DAY_TEMP):
-				self.daytime_temp = old_state.attributes.get(ATTR_STATE_DAY_TEMP)
+			if not old_state.attributes.get(ATTR_STATE_DAY_SET_TEMP):
+				self.daytime_temp = old_state.attributes.get(ATTR_STATE_DAY_SET_TEMP)
 			if not old_state.attributes.get(ATTR_STATE_CALL_FOR_HEAT):
 				self.call_for_heat = old_state.attributes.get(ATTR_STATE_CALL_FOR_HEAT)
 			if not old_state.attributes.get(ATTR_STATE_NIGHT_MODE):
 				self.night_status = old_state.attributes.get(ATTR_STATE_NIGHT_MODE)
 				if self.night_status:
-					self._target_temp = float(self.night_temp)				
+					if self.night_temp and isinstance(self.night_temp, numbers.Number):
+						self._target_temp = float(self.night_temp)				
+					else:
+						_LOGGER.error("Night temp is not a number")
 
 		else:
 			# No previous state, try and restore defaults

--- a/custom_components/ai_thermostat/climate.py
+++ b/custom_components/ai_thermostat/climate.py
@@ -50,6 +50,7 @@ ATTR_STATE_WINDOW_OPEN = "window_open"
 ATTR_STATE_NIGHT_MODE = "night_mode"
 ATTR_STATE_CALL_FOR_HEAT = "winter"
 ATTR_STATE_LAST_CHANGE = "last_change"
+ATTR_STATE_DAY_TEMP = "last_day_temp"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 		{
@@ -264,8 +265,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 				self.last_change = old_state.attributes.get(ATTR_STATE_LAST_CHANGE)
 			if old_state.attributes.get(ATTR_STATE_WINDOW_OPEN) is not None:
 				self.window_open = old_state.attributes.get(ATTR_STATE_WINDOW_OPEN)
+			if old_state.attributes.get(ATTR_STATE_DAY_TEMP) is not None:
+				self.daytime_temp = old_state.attributes.get(ATTR_STATE_DAY_TEMP)
 			if old_state.attributes.get(ATTR_STATE_NIGHT_MODE) is not None:
 				self.night_status = old_state.attributes.get(ATTR_STATE_NIGHT_MODE)
+				if self.night_status:
+					self._target_temp = float(self.night_temp)				
 
 		else:
 			# No previous state, try and restore defaults
@@ -369,6 +374,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 			ATTR_STATE_NIGHT_MODE   : self.night_status,
 			ATTR_STATE_CALL_FOR_HEAT: not self.call_for_heat,
 			ATTR_STATE_LAST_CHANGE  : self.last_change,
+			ATTR_STATE_DAY_TEMP     : self.daytime_temp,
 		}
 		
 		return dev_specific


### PR DESCRIPTION
## Motivation:

If HA is restated we lost the information of open window state, night mode and more, this PR will add a restore function of the last change mode behavior to reinit the correct state set

## Changes:

-  Add last mode saving for window open, and summer modes
-  Add last mode restore if HA restart
-  Add night mode restore if HA restart
-  Add window state restore if HA restart
-  Fix the exposed value of summer mode for better thermostat UI

## Related issue (check one):

- [X] fixes #150 #143 
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.


