### PR TITLE
Fix model configs with has mode

### DIFF
--- a/custom_components/better_thermostat/models/devices/SEA801-Zigbee_SEA802-Zigbee.yaml
+++ b/custom_components/better_thermostat/models/devices/SEA801-Zigbee_SEA802-Zigbee.yaml
@@ -1,2 +1,3 @@
 calibration_type: 0
 calibration_round: true
+has_system_mode: True

--- a/custom_components/better_thermostat/models/devices/SPZB0001.yaml
+++ b/custom_components/better_thermostat/models/devices/SPZB0001.yaml
@@ -1,4 +1,5 @@
 calibration_type: 0
 calibration_round: false
+has_system_mode: True
 mode_map:
   heat: auto

--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -161,16 +161,16 @@ def convert_outbound_states(self, hvac_mode) -> Union[dict, None]:
 						f"better_thermostat {self.name}: device config expects no system mode, while the device has one. Device system mode will be ignored"
 					)
 				if hvac_mode == HVAC_MODE_OFF:
-					hvac_mode = None
 					_new_heating_setpoint = 5
+				hvac_mode = None
 			
 			elif _has_system_mode is None and _system_mode is None:
 				if hvac_mode == HVAC_MODE_OFF:
 					_LOGGER.info(
 						f"better_thermostat {self.name}: sending 5°C to the TRV because this device has no system mode and heater should be off"
 					)
-					hvac_mode = None
 					_new_heating_setpoint = 5
+				hvac_mode = None
 	
 	return {
 		"current_heating_setpoint"     : _new_heating_setpoint,

--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -160,16 +160,16 @@ def convert_outbound_states(self, hvac_mode) -> Union[dict, None]:
 					_LOGGER.warning(
 						f"better_thermostat {self.name}: device config expects no system mode, while the device has one. Device system mode will be ignored"
 					)
-				hvac_mode = None
 				if hvac_mode == HVAC_MODE_OFF:
+					hvac_mode = None
 					_new_heating_setpoint = 5
 			
 			elif _has_system_mode is None and _system_mode is None:
-				hvac_mode = None
 				if hvac_mode == HVAC_MODE_OFF:
 					_LOGGER.info(
 						f"better_thermostat {self.name}: sending 5°C to the TRV because this device has no system mode and heater should be off"
 					)
+					hvac_mode = None
 					_new_heating_setpoint = 5
 	
 	return {


### PR DESCRIPTION
## Motivation:

Fix Spirit Zigbee and SEA801-SEA802 configs and fix a logic bug if TRV hasn't a mode

## Changes:

- Add has mode to configs
- Fix a logic bug

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [X] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.

