### PR TITLE
Enhance processing of TRV system mode changes

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -412,10 +412,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 			_LOGGER.debug(f"better_thermostat {self.name}: HA asked for our HVAC action, we will respond with: {CURRENT_HVAC_OFF}")
 			return CURRENT_HVAC_OFF
 		if self._bt_hvac_mode == HVAC_MODE_HEAT:
-			if self.window_open or not self.call_for_heat:
+			if self.window_open or self.call_for_heat is False:
 				_LOGGER.debug(
 					f"better_thermostat {self.name}: HA asked for our HVAC action, we will respond with: {CURRENT_HVAC_IDLE}. Window open: {self.window_open}, call for heat: {self.call_for_heat}"
-					)
+				)
 				return CURRENT_HVAC_IDLE
 			_LOGGER.debug(f"better_thermostat {self.name}: HA asked for our HVAC action, we will respond with: {CURRENT_HVAC_HEAT}")
 			return CURRENT_HVAC_HEAT

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -186,6 +186,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		self.load_saved_state = False
 		self._last_reported_valve_position = None
 		self._last_reported_valve_position_update_wait_lock = asyncio.Lock()
+		self._last_window_state = None
 	
 	async def async_added_to_hass(self):
 		"""Run when entity about to be added."""

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -413,9 +413,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 			_LOGGER.debug(f"better_thermostat {self.name}: HA asked for our HVAC action, we will respond with: {CURRENT_HVAC_OFF}")
 			return CURRENT_HVAC_OFF
 		if self._bt_hvac_mode == HVAC_MODE_HEAT:
