### PR TITLE
rewrite trigger_window_change() to be interruptable by new changes

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -291,17 +291,17 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 			_async_startup()
 		else:
 			self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _async_startup)
-
-	async def _trigger_time(self,event):
-		await trigger_time(self,event)
-
-	async def _trigger_temperature_change(self,event):
-		await trigger_temperature_change(self,event)
-
-	async def _trigger_trv_change(self,event):
-		await trigger_trv_change(self,event)
-
-	async def _trigger_window_change(self,event):
+	
+	async def _trigger_time(self, event):
+		await trigger_time(self, event)
+	
+	async def _trigger_temperature_change(self, event):
+		await trigger_temperature_change(self, event)
+	
+	async def _trigger_trv_change(self, event):
+		await trigger_trv_change(self, event)
+	
+	async def _trigger_window_change(self, event):
 		await trigger_window_change(self)
 	
 	@property

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -302,7 +302,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		await trigger_trv_change(self, event)
 	
 	async def _trigger_window_change(self, event):
-		await trigger_window_change(self)
+		await trigger_window_change(self, event)
 	
 	@property
 	def extra_state_attributes(self):

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -128,11 +128,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 	"""Representation of a Better Thermostat device."""
 	
 	def __init__(
-			self,
-			name,
+		self,
+		name,
 		heater_entity_id,
 		sensor_entity_id,
-		window_sensors_entity_ids,
+		window_id,
 		window_delay,
 		weather_entity,
 		outdoor_sensor,
@@ -157,7 +157,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		name : 
 		heater_entity_id : 
 		sensor_entity_id : 
-		window_sensors_entity_ids : 
+		window_id : 
 		window_delay : 
 		weather_entity : 
 		outdoor_sensor : 
@@ -178,7 +178,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		self._name = name
 		self.heater_entity_id = heater_entity_id
 		self.sensor_entity_id = sensor_entity_id
-		self.window_sensors_entity_ids = window_sensors_entity_ids
+		self.window_id = window_id
 		self.window_delay = window_delay or 0
 		self.weather_entity = weather_entity
 		self.outdoor_sensor = outdoor_sensor
@@ -194,6 +194,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		self._hvac_list = [HVAC_MODE_HEAT, HVAC_MODE_OFF]
 		self._cur_temp = None
 		self._temp_lock = asyncio.Lock()
+		self._window_delay_lock = asyncio.Lock()
+		self._window_action_timestamp = None
+		self._window_action_timestamp_lock = asyncio.Lock()
+		self._window_most_recent_action = None
 		self._min_temp = min_temp
 		self._TRV_min_temp = 5.0
 		self._max_temp = max_temp
@@ -250,9 +254,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 		async_track_state_change_event(
 			self.hass, [self.heater_entity_id], self._trigger_trv_change
 		)
-		if self.window_sensors_entity_ids:
+		if self.window_id:
 			async_track_state_change_event(
-				self.hass, [self.window_sensors_entity_ids], self._trigger_window_change
+				self.hass, [self.window_id], self._trigger_window_change
 			)
 		
 		# check if night mode was configured

--- a/custom_components/better_thermostat/events/window.py
+++ b/custom_components/better_thermostat/events/window.py
@@ -9,13 +9,15 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @callback
-async def trigger_window_change(self) -> None:
+async def trigger_window_change(self, event) -> None:
 	"""Triggerd by window sensor event from HA to check if the window is open.
 
 	Parameters
 	----------
 	self : 
 		self instance of better_thermostat
+	event : 
+		Event object from the eventbus. Contains the new and old state from the window (group).
 
 	Returns
 	-------

--- a/custom_components/better_thermostat/events/window.py
+++ b/custom_components/better_thermostat/events/window.py
@@ -9,7 +9,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @callback
-async def trigger_window_change(self):
+async def trigger_window_change(self) -> None:
 	"""Triggerd by window sensor event from HA to check if the window is open.
 
 	Parameters
@@ -25,6 +25,7 @@ async def trigger_window_change(self):
 		return
 	if self.hass.states.get(self.heater_entity_id) is None:
 		return
+	
 	await asyncio.sleep(int(self.window_delay))
 	check = self.hass.states.get(self.window_sensors_entity_ids).state
 	if check == 'on':

--- a/custom_components/better_thermostat/events/window.py
+++ b/custom_components/better_thermostat/events/window.py
@@ -23,19 +23,20 @@ async def trigger_window_change(self):
 	"""
 	if self.startup_running:
 		return
-	if self.hass.states.get(self.heater_entity_id) is not None:
-		await asyncio.sleep(int(self.window_delay))
-		check = self.hass.states.get(self.window_sensors_entity_ids).state
-		if check == 'on':
-			self.window_open = True
-		elif check == 'off':
-			self.window_open = False
-		elif check == 'unknown':
-			self.window_open = True
-			_LOGGER.warning("better_thermostat %s: Window sensor state is unknown, assuming window is open", self.name)
-		else:
-			_LOGGER.error("better_thermostat %s: New window sensor state not recognized", self.name)
-			return
-		_LOGGER.debug("better_thermostat %s: Window (group) state changed to %s", self.name, "open" if self.window_open else "closed")
-		self.async_write_ha_state()
-		await control_trv(self)
+	if self.hass.states.get(self.heater_entity_id) is None:
+		return
+	await asyncio.sleep(int(self.window_delay))
+	check = self.hass.states.get(self.window_sensors_entity_ids).state
+	if check == 'on':
+		self.window_open = True
+	elif check == 'off':
+		self.window_open = False
+	elif check == 'unknown':
+		self.window_open = True
+		_LOGGER.warning("better_thermostat %s: Window sensor state is unknown, assuming window is open", self.name)
+	else:
+		_LOGGER.error("better_thermostat %s: New window sensor state not recognized", self.name)
+		return
+	_LOGGER.debug("better_thermostat %s: Window (group) state changed to %s", self.name, "open" if self.window_open else "closed")
+	self.async_write_ha_state()
+	await control_trv(self)

--- a/custom_components/better_thermostat/events/window.py
+++ b/custom_components/better_thermostat/events/window.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from datetime import datetime, timedelta
 
 from homeassistant.core import callback
 
@@ -23,23 +24,74 @@ async def trigger_window_change(self, event) -> None:
 	-------
 	None
 	"""
-	if self.startup_running:
-		return
-	if self.hass.states.get(self.heater_entity_id) is None:
+	
+	new_state = event.data.get("new_state")
+	
+	if None in (self.hass.states.get(self.window_id), self.window_id, new_state):
 		return
 	
-	await asyncio.sleep(int(self.window_delay))
-	check = self.hass.states.get(self.window_sensors_entity_ids).state
-	if check == 'on':
-		self.window_open = True
-	elif check == 'off':
-		self.window_open = False
-	elif check == 'unknown':
-		self.window_open = True
-		_LOGGER.warning("better_thermostat %s: Window sensor state is unknown, assuming window is open", self.name)
+	new_state = new_state.state
+	
+	old_window_open = self.window_open
+	
+	if new_state in ('on', 'unknown'):
+		new_window_open = True
+		if new_state == 'unknown':
+			_LOGGER.warning("better_thermostat %s: Window sensor state is unknown, assuming window is open", self.name)
+	elif new_state == 'off':
+		new_window_open = False
 	else:
-		_LOGGER.error("better_thermostat %s: New window sensor state not recognized", self.name)
+		_LOGGER.error(f"better_thermostat {self.name}: New window sensor state '{new_state}' not recognized")
 		return
-	_LOGGER.debug("better_thermostat %s: Window (group) state changed to %s", self.name, "open" if self.window_open else "closed")
-	self.async_write_ha_state()
-	await control_trv(self)
+	
+	# make sure to skip events which do not change the saved window state:
+	if new_window_open == old_window_open:
+		_LOGGER.debug(f"better_thermostat {self.name}: Window state did not change, skipping event")
+		return
+	
+	# Get timestamp lock (or wait) 
+	self._window_action_timestamp_lock.acquire()
+	# Update timestamp
+	self._window_action_timestamp = datetime.now()
+	self._window_most_recent_action = new_window_open
+	
+	# Check if another coroutine is already waiting 
+	if self._window_delay_lock.locked():
+		self._window_action_timestamp_lock.release()
+		return
+	
+	# Get delay lock (or wait) 
+	self._window_delay_lock.acquire()
+	
+	while True:
+		# save our timestamp
+		_window_action_timestamp = self._window_action_timestamp
+		# Let other coroutines update the timestamp
+		self._window_action_timestamp_lock.release()
+		
+		# calculate the delay
+		_delay = round((timedelta(seconds=self.window_delay) - (datetime.now() - _window_action_timestamp)).total_seconds())
+		
+		if _delay > 0:
+			await asyncio.sleep(_delay)
+		
+		self._window_action_timestamp_lock.acquire()
+		
+		# Check if the timestamp hasn't changed
+		if self._window_action_timestamp == _window_action_timestamp:
+			break
+	
+	self._window_delay_lock.release()
+	
+	if self._window_most_recent_action != old_window_open:
+		self.window_open = self._window_most_recent_action
+		
+		if self.window_open:
+			_LOGGER.debug(f"better_thermostat {self.name}: Window was opened")
+		else:
+			_LOGGER.debug(f"better_thermostat {self.name}: Window was closed")
+		
+		self.async_write_ha_state()
+		await control_trv(self)
+	
+	self._window_action_timestamp_lock.release()

--- a/custom_components/better_thermostat/helpers.py
+++ b/custom_components/better_thermostat/helpers.py
@@ -71,14 +71,14 @@ async def startup(self):
 				self.heater_entity_id
 			)
 			return False
