### PR TITLE
self.async_update_ha_state should be awaited

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -661,7 +661,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             await asyncio.sleep(10)
             self._available = True
             self.startup_running = False
-            self.async_update_ha_state()
+            await self.async_update_ha_state()
             # await self.control_queue_task.put(self)
             _LOGGER.info("better_thermostat %s: startup completed.", self.name)
             break


### PR DESCRIPTION
## Motivation:
All entities unavailable, checked logs and found error:
Got error:
/config/custom_components/better_thermostat/climate.py:664: RuntimeWarning: coroutine 'Entity.async_update_ha_state' was never awaited
  self.async_update_ha_state()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback

## Changes:
Add necessary `await`
## Related issue (check one):

- [x] fixes #594 (probably)
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.