-			if self.window_open or self.call_for_heat is False:
+			if self.window_open:
 				_LOGGER.debug(
-					f"better_thermostat {self.name}: HA asked for our HVAC action, we will respond with: {CURRENT_HVAC_IDLE}. Window open: {self.window_open}, call for heat: {self.call_for_heat}"
+					f"better_thermostat {self.name}: HA asked for our HVAC action, we will respond with '{CURRENT_HVAC_OFF}' because a window is open"
+					)
+				return CURRENT_HVAC_OFF
+			
+			if self.call_for_heat is False:
+				_LOGGER.debug(
+					f"better_thermostat {self.name}: HA asked for our HVAC action, we will respond with '{CURRENT_HVAC_IDLE}' since call for heat is false"
 				)
 				return CURRENT_HVAC_IDLE
 			_LOGGER.debug(f"better_thermostat {self.name}: HA asked for our HVAC action, we will respond with: {CURRENT_HVAC_HEAT}")

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -409,10 +409,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		"""
 		
 		if self._bt_hvac_mode == HVAC_MODE_OFF:
+			_LOGGER.debug(f"better_thermostat {self.name}: HA asked for our HVAC action, we will respond with: {CURRENT_HVAC_OFF}")
 			return CURRENT_HVAC_OFF
 		if self._bt_hvac_mode == HVAC_MODE_HEAT:
 			if self.window_open or not self.call_for_heat:
+				_LOGGER.debug(
+					f"better_thermostat {self.name}: HA asked for our HVAC action, we will respond with: {CURRENT_HVAC_IDLE}. Window open: {self.window_open}, call for heat: {self.call_for_heat}"
+					)
 				return CURRENT_HVAC_IDLE
+			_LOGGER.debug(f"better_thermostat {self.name}: HA asked for our HVAC action, we will respond with: {CURRENT_HVAC_HEAT}")
 			return CURRENT_HVAC_HEAT
 	
 	@property

--- a/custom_components/better_thermostat/controlling.py
+++ b/custom_components/better_thermostat/controlling.py
@@ -25,6 +25,7 @@ async def control_trv(self):
 		_current_TRV_mode = self.hass.states.get(self.heater_entity_id).state
 		system_mode_change = False
 		window_open_status_changed = False
+		call_for_heat_updated = False
 		
 		if self._bt_hvac_mode == HVAC_MODE_OFF:
 			_LOGGER.debug(f"better_thermostat {self.name}: control_trv: own mode is off, setting TRV mode to off")

--- a/custom_components/better_thermostat/controlling.py
+++ b/custom_components/better_thermostat/controlling.py
@@ -63,6 +63,9 @@ async def control_trv(self):
 			current_heating_setpoint = remapped_states.get('current_heating_setpoint') or None
 			calibration = remapped_states.get('local_temperature_calibration') or None
 			if converted_hvac_mode is not None:
+				_LOGGER.debug(
+					f"better_thermostat {self.name}: control_trv: current TRV mode: {_current_TRV_mode} new TRV mode: {converted_hvac_mode}"
+					)
 				if _current_TRV_mode != converted_hvac_mode:
 					system_mode_change = True
 					await set_trv_values(self, 'hvac_mode', converted_hvac_mode)

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -19,10 +19,7 @@ async def trigger_trv_change(self, event):
 	old_state = event.data.get("old_state")
 	new_state = event.data.get("new_state")
 	
-	if new_state is None or old_state is None:
-		return
-	
-	if new_state.attributes is None:
+	if not all([new_state, old_state, new_state.attributes]):
 		return
 	
 	try:

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -22,6 +22,8 @@ async def trigger_trv_change(self, event):
 	old_state = event.data.get("old_state")
 	new_state = event.data.get("new_state")
 	
+	_LOGGER.debug(f"better_thermostat {self.name}: trigger_trv_change: old_state: {old_state.state} new_state: {new_state.state}")
+	
 	if not all([new_state, old_state, new_state.attributes]):
 		_LOGGER.debug(f"better_thermostat {self.name}: TRV update contained not all necessary data for processing, skipping")
 		return
@@ -42,6 +44,10 @@ async def trigger_trv_change(self, event):
 		return
 	
 	new_decoded_system_mode = str(new_state.state)
+	
+	_LOGGER.debug(
+		f"better_thermostat {self.name}: trigger_trv_change: new_decoded_system_mode: {new_decoded_system_mode}, expected system mode: {self._trv_hvac_mode}"
+		)
 	
 	if new_decoded_system_mode not in (HVAC_MODE_OFF, HVAC_MODE_HEAT):
 		# not an valid mode, overwriting

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -24,10 +24,8 @@ async def trigger_trv_change(self, event):
 	
 	try:
 		remapped_state = convert_inbound_states(self, new_state.attributes)
-		# write valve position to local variable
-		if remapped_state.get(ATTR_VALVE_POSITION) is not None:
-			self._last_reported_valve_position = remapped_state.get(ATTR_VALVE_POSITION)
-			self._last_reported_valve_position_update_wait_lock.release()
+		
+		update_valve_position(self, remapped_state.get(ATTR_VALVE_POSITION))
 		
 		if old_state.attributes.get('system_mode') != new_state.attributes.get('system_mode'):
 			self._hvac_mode = remapped_state.get('system_mode')
@@ -66,8 +64,26 @@ async def trigger_trv_change(self, event):
 				)
 				await control_trv(self)
 	
-	
 	except TypeError as e:
 		_LOGGER.debug("better_thermostat entity not ready or device is currently not supported %s", e)
 	
 	self.async_write_ha_state()
+
+
+def update_valve_position(self, valve_position):
+	"""Updates the stored valve position and triggers async tasks waiting for this
+
+	Parameters
+	----------
+	self : 
+		FIXME
+	valve_position :
+		the new valve position
+	
+	Returns
+	-------
+	None 
+	"""
+	if valve_position is not None:
+		self._last_reported_valve_position = valve_position
+		self._last_reported_valve_position_update_wait_lock.release()

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -1,73 +1,74 @@
 import logging
 
-from ..controlling import control_trv
-from ..const import ATTR_VALVE_POSITION
-from ..models.models import convert_inbound_states
 from homeassistant.components.climate.const import (HVAC_MODE_OFF)
 from homeassistant.core import callback
 
+from ..const import ATTR_VALVE_POSITION
+from ..controlling import control_trv
+from ..models.models import convert_inbound_states
 
 _LOGGER = logging.getLogger(__name__)
+
 
 @callback
 async def trigger_trv_change(self, event):
 	"""Process TRV status updates"""
 	if self.startup_running:
-			return
-
+		return
+	
 	old_state = event.data.get("old_state")
 	new_state = event.data.get("new_state")
-
+	
 	if new_state is None or old_state is None:
-			return
-
+		return
+	
 	if new_state.attributes is not None:
-			try:
-					remapped_state = convert_inbound_states(self, new_state.attributes)
-					# write valve position to local variable
-					if remapped_state.get(ATTR_VALVE_POSITION) is not None:
-							self._last_reported_valve_position = remapped_state.get(ATTR_VALVE_POSITION)
-							self._last_reported_valve_position_update_wait_lock.release()
-					
-					if old_state.attributes.get('system_mode') != new_state.attributes.get('system_mode'):
-							self._hvac_mode = remapped_state.get('system_mode')
-							
-							if self._hvac_mode != HVAC_MODE_OFF and self.window_open:
-									self._hvac_mode = HVAC_MODE_OFF
-									_LOGGER.debug("better_thermostat %s: Window open, turn off the heater", self.name)
-									await control_trv(self)
-					
-					if not self.ignore_states and new_state.attributes.get(
-									'current_heating_setpoint'
-					) is not None and self._hvac_mode != HVAC_MODE_OFF and self.calibration_type == 0:
-							_new_heating_setpoint = float(new_state.attributes.get('current_heating_setpoint'))
-							# if new setpoint is lower than the min setpoint, set it to the min setpoint
-							_overwrite_thermostat_update = False
-							if _new_heating_setpoint < self._min_temp:
-									_new_heating_setpoint = self._min_temp
-									_overwrite_thermostat_update = True
-							# if new setpoint is higher than the max setpoint, set it to the max setpoint
-							if _new_heating_setpoint > self._max_temp:
-									_new_heating_setpoint = self._max_temp
-									_overwrite_thermostat_update = True
-							if self._target_temp != _new_heating_setpoint:
-									self._target_temp = _new_heating_setpoint
-							else:
-									_overwrite_thermostat_update = False
-							
-							# if the user has changed the setpoint to a value that is not in the allowed range,
-							# overwrite the change with an TRV update
-							if _overwrite_thermostat_update:
-									_LOGGER.warning(
-											"better_thermostat %s: Overwriting setpoint %s with %s, as the new setpoint is out of bound (min/max temperature)",
-											self.name,
-											new_state.attributes.get('current_heating_setpoint'),
-											_new_heating_setpoint
-									)
-									await control_trv(self)
+		try:
+			remapped_state = convert_inbound_states(self, new_state.attributes)
+			# write valve position to local variable
+			if remapped_state.get(ATTR_VALVE_POSITION) is not None:
+				self._last_reported_valve_position = remapped_state.get(ATTR_VALVE_POSITION)
+				self._last_reported_valve_position_update_wait_lock.release()
 			
+			if old_state.attributes.get('system_mode') != new_state.attributes.get('system_mode'):
+				self._hvac_mode = remapped_state.get('system_mode')
+				
+				if self._hvac_mode != HVAC_MODE_OFF and self.window_open:
+					self._hvac_mode = HVAC_MODE_OFF
+					_LOGGER.debug("better_thermostat %s: Window open, turn off the heater", self.name)
+					await control_trv(self)
 			
-			except TypeError as e:
-					_LOGGER.debug("better_thermostat entity not ready or device is currently not supported %s", e)
-			
-			self.async_write_ha_state()
+			if not self.ignore_states and new_state.attributes.get(
+				'current_heating_setpoint'
+			) is not None and self._hvac_mode != HVAC_MODE_OFF and self.calibration_type == 0:
+				_new_heating_setpoint = float(new_state.attributes.get('current_heating_setpoint'))
+				# if new setpoint is lower than the min setpoint, set it to the min setpoint
+				_overwrite_thermostat_update = False
+				if _new_heating_setpoint < self._min_temp:
+					_new_heating_setpoint = self._min_temp
+					_overwrite_thermostat_update = True
+				# if new setpoint is higher than the max setpoint, set it to the max setpoint
+				if _new_heating_setpoint > self._max_temp:
+					_new_heating_setpoint = self._max_temp
+					_overwrite_thermostat_update = True
+				if self._target_temp != _new_heating_setpoint:
+					self._target_temp = _new_heating_setpoint
+				else:
+					_overwrite_thermostat_update = False
+				
+				# if the user has changed the setpoint to a value that is not in the allowed range,
+				# overwrite the change with an TRV update
+				if _overwrite_thermostat_update:
+					_LOGGER.warning(
+						"better_thermostat %s: Overwriting setpoint %s with %s, as the new setpoint is out of bound (min/max temperature)",
+						self.name,
+						new_state.attributes.get('current_heating_setpoint'),
+						_new_heating_setpoint
+					)
+					await control_trv(self)
+		
+		
+		except TypeError as e:
+			_LOGGER.debug("better_thermostat entity not ready or device is currently not supported %s", e)
+		
+		self.async_write_ha_state()

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -50,7 +50,7 @@ async def trigger_trv_change(self, event):
 		force_update = True
 	
 	# check if this change is what we expected (if not already an update is forced)
-	if not force_update and self._hvac_mode != new_decoded_system_mode:
+	if not force_update and self._trv_hvac_mode != new_decoded_system_mode:
 		_LOGGER.warning(
 			f"better_thermostat {self.name}: TRV is not in the expected mode, we will force an update"
 		)
@@ -65,7 +65,7 @@ async def trigger_trv_change(self, event):
 		return
 	
 	# we only read setpoint changes from TRV if we are in heating mode
-	if self._hvac_mode == HVAC_MODE_OFF:
+	if self._trv_hvac_mode == HVAC_MODE_OFF:
 		return
 	
 	if _new_heating_setpoint := convert_to_float(new_state.attributes.get('current_heating_setpoint'), self.name, "trigger_trv_change()") \

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -1,11 +1,12 @@
 import logging
 
-from homeassistant.components.climate.const import (HVAC_MODE_OFF)
+from homeassistant.components.climate.const import HVAC_MODE_HEAT, HVAC_MODE_OFF
 from homeassistant.core import callback
 
 from ..const import ATTR_VALVE_POSITION
 from ..controlling import control_trv
 from ..models.models import convert_inbound_states
+from ..models.utils import convert_to_float
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -16,57 +17,73 @@ async def trigger_trv_change(self, event):
 	if self.startup_running:
 		return
 	
+	force_update = False
+	
 	old_state = event.data.get("old_state")
 	new_state = event.data.get("new_state")
 	
 	if not all([new_state, old_state, new_state.attributes]):
 		return
 	
-	try:
-		remapped_state = convert_inbound_states(self, new_state.attributes)
+	remapped_state = convert_inbound_states(self, new_state.attributes)
+	
+	update_valve_position(self, remapped_state.get(ATTR_VALVE_POSITION))
+	
+	# if flag is on, we won't do any further processing
+	if self.ignore_states:
+		return
+	
+	# system mode has been changed
+	if old_state.attributes.get('system_mode') != new_state.attributes.get('system_mode'):
 		
-		update_valve_position(self, remapped_state.get(ATTR_VALVE_POSITION))
+		new_decoded_system_mode = remapped_state.get('system_mode')
 		
-		if old_state.attributes.get('system_mode') != new_state.attributes.get('system_mode'):
-			self._hvac_mode = remapped_state.get('system_mode')
+		if new_decoded_system_mode is None or new_decoded_system_mode not in (HVAC_MODE_OFF, HVAC_MODE_HEAT):
+			# we don't understand this system mode, so we'll force an update to overwrite it
 			
-			if self._hvac_mode != HVAC_MODE_OFF and self.window_open:
-				self._hvac_mode = HVAC_MODE_OFF
-				_LOGGER.debug("better_thermostat %s: Window open, turn off the heater", self.name)
-				await control_trv(self)
-		
-		if not self.ignore_states and new_state.attributes.get(
-			'current_heating_setpoint'
-		) is not None and self._hvac_mode != HVAC_MODE_OFF and self.calibration_type == 0:
-			_new_heating_setpoint = float(new_state.attributes.get('current_heating_setpoint'))
-			# if new setpoint is lower than the min setpoint, set it to the min setpoint
-			_overwrite_thermostat_update = False
-			if _new_heating_setpoint < self._min_temp:
-				_new_heating_setpoint = self._min_temp
-				_overwrite_thermostat_update = True
-			# if new setpoint is higher than the max setpoint, set it to the max setpoint
-			if _new_heating_setpoint > self._max_temp:
-				_new_heating_setpoint = self._max_temp
-				_overwrite_thermostat_update = True
-			if self._target_temp != _new_heating_setpoint:
-				self._target_temp = _new_heating_setpoint
-			else:
-				_overwrite_thermostat_update = False
-			
-			# if the user has changed the setpoint to a value that is not in the allowed range,
-			# overwrite the change with an TRV update
-			if _overwrite_thermostat_update:
-				_LOGGER.warning(
-					"better_thermostat %s: Overwriting setpoint %s with %s, as the new setpoint is out of bound (min/max temperature)",
-					self.name,
-					new_state.attributes.get('current_heating_setpoint'),
-					_new_heating_setpoint
+			force_update = True
+			_LOGGER.debug(
+				f"better_thermostat {self.name}: Could not parse new system mode from TRV, forcing an update with the "
+				f"expected system mode: {self._hvac_mode}"
 				)
-				await control_trv(self)
+		
+		# check if this change is what we expected (if not already an update is forced)
+		if not force_update and self._hvac_mode != new_decoded_system_mode:
+			_LOGGER.warning(
+				f"better_thermostat {self.name}: TRV system mode but not to the mode we expect it to have, we will force an update"
+			)
+			force_update = True
+		
+		if force_update:
+			await control_trv(self)
+			return
 	
-	except TypeError as e:
-		_LOGGER.debug("better_thermostat entity not ready or device is currently not supported %s", e)
+	# we only read user input at the TRV on mode 0
+	if self.calibration_type != 0:
+		return
 	
+	# we only read setpoint changes from TRV if we are in heating mode
+	if self._hvac_mode == HVAC_MODE_OFF:
+		return
+	
+	if _new_heating_setpoint := convert_to_float(
+		new_state.attributes.get('current_heating_setpoint'),
+		self.name,
+		"trigger_trv_change()"
+		) is None:
+		return
+	
+	if _new_heating_setpoint < self._min_temp or self._max_temp < _new_heating_setpoint:
+		_LOGGER.warning(f"better_thermostat {self.name}: New TRV setpoint outside of range, overwriting it")
+		
+		if _new_heating_setpoint < self._min_temp:
+			_new_heating_setpoint = self._min_temp
+		else:
+			_new_heating_setpoint = self._max_temp
+		
+		self._target_temp = _new_heating_setpoint
+		
+		await control_trv(self)
 	self.async_write_ha_state()
 
 

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -1,9 +1,8 @@
 import logging
 
 from homeassistant.components.climate.const import HVAC_MODE_HEAT, HVAC_MODE_OFF
-from homeassistant.core import callback
+from homeassistant.core import callback, State
 
-from ..const import ATTR_VALVE_POSITION
 from ..controlling import control_trv
 from ..models.models import convert_inbound_states
 from ..models.utils import convert_to_float
@@ -27,49 +26,39 @@ async def trigger_trv_change(self, event):
 		_LOGGER.debug(f"better_thermostat {self.name}: TRV update contained not all necessary data for processing, skipping")
 		return
 	
-	remapped_state = convert_inbound_states(self, new_state)
+	if not isinstance(new_state, State) or not isinstance(old_state, State):
+		_LOGGER.debug(f"better_thermostat {self.name}: TRV update contained not a State, skipping")
+		return
 	
-	update_valve_position(self, remapped_state.get(ATTR_VALVE_POSITION))
+	try:
+		convert_inbound_states(self, new_state)
+	except TypeError:
+		_LOGGER.debug(f"better_thermostat {self.name}: remapping TRV state failed, skipping")
+		return
 	
 	# if flag is on, we won't do any further processing
 	if self.ignore_states:
 		_LOGGER.debug(f"better_thermostat {self.name}: skipping trigger_trv_change because ignore_states is true")
 		return
 	
-	# system mode has been changed
-	if old_state != new_state:
-		_LOGGER.debug(
-			f"better_thermostat {self.name}: TRV System Mode changed from '{old_state}' to '{new_state}'"
-		)
-		
-		new_decoded_system_mode = remapped_state.get('system_mode')
-		_LOGGER.debug(
-			f"better_thermostat {self.name}: Expected decoded TRV mode: '{self._hvac_mode}'. TRV's decoded TRV mode: '{new_decoded_system_mode}'"
-		)
-		
-		if new_decoded_system_mode is None or new_decoded_system_mode not in (HVAC_MODE_OFF, HVAC_MODE_HEAT):
-			# we don't understand this system mode, so we'll force an update to overwrite it
-			_LOGGER.debug(f"better_thermostat {self.name}: TRV's decoded TRV mode is not valid, overwriting with correct system mode")
-			
-			force_update = True
-			_LOGGER.debug(
-				f"better_thermostat {self.name}: Could not parse new system mode from TRV, forcing an update with the "
-				f"expected system mode: {self._hvac_mode}"
-			)
-		
-		# check if this change is what we expected (if not already an update is forced)
-		if not force_update and self._hvac_mode != new_decoded_system_mode:
-			_LOGGER.warning(
-				f"better_thermostat {self.name}: TRV is not in the expected mode, we will force an update"
-			)
-			force_update = True
-		
-		if force_update:
-			await control_trv(self)
-			return
+	new_decoded_system_mode = str(new_state.state)
 	
-	else:
-		_LOGGER.debug(f"better_thermostat {self.name}: trigger_trv_change detected no system mode change")
+	if new_decoded_system_mode not in (HVAC_MODE_OFF, HVAC_MODE_HEAT):
+		# not an valid mode, overwriting
+		_LOGGER.debug(f"better_thermostat {self.name}: TRV's decoded TRV mode is not valid, overwriting with correct system mode")
+		
+		force_update = True
+	
+	# check if this change is what we expected (if not already an update is forced)
+	if not force_update and self._hvac_mode != new_decoded_system_mode:
+		_LOGGER.warning(
+			f"better_thermostat {self.name}: TRV is not in the expected mode, we will force an update"
+		)
+		force_update = True
+	
+	if force_update:
+		await control_trv(self)
+		return
 	
 	# we only read user input at the TRV on mode 0
 	if self.calibration_type != 0:
@@ -79,11 +68,8 @@ async def trigger_trv_change(self, event):
 	if self._hvac_mode == HVAC_MODE_OFF:
 		return
 	
-	if _new_heating_setpoint := convert_to_float(
-		new_state.attributes.get('current_heating_setpoint'),
-		self.name,
-		"trigger_trv_change()"
-	) is None:
+	if _new_heating_setpoint := convert_to_float(new_state.attributes.get('current_heating_setpoint'), self.name, "trigger_trv_change()") \
+	                            is None:
 		return
 	
 	if _new_heating_setpoint < self._min_temp or self._max_temp < _new_heating_setpoint:
@@ -114,6 +100,10 @@ def update_valve_position(self, valve_position):
 	-------
 	None 
 	"""
