### PR TITLE
get the device object as log for debugging

### DIFF
--- a/custom_components/better_thermostat/models/models.py
+++ b/custom_components/better_thermostat/models/models.py
@@ -66,6 +66,8 @@ async def get_device_model(self):
 			entry = entity_reg.async_get(self.heater_entity_id)
 			dev_reg = await dr.async_get_registry(self.hass)
 			device = dev_reg.async_get(entry.device_id)
+			_LOGGER.debug(f"better_thermostat {self.name}: found device:")
+			_LOGGER.debug(device)
 			try:
 				# Z2M reports the device name as a long string with the actual model name in braces, we need to extract it
 				return re.search('\((.+?)\)', device.model).group(1)


### PR DESCRIPTION
## Motivation:

We need a way to get the device infos from HA to get the right model of different intigrations, a log will help to do that.

## Changes:

- Add detail log

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [X] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.