### PR TITLE
Update SEA801-Zigbee_SEA802-Zigbee.py

### DIFF
--- a/custom_components/better_thermostat/model_fixes/SEA801-Zigbee_SEA802-Zigbee.py
+++ b/custom_components/better_thermostat/model_fixes/SEA801-Zigbee_SEA802-Zigbee.py
@@ -16,9 +16,9 @@ def fix_target_temperature_calibration(self, entity_id, temperature):
         return temperature
     if (
         round(temperature, 1) > round(_cur_trv_temp, 1)
-        and temperature - _cur_trv_temp < 1.5
+        and temperature - _cur_trv_temp < 2.5
     ):
-        temperature += 1.5
+        temperature += 2.5
     return temperature
 
 


### PR DESCRIPTION
Changed device specific temperature offset for temperature calibration mode from 1.5 to 2.5.

## Motivation:

SEA 801-Zigbee/SEA 802-Zigbee TRVs tend to have a very high tolerance between current temperature and target temperature (about 2° C), see also @wtom comment here: https://github.com/KartoffelToby/better_thermostat/issues/599#issuecomment-1314987290. Therefore the quirk for these devices adds 1.5° C to the target temperature of the TRV (in target temperature calibration mode). With this quirk the valve opens very reliable but it may close very fast again if current TRV temperature is rising fast (difference between current TRV temperature and TRV setpoint becoms below 2° C) and new current TRV temperature is not yet reported/not within new calibration cycle.

This leads to a valve that opens reliable, but then closes itself again until new temperature is reported and/or new calibration cycle started. Therefore the valve consumes a lot of battery power, is noisy and also heating power is reduced. 

Setting the quirk for target temperature calibration to +2.5° C solves this problem for my setup, I tested it locally for some days. Would be great if you could accept that pull request and integrate the change into your code. Thanks a lot for your great work, I really like Better Thermostat. 

Hint: For local calibration the value is already set to 2.5° C.   

## Changes:

Changed device specific temperature offset for temperature calibration mode from 1.5 to 2.5.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2022.12.5
Zigbee2MQTT Version: 1.24.0
TRV Hardware: [SEA801-Zigbee/SEA802-Zigbee] TS0601__TZE200_c88teujp

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
