### PR TITLE
Add rounding to half degrees for setpoint calculations

### DIFF
--- a/custom_components/better_thermostat/models/utils.py
+++ b/custom_components/better_thermostat/models/utils.py
@@ -1,4 +1,5 @@
 """Utility functions for the Better Thermostat."""
+import decimal
 import logging
 from typing import Union
 
@@ -59,7 +60,7 @@ def calculate_setpoint_override(self) -> Union[float, None]:
 	if not all([self._target_temp, self._cur_temp, _current_trv_temp]):
 		return None
 	
-	_calibrated_setpoint = self._target_temp - self._cur_temp + _current_trv_temp
+	_calibrated_setpoint = round_to_half_degree(self._target_temp - self._cur_temp + _current_trv_temp)
 	
 	# check if new setpoint is inside the TRV's range, else set to min or max
 	if _calibrated_setpoint < self._TRV_min_temp:
@@ -80,3 +81,23 @@ def convert_to_float(value: Union[str, int, float], instance_name: str, context:
 		except (ValueError, TypeError, AttributeError, KeyError):
 			_LOGGER.error(f"better thermostat {instance_name}: Could not convert '{value}' to float in {context}")
 			return None
+
+
+def round_to_half_degree(value: Union[int, float]) -> Union[float, int]:
+	"""Rounds numbers to the nearest n.5/n.0
+
+	Parameters
+	----------
+	value : int, float
+		input value
+
+	Returns
+	-------
+	float, int
+		either an int, if input was an int, or a float rounded to n.5/n.0
+
+	"""
+	if isinstance(value, float):
+		return round(value * 2) / 2
+	elif isinstance(value, int):
+		return value

--- a/custom_components/better_thermostat/models/utils.py
+++ b/custom_components/better_thermostat/models/utils.py
@@ -1,5 +1,5 @@
 """Utility functions for the Better Thermostat."""
-import decimal
+
 import logging
 from typing import Union
 


### PR DESCRIPTION
## Motivation:

Currently we let the thermostat (or HA software) round the setpoints after we send them floats. Since the most thermostats can only accept half degrees of temperature setpoints, we should round to the nearest half degree and send this to HA

## Changes:

- Implement rounding to half degrees for setpoint override mode

## Related issue (check one):

- [x] fixes #301
- [ ] there is no related issue ticket

