### PR TITLE
improve temperature sensor update processing

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -663,10 +663,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 	def _async_update_temp(self, state):
 		"""Update thermostat with the latest state from sensor."""
 		try:
-			if check_float(state.state):
-				self._cur_temp = convert_decimal(state.state)
-		except ValueError as e:
-			_LOGGER.error("better_thermostat %s: Unable to update temperature sensor status: %s", self.name, e)
+			self._cur_temp = float(state.state)
+		except (ValueError, AttributeError, KeyError, TypeError, NameError, IndexError):
+			_LOGGER.error(
+				"better_thermostat %s: Unable to update temperature sensor status from status update, current temperature not a number",
+				self.name
+				)
 	
 	@callback
 	async def _async_trv_changed(self, event):


### PR DESCRIPTION
## Motivation:

The temperature sensor update might write none into the variable which stores the last info on that.

## Changes:

- Skip updates which would write none into it properly.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.
- [x] The code was not tested. @KartoffelToby, please test on your review