### PR TITLE
rewrite get_device_model

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -178,7 +178,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		self.window_open = None
 		self._is_away = False
 		self.startup_running = True
-		self.model = "-"
+		self.model = None
 		self.next_valve_maintenance = datetime.now() + timedelta(hours=randint(1, 24 * 5))
 		self.calibration_type = 2
 		self.daytime_temp = 5

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -587,13 +587,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		if new_state is None or old_state is None:
 			return
 		
-		try:
-			if self.hass.states.get(self.heater_entity_id).attributes.get('device') is not None:
-				self.model = self.hass.states.get(self.heater_entity_id).attributes.get('device').get('model')
-			else:
-				_LOGGER.debug("better_thermostat: can't read the device model of TRV, Enable include_device_information in z2m or checkout issue #1")
-		except RuntimeError:
-			_LOGGER.debug("better_thermostat: error can't get the TRV model")
+		# fetch device model from HA if necessary
+		get_device_model(self)
 		
 		if new_state.attributes is not None:
 			try:

--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -35,13 +35,18 @@ def convert_inbound_states(self, state):
 
 
 def get_device_model(self):
-	try:
-		if self.hass.states.get(self.heater_entity_id).attributes.get('device') is not None:
-			self.model = self.hass.states.get(self.heater_entity_id).attributes.get('device').get('model')
-		else:
-			_LOGGER.exception("better_thermostat: can't read the device model of TVR, Enable include_device_information in z2m or checkout issue #1")
-	except RuntimeError:
-		_LOGGER.exception("better_thermostat: error can't get the TRV")
+	"""Fetches the device model from HA."""
+	
+	if self.model is None:
+		try:
+			if self.hass.states.get(self.heater_entity_id).attributes.get('device') is not None:
+				self.model = self.hass.states.get(self.heater_entity_id).attributes.get('device').get('model')
+			else:
+				raise ValueError
+		except (RuntimeError, ValueError, AttributeError, KeyError, TypeError, NameError, IndexError) as e:
+			_LOGGER.error("better_thermostat %s: can't read the device model of TVR. enable include_device_information in z2m or checkout issue #1", self.name)
+	else:
+		return self.model
 
 
 def convert_outbound_states(self, hvac_mode):


### PR DESCRIPTION
## Motivation:

Currently the device model is fetched from HA multiple times (each time the info is needed). This is unneccesary as the device model will never change while HA is running.

## Changes:

- Just return the device model stored in the local variable if it was already fetched
- Remove the redundancy in _async_trv_changed() by calling get_device_model()

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.
- [x] The code was not tested. @KartoffelToby, please test on your review
