### PR TITLE
Fix a issue that the last set temperature not set correctly after restart

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import numbers
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 import voluptuous as vol

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2,13 +2,14 @@
 
 import asyncio
 import logging
-from abc import ABC
-from datetime import datetime, timedelta
-from random import randint
-
+import numbers
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 import voluptuous as vol
+from abc import ABC
+
+from datetime import datetime, timedelta
+from random import randint
 from homeassistant.components.climate import ClimateEntity, PLATFORM_SCHEMA
 from homeassistant.components.climate.const import (CURRENT_HVAC_HEAT, CURRENT_HVAC_IDLE, CURRENT_HVAC_OFF, HVAC_MODE_HEAT, HVAC_MODE_OFF)
 from homeassistant.const import (CONF_NAME, CONF_UNIQUE_ID, EVENT_HOMEASSISTANT_START)
@@ -16,21 +17,15 @@ from homeassistant.core import callback, CoreState
 from homeassistant.helpers.event import (async_track_state_change_event, async_track_time_change)
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.restore_state import RestoreEntity
-
 from . import DOMAIN, PLATFORMS
-from .const import (
-	ATTR_STATE_CALL_FOR_HEAT, ATTR_STATE_DAY_SET_TEMP, ATTR_STATE_LAST_CHANGE, ATTR_STATE_NIGHT_MODE, ATTR_STATE_WINDOW_OPEN, CONF_HEATER,
-	CONF_MAX_TEMP, CONF_MIN_TEMP, CONF_NIGHT_END, CONF_NIGHT_START, CONF_NIGHT_TEMP, CONF_OFF_TEMPERATURE, CONF_OUTDOOR_SENSOR,
-	CONF_PRECISION, CONF_SENSOR, CONF_SENSOR_WINDOW, CONF_TARGET_TEMP, CONF_VALVE_MAINTENANCE, CONF_WEATHER, CONF_WINDOW_TIMEOUT,
-	DEFAULT_NAME, SUPPORT_FLAGS, VERSION
-)
+from .const import (VERSION,SUPPORT_FLAGS,CONF_HEATER,CONF_SENSOR,CONF_SENSOR_WINDOW,CONF_WEATHER,CONF_OUTDOOR_SENSOR,CONF_OFF_TEMPERATURE,CONF_WINDOW_TIMEOUT,CONF_VALVE_MAINTENANCE,CONF_NIGHT_TEMP,CONF_NIGHT_START,CONF_NIGHT_END,CONF_MIN_TEMP,CONF_MAX_TEMP,CONF_PRECISION,CONF_TARGET_TEMP,ATTR_STATE_CALL_FOR_HEAT,ATTR_STATE_DAY_SET_TEMP,ATTR_STATE_LAST_CHANGE,ATTR_STATE_NIGHT_MODE,ATTR_STATE_WINDOW_OPEN,DEFAULT_NAME)
+from .helpers import check_float, startup
+from .models.models import get_device_model, load_device_config
 from .controlling import set_hvac_mode, set_target_temperature
 from .events.temperature import trigger_temperature_change
 from .events.time import trigger_time
 from .events.trv import trigger_trv_change
 from .events.window import trigger_window_change
-from .helpers import check_float, startup
-from .models.models import get_device_model, load_device_config
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2,14 +2,13 @@
 
 import asyncio
 import logging
-import numbers
+from abc import ABC
+from datetime import datetime, timedelta
+from random import randint
+
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 import voluptuous as vol
-from abc import ABC
-
-from datetime import datetime, timedelta
-from random import randint
 from homeassistant.components.climate import ClimateEntity, PLATFORM_SCHEMA
 from homeassistant.components.climate.const import (CURRENT_HVAC_HEAT, CURRENT_HVAC_IDLE, CURRENT_HVAC_OFF, HVAC_MODE_HEAT, HVAC_MODE_OFF)
 from homeassistant.const import (CONF_NAME, CONF_UNIQUE_ID, EVENT_HOMEASSISTANT_START)
@@ -17,15 +16,21 @@ from homeassistant.core import callback, CoreState
 from homeassistant.helpers.event import (async_track_state_change_event, async_track_time_change)
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.restore_state import RestoreEntity
+
 from . import DOMAIN, PLATFORMS
