### PR TITLE
Document docstring type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,3 +18,9 @@ If you have a Devices that's not supported feel free to create a pull request.
 #### How it works
 
 Just look at an existing model and adjust the remapping for your devices, an info.md and a remap.py is required. Don't forget to add it in the models.py
+
+## Docstring type
+
+We use numpy type docstrings. Documentation can be found here:
+
+https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html


### PR DESCRIPTION
## Motivation:

Used Docstring type wasn't documented.

## Changes:

- Add documentation of the used Docstring type to CONTRIBUTING.md

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [x] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.
