### PR TITLE
New model identification and removal of z2m dependency

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -212,6 +212,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		"""Run when entity about to be added."""
 		await super().async_added_to_hass()
 		
+		# fetch device model from HA if necessary
+		await get_device_model(self)
+				
 		# Add listener
 		async_track_state_change_event(
 				self.hass, [self.sensor_entity_id], self._async_sensor_changed
@@ -255,7 +258,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 			_async_startup()
 		else:
 			self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _async_startup)
-		
+
 		# Check If we have an old state
 		old_state = await self.async_get_last_state()
 		if old_state is not None:
@@ -732,9 +735,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		
 		if new_state is None or old_state is None:
 			return
-		
-		# fetch device model from HA if necessary
-		get_device_model(self)
 		
 		if new_state.attributes is not None:
 			try:

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1,5 +1,4 @@
-"""Special support for Better Thermostat units.
-Z2M version """
+"""Better Thermostat"""
 
 import asyncio
 import logging
@@ -8,6 +7,7 @@ import numbers
 from abc import ABC
 from datetime import datetime, timedelta
 from random import randint
+from time import sleep
 
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
@@ -213,8 +213,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		await super().async_added_to_hass()
 		
 		# fetch device model from HA if necessary
-		await get_device_model(self)
-				
+		self.model = await get_device_model(self)
+		if self.model is None:
+			_LOGGER.error("better_thermostat %s: can't read the device model of TVR. please check if you have a device in HA", self.name)
+			return
+
 		# Add listener
 		async_track_state_change_event(
 				self.hass, [self.sensor_entity_id], self._async_sensor_changed

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -263,7 +263,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 			_async_startup()
 		else:
 			self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _async_startup)
-
+		
 		# Check If we have an old state
 		old_state = await self.async_get_last_state()
 		if old_state is not None:

--- a/custom_components/better_thermostat/helpers.py
+++ b/custom_components/better_thermostat/helpers.py
@@ -3,7 +3,9 @@
 import asyncio
 import logging
 from datetime import datetime
-
+import re
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr
 from homeassistant.components.climate.const import (SERVICE_SET_TEMPERATURE, SERVICE_SET_HVAC_MODE)
 from homeassistant.components.number.const import (SERVICE_SET_VALUE)
 
@@ -36,6 +38,19 @@ def convert_decimal(decimal_string):
 	except ValueError:
 		return None
 
+async def get_trv_model(self):
+	"""Returns the HA device model string"""
+	try:
+		entity_reg = await er.async_get_registry(self.hass)
+		entry = entity_reg.async_get(self.heater_entity_id)
+		dev_reg = await dr.async_get_registry(self.hass)
+		device = dev_reg.async_get(entry.device_id)
+		try:
+			return re.search('\((.+?)\)', device.model).group(1)
+		except AttributeError:
+			return None
+	except ValueError:
+		return None
 
 async def set_trv_values(self, key, value):
 	"""Do necessary actions to set the TRV values."""

--- a/custom_components/better_thermostat/helpers.py
+++ b/custom_components/better_thermostat/helpers.py
@@ -3,9 +3,6 @@
 import asyncio
 import logging
 from datetime import datetime
-import re
-from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers import device_registry as dr
 from homeassistant.components.climate.const import (SERVICE_SET_TEMPERATURE, SERVICE_SET_HVAC_MODE)
 from homeassistant.components.number.const import (SERVICE_SET_VALUE)
 
@@ -35,20 +32,6 @@ def convert_decimal(decimal_string):
 	"""Convert a decimal string to a float."""
 	try:
 		return float(format(float(decimal_string), '.1f'))
-	except ValueError:
-		return None
-
-async def get_trv_model(self):
-	"""Returns the HA device model string"""
-	try:
-		entity_reg = await er.async_get_registry(self.hass)
-		entry = entity_reg.async_get(self.heater_entity_id)
-		dev_reg = await dr.async_get_registry(self.hass)
-		device = dev_reg.async_get(entry.device_id)
-		try:
-			return re.search('\((.+?)\)', device.model).group(1)
-		except AttributeError:
-			return None
 	except ValueError:
 		return None
 

--- a/custom_components/better_thermostat/helpers.py
+++ b/custom_components/better_thermostat/helpers.py
@@ -2,12 +2,10 @@
 
 import asyncio
 import logging
