### PR TITLE
fix None check

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -256,7 +256,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 			)
 		
 		# check if night mode was configured
-		if all([self.night_start, self.night_end, self.night_temp]):
+		if None not in (self.night_start, self.night_end, self.night_temp):
 			_LOGGER.debug("Night mode configured")
 			async_track_time_change(
 				self.hass,
@@ -470,7 +470,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		float
 			Target temperature.
 		"""
-		if not all([self._max_temp, self._min_temp, self._target_temp]):
+		if None in (self._max_temp, self._min_temp, self._target_temp):
 			return self._target_temp
 		# if target temp is below minimum, return minimum
 		if self._target_temp < self._min_temp:

--- a/custom_components/better_thermostat/events/time.py
+++ b/custom_components/better_thermostat/events/time.py
@@ -66,7 +66,7 @@ def _nighttime(self, current_time):
 	_return_value = None
 	
 	# one or more of the inputs is None or empty
-	if not all([self.night_start, self.night_end, current_time]):
+	if None in (self.night_start, self.night_end, current_time):
 		return _return_value
 	
 	if self.night_start.hour == current_time.hour and self.night_start.minute == current_time.minute:

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -36,7 +36,7 @@ async def trigger_trv_change(self, event):
 	
 	_LOGGER.debug(f"better_thermostat {self.name}: trigger_trv_change: old_state: {old_state.state} new_state: {new_state.state}")
 	
-	if not all([new_state, old_state, new_state.attributes]):
+	if None in (new_state, old_state, new_state.attributes):
 		_LOGGER.debug(f"better_thermostat {self.name}: TRV update contained not all necessary data for processing, skipping")
 		return
 	

--- a/custom_components/better_thermostat/models/utils.py
+++ b/custom_components/better_thermostat/models/utils.py
@@ -126,7 +126,7 @@ def calculate_setpoint_override(self) -> Union[float, None]:
 	
 	_current_trv_temp = convert_to_float(state.get('current_temperature'), self.name, _context)
 	
-	if not all([self._target_temp, self._cur_temp, _current_trv_temp]):
+	if None in (self._target_temp, self._cur_temp, _current_trv_temp):
 		return None
 	
 	_calibrated_setpoint = round_to_half_degree(self._target_temp - self._cur_temp + _current_trv_temp)


### PR DESCRIPTION
## Motivation:

As discussed in #353 we used all() wrong previously, as it also checks for zeros in integers.

## Changes:

Fix None check.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.
- [x] I did not test this code change (yet).
