### PR TITLE
Force heater mode updates if we detect a wrong one (regardless what HA reports to us)

### DIFF
--- a/custom_components/better_thermostat/controlling.py
+++ b/custom_components/better_thermostat/controlling.py
@@ -12,8 +12,13 @@ from .weather import check_weather
 _LOGGER = logging.getLogger(__name__)
 
 
-async def control_trv(self):
+async def control_trv(self, force_mode_change: bool = False):
 	"""This is the main controller for the real TRV
+
+	Parameters
+	----------
+	self : instance of better_thermostat
+	force_mode_change : forces a mode change regardless which mode the TRV is in.
 
 	Returns
 	-------
@@ -72,7 +77,7 @@ async def control_trv(self):
 				_LOGGER.debug(
 					f"better_thermostat {self.name}: control_trv: current TRV mode: {_current_TRV_mode} new TRV mode: {converted_hvac_mode}"
 					)
-				if _current_TRV_mode != converted_hvac_mode:
+				if _current_TRV_mode != converted_hvac_mode or force_mode_change:
 					system_mode_change = True
 					await set_trv_values(self, 'hvac_mode', converted_hvac_mode)
 			if current_heating_setpoint is not None:

--- a/custom_components/better_thermostat/controlling.py
+++ b/custom_components/better_thermostat/controlling.py
@@ -17,8 +17,10 @@ async def control_trv(self, force_mode_change: bool = False):
 
 	Parameters
 	----------
-	self : instance of better_thermostat
-	force_mode_change : forces a mode change regardless which mode the TRV is in.
+	self :
+		instance of better_thermostat
+	force_mode_change : bool
+		forces a mode change regardless which mode the TRV is in.
 
 	Returns
 	-------

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -75,7 +75,7 @@ async def trigger_trv_change(self, event):
 		force_update = True
 	
 	if force_update:
-		await control_trv(self)
+		await control_trv(self, force_mode_change=True)
 		return
 	
 	# we only read user input at the TRV on mode 0


### PR DESCRIPTION
## Motivation:

We ask HA in which mode the heater is in, after we received an update for the mode which we're not satisfied with. But HA reports unexpectedly not the updated but the old mode for the heater - which results in a loop in the code to correct this.

## Changes:

- Avoid the loop by forcing an update of the heater to the right mode.

## Related issue (check one):

- [x] fixes ##350
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.
- [x] I did not test the code change.
