### PR TITLE
fix typo in ATTR_STATE_DAY_SET_TEMP

### DIFF
--- a/custom_components/ai_thermostat/climate.py
+++ b/custom_components/ai_thermostat/climate.py
@@ -383,7 +383,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 			ATTR_STATE_NIGHT_MODE   : self.night_status,
 			ATTR_STATE_CALL_FOR_HEAT: self.call_for_heat,
 			ATTR_STATE_LAST_CHANGE  : self.last_change,
-			ATTR_STATE_DAY_SET_TEMP : self.daytime_temp, }
+			ATTR_STATE_DAY_SET_TEMP : self.daytime_temp,
+		}
 		
 		return dev_specific
 	

--- a/custom_components/ai_thermostat/climate.py
+++ b/custom_components/ai_thermostat/climate.py
@@ -379,12 +379,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 	def extra_state_attributes(self):
 		"""Return the device specific state attributes."""
 		dev_specific = {
-			ATTR_STATE_WINDOW_OPEN   : self.window_open,
-			ATTR_STATE_NIGHT_MODE    : self.night_status,
-			ATTR_STATE_CALL_FOR_HEAT : self.call_for_heat,
-			ATTR_STATE_LAST_CHANGE   : self.last_change,
-			ATTR_STATE_DAY_TEMP      : self.daytime_temp,
-		}
+			ATTR_STATE_WINDOW_OPEN  : self.window_open,
+			ATTR_STATE_NIGHT_MODE   : self.night_status,
+			ATTR_STATE_CALL_FOR_HEAT: self.call_for_heat,
+			ATTR_STATE_LAST_CHANGE  : self.last_change,
+			ATTR_STATE_DAY_SET_TEMP : self.daytime_temp, }
 		
 		return dev_specific
 	


### PR DESCRIPTION
## Motivation:

smash bugs ;)

## Changes:

fix typo in variable

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.
