### PR TITLE
Remove unused variable self._today_nightmode_end

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -190,7 +190,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		self.last_dampening_timestamp = None
 		self._device_class = device_class
 		self._state_class = state_class
-		self._today_nightmode_end = datetime.now()
 		self.local_temperature_calibration_entity = None
 		self.valve_position_entity = None
 		self.version = "1.0.0"


### PR DESCRIPTION
## Motivation:

Cleanup an unused variable

## Changes:

- Remove unused variable self._today_nightmode_end

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.
- [x] No change of the active code is to be expected.
