### PR TITLE
Update deconz.configure command

### DIFF
--- a/custom_components/better_thermostat/adapters/deconz.py
+++ b/custom_components/better_thermostat/adapters/deconz.py
@@ -54,7 +54,7 @@ async def set_offset(self, entity_id, offset):
     await self.hass.services.async_call(
         "deconz",
         "configure",
-        {"entity_id": entity_id, "offset": offset},
+        {"entity": entity_id, "field": "/config", "data": {"offset": offset}},
         blocking=True,
         limit=None,
         context=self._context,


### PR DESCRIPTION
Fix for "extra keys not allowed @ data['entity_id']"

## Motivation:
Integration not starting and is unavailable because the deconz offset command is wrong.

## Changes:
Updates deconz.configure offset command to new syntax

## Related issue (check one):

- [x] fixes #991 #990 
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2023.3.3
Deconz Version: 2.21.0
TRV Hardware: TS601 (_TZE200_yw7cahqs)

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
