### PR TITLE
potential fix for overheat protection

### DIFF
--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -229,10 +229,22 @@ def calculate_setpoint_override(self, entity_id) -> Union[float, None]:
     )
 
     if _overheating_protection is True:
-        if (self.cur_temp + 0.10) >= self.bt_target_temp:
-            _calibrated_setpoint -= 1.0
-
+        if self.cur_temp > (self.bt_target_temp + 0.50): 
+            _calibrated_setpoint = self.bt_target_temp
+        elif self.cur_temp > (self.bt_target_temp + 0.40):
+            _calibrated_setpoint -= 3
+        elif self.cur_temp > (self.bt_target_temp + 0.30):
+            _calibrated_setpoint -= 2.5
+        elif self.cur_temp > (self.bt_target_temp + 0.20):
+            _calibrated_setpoint -= 2
+        elif self.cur_temp > (self.bt_target_temp + 0.10):
+            _calibrated_setpoint -= 1.5
+                         
     _calibrated_setpoint = round_down_to_half_degree(_calibrated_setpoint)
+
+    # check if new setpoint is above bt_target_temp
+    if _calibrated_setpoint < self.bt_target_temp:
+        _calibrated_setpoint = self.bt_target_temp
 
     # check if new setpoint is inside the TRV's range, else set to min or max
     if _calibrated_setpoint < self.real_trvs[entity_id]["min_temp"]:


### PR DESCRIPTION
## Motivation:

## Changes:
Added a more aggressive overheat protection with bt_target_temp as a fallback.

## Related issue (check one):

- [x] fixes #889
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2023.1.4
Zigbee2MQTT Version:
TRV Hardware:  HmIP-eTRV-B-2 R4M

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
