### PR TITLE
Siterwell GS361A-H04

### DIFF
--- a/custom_components/better_thermostat/devices/Siterwell GS361A‑H04.yaml
+++ b/custom_components/better_thermostat/devices/Siterwell GS361A‑H04.yaml
@@ -3,8 +3,8 @@ device:
   product_name: Radiator Thermostat
   product_number: GS361A‑H04
   ha_device_info:
-    manufacturer: unknown
-    model: unknown
+    manufacturer: "Siterwell"
+    model: "Radiator valve with thermostat (GS361A-H04)"
   temperature_correction_mode: setpoint_override
   device_features:
     local_setpoint_delta:


### PR DESCRIPTION
adding missing data

HA Version: 2021.12.10
Zigbee2MQTT Version: Zigbee2MQTT 1.22.0
TRV Hardware: Siterwell GS361A-H04