### PR TITLE
improve window state decoding

### DIFF
--- a/custom_components/better_thermostat/events/window.py
+++ b/custom_components/better_thermostat/events/window.py
@@ -16,8 +16,14 @@ async def trigger_window_change(self):
 		check = self.hass.states.get(self.window_sensors_entity_ids).state
 		if check == 'on':
 			self.window_open = True
-		else:
+		elif check == 'off':
 			self.window_open = False
+		elif check == 'unknown':
+			self.window_open = True
+			_LOGGER.warning("better_thermostat %s: Window sensor state is unknown, assuming window is open", self.name)
+		else:
+			_LOGGER.error("better_thermostat %s: New window sensor state not recognized", self.name)
+			return
 		_LOGGER.debug("better_thermostat %s: Window (group) state changed to %s", self.name, "open" if self.window_open else "closed")
 		self.async_write_ha_state()
 		await control_trv(self)


### PR DESCRIPTION
## Motivation:

Window state decoding was somewhat "brittle".

## Changes:

- Decode off/on/unknown properly
- Report an error when the window state cannot be determined
- Report a warning if the window state is "unknown" (that's the case when the sensor is offline)

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

