### PR TITLE
await check_ambient_air_temperature

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -334,7 +334,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
     async def _trigger_time(self, event=None):
         _LOGGER.debug("better_thermostat %s: get last avg outdoor temps...", self.name)
-        asyncio.create_task(check_ambient_air_temperature(self))
+        await asyncio.create_task(check_ambient_air_temperature(self))
         if event is not None:
             self.async_write_ha_state()
             await self.control_queue_task.put(self)


### PR DESCRIPTION
## Motivation:
Beta35 didn't register state change events because of this:

```
2022-11-08 15:41:08.487 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/config/custom_components/better_thermostat/climate.py", line 632, in startup
    await self._trigger_check_weather(None)
  File "/config/custom_components/better_thermostat/climate.py", line 329, in _trigger_check_weather
    check_weather(self)
  File "/config/custom_components/better_thermostat/utils/weather.py", line 35, in check_weather
    self.call_for_heat = self._last_avg_outdoor_temp < self.off_temperature
TypeError: '<' not supported between instances of 'NoneType' and 'float'
```
This is happening because the check_ambient_air_temperature is not done yet to set the self._last_avg_outdoor_temp

The exception would terminate  self.startup_running loop and loose the chance of setting the listener.

## Changes:

Actually await for the task check_ambient_air_temperature to finish

## Related issue (check one):

- [x] fixes #566 
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
