### PR TITLE
[FIX] Catch exceptions in the control queue

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -42,11 +42,21 @@ async def control_queue(self):
                 self.ignore_states = True
                 result = True
                 for trv in self.real_trvs.keys():
-                    _temp = await control_trv(self, trv)
-                    if _temp is False:
+                    try:
+                        _temp = await control_trv(self, trv)
+                        if _temp is False:
+                            result = False
+                    except Exception:
+                        _LOGGER.exception(
+                            "better_thermostat %s: ERROR controlling: %s",
+                            self.name,
+                            trv,
+                        )
                         result = False
+
                 if result is False:
                     await self.control_queue_task.put(self)
+
                 self.control_queue_task.task_done()
                 self.ignore_states = False
 


### PR DESCRIPTION
## Motivation:

My thermostats stopped responding and were not updating the real TRVs anymore. They work after HA is restarted or the integration is reloaded but stop after some time.

I noticed some transient errors while updating a TRV. It looks like they caused the control queue to stop handing tasks. 

```
2023-02-05 18:40:03.253 DEBUG (MainThread) [custom_components.better_thermostat.events.trv] better_thermostat Wohnen: trigger_trv_change / _old_heating_setpoint: 22.0 - _new_heating_setpoint: 22.0 - _last_temperature: 22.0
2023-02-05 18:40:03.256 DEBUG (MainThread) [custom_components.better_thermostat.utils.controlling] better_thermostat Wohnen: TO TRV set_temperature: climate.esszimmer_thermostat from: 22.0 to: 21.5
2023-02-05 18:40:32.780 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/asyncio/tasks.py", line 456, in wait_for
    return fut.result()
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/config/custom_components/better_thermostat/utils/controlling.py", line 45, in control_queue
    _temp = await control_trv(self, trv)
  File "/config/custom_components/better_thermostat/utils/controlling.py", line 159, in control_trv
    await set_temperature(self, heater_entity_id, _temperature)
  File "/config/custom_components/better_thermostat/utils/bridge.py", line 77, in set_temperature
    return await self.real_trvs[entity_id]["adapter"].set_temperature(
  File "/config/custom_components/better_thermostat/adapters/generic.py", line 37, in set_temperature
    await self.hass.services.async_call(
  File "/usr/src/homeassistant/homeassistant/core.py", line 1787, in async_call
    task.result()
  File "/usr/src/homeassistant/homeassistant/core.py", line 1824, in _execute_service
    await cast(Callable[[ServiceCall], Awaitable[None]], handler.job.target)(
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 213, in handle_service
    await service.entity_service_call(
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 681, in entity_service_call
    future.result()  # pop exception if have
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 968, in async_request_call
    await coro
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 721, in _handle_entity_call
    await result
  File "/usr/src/homeassistant/homeassistant/components/climate/__init__.py", line 613, in async_service_temperature_set
    await entity.async_set_temperature(**kwargs)
  File "/usr/src/homeassistant/homeassistant/components/zha/climate.py", line 463, in async_set_temperature
    success = await thrm.async_set_heating_setpoint(
  File "/usr/src/homeassistant/homeassistant/components/zha/core/channels/hvac.py", line 266, in async_set_heating_setpoint
    if not await self.write_attributes(data):
  File "/usr/src/homeassistant/homeassistant/components/zha/core/channels/hvac.py", line 301, in write_attributes
    res = await self.cluster.write_attributes(data, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/zhaquirks/danfoss/thermostat.py", line 82, in write_attributes
    await self.setpoint_command(
  File "/usr/local/lib/python3.10/site-packages/zigpy/quirks/__init__.py", line 180, in command
    return await self.request(
  File "/usr/local/lib/python3.10/site-packages/zigpy/zcl/__init__.py", line 324, in request
    return await self._endpoint.request(
  File "/usr/local/lib/python3.10/site-packages/zigpy/endpoint.py", line 237, in request
    return await self.device.request(
  File "/usr/local/lib/python3.10/site-packages/zigpy/device.py", line 313, in request
    return await asyncio.wait_for(req.result, timeout)
  File "/usr/local/lib/python3.10/asyncio/tasks.py", line 458, in wait_for
    raise exceptions.TimeoutError() from exc
asyncio.exceptions.TimeoutError
```

## Changes:

Wrap `control_trv()` in a try/catch block.

## Related issue (check one):

- [x] Might fix the following issues: #941, #943
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2023.02
TRV Hardware: Danfoss eTRV0100