-from .const import (VERSION,SUPPORT_FLAGS,CONF_HEATER,CONF_SENSOR,CONF_SENSOR_WINDOW,CONF_WEATHER,CONF_OUTDOOR_SENSOR,CONF_OFF_TEMPERATURE,CONF_WINDOW_TIMEOUT,CONF_VALVE_MAINTENANCE,CONF_NIGHT_TEMP,CONF_NIGHT_START,CONF_NIGHT_END,CONF_MIN_TEMP,CONF_MAX_TEMP,CONF_PRECISION,CONF_TARGET_TEMP,ATTR_STATE_CALL_FOR_HEAT,ATTR_STATE_DAY_SET_TEMP,ATTR_STATE_LAST_CHANGE,ATTR_STATE_NIGHT_MODE,ATTR_STATE_WINDOW_OPEN,DEFAULT_NAME)
-from .helpers import check_float, startup
-from .models.models import get_device_model, load_device_config
+from .const import (
+	ATTR_STATE_CALL_FOR_HEAT, ATTR_STATE_DAY_SET_TEMP, ATTR_STATE_LAST_CHANGE, ATTR_STATE_NIGHT_MODE, ATTR_STATE_WINDOW_OPEN, CONF_HEATER,
+	CONF_MAX_TEMP, CONF_MIN_TEMP, CONF_NIGHT_END, CONF_NIGHT_START, CONF_NIGHT_TEMP, CONF_OFF_TEMPERATURE, CONF_OUTDOOR_SENSOR,
+	CONF_PRECISION, CONF_SENSOR, CONF_SENSOR_WINDOW, CONF_TARGET_TEMP, CONF_VALVE_MAINTENANCE, CONF_WEATHER, CONF_WINDOW_TIMEOUT,
+	DEFAULT_NAME, SUPPORT_FLAGS, VERSION
+)
 from .controlling import set_hvac_mode, set_target_temperature
 from .events.temperature import trigger_temperature_change
 from .events.time import trigger_time
 from .events.trv import trigger_trv_change
 from .events.window import trigger_window_change
+from .helpers import check_float, startup
+from .models.models import get_device_model, load_device_config
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/better_thermostat/helpers.py
+++ b/custom_components/better_thermostat/helpers.py
@@ -7,7 +7,6 @@ from datetime import datetime
 import numbers
 
 from .const import ATTR_STATE_CALL_FOR_HEAT, ATTR_STATE_DAY_SET_TEMP, ATTR_STATE_LAST_CHANGE, ATTR_STATE_NIGHT_MODE, ATTR_STATE_WINDOW_OPEN
-from .events.temperature import _async_update_temp
 from .controlling import control_trv
 from homeassistant.helpers.entity_registry import (async_entries_for_config_entry)
 from homeassistant.const import (STATE_UNAVAILABLE, STATE_UNKNOWN, ATTR_TEMPERATURE)
@@ -229,7 +228,6 @@ async def startup(self):
 				self.name
 			)
 			self._hvac_mode = HVAC_MODE_OFF
-		_async_update_temp(self,sensor_state)
 		self.async_write_ha_state()
 		_LOGGER.info("better_thermostat %s: startup completed.", self.name)
 		await control_trv(self)

--- a/custom_components/better_thermostat/helpers.py
+++ b/custom_components/better_thermostat/helpers.py
@@ -2,16 +2,18 @@
 
 import asyncio
 import logging
+
 from datetime import datetime
+import numbers
 
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
-from homeassistant.helpers.entity_registry import async_entries_for_config_entry
-
-from .controlling import control_trv
+from .const import ATTR_STATE_CALL_FOR_HEAT, ATTR_STATE_DAY_SET_TEMP, ATTR_STATE_LAST_CHANGE, ATTR_STATE_NIGHT_MODE, ATTR_STATE_WINDOW_OPEN
 from .events.temperature import _async_update_temp
+from .controlling import control_trv
+from homeassistant.helpers.entity_registry import (async_entries_for_config_entry)
+from homeassistant.const import (STATE_UNAVAILABLE, STATE_UNKNOWN, ATTR_TEMPERATURE)
+from homeassistant.components.climate.const import (HVAC_MODE_OFF)
 
 _LOGGER = logging.getLogger(__name__)
-
 
 def log_info(self, message):
 	"""Log a message to the info log."""
@@ -105,8 +107,10 @@ async def startup(self):
 			check = window.state
 			if check == 'on':
 				self.window_open = True
+				self._hvac_mode = HVAC_MODE_OFF
 			else:
 				self.window_open = False
