### PR TITLE
Fix diagnostics data failure

### DIFF
--- a/custom_components/better_thermostat/diagnostics.py
+++ b/custom_components/better_thermostat/diagnostics.py
@@ -30,13 +30,15 @@ async def async_get_config_entry_diagnostics(
             "model": trv_id["model"],
         }
     external_temperature = hass.states.get(config_entry.data[CONF_SENSOR])
-    if CONF_SENSOR_WINDOW in config_entry.data:
+    
+    window = "-"
+    window_entity_id = config_entry.data.get(CONF_SENSOR_WINDOW)
+    if window_entity_id:
         try:
-            window = hass.states.get(config_entry.data[CONF_SENSOR_WINDOW])
+            window = hass.states.get(window_entity_id)
         except KeyError:
-            window = "-"
-    else:
-        window = "-"
+            pass
+        
     _cleaned_data = dict(config_entry.data.copy())
     del _cleaned_data[CONF_HEATER]
     diagnostics_data = {


### PR DESCRIPTION


## Motivation:

Fix failure of diagnostics data 
Fail happens when the  `config_entry.data[CONF_SENSOR_WINDOW]` is`None`


## Changes:

Add additional null  None check

## Related issue (check one):

- [x] fixes #650
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2022.11.3
Zigbee2MQTT Version: 1.28.2-1
TRV Hardware: TS0601_thermostat

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
