### PR TITLE
Make control logic more robust by using lock

### DIFF
--- a/custom_components/better_thermostat/controlling.py
+++ b/custom_components/better_thermostat/controlling.py
@@ -58,10 +58,15 @@ async def control_trv(self, force_mode_change: bool = False):
 					f"better_thermostat {self.name}: control_trv: own mode is on, call for heat decision is false, setting TRV mode to off"
 				)
 				self._trv_hvac_mode = HVAC_MODE_OFF
-			else:
+			elif self.call_for_heat is True:
 				_LOGGER.debug(
 					f"better_thermostat {self.name}: control_trv: own mode is on, call for heat decision is true, setting TRV mode to on"
 				)
+				self._trv_hvac_mode = HVAC_MODE_HEAT
+			else:
+				_LOGGER.debug(
+					f"better_thermostat {self.name}: control_trv: own mode is on, call for heat decision is unknown, setting TRV mode to on"
+					)
 				self._trv_hvac_mode = HVAC_MODE_HEAT
 		
 		if self._trv_hvac_mode == HVAC_MODE_OFF:

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -25,82 +25,96 @@ async def trigger_trv_change(self, event):
 	-------
 	None
 	"""
-	if self.startup_running:
-		_LOGGER.debug(f"better_thermostat {self.name}: skipping trigger_trv_change because startup is running")
-		return
 	
-	force_update = False
+	run_control_trv = False
 	
-	old_state = event.data.get("old_state")
-	new_state = event.data.get("new_state")
-	
-	_LOGGER.debug(f"better_thermostat {self.name}: trigger_trv_change: old_state: {old_state.state} new_state: {new_state.state}")
-	
-	if None in (new_state, old_state, new_state.attributes):
-		_LOGGER.debug(f"better_thermostat {self.name}: TRV update contained not all necessary data for processing, skipping")
-		return
-	
-	if not isinstance(new_state, State) or not isinstance(old_state, State):
-		_LOGGER.debug(f"better_thermostat {self.name}: TRV update contained not a State, skipping")
-		return
-	
-	try:
-		convert_inbound_states(self, new_state)
-	except TypeError:
-		_LOGGER.debug(f"better_thermostat {self.name}: remapping TRV state failed, skipping")
-		return
-	
-	# if flag is on, we won't do any further processing
-	if self.ignore_states:
-		_LOGGER.debug(f"better_thermostat {self.name}: skipping trigger_trv_change because ignore_states is true")
-		return
-	
-	new_decoded_system_mode = str(new_state.state)
-	
-	_LOGGER.debug(
-		f"better_thermostat {self.name}: trigger_trv_change: new_decoded_system_mode: {new_decoded_system_mode}, expected system mode: {self._trv_hvac_mode}"
-		)
-	
-	if new_decoded_system_mode not in (HVAC_MODE_OFF, HVAC_MODE_HEAT):
-		# not an valid mode, overwriting
-		_LOGGER.debug(f"better_thermostat {self.name}: TRV's decoded TRV mode is not valid, overwriting with correct system mode")
+	async with self._temp_lock:
+		if self.startup_running:
+			_LOGGER.debug(f"better_thermostat {self.name}: skipping trigger_trv_change because startup is running")
+			return
 		
-		force_update = True
-	
-	# check if this change is what we expected (if not already an update is forced)
-	if not force_update and self._trv_hvac_mode != new_decoded_system_mode:
-		_LOGGER.warning(
-			f"better_thermostat {self.name}: TRV is not in the expected mode, we will force an update"
+		force_update = False
+		
+		old_state = event.data.get("old_state")
+		new_state = event.data.get("new_state")
+		
+		_LOGGER.debug(f"better_thermostat {self.name}: trigger_trv_change: old_state: {old_state.state} new_state: {new_state.state}")
+		
+		if None in (new_state, old_state, new_state.attributes):
+			_LOGGER.debug(f"better_thermostat {self.name}: TRV update contained not all necessary data for processing, skipping")
+			return
+		
+		if not isinstance(new_state, State) or not isinstance(old_state, State):
+			_LOGGER.debug(f"better_thermostat {self.name}: TRV update contained not a State, skipping")
+			return
+		
+		try:
+			convert_inbound_states(self, new_state)
+		except TypeError:
+			_LOGGER.debug(f"better_thermostat {self.name}: remapping TRV state failed, skipping")
+			return
+		
+		# if flag is on, we won't do any further processing
+		if self.ignore_states:
+			_LOGGER.debug(f"better_thermostat {self.name}: skipping trigger_trv_change because ignore_states is true")
+			return
+		
+		new_decoded_system_mode = str(new_state.state)
+		
+		_LOGGER.debug(
+			f"better_thermostat {self.name}: trigger_trv_change: new_decoded_system_mode: {new_decoded_system_mode}, expected system mode: {self._trv_hvac_mode}"
 		)
-		force_update = True
+		
+		if new_decoded_system_mode not in (HVAC_MODE_OFF, HVAC_MODE_HEAT):
+			# not an valid mode, overwriting
+			_LOGGER.debug(f"better_thermostat {self.name}: TRV's decoded TRV mode is not valid, overwriting with correct system mode")
+			
+			force_update = True
+		
+		# check if this change is what we expected (if not already an update is forced)
+		if not force_update and self._trv_hvac_mode != new_decoded_system_mode:
+			_LOGGER.warning(
+				f"better_thermostat {self.name}: TRV is not in the expected mode, we will force an update"
+			)
+			force_update = True
+		
+		if not force_update:
+			
+			# we only read user input at the TRV on mode 0
+			if self.calibration_type != 0:
+				return
+			
+			# we only read setpoint changes from TRV if we are in heating mode
+			if self._trv_hvac_mode == HVAC_MODE_OFF:
+				return
+			
+			if _new_heating_setpoint := convert_to_float(
+				new_state.attributes.get('current_heating_setpoint'),
+				self.name,
+				"trigger_trv_change()"
+			) \
+			                            is None:
+				return
+			
+			if _new_heating_setpoint < self._min_temp or self._max_temp < _new_heating_setpoint:
+				_LOGGER.warning(f"better_thermostat {self.name}: New TRV setpoint outside of range, overwriting it")
+				
+				if _new_heating_setpoint < self._min_temp:
+					_new_heating_setpoint = self._min_temp
+				else:
+					_new_heating_setpoint = self._max_temp
+				
+				self._target_temp = _new_heating_setpoint
+				
+				run_control_trv = True
 	
 	if force_update:
 		await control_trv(self, force_mode_change=True)
 		return
 	
-	# we only read user input at the TRV on mode 0
-	if self.calibration_type != 0:
-		return
-	
-	# we only read setpoint changes from TRV if we are in heating mode
-	if self._trv_hvac_mode == HVAC_MODE_OFF:
-		return
-	
-	if _new_heating_setpoint := convert_to_float(new_state.attributes.get('current_heating_setpoint'), self.name, "trigger_trv_change()") \
-	                            is None:
-		return
-	
-	if _new_heating_setpoint < self._min_temp or self._max_temp < _new_heating_setpoint:
-		_LOGGER.warning(f"better_thermostat {self.name}: New TRV setpoint outside of range, overwriting it")
-		
-		if _new_heating_setpoint < self._min_temp:
-			_new_heating_setpoint = self._min_temp
-		else:
-			_new_heating_setpoint = self._max_temp
-		
-		self._target_temp = _new_heating_setpoint
-		
+	if run_control_trv:
 		await control_trv(self)
+	
 	self.async_write_ha_state()
 
 

--- a/custom_components/better_thermostat/weather.py
+++ b/custom_components/better_thermostat/weather.py
@@ -26,11 +26,11 @@ def check_weather(self) -> bool:
 	
 	if self.weather_entity is not None:
 		_LOGGER.debug(f"better_thermostat {self.name}: checking weather predictions...")
-		new_call_for_heat = check_weather_prediction(self)
+		self.call_for_heat = check_weather_prediction(self)
 	
 	elif self.outdoor_sensor is not None:
 		_LOGGER.debug(f"better_thermostat {self.name}: checking ambient air sensor data...")
-		new_call_for_heat = check_ambient_air_temperature(self)
+		self.call_for_heat = check_ambient_air_temperature(self)
 	else:
 		_LOGGER.debug(f"better_thermostat {self.name}: could not find any weather sensors... setting call_for_heat to true")
 		self.call_for_heat = True

--- a/custom_components/better_thermostat/weather.py
+++ b/custom_components/better_thermostat/weather.py
@@ -26,15 +26,13 @@ def check_weather(self) -> bool:
 	
 	if self.weather_entity is not None:
 		_LOGGER.debug(f"better_thermostat {self.name}: checking weather predictions...")
-		self.call_for_heat = check_weather_prediction(self)
-		return check_weather_prediction(self)
+		new_call_for_heat = check_weather_prediction(self)
 	
 	elif self.outdoor_sensor is not None:
 		_LOGGER.debug(f"better_thermostat {self.name}: checking ambient air sensor data...")
-		self.call_for_heat = check_ambient_air_temperature(self)
-		return check_ambient_air_temperature(self)
+		new_call_for_heat = check_ambient_air_temperature(self)
 	else:
-		# no weather evaluation: call for heat is always true
+		_LOGGER.debug(f"better_thermostat {self.name}: could not find any weather sensors... setting call_for_heat to true")
 		self.call_for_heat = True
 	
 	if old_call_for_heat != self.call_for_heat:
@@ -131,5 +129,5 @@ def check_ambient_air_temperature(self):
 	
 	# calculate the average temperature
 	avg_temp = int(round(sum(valid_historic_sensor_data) / len(valid_historic_sensor_data)))
-	_LOGGER.debug(f"better_thermostat {self.name}: avg outdoor temp: %s", avg_temp)
+	_LOGGER.debug(f"better_thermostat {self.name}: avg outdoor temp: {avg_temp}, threshold is {self.off_temperature}")
 	return avg_temp < self.off_temperature


### PR DESCRIPTION
## Motivation:

The control was prone to be executed while a change in the trv status was processed, leading to parallel-ish execution. Using a lock this is avoided.

The code needed a minor restructure to avoid calling the control side while the lock isn't yet released.

## Changes:

- skip non-evaluated call_for_heat in control_trv
- run trigger_trv_change with lock to not interfere with control_trv
- fix wrong merge in weather (return values)

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.
