### PR TITLE
min/max temp + precision in the config file

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -42,6 +42,9 @@ CONF_VALVE_MAINTENANCE = "valve_maintenance"
 CONF_NIGHT_TEMP = "night_temp"
 CONF_NIGHT_START = "night_start"
 CONF_NIGHT_END = "night_end"
+CONF_MIN_TEMP = "min_temp"
+CONF_MAX_TEMP = "max_temp"
+CONF_PRECISION = "precision"
 
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
 
@@ -69,6 +72,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 			vol.Optional(CONF_NAME, default=DEFAULT_NAME)      : cv.string,
 			vol.Optional(CONF_TARGET_TEMP)                     : vol.Coerce(float),
 			vol.Optional(CONF_UNIQUE_ID)                       : cv.string,
+			vol.Optional(CONF_MIN_TEMP, default=5.0)           : vol.Coerce(float),
+			vol.Optional(CONF_MAX_TEMP, default=35.0)          : vol.Coerce(float),
+			vol.Optional(CONF_PRECISION, default=0.5)          : vol.Coerce(float),
 		}
 )
 
@@ -90,10 +96,10 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 	night_start = config.get(CONF_NIGHT_START)
 	night_end = config.get(CONF_NIGHT_END)
 	
-	min_temp = 5.0
-	max_temp = 30.0
+	min_temp = config.get(CONF_MIN_TEMP)
+	max_temp = config.get(CONF_MAX_TEMP)
 	target_temp = config.get(CONF_TARGET_TEMP)
-	precision = 0.5
+	precision = config.get(CONF_PRECISION)
 	unit = hass.config.units.temperature_unit
 	unique_id = config.get(CONF_UNIQUE_ID)
 

--- a/custom_components/better_thermostat/models/utils.py
+++ b/custom_components/better_thermostat/models/utils.py
@@ -37,9 +37,9 @@ def temperature_calibration(self):
 	
 	state = self.hass.states.get(self.heater_entity_id).attributes
 	new_calibration = abs(float(round((float(self._target_temp) - float(self._cur_temp)) + float(state.get('local_temperature')), 2)))
-	if new_calibration < float(self._min_temp):
-		new_calibration = float(self._min_temp)
-	if new_calibration > float(self._max_temp):
-		new_calibration = float(self._max_temp)
+	if new_calibration < float(self._TRV_min_temp):
+		new_calibration = float(self._TRV_min_temp)
+	if new_calibration > float(self._TRV_max_temp):
+		new_calibration = float(self._TRV_max_temp)
 	
 	return new_calibration


### PR DESCRIPTION
@NikDevx started the work in #198, but since I can't force puch changes to update his branch I imported his changes to a project branch to extend them.

## Motivation:

- Allow a user to specify the precision and the temperature range of the better thermostat via the config file.

## Changes:

- adds minimum/maximum temperature and precision fields to the config file and replaces the default values with it, if specified
- add some checks to the temperature range, to avoid that a user sets a higher/lower temperature via
- - night mode
- - local input on the TRV
- add some checks to avoid that a recovered night mode temperature or a recovered setpoint is higher or lower than the temperature range

## Related issue (check one):

- [x] fixes #175
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.
 s)
- [x] The code change is not tested, please test while reviewing.