+				self.closed_window_triggered = False
 			_LOGGER.debug(
 				"better_thermostat %s: detected window state at startup: %s",
 				self.name,
@@ -127,8 +131,6 @@ async def startup(self):
 					self.local_temperature_calibration_entity = entity.entity_id
 				if "valve_position" in uid:
 					self.valve_position_entity = entity.entity_id
-		_async_update_temp(self,sensor_state)
-		self.async_write_ha_state()
 		await asyncio.sleep(5)
 		# Use the same precision and min and max as the TRV
 		if self.hass.states.get(self.heater_entity_id).attributes.get('target_temp_step') is not None:
@@ -143,6 +145,92 @@ async def startup(self):
 			self._TRV_max_temp = float(self.hass.states.get(self.heater_entity_id).attributes.get('max_temp'))
 		else:
 			self._TRV_max_temp = 30
+
+		# Check If we have an old state
+		if (old_state := await self.async_get_last_state()) is not None:
+			# If we have no initial temperature, restore
+			if self._target_temp is None:
+				# If we have a previously saved temperature
+				if old_state.attributes.get(ATTR_TEMPERATURE) is None:
+					self._target_temp = self._min_temp
+					_LOGGER.debug(
+						"better_thermostat %s: Undefined target temperature, falling back to %s", self.name, self._target_temp
+					)
+				else:
+					_old_target_temperature = float(old_state.attributes.get(ATTR_TEMPERATURE))
+					# if the saved temperature is lower than the _min_temp, set it to _min_temp
+					if _old_target_temperature < self._min_temp:
+						_LOGGER.warning(
+							"better_thermostat %s: Saved target temperature %s is lower than _min_temp %s, setting to _min_temp",
+							self.name,
+							_old_target_temperature,
+							self._min_temp
+						)
+						self._target_temp = self._min_temp
+					# if the saved temperature is higher than the _max_temp, set it to _max_temp
+					elif _old_target_temperature > self._max_temp:
+						_LOGGER.warning(
+							"better_thermostat %s: Saved target temperature %s is higher than _max_temp %s, setting to _max_temp",
+							self.name,
+							_old_target_temperature,
+							self._min_temp
+						)
+						self._target_temp = self._max_temp
+			if not self._hvac_mode and old_state.state:
+				self._hvac_mode = old_state.state
+			if not old_state.attributes.get(ATTR_STATE_LAST_CHANGE):
+				self.last_change = old_state.attributes.get(ATTR_STATE_LAST_CHANGE)
+			else:
+				self.last_change = HVAC_MODE_OFF
+			if not old_state.attributes.get(ATTR_STATE_WINDOW_OPEN):
+				self.window_open = old_state.attributes.get(ATTR_STATE_WINDOW_OPEN)
+			if not old_state.attributes.get(ATTR_STATE_DAY_SET_TEMP):
+				self.last_daytime_temp = old_state.attributes.get(ATTR_STATE_DAY_SET_TEMP)
+			if not old_state.attributes.get(ATTR_STATE_CALL_FOR_HEAT):
+				self.call_for_heat = old_state.attributes.get(ATTR_STATE_CALL_FOR_HEAT)
+			if not old_state.attributes.get(ATTR_STATE_NIGHT_MODE):
+				self.night_mode_active = old_state.attributes.get(ATTR_STATE_NIGHT_MODE)
+				if self.night_mode_active:
+					if self.night_temp and isinstance(self.night_temp, numbers.Number):
+						_night_temp = float(self.night_temp)
+						# if the night temperature is lower than _min_temp, set it to _min_temp
+						if _night_temp < self._min_temp:
+							_LOGGER.error(
+								"better_thermostat %s: Night temperature %s is lower than _min_temp %s, setting to _min_temp",
+								self.name,
+								_night_temp,
+								self._min_temp
+							)
+							self._target_temp = self._min_temp
+						# if the night temperature is higher than the _max_temp, set it to max_temp
+						elif _night_temp > self._max_temp:
+							_LOGGER.warning(
+								"better_thermostat %s: Night temperature %s is higher than _max_temp %s, setting to _max_temp",
+								self.name,
+								_night_temp,
+								self._min_temp
+							)
+							self._target_temp = self._max_temp
+					else:
+						_LOGGER.error("better_thermostat %s: Night temp '%s' is not a number", self.name, str(self.night_temp))
+		
+		else:
+			# No previous state, try and restore defaults
+			if self._target_temp is None:
+				_LOGGER.info(
+					"better_thermostat %s: No previously saved temperature found on startup, turning heat off",
+					self.name
+				)
+				self._hvac_mode = HVAC_MODE_OFF
+		# if hvac mode could not be restored, turn heat off
+		if not self._hvac_mode:
+			_LOGGER.warning(
+				"better_thermostat %s: No previously hvac mode found on startup, turn heat off",
+				self.name
+			)
+			self._hvac_mode = HVAC_MODE_OFF
+		_async_update_temp(self,sensor_state)
+		self.async_write_ha_state()
 		_LOGGER.info("better_thermostat %s: startup completed.", self.name)
 		await control_trv(self)
 	return True


### PR DESCRIPTION
## Motivation:

Fix a issue that the last set temperature not set correctly after restart

## Changes:

Add the load function to the startup function

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [X] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.
