### PR TITLE
A typo fix

### DIFF
--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -156,7 +156,7 @@ async def trigger_trv_change(self, event):
             self.async_write_ha_state()
             return
 
-        _LOGGER.debug(f"better_thermostat {self.name}: {entity_id} TRV update triggerd")
+        _LOGGER.debug(f"better_thermostat {self.name}: {entity_id} TRV update triggered")
         self.async_write_ha_state()
         await self.control_queue_task.put(self)
 

--- a/custom_components/better_thermostat/events/window.py
+++ b/custom_components/better_thermostat/events/window.py
@@ -9,7 +9,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @callback
 async def trigger_window_change(self, event) -> None:
-    """Triggerd by window sensor event from HA to check if the window is open.
+    """Triggered by window sensor event from HA to check if the window is open.
 
     Parameters
     ----------


### PR DESCRIPTION
## Motivation:

- to allow better searching in the logs

## Changes:

- fixed a typo: triggerd -> triggered

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2022.10.5
Zigbee2MQTT Version: 1.28.2 commit: afcab53a
TRV Hardware: Aqara Smart Radiator Thermostat E1 (`lumi.airrtc.agl001`)

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