-import re
 from datetime import datetime
 
 from homeassistant.components.climate.const import (SERVICE_SET_HVAC_MODE, SERVICE_SET_TEMPERATURE)
 from homeassistant.components.number.const import (SERVICE_SET_VALUE)
-from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/better_thermostat/manifest.json
+++ b/custom_components/better_thermostat/manifest.json
@@ -8,11 +8,9 @@
   "dependencies": [
     "sensor",
     "climate",
-    "mqtt",
     "recorder"
   ],
   "after_dependencies": [
-    "mqtt",
     "climate",
     "sensor"
   ],

--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -55,7 +55,7 @@ async def get_device_model(self):
 			except AttributeError:
 				return device.model
 		except (RuntimeError, ValueError, AttributeError, KeyError, TypeError, NameError, IndexError) as e:
-			_LOGGER.error("better_thermostat %s: can't read the device model of TVR. please check if you have a device in HA", self.name)
+			_LOGGER.error("better_thermostat %s: could not read device model of your TVR. Make sure this device exists in Home Assistant.", self.name)
 	else:
 		return self.model
 

--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -35,8 +35,11 @@ def convert_inbound_states(self, state):
 		if config.get('mode_map') is not None and state.get('system_mode') is not None:
 			hvac_mode = mode_remap(hvac_mode, reverse_modes(config.get('mode_map')))
 	
-	return {"current_heating_setpoint": current_heating_setpoint, "local_temperature": state.get('local_temperature'), "local_temperature_calibration": state.get('local_temperature_calibration'),
-		"system_mode"                 : hvac_mode}
+	return {
+		"current_heating_setpoint"     : current_heating_setpoint,
+		"local_temperature"            : state.get('local_temperature'),
+		"local_temperature_calibration": state.get('local_temperature_calibration'),
+		"system_mode"                  : hvac_mode}
 
 
 async def get_device_model(self):

--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -51,8 +51,10 @@ async def get_device_model(self):
 			dev_reg = await dr.async_get_registry(self.hass)
 			device = dev_reg.async_get(entry.device_id)
 			try:
+				# Z2M reports the device name as a long string with the actual model name in braces, we need to extract it
 				return re.search('\((.+?)\)', device.model).group(1)
 			except AttributeError:
+				# Other climate integrations might report the model name plainly, need more infos on this
 				return device.model
 		except (RuntimeError, ValueError, AttributeError, KeyError, TypeError, NameError, IndexError) as e:
 			_LOGGER.error("better_thermostat %s: could not read device model of your TVR. Make sure this device exists in Home Assistant.", self.name)

--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -5,17 +5,18 @@ import math
 import os
 import re
 from pathlib import Path
+
 from homeassistant.components.climate.const import (HVAC_MODE_HEAT, HVAC_MODE_OFF)
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import yaml
 
 from .utils import calibration, mode_remap, reverse_modes
-from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers import device_registry as dr
+
 _LOGGER = logging.getLogger(__name__)
 
 
 def convert_inbound_states(self, state):
-	"""Convert inbound thermostat state to HA state."""	
+	"""Convert inbound thermostat state to HA state."""
 	config_file = os.path.dirname(os.path.realpath(__file__)) + '/devices/' + self.model.replace("/", "_") + '.yaml'
 	
 	if state.get('system_mode') is not None:

--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -58,7 +58,6 @@ async def get_device_model(self):
 
 def convert_outbound_states(self, hvac_mode):
 	"""Convert HA state to outbound thermostat state."""
-
 	state = self.hass.states.get(self.heater_entity_id).attributes
 	
 	config_file = os.path.dirname(os.path.realpath(__file__)) + '/devices/' + self.model.replace("/", "_") + '.yaml'

--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -55,7 +55,7 @@ async def get_device_model(self):
 			except AttributeError:
 				return device.model
 		except (RuntimeError, ValueError, AttributeError, KeyError, TypeError, NameError, IndexError) as e:
-				_LOGGER.error("better_thermostat %s: can't read the device model of TVR. please check if you have a device in HA", self.name)
+			_LOGGER.error("better_thermostat %s: can't read the device model of TVR. please check if you have a device in HA", self.name)
 	else:
 		return self.model
 


### PR DESCRIPTION
## Motivation:

We want to remove Zigbee2Mqtt as an dependency, so we need a other way to detect the model.
Also remove mqtt as an dependency

## Changes:

- [x] remove mqtt as dependency
- [x] change model detection to HA native

## Related issue (check one):

- [X] fixes #182
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.

