### PR TITLE
Improve error logging for empty sensor data

### DIFF
--- a/custom_components/better_thermostat/models/utils.py
+++ b/custom_components/better_thermostat/models/utils.py
@@ -165,7 +165,7 @@ def convert_to_float(value: Union[str, int, float], instance_name: str, context:
 		try:
 			return float(value)
 		except (ValueError, TypeError, AttributeError, KeyError):
-			_LOGGER.error(f"better thermostat {instance_name}: Could not convert '{value}' to float in {context}")
+			_LOGGER.debug(f"better thermostat {instance_name}: Could not convert '{value}' to float in {context}")
 			return None
 
 

--- a/custom_components/better_thermostat/weather.py
+++ b/custom_components/better_thermostat/weather.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from datetime import datetime, timedelta
 
@@ -9,7 +11,7 @@ from .models.utils import convert_to_float
 _LOGGER = logging.getLogger(__name__)
 
 
-def check_weather(self) -> bool:
+def check_weather(self) -> bool | None:
 	"""check weather predictions or ambient air temperature if available
 
 	Parameters
@@ -43,7 +45,7 @@ def check_weather(self) -> bool:
 		return False
 
 
-def check_weather_prediction(self):
+def check_weather_prediction(self) -> bool | None:
 	"""Checks configured weather entity for next two days of temperature predictions.
 
 	Returns
@@ -78,7 +80,7 @@ def check_weather_prediction(self):
 		return None
 
 
-def check_ambient_air_temperature(self):
+def check_ambient_air_temperature(self) -> bool | None:
 	"""Gets the history for two days and evaluates the necessary for heating.
 	
 	Returns
@@ -108,13 +110,21 @@ def check_ambient_air_temperature(self):
 	
 	# create a list from valid data in historic_sensor_data
 	valid_historic_sensor_data = []
+	invalid_sensor_data_count = 0
 	for measurement in historic_sensor_data:
 		if isinstance(measurement := convert_to_float(str(measurement.state), self.name, "check_ambient_air_temperature()"), float):
 			valid_historic_sensor_data.append(measurement)
+		else:
+			invalid_sensor_data_count += 1
 	
 	if len(valid_historic_sensor_data) == 0:
 		_LOGGER.warning(f"better_thermostat {self.name}: no valid outdoor sensor data found.")
 		return None
+	
+	if invalid_sensor_data_count:
+		_LOGGER.warning(
+			f"better_thermostat {self.name}: ignored {invalid_sensor_data_count} invalid outdoor sensor data entries."
+		)
 	
 	# remove the upper and lower 5% of the data
 	valid_historic_sensor_data.sort()


### PR DESCRIPTION
## Motivation:

We used to log an error for each sensor data which couldn't be converted to float. This is a bit excessive.,

## Changes:

- Change error message for float conversions to debug
- Print a warning on how much of the sensordata cannot be converted.

## Related issue (check one):

- [x] fixes #348
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