+	
 	if valve_position is not None:
+		_LOGGER.debug(f"better_thermostat {self.name}: Updating valve position to {valve_position}")
 		self._last_reported_valve_position = valve_position
 		self._last_reported_valve_position_update_wait_lock.release()
+	else:
+		_LOGGER.debug(f"better_thermostat {self.name}: Valve position is None, skipping")

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -27,7 +27,7 @@ async def trigger_trv_change(self, event):
 		_LOGGER.debug(f"better_thermostat {self.name}: TRV update contained not all necessary data for processing, skipping")
 		return
 	
-	remapped_state = convert_inbound_states(self, new_state.attributes)
+	remapped_state = convert_inbound_states(self, new_state)
 	
 	update_valve_position(self, remapped_state.get(ATTR_VALVE_POSITION))
 	
@@ -39,7 +39,7 @@ async def trigger_trv_change(self, event):
 	# system mode has been changed
 	if old_state != new_state:
 		_LOGGER.debug(
-			f"better_thermostat {self.name}: TRV System Mode changed from '{old_state.attributes.get('system_mode')}' to '{new_state.attributes.get('system_mode')}'"
+			f"better_thermostat {self.name}: TRV System Mode changed from '{old_state}' to '{new_state}'"
 		)
 		
 		new_decoded_system_mode = remapped_state.get('system_mode')

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -37,7 +37,7 @@ async def trigger_trv_change(self, event):
 		return
 	
 	# system mode has been changed
