### PR TITLE
Bugfix for:

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -82,7 +82,7 @@ async def control_trv(self, heater_entity_id=None):
     """
     async with self._temp_lock:
         self.real_trvs[heater_entity_id]["ignore_trv_states"] = True
-        update_hvac_action(self)
+        await update_hvac_action(self)
         await self.calculate_heating_power()
         _trv = self.hass.states.get(heater_entity_id)
         _current_set_temperature = convert_to_float(


### PR DESCRIPTION
## Motivation:
bugfix for:
     WARNING (MainThread) [py.warnings] /config/custom_components/better_thermostat/utils/controlling.py:85: RuntimeWarning: coroutine 'update_hvac_action' was never awaited


## Changes:

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.




