### PR TITLE
[climate.py] BetterThermostat._async_trv_changed docstring rewrite

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -672,7 +672,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 	
 	@callback
 	async def _async_trv_changed(self, event):
-		"""Handle temperature changes."""
+		"""Process TRV status updates"""
 		if self.startup_running:
 			return
 		


### PR DESCRIPTION
## Motivation:

docstring was pretty ambiguous 

## Changes:

- rewrite docstring for BetterThermostat._async_trv_changed in climate.py

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [x] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.
