### PR TITLE
Re-Introduce fixes for TS0601 and TS601_thermostat

### DIFF
--- a/custom_components/better_thermostat/model_fixes/TS0601.py
+++ b/custom_components/better_thermostat/model_fixes/TS0601.py
@@ -3,7 +3,8 @@ def fix_local_calibration(self, entity_id, offset):
         offset -= 2.5
     elif (self.cur_temp + 0.10) >= self.bt_target_temp:
         offset = round(offset + 0.5, 1)
-
+    if (self.cur_temp + 0.5) > self.bt_target_temp:
+        offset += 1
     return offset
 
 
@@ -18,7 +19,8 @@ def fix_target_temperature_calibration(self, entity_id, temperature):
         and temperature - _cur_trv_temp < 1.5
     ):
         temperature += 1.5
-
+    if (self.cur_temp + 0.5) > self.bt_target_temp:
+        temperature -= 2
     return temperature
 
 

--- a/custom_components/better_thermostat/model_fixes/TS0601_thermostat.py
+++ b/custom_components/better_thermostat/model_fixes/TS0601_thermostat.py
@@ -3,7 +3,8 @@ def fix_local_calibration(self, entity_id, offset):
         offset -= 2.5
     elif (self.cur_temp + 0.10) >= self.bt_target_temp:
         offset = round(offset + 0.5, 1)
-
+    if (self.cur_temp + 0.5) > self.bt_target_temp:
+        offset += 1
     return offset
 
 
@@ -18,7 +19,8 @@ def fix_target_temperature_calibration(self, entity_id, temperature):
         and temperature - _cur_trv_temp < 1.5
     ):
         temperature += 1.5
-
+    if (self.cur_temp + 0.5) > self.bt_target_temp:
+        temperature -= 2
     return temperature
 
 


### PR DESCRIPTION
## Motivation:

 #898 is wrong about TS0601 and TS601_thermostat, they are required to close the valve when temperature is reached.

Without these fixes, BT is not giving enough temperature difference to close the valve when temperature is reached.

TRV1

    Current Temperature: 19.6
    Target Temperature: 19.5
    Valve is opened at 25%
    Valve detected temperature: 19
    Valve target temperature: 18.5 <<<<< this is not enough for this model to close the valve

TRV2

    Current Temperature: 20.2
    Target Temperature: 20
    Valve is opened at 25%
    Valve detected temperature: 18.5
    Valve target temperature: 18 <<<<< this is not enough for this model to close the valve

With these fixes they close correctly when reaching temperature, because the offset is higher.

## Changes:
Reverting fixes to the previous version.


## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2023.1.7
Zigbee2MQTT Version:  1.30.1-1
TRV Hardware: TS601_thermostat


