### PR TITLE
Get the right setting entity from TVR

### DIFF
--- a/custom_components/better_thermostat/helpers.py
+++ b/custom_components/better_thermostat/helpers.py
@@ -123,9 +123,9 @@ async def startup(self):
 		entity_entries = async_entries_for_config_entry(entity_registry, reg_entity.config_entry_id)
 		for entity in entity_entries:
 			uid = entity.unique_id
-			if "local_temperature_calibration" in uid:
+			if "local_temperature_calibration" in uid and entity.device_id == reg_entity.device_id:
 				self.local_temperature_calibration_entity = entity.entity_id
-			if "valve_position" in uid:
+			if "valve_position" in uid and entity.device_id == reg_entity.device_id:
 				self.valve_position_entity = entity.entity_id
 		_async_update_temp(self,sensor_state)
 		self.async_write_ha_state()

--- a/custom_components/better_thermostat/helpers.py
+++ b/custom_components/better_thermostat/helpers.py
@@ -123,10 +123,12 @@ async def startup(self):
 		entity_entries = async_entries_for_config_entry(entity_registry, reg_entity.config_entry_id)
 		for entity in entity_entries:
 			uid = entity.unique_id
-			if "local_temperature_calibration" in uid and entity.device_id == reg_entity.device_id:
-				self.local_temperature_calibration_entity = entity.entity_id
-			if "valve_position" in uid and entity.device_id == reg_entity.device_id:
-				self.valve_position_entity = entity.entity_id
+			# Make sure we use the correct device entities
+			if entity.device_id == reg_entity.device_id:
+				if "local_temperature_calibration" in uid:
+					self.local_temperature_calibration_entity = entity.entity_id
+				if "valve_position" in uid:
+					self.valve_position_entity = entity.entity_id
 		_async_update_temp(self,sensor_state)
 		self.async_write_ha_state()
 		await asyncio.sleep(5)


### PR DESCRIPTION
## Motivation:

There was a logic bug in the entity filter to get HA devices setting entities

## Changes:

Fix device entity filter with the target device entity ID

## Related issue (check one):

- [X] fixes #276
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.

