### PR TITLE
Fixes #1133 in a workaround manner

### DIFF
--- a/custom_components/better_thermostat/model_fixes/HmIP-eTRV-2.py
+++ b/custom_components/better_thermostat/model_fixes/HmIP-eTRV-2.py
@@ -2,11 +2,11 @@ def fix_local_calibration(self, entity_id, offset):
     return offset
 
 def fix_target_temperature_calibration(self, entity_id, temperature):
-	"""
-	Fixes endless heating loops caused by homeaticIP device algorithm heating already when temperature is not below the set temperature yet. 
-	Adds a bigger delta of at least -1.5 when not trying to heat.
     """
-
+    Fixes endless heating loops caused by homeaticIP device algorithm heating already when temperature is not below the set temperature yet. 
+    Adds a bigger delta of at least -1.5 when not trying to heat.
+    """
+    
     _cur_trv_temp = float(
         self.hass.states.get(entity_id).attributes["current_temperature"]
     )
@@ -14,7 +14,7 @@ def fix_target_temperature_calibration(self, entity_id, temperature):
         return temperature
     if temperature < _cur_trv_temp:
         temperature -= 1.5
-
+    
     return temperature
 
 async def override_set_hvac_mode(self, entity_id, hvac_mode):

--- a/custom_components/better_thermostat/model_fixes/HmIP-eTRV-2.py
+++ b/custom_components/better_thermostat/model_fixes/HmIP-eTRV-2.py
@@ -1,0 +1,24 @@
+def fix_local_calibration(self, entity_id, offset):
+    return offset
+
+def fix_target_temperature_calibration(self, entity_id, temperature):
+	"""
+	Fixes endless heating loops caused by homeaticIP device algorithm heating already when temperature is not below the set temperature yet. 
+	Adds a bigger delta of at least -1.5 when not trying to heat.
+    """
+
+    _cur_trv_temp = float(
+        self.hass.states.get(entity_id).attributes["current_temperature"]
+    )
+    if _cur_trv_temp is None:
+        return temperature
+    if temperature < _cur_trv_temp:
+        temperature -= 1.5
+
+    return temperature
+
+async def override_set_hvac_mode(self, entity_id, hvac_mode):
+    return False
+
+async def override_set_temperature(self, entity_id, temperature):
+    return False

--- a/custom_components/better_thermostat/model_fixes/HmIP-eTRV-C.py
+++ b/custom_components/better_thermostat/model_fixes/HmIP-eTRV-C.py
@@ -2,11 +2,11 @@ def fix_local_calibration(self, entity_id, offset):
     return offset
 
 def fix_target_temperature_calibration(self, entity_id, temperature):
-	"""
-	Fixes endless heating loops caused by homeaticIP device algorithm heating already when temperature is not below the set temperature yet. 
-	Adds a bigger delta of at least -1.5 when not trying to heat.
     """
-
+    Fixes endless heating loops caused by homeaticIP device algorithm heating already when temperature is not below the set temperature yet. 
+    Adds a bigger delta of at least -1.5 when not trying to heat.
+    """
+    
     _cur_trv_temp = float(
         self.hass.states.get(entity_id).attributes["current_temperature"]
     )
@@ -14,7 +14,7 @@ def fix_target_temperature_calibration(self, entity_id, temperature):
         return temperature
     if temperature < _cur_trv_temp:
         temperature -= 1.5
-
+    
     return temperature
 
 async def override_set_hvac_mode(self, entity_id, hvac_mode):

--- a/custom_components/better_thermostat/model_fixes/HmIP-eTRV-C.py
+++ b/custom_components/better_thermostat/model_fixes/HmIP-eTRV-C.py
@@ -1,0 +1,24 @@
+def fix_local_calibration(self, entity_id, offset):
+    return offset
+
+def fix_target_temperature_calibration(self, entity_id, temperature):
+	"""
+	Fixes endless heating loops caused by homeaticIP device algorithm heating already when temperature is not below the set temperature yet. 
+	Adds a bigger delta of at least -1.5 when not trying to heat.
+    """
+
+    _cur_trv_temp = float(
+        self.hass.states.get(entity_id).attributes["current_temperature"]
+    )
+    if _cur_trv_temp is None:
+        return temperature
+    if temperature < _cur_trv_temp:
+        temperature -= 1.5
+
+    return temperature
+
+async def override_set_hvac_mode(self, entity_id, hvac_mode):
+    return False
+
+async def override_set_temperature(self, entity_id, temperature):
+    return False


### PR DESCRIPTION
Fixes #1133 in a workaround manner
## Motivation:
Was looking for a way to fix #1133 without affecting any other components and doing too major of any changes.

## Changes:
Added model_fixes for HmIP-eTRV-C and HmIP-eTRV-2 models.
It includes an adjustment for fix_target_temperature_calibration to reduce the value further by 1.5° if the set temperature is lower than the current TRV temperature. This way the set temperature is way lower and the homeatic algorithm won't try to open the valve. 

## Related issue (check one):

- [x] fixes #1133 
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: HA Core 2023.11.2
TRV Hardware: 
HmIP-eTRV-C and HmIP-eTRV-2

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
