### PR TITLE
fix for not send out temperature setpoints to TRV

### DIFF
--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -122,7 +122,7 @@ def convert_outbound_states(self, hvac_mode) -> Union[dict, None]:
 				_new_heating_setpoint = self._target_temp
 			
 			elif _calibration_type == 1:
-				_new_setpoint = calculate_setpoint_override(self)
+				_new_heating_setpoint = calculate_setpoint_override(self)
 				
 			_has_system_mode = self._config.get('has_system_mode')
 			_system_mode = self._config.get('system_mode')

--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -111,8 +111,6 @@ def convert_outbound_states(self, hvac_mode) -> Union[dict, None]:
 			_new_local_calibration = round(calculate_local_setpoint_delta(self))
 		
 		else:
-			_calibration_type = self._config.get('calibration_type')
-			
 			if _calibration_type == 0:
 				_round_calibration = self._config.get('calibration_round')
 				


### PR DESCRIPTION
## Motivation:

Bugfix

## Changes:

- convert_outbound_states: remove unnecessary duplicate code
- convert_outbound_states: fix writing to wrong variable