-	if old_state.attributes.get('system_mode') != new_state.attributes.get('system_mode'):
+	if old_state != new_state:
 		_LOGGER.debug(
 			f"better_thermostat {self.name}: TRV System Mode changed from '{old_state.attributes.get('system_mode')}' to '{new_state.attributes.get('system_mode')}'"
 		)

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -22,53 +22,55 @@ async def trigger_trv_change(self, event):
 	if new_state is None or old_state is None:
 		return
 	
-	if new_state.attributes is not None:
-		try:
-			remapped_state = convert_inbound_states(self, new_state.attributes)
-			# write valve position to local variable
-			if remapped_state.get(ATTR_VALVE_POSITION) is not None:
-				self._last_reported_valve_position = remapped_state.get(ATTR_VALVE_POSITION)
-				self._last_reported_valve_position_update_wait_lock.release()
+	if new_state.attributes is None:
+		return
+	
+	try:
+		remapped_state = convert_inbound_states(self, new_state.attributes)
+		# write valve position to local variable
+		if remapped_state.get(ATTR_VALVE_POSITION) is not None:
+			self._last_reported_valve_position = remapped_state.get(ATTR_VALVE_POSITION)
+			self._last_reported_valve_position_update_wait_lock.release()
+		
+		if old_state.attributes.get('system_mode') != new_state.attributes.get('system_mode'):
+			self._hvac_mode = remapped_state.get('system_mode')
 			