-		if self.window_sensors_entity_ids:
-			window = self.hass.states.get(self.window_sensors_entity_ids)
+		if self.window_id:
+			window = self.hass.states.get(self.window_id)
 			
 			if window is None:
 				_LOGGER.error(
 					"better_thermostat %s: configured window sensor entry or group with id '%s' could not be located",
 					self.name,
-					self.window_sensors_entity_ids
+					self.window_id
 				)
 				return False
 			
@@ -90,7 +90,7 @@ async def startup(self):
 				_LOGGER.error(
 					"better_thermostat %s: configured window sensor entry or group with id '%s' could not be located",
 					self.name,
-					self.window_sensors_entity_ids
+					self.window_id
 				)
 				return False
 		
@@ -110,13 +110,13 @@ async def startup(self):
 				self.heater_entity_id
 			)
 			_ready = False
-		if self.window_sensors_entity_ids:
-			if self.window_sensors_entity_ids in (STATE_UNAVAILABLE, STATE_UNKNOWN, None) or window.state in (
-					STATE_UNAVAILABLE, STATE_UNKNOWN, None):
+		if self.window_id:
+			if self.window_id in (STATE_UNAVAILABLE, STATE_UNKNOWN, None) or window.state in (
+				STATE_UNAVAILABLE, STATE_UNKNOWN, None):
 				_LOGGER.info(
 					"better_thermostat %s: waiting for window sensor entity with id '%s' to become fully available...",
 					self.name,
-					self.window_sensors_entity_ids
+					self.window_id
 				)
 				_ready = False
 		
@@ -125,8 +125,8 @@ async def startup(self):
 			await asyncio.sleep(15)
 			continue
 		
-		if self.window_sensors_entity_ids:
-			window = self.hass.states.get(self.window_sensors_entity_ids)
+		if self.window_id:
+			window = self.hass.states.get(self.window_id)
 			
 			check = window.state
 			if check == 'on':
@@ -140,7 +140,7 @@ async def startup(self):
 				self.name,
 				"Open" if self.window_open else "Closed"
 			)
-		if not self.window_sensors_entity_ids:
+		if not self.window_id:
 			self.window_open = False
 		
 		self.startup_running = False


### PR DESCRIPTION
## Motivation:

All state changes would just start a delay (in a concurrent fashion) and if any of those delays are seeing a state change after waiting for the delay, regardless how short the individual state change has
been, the TRV would react to it.

## Changes:

- change trigger_window_change() to only run one delay
- let trigger_window_change() process the event directly instead of asking HA for the current state
- let new trigger_window_change() calls update the delay time and window state

### Minor changes:
- rename window_sensors_entity_ids to window_id in BetterThermostat

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.
- [x] Not yet tested