### PR TITLE
BHT-002-GCLZB local calibration quirk

### DIFF
--- a/custom_components/better_thermostat/model_fixes/BHT-002-GCLZB.py
+++ b/custom_components/better_thermostat/model_fixes/BHT-002-GCLZB.py
@@ -1,17 +1,20 @@
 """
 This model fix is due to any floating point number being set to +/- 1 million by Zigbee2MQTT for the local_calibration
-
 """
 
 import math
 
 
 def fix_local_calibration(self, entity_id, offset):
-    # If still heating, round down
-    if self.cur_temp <= self.bt_target_temp:
-        offset = math.floor(offset)
-    else:
+    """
+    If still heating, round UP the offset
+    
+    This creates a lower "fake" thermostat temperature, making it heat the room
+    """
+    if self.cur_temp < self.bt_target_temp:
         offset = math.ceil(offset)
+    else:
+        offset = math.floor(offset)
 
     return offset
 

--- a/custom_components/better_thermostat/model_fixes/BHT-002-GCLZB.py
+++ b/custom_components/better_thermostat/model_fixes/BHT-002-GCLZB.py
@@ -1,0 +1,31 @@
+"""
+This model fix is due to any floating point number being set to +/- 1 million by Zigbee2MQTT for the local_calibration
+
+"""
+
+import math
+
+
+def fix_local_calibration(self, entity_id, offset):
+    # If still heating, round down
+    if self.cur_temp <= self.bt_target_temp:
+        offset = math.floor(offset)
+    else:
+        offset = math.ceil(offset)
+
+    return offset
+
+
+def fix_target_temperature_calibration(self, entity_id, temperature):
+    return temperature
+
+
+async def override_set_hvac_mode(self, entity_id, hvac_mode):
+    return False
+
+
+async def override_set_temperature(self, entity_id, temperature):
+    return False
+
+
+


### PR DESCRIPTION
## Motivation:

When BT sets the offset to a non int value, Zigbee2MQTT sets the value to an out of range int (+/- million )

https://user-images.githubusercontent.com/47489826/212716785-050592cc-74a9-4691-8c0f-d1cdfb70ecc0.mov



## Changes:

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2023.1.4
Zigbee2MQTT Version: 1.29.2-1
TRV Hardware: BHT-002-GCLZB

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
