### PR TITLE
fixes window open bug

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -74,10 +74,7 @@ async def control_trv(self):
         if self.call_for_heat is True:
             _hvac_mode_send = _converted_hvac_mode
 
-            if (
-                self.window_open is True
-                and self._last_states.get("last_window_open", False) is False
-            ):
+            if self.window_open is True:
                 # if the window is open or the sensor is not available, we're done
                 self._last_main_hvac_mode = _hvac_mode_send
                 _hvac_mode_send = HVAC_MODE_OFF


### PR DESCRIPTION
## Motivation:
Heaters started heating again, even though the windows are open.

## Changes:
Changed the window open condition in the controlling.py. The condition was wrong. Because the window_open can be true and last_window_open as well. That case was not addressed, and the heating needs to be still off. So always when window_open is true needs to be off, and when window_open is false and last state is true, then we can start heating again.

## Related issue (check one):

- [x] fixes #569
- [ ] fixes #557 (most probably)

## Checklist (check one):

- [x] The code change is tested and works locally.
