### PR TITLE
Update BECA BRT‑100‑TRV.yaml

### DIFF
--- a/custom_components/better_thermostat/devices/BECA BRT‑100‑TRV.yaml
+++ b/custom_components/better_thermostat/devices/BECA BRT‑100‑TRV.yaml
@@ -3,8 +3,8 @@ device:
   product_name: BRT-100 ZB
   product_number: BRT‑100‑TRV
   ha_device_info:
-    manufacturer: unknown
-    model: unknown
+    manufacturer: "Moes"
+    model: "Thermostatic radiator valve (BRT-100-TRV)"
   temperature_correction_mode: setpoint_override
   device_features:
     local_setpoint_delta:


### PR DESCRIPTION
## Motivation:
adding missing data

HA Version: 2021.12.10
Zigbee2MQTT Version:  Zigbee2MQTT 1.22.0
TRV Hardware: BECA BRT‑100‑TRV