-			if old_state.attributes.get('system_mode') != new_state.attributes.get('system_mode'):
-				self._hvac_mode = remapped_state.get('system_mode')
-				
-				if self._hvac_mode != HVAC_MODE_OFF and self.window_open:
-					self._hvac_mode = HVAC_MODE_OFF
-					_LOGGER.debug("better_thermostat %s: Window open, turn off the heater", self.name)
-					await control_trv(self)
-			
-			if not self.ignore_states and new_state.attributes.get(
-				'current_heating_setpoint'
-			) is not None and self._hvac_mode != HVAC_MODE_OFF and self.calibration_type == 0:
-				_new_heating_setpoint = float(new_state.attributes.get('current_heating_setpoint'))
-				# if new setpoint is lower than the min setpoint, set it to the min setpoint
+			if self._hvac_mode != HVAC_MODE_OFF and self.window_open:
+				self._hvac_mode = HVAC_MODE_OFF
+				_LOGGER.debug("better_thermostat %s: Window open, turn off the heater", self.name)
+				await control_trv(self)
+		
+		if not self.ignore_states and new_state.attributes.get(
+			'current_heating_setpoint'
+		) is not None and self._hvac_mode != HVAC_MODE_OFF and self.calibration_type == 0:
+			_new_heating_setpoint = float(new_state.attributes.get('current_heating_setpoint'))
+			# if new setpoint is lower than the min setpoint, set it to the min setpoint
+			_overwrite_thermostat_update = False
+			if _new_heating_setpoint < self._min_temp:
+				_new_heating_setpoint = self._min_temp
+				_overwrite_thermostat_update = True
+			# if new setpoint is higher than the max setpoint, set it to the max setpoint
+			if _new_heating_setpoint > self._max_temp:
+				_new_heating_setpoint = self._max_temp
+				_overwrite_thermostat_update = True
+			if self._target_temp != _new_heating_setpoint:
+				self._target_temp = _new_heating_setpoint
+			else:
 				_overwrite_thermostat_update = False
