### PR TITLE
fix hvac action

### DIFF
--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -199,11 +199,10 @@ def update_hvac_action(self):
     if all(a == HVACAction.OFF for a in hvac_actions):
         self.attr_hvac_action = HVACAction.OFF
     # else check if is heating
-    else:
-        if self.bt_target_temp > self.cur_temp:
+    elif self.bt_target_temp > self.cur_temp:
             self.attr_hvac_action = HVACAction.HEATING
-    # otherwise is idle
-    self.attr_hvac_action = HVACAction.IDLE
+    else:
+        self.attr_hvac_action = HVACAction.IDLE
 
     calculate_heating_power(self)
 

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -200,7 +200,7 @@ def update_hvac_action(self):
         self.attr_hvac_action = HVACAction.OFF
     # else check if is heating
     elif self.bt_target_temp > self.cur_temp:
-            self.attr_hvac_action = HVACAction.HEATING
+        self.attr_hvac_action = HVACAction.HEATING
     else:
         self.attr_hvac_action = HVACAction.IDLE
 

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -195,18 +195,15 @@ def update_hvac_action(self):
         self.async_write_ha_state()
         return
 
-    current_hvac_actions = [a for a in hvac_actions if a != HVACAction.OFF]
-    # return the most common action if it is not off
-    if current_hvac_actions:
-        self.attr_hvac_action = max(
-            set(current_hvac_actions), key=current_hvac_actions.count
-        )
     # return action off if all are off
-    elif all(a == HVACAction.OFF for a in hvac_actions):
+    if all(a == HVACAction.OFF for a in hvac_actions):
         self.attr_hvac_action = HVACAction.OFF
-    # else it's none
+    # else check if is heating
     else:
-        self.attr_hvac_action = HVACAction.IDLE
+        if self.bt_target_temp > self.cur_temp:
+            self.attr_hvac_action = HVACAction.HEATING
+    # otherwise is idle
+    self.attr_hvac_action = HVACAction.IDLE
 
     calculate_heating_power(self)
 


### PR DESCRIPTION
## Motivation:
hvac action was not precise. e.g. 'heating' while idling

## Changes:
trv.py/update_hvac_action 
set off if all off
set heating if bt target > current temp
else set idle

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
