### PR TITLE
update platform to ai_thermostat

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Here is a minimal configuration example
 
 ```yaml
 climate:
-  - platform: better_thermostat
+  - platform: ai_thermostat
     name: room
     thermostat: climate.trv
     temperature_sensor: sensor.temperature
@@ -70,7 +70,7 @@ Here is a full configuration example
 
 ```yaml
 climate:
-  - platform: better_thermostat
+  - platform: ai_thermostat
     name: room
     thermostat: climate.trv
     temperature_sensor: sensor.temperature
@@ -128,7 +128,7 @@ Example:
 
 ```yaml
 climate:
-  - platform: better_thermostat
+  - platform: ai_thermostat
     name: Ai - TRV - Office - 1
     thermostat: climate.real_trv_office_1
     temperature_sensor: sensor.temperatur_office_temperature
@@ -136,7 +136,7 @@ climate:
     weather: weather.home
     off_temperature: 19.5
     unique_id: 1
-  - platform: better_thermostat
+  - platform: ai_thermostat
     name: Ai - TRV - Office - 2
     thermostat: climate.real_trv_office_2
     temperature_sensor: sensor.temperatur_office_temperature


### PR DESCRIPTION
I hope I am not wrong but I run into issues when I first installed it yesterday with hacs.

## Motivation:

## Changes:
just update the platform to ai_thermostat.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [x] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
