### PR TITLE
Make sane settings for stale bot (no closure, just tags)

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,17 +1,21 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 30
+daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 14
+daysUntilClose: false
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
-  - bug
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  recent activity.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 1
+
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
## Motivation:

- The stalebot has gone haywire and closed a bunch of tickets, making more harm than good.

## Changes:

- Change settings to just add markings and don't close issues anymore.