-				if _new_heating_setpoint < self._min_temp:
-					_new_heating_setpoint = self._min_temp
-					_overwrite_thermostat_update = True
-				# if new setpoint is higher than the max setpoint, set it to the max setpoint
-				if _new_heating_setpoint > self._max_temp:
-					_new_heating_setpoint = self._max_temp
-					_overwrite_thermostat_update = True
-				if self._target_temp != _new_heating_setpoint:
-					self._target_temp = _new_heating_setpoint
-				else:
-					_overwrite_thermostat_update = False
-				
-				# if the user has changed the setpoint to a value that is not in the allowed range,
-				# overwrite the change with an TRV update
-				if _overwrite_thermostat_update:
-					_LOGGER.warning(
-						"better_thermostat %s: Overwriting setpoint %s with %s, as the new setpoint is out of bound (min/max temperature)",
-						self.name,
-						new_state.attributes.get('current_heating_setpoint'),
-						_new_heating_setpoint
-					)
-					await control_trv(self)
-		
-		
-		except TypeError as e:
-			_LOGGER.debug("better_thermostat entity not ready or device is currently not supported %s", e)
-		
-		self.async_write_ha_state()
+			
+			# if the user has changed the setpoint to a value that is not in the allowed range,
+			# overwrite the change with an TRV update
+			if _overwrite_thermostat_update:
+				_LOGGER.warning(
+					"better_thermostat %s: Overwriting setpoint %s with %s, as the new setpoint is out of bound (min/max temperature)",
+					self.name,
+					new_state.attributes.get('current_heating_setpoint'),
+					_new_heating_setpoint
+				)
+				await control_trv(self)
+	
+	
+	except TypeError as e:
+		_LOGGER.debug("better_thermostat entity not ready or device is currently not supported %s", e)
+	
+	self.async_write_ha_state()

