### PR TITLE
MQTT/max&min_offset: remove fixed value from getter

### DIFF
--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -104,8 +104,6 @@ async def get_offset_steps(self, entity_id):
 
 async def get_min_offset(self, entity_id):
     """Get min offset."""
-    # looks like z2m has a min max bug currently force to -10
-    return -6.0
     return float(
         str(
             self.hass.states.get(
@@ -117,8 +115,6 @@ async def get_min_offset(self, entity_id):
 
 async def get_max_offset(self, entity_id):
     """Get max offset."""
-    # looks like z2m has a min max bug currently force to 10
-    return 6.0
     return float(
         str(
             self.hass.states.get(


### PR DESCRIPTION
## Motivation:

Bug #908. BT stops working due to an ValueError Exception

## Changes:

remove fixed -6/+6 from mqtt.py, replace it by the min/max returned by the attribute (those do work for me on my setup with my thermostats & zigbee version)

## Related issue (check one):

- [ ] fixes #908
-
## Checklist (check one):

- [ ] The code change is tested and works locally.

## Test-Hardware list (for code changes)



HA 2023.1.6
Zigbee2MQTT 1.29.2-1

TRV Hardware: TS-601
