### PR TITLE
Add a entity watcher to observe if a trv or sensor is disconnected

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,20 @@ document in a pull request.
 
 ## How Can I Contribute?
 
+## New Adapter
+
+If you want to add a new adapter, please create a new python file with the name of the adapter in the adapters folder. The file should contain all functions find in the generic.py. The if you adapter needs a special handling for one of the base functions, override it, if you can use generic functions, use them like:
+
+```python
+async def set_temperature(self, entity_id, temperature):
+    """Set new target temperature."""
+    return await generic_set_temperature(self, entity_id, temperature)
+```
+
+## Translations
+
+[INLANG Editor](https://inlang.com/editor/github.com/KartoffelToby/better_thermostat)
+
 ### Reporting Bugs
 
 You can create an issue if you have any kind of bug or error but please use the issue template.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ No worry, Better Thermostat supports grouping out of the box
 
 ---
 
+# Contributing?
+
+checkout the [CONTRIBUTING.md](CONTRIBUTING.md) file
+
 # ☕ Support
 
 If you want to support this project, you can ☕ [**buy a coffee here**](https://www.buymeacoffee.com/kartoffeltoby).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Active installations](https://badge.t-haber.de/badge/better_thermostat?kill_cache=1)](https://github.com/KartoffelToby/better_thermostat/)
 [![GitHub issues](https://img.shields.io/github/issues/KartoffelToby/better_thermostat?style=for-the-badge)](https://github.com/KartoffelToby/better_thermostat/issues)
-[![Version - 1.1.0](https://img.shields.io/badge/Version-1.1.0-009688?style=for-the-badge)](https://github.com/KartoffelToby/better_thermostat/releases)
+[![Version - 1.2.0](https://img.shields.io/badge/Version-1.2.0-009688?style=for-the-badge)](https://github.com/KartoffelToby/better_thermostat/releases)
 [![Discord](https://img.shields.io/discord/925725316540923914.svg?style=for-the-badge)](https://discord.gg/9BUegWTG3K)
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
 
@@ -11,7 +11,7 @@
 ### Requirements
 
 - Minimum required Home Assistant version: `2022.8.0`
-  (_Latest tested version: `2023.2.1`_)
+  (_Latest tested version: `2023.7.0`_)
 
 ### Companion UI
 

--- a/custom_components/better_thermostat/const.py
+++ b/custom_components/better_thermostat/const.py
@@ -60,6 +60,8 @@ ATTR_STATE_HUMIDIY = "humidity"
 ATTR_STATE_MAIN_MODE = "main_mode"
 ATTR_STATE_HEATING_POWER = "heating_power"
 ATTR_STATE_HEATING_STATS = "heating_stats"
+ATTR_STATE_ERRORS = "errors"
+ATTR_STATE_BATTERIES = "batteries"
 
 SERVICE_RESTORE_SAVED_TARGET_TEMPERATURE = "restore_saved_target_temperature"
 SERVICE_SET_TEMP_TARGET_TEMPERATURE = "set_temp_target_temperature"

--- a/custom_components/better_thermostat/manifest.json
+++ b/custom_components/better_thermostat/manifest.json
@@ -16,5 +16,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/KartoffelToby/better_thermostat/issues",
   "requirements": [],
-  "version": "1.1.0-dev"
+  "version": "1.2.0-dev"
 }

--- a/custom_components/better_thermostat/strings.json
+++ b/custom_components/better_thermostat/strings.json
@@ -87,5 +87,18 @@
                                 }
                         }
                 }
+        },
+        "issues": {
+                "missing_entity": {
+                        "title": "BT: {name} - related entity is missing",
+                        "fix_flow": {
+                                "step": {
+                                        "confirm": {
+                                                "title": "The related entity {entity} is missing",
+                                                "description": "The reason for this is that the entity ({entity}) is not available in your Home Assistant.\n\nYou can fix this by checking if the batterie of the device is full or reconnect it to HA. Make sure that the entity is back in HA before you continue."
+                                        }
+                                }
+                        }
+                }
         }
 }

--- a/custom_components/better_thermostat/translations/da.json
+++ b/custom_components/better_thermostat/translations/da.json
@@ -76,5 +76,18 @@
         }
       }
     }
+  },
+  "issues": {
+    "missing_entity": {
+      "title": "BT: {name} - related entity is missing",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "The related entity {entity} is missing",
+            "description": "The reason for this is that the entity ({entity}) is not available in your Home Assistant.\n\nYou can fix this by checking if the batterie of the device is full or reconnect it to HA. Make sure that the entity is back in HA before you continue."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/better_thermostat/translations/de.json
+++ b/custom_components/better_thermostat/translations/de.json
@@ -90,5 +90,18 @@
         }
       }
     }