--- a/custom_components/better_thermostat/helpers.py
+++ b/custom_components/better_thermostat/helpers.py
@@ -2,16 +2,16 @@
 
 import asyncio
 import logging
-
 from datetime import datetime
 
-from .events.temperature import _async_update_temp
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.helpers.entity_registry import async_entries_for_config_entry
+
 from .controlling import control_trv
-from homeassistant.helpers.entity_registry import (async_entries_for_config_entry)
-from homeassistant.const import (STATE_UNAVAILABLE, STATE_UNKNOWN)
-from homeassistant.components.climate.const import (HVAC_MODE_OFF)
+from .events.temperature import _async_update_temp
 
 _LOGGER = logging.getLogger(__name__)
+
 
 def log_info(self, message):
 	"""Log a message to the info log."""
@@ -105,10 +105,8 @@ async def startup(self):
 			check = window.state
 			if check == 'on':
 				self.window_open = True
-				self._hvac_mode = HVAC_MODE_OFF
 			else:
 				self.window_open = False
-				self.closed_window_triggered = False
 			_LOGGER.debug(
 				"better_thermostat %s: detected window state at startup: %s",
 				self.name,

--- a/custom_components/better_thermostat/models/devices/BRT_100_TRV.yaml
+++ b/custom_components/better_thermostat/models/devices/BRT_100_TRV.yaml
@@ -1,1 +1,2 @@
 calibration_type: 1
+heat_auto_swapped: False

--- a/custom_components/better_thermostat/models/devices/GS361A_H04.yaml
+++ b/custom_components/better_thermostat/models/devices/GS361A_H04.yaml
@@ -1,1 +1,2 @@
 calibration_type: 1
+heat_auto_swapped: False

--- a/custom_components/better_thermostat/models/devices/SEA801-Zigbee_SEA802-Zigbee.yaml
+++ b/custom_components/better_thermostat/models/devices/SEA801-Zigbee_SEA802-Zigbee.yaml
@@ -1,3 +1,4 @@
 calibration_type: 0
 calibration_round: true
 has_system_mode: True
+heat_auto_swapped: False

--- a/custom_components/better_thermostat/models/devices/SPZB0001.yaml
+++ b/custom_components/better_thermostat/models/devices/SPZB0001.yaml
@@ -1,6 +1,4 @@
 calibration_type: 0
 calibration_round: false
 has_system_mode: True
-mode_map:
-  heat: auto
-  auto: heat
+heat_auto_swapped: True

--- a/custom_components/better_thermostat/models/devices/SPZB0001.yaml
+++ b/custom_components/better_thermostat/models/devices/SPZB0001.yaml
@@ -3,3 +3,4 @@ calibration_round: false
 has_system_mode: True
 mode_map:
   heat: auto
+  auto: heat

--- a/custom_components/better_thermostat/models/devices/TS0601_thermostat.yaml
+++ b/custom_components/better_thermostat/models/devices/TS0601_thermostat.yaml
@@ -2,3 +2,4 @@ calibration_type: 1
 has_system_mode: True
 mode_map:
   heat: auto
+  auto: heat

--- a/custom_components/better_thermostat/models/devices/TS0601_thermostat.yaml
+++ b/custom_components/better_thermostat/models/devices/TS0601_thermostat.yaml
@@ -1,5 +1,3 @@
 calibration_type: 1
 has_system_mode: True
-mode_map:
-  heat: auto
-  auto: heat
+heat_auto_swapped: True

--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -16,42 +16,33 @@ from .utils import calculate_local_setpoint_delta, calculate_setpoint_override, 
 _LOGGER = logging.getLogger(__name__)
 
 
-def convert_inbound_states(self, state: State) -> Union[None, State]:
+def convert_inbound_states(self, state: State):
 	"""Convert inbound thermostat state to HA state.
 
 	Parameters
 	----------
 	self : 
 	state : State
-		Inbound thermostat state.
+		Inbound thermostat state, which will be modified
 
 	Returns
 	-------
-	State
-		the converted thermostat state
 	None
-	if the state is not supported
 	"""
 	
 	if state is None:
-		_LOGGER.warning(f"better_thermostat {self.name}: convert_inbound_states() received None state, cannot convert")
-		return None
+		raise TypeError("convert_inbound_states() received None state, cannot convert")
 	
 	if state.attributes is None or state.state is None:
-		_LOGGER.error(
-			f"better_thermostat {self.name}: convert_inbound_states() received None state for the state attributes, cannot convert"
-		)
-		return None
+		raise TypeError("convert_inbound_states() received None state, cannot convert")
 	
 	_decoded_hvac_mode = None
 	
 	if self._config is None:
-		_LOGGER.error(f"better_thermostat {self.name}: convert_inbound_states() could not load config, cannot convert")
+		raise TypeError("convert_inbound_states() could not find config, cannot convert")
 	
 	if self._config.get('mode_map') is not None:
 		state.state = mode_remap(str(state.state), reverse_modes(self._config.get('mode_map')))
-	
-	return state
 
 
 async def get_device_model(self):

--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -36,8 +36,6 @@ def convert_inbound_states(self, state: State):
 	if state.attributes is None or state.state is None:
 		raise TypeError("convert_inbound_states() received None state, cannot convert")
 	
-	_decoded_hvac_mode = None
-	
 	if self._config is None:
 		raise TypeError("convert_inbound_states() could not find config, cannot convert")
 	

--- a/custom_components/better_thermostat/models/utils.py
+++ b/custom_components/better_thermostat/models/utils.py
@@ -6,8 +6,22 @@ from typing import Union
 _LOGGER = logging.getLogger(__name__)
 
 
-def mode_remap(hvac_mode, modes):
-	"""Remap HVAC mode to better mode."""
+def mode_remap(hvac_mode: str, modes: dict) -> str:
+	"""Remap HVAC mode to correct mode
+
+	Parameters
+	----------
+	hvac_mode : str
+		HVAC mode to be remapped
+	modes : 
+		Dictionary with HVAC mode remappings
+
+	Returns
+	-------
+	str
+		remapped mode according to device's quirks
+	"""
+	
 	if modes is None:
 		return hvac_mode
 	if modes.get(hvac_mode) is not None:

--- a/custom_components/better_thermostat/weather.py
+++ b/custom_components/better_thermostat/weather.py
@@ -9,8 +9,16 @@ from .models.utils import convert_to_float
 _LOGGER = logging.getLogger(__name__)
 
 
-def check_weather(self):
-	# check weather predictions or ambient air temperature if available
+def check_weather(self) -> bool:
+	"""check weather predictions or ambient air temperature if available
+
+	Returns
+	-------
+	bool
+		true if call_for_heat was changed
+	"""
+	old_call_for_heat = self.call_for_heat
+	
 	if self.weather_entity is not None:
 		self.call_for_heat = check_weather_prediction(self)
 	elif self.outdoor_sensor is not None:
@@ -18,6 +26,11 @@ def check_weather(self):
 	else:
 		# no weather evaluation: call for heat is always true
 		self.call_for_heat = True
+	
+	if old_call_for_heat != self.call_for_heat:
+		return True
+	else:
+		return False
 
 
 def check_weather_prediction(self):

--- a/custom_components/better_thermostat/weather.py
+++ b/custom_components/better_thermostat/weather.py
@@ -9,15 +9,15 @@ from .models.utils import convert_to_float
 _LOGGER = logging.getLogger(__name__)
 
 
-async def check_weather(self):
+def check_weather(self):
 	# check weather predictions or ambient air temperature if available
 	if self.weather_entity is not None:
-		return check_weather_prediction(self)
+		self.call_for_heat = check_weather_prediction(self)
 	elif self.outdoor_sensor is not None:
-		return check_ambient_air_temperature(self)
+		self.call_for_heat = check_ambient_air_temperature(self)
 	else:
 		# no weather evaluation: call for heat is always true
-		return True
+		self.call_for_heat = True
 
 
 def check_weather_prediction(self):


### PR DESCRIPTION
## Motivation:

We haven't really processed system mode changes received from the TRV in terms of validity. We should check if an system mode change is what we expect to happen and if not overwrite it.

## Changes:

- Check changes to system modes and override them if they are unexpected
- Override system modes which we do not understand with the expected value
- Create a function to store valve position updates
- changes the behaivor of BT, as it won't switch modes anymore but instead show "off" or "idle", but stay on. "Off" is shown on open windows, "idle" is shown if the heating is stopped because of weather

## Related issue (check one):

- [x] fixes #331
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] Code hasn't been tested yet
- [ ] The code change is tested and works locally.
