### PR TITLE
Remove workaround for fetching MQTT min and max offset

### DIFF
--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -104,8 +104,6 @@ async def get_offset_steps(self, entity_id):
 
 async def get_min_offset(self, entity_id):
     """Get min offset."""
-    # looks like z2m has a min max bug currently force to -10
-    return -6.0
     return float(
         str(
             self.hass.states.get(
@@ -117,8 +115,6 @@ async def get_min_offset(self, entity_id):
 
 async def get_max_offset(self, entity_id):
     """Get max offset."""
-    # looks like z2m has a min max bug currently force to 10
-    return 6.0
     return float(
         str(
             self.hass.states.get(


### PR DESCRIPTION
## Motivation:

#881 

## Changes:

I removed the workaround for fetching `local_calibration_min` and `local_calibration_max` from mqtt.js because that resulted in an invalid calibration value being published.

## Related issue (check one):

- [X] fixes #881 
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2023.1.4
Zigbee2MQTT Version: 1.29.1
TRV Hardware: Bosch Heizkörper-Thermostat II

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [x] I avoided any changes to other device mappings
- [X] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