+  },
+  "issues": {
+    "missing_entity": {
+      "title": "BT: {name} - related entity is missing",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "The related entity {entity} is missing",
+            "description": "The reason for this is that the entity ({entity}) is not available in your Home Assistant.\n\nYou can fix this by checking if the batterie of the device is full or reconnect it to HA. Make sure that the entity is back in HA before you continue."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/better_thermostat/translations/en.json
+++ b/custom_components/better_thermostat/translations/en.json
@@ -88,5 +88,18 @@
         }
       }
     }
+  },
+  "issues": {
+    "missing_entity": {
+      "title": "BT: {name} - related entity is missing",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "The related entity {entity} is missing",
+            "description": "The reason for this is that the entity ({entity}) is not available in your Home Assistant.\n\nYou can fix this by checking if the batterie of the device is full or reconnect it to HA. Make sure that the entity is back in HA before you continue."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/better_thermostat/translations/fr.json
+++ b/custom_components/better_thermostat/translations/fr.json
@@ -76,5 +76,18 @@
         }
       }
     }
+  },
+  "issues": {
+    "missing_entity": {
+      "title": "BT: {name} - related entity is missing",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "The related entity {entity} is missing",
+            "description": "The reason for this is that the entity ({entity}) is not available in your Home Assistant.\n\nYou can fix this by checking if the batterie of the device is full or reconnect it to HA. Make sure that the entity is back in HA before you continue."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/better_thermostat/translations/pl.json
+++ b/custom_components/better_thermostat/translations/pl.json
@@ -76,5 +76,18 @@
         }
       }
     }
+  },
+  "issues": {
+    "missing_entity": {
+      "title": "BT: {name} - related entity is missing",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "The related entity {entity} is missing",
+            "description": "The reason for this is that the entity ({entity}) is not available in your Home Assistant.\n\nYou can fix this by checking if the batterie of the device is full or reconnect it to HA. Make sure that the entity is back in HA before you continue."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/better_thermostat/utils/watcher.py
+++ b/custom_components/better_thermostat/utils/watcher.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from homeassistant.helpers import issue_registry as ir
+from .. import DOMAIN
+
+
+async def check_entity(self, entity) -> bool:
+    if entity is None:
+        return False
+    entity_states = self.hass.states.get(entity)
+    state = (
+        "missing"
+        if not entity_states
+        else str(entity_states.state).replace("unavailable", "unavail")
+    )
+    if entity_states is None or state in ["missing", "unknown", "unavail"]:
+        return False
+    return True
+
+
+async def check_all_entities(self) -> bool:
+    entities = self.all_entities
+    for entity in entities:
+        if not await check_entity(self, entity):
+            name = entity
+            ir.async_create_issue(
+                hass=self.hass,
+                domain=DOMAIN,
+                issue_id=f"missing_entity_{name}",
+                is_fixable=True,
+                is_persistent=True,
+                learn_more_url="https://better-thermostat.org/qanda/missing_entity",
+                severity=ir.IssueSeverity.WARNING,
+                translation_key="missing_entity",
+                translation_placeholders={"entity": str(name), "name": str(self.name)},
+            )
+            return False
+    return True

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,1 +1,1 @@
-homeassistant==2023.7.0b5
+homeassistant==2023.7.0


### PR DESCRIPTION
## Motivation:

## Changes:

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
