### PR TITLE
Fixing "No such file or directory" for manifest.json for docker users

### DIFF
--- a/custom_components/better_thermostat/const.py
+++ b/custom_components/better_thermostat/const.py
@@ -19,7 +19,9 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME = "Better Thermostat"
 VERSION = "master"
 try:
-    with open(f"{os.path.dirname(os.path.realpath(__file__))}/manifest.json") as manifest_file:
+    with open(
+        f"{os.path.dirname(os.path.realpath(__file__))}/manifest.json"
+    ) as manifest_file:
         manifest = json.load(manifest_file)
         VERSION = manifest["version"]
 except (FileNotFoundError, KeyError, json.JSONDecodeError) as e:

--- a/custom_components/better_thermostat/const.py
+++ b/custom_components/better_thermostat/const.py
@@ -1,4 +1,5 @@
 """"""
+import os
 import json
 from enum import IntEnum
 from homeassistant.backports.enum import StrEnum
@@ -18,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_NAME = "Better Thermostat"
 VERSION = "master"
 try:
-    with open("custom_components/better_thermostat/manifest.json") as manifest_file:
+    with open(f"{os.path.dirname(os.path.realpath(__file__))}/manifest.json") as manifest_file:
         manifest = json.load(manifest_file)
         VERSION = manifest["version"]
 except (FileNotFoundError, KeyError, json.JSONDecodeError) as e:


### PR DESCRIPTION
Fixing "No such file or directory: 'custom_components/better_thermostat/manifest.json': could not read version from manifest file." for docker users.

## Motivation:
Eversince my homeassistant log shows the following:
2023-11-03 14:55:13.885 ERROR (MainThread) [custom_components.better_thermostat.const] better_thermostat [Errno 2] No such file or directory: 'custom_components/better_thermostat/manifest.json': could not read version from manifest file.

This is annoying, so I fixed it by resolving the path to manifest.json inside the const.py.

## Changes:
Using relativ-to-current-file path discovery for manifest.json.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ x ] The code change is tested and works locally.

## Test-Hardware list (for code changes)
HA Version: 2023.11.0 (using this container: https://docs.linuxserver.io/images/docker-homeassistant/#usage)
Zigbee2MQTT Version: [1.33.2](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.33.2) commit: [9996c93](https://github.com/Koenkk/zigbee2mqtt/commit/9996c93)
TRV Hardware: [SEA801-Zigbee/SEA802-Zigbee](https://www.zigbee2mqtt.io/devices/SEA801-Zigbee_SEA802-Zigbee.html#saswell-sea801-zigbee%252Fsea802-zigbee)
HACS 1.33.0
BetterThermostat 1.4.0

## New device mappings
N/A
