### PR TITLE
make errors on HVAC actions more verbose

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -459,8 +459,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 						return CURRENT_HVAC_HEAT
 					else:
 						return CURRENT_HVAC_IDLE
-		except RuntimeError:
-			_LOGGER.debug("better_thermostat: currently can't get the TRV")
+		except (RuntimeError, ValueError, AttributeError, KeyError, TypeError, NameError, IndexError) as e:
+			_LOGGER.error("better_thermostat %s: RuntimeError occurred while running TRV operation, %s", self.name, e)
 		
 		if not self._is_device_active:
 			return CURRENT_HVAC_IDLE


### PR DESCRIPTION
## Motivation:

We can be more verbose to help debug efforts if HVAC actions fail.

## Changes:

- Increase verbosity by printing out the python error message on failed HVAC actions.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.
- [x] The code was not tested. @KartoffelToby, please test on your review 