### PR TITLE
Feature/add target temp step

### DIFF
--- a/custom_components/better_thermostat/adapters/generic.py
+++ b/custom_components/better_thermostat/adapters/generic.py
@@ -21,7 +21,7 @@ async def get_info(self, entity_id):
 async def init(self, entity_id):
     if (
         self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None
-        and self.real_trvs[entity_id]["calibration"] == 0
+        and self.real_trvs[entity_id]["calibration"] != 1
     ):
         self.real_trvs[entity_id][
             "local_temperature_calibration_entity"

--- a/custom_components/better_thermostat/adapters/generic.py
+++ b/custom_components/better_thermostat/adapters/generic.py
@@ -119,13 +119,23 @@ async def set_temperature(self, entity_id, temperature):
 
 async def set_hvac_mode(self, entity_id, hvac_mode):
     """Set new target hvac mode."""
-    await self.hass.services.async_call(
-        "climate",
-        "set_hvac_mode",
-        {"entity_id": entity_id, "hvac_mode": hvac_mode},
-        blocking=True,
-        context=self.context,
+    _LOGGER.debug(
+        "better_thermostat %s: set_hvac_mode %s",
+        self.name,
+        hvac_mode,
     )
+    try:
+        await self.hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {"entity_id": entity_id, "hvac_mode": hvac_mode},
+            blocking=True,
+            context=self.context,
+        )
+    except TypeError:
+        _LOGGER.debug(
+            "TypeError in set_hvac_mode"
+        )
 
 
 async def set_offset(self, entity_id, offset):

--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -29,7 +29,7 @@ async def get_info(self, entity_id):
 async def init(self, entity_id):
     if (
         self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None
-        and self.real_trvs[entity_id]["calibration"] == 0
+        and self.real_trvs[entity_id]["calibration"] != 1
     ):
         self.real_trvs[entity_id][
             "local_temperature_calibration_entity"

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -322,6 +322,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             _calibration = 1
             if trv["advanced"]["calibration"] == "local_calibration_based":
                 _calibration = 0
+            if trv["advanced"]["calibration"] == "hybrid_calibration":
+                _calibration = 2
             _adapter = load_adapter(self, trv["integration"], trv["trv"])
             _model_quirks = load_model_quirks(self, trv["model"], trv["trv"])
             self.real_trvs[trv["trv"]] = {
@@ -770,7 +772,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             for trv in self.real_trvs.keys():
                 self.all_entities.append(trv)
                 await init(self, trv)
-                if self.real_trvs[trv]["calibration"] == 0:
+                if self.real_trvs[trv]["calibration"] != 1:
                     self.real_trvs[trv]["last_calibration"] = await get_current_offset(
                         self, trv
                     )

--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -65,6 +65,15 @@ CALIBRATION_TYPE_ALL_SELECTOR = selector.SelectSelector(
             selector.SelectOptionDict(
                 value=CalibrationType.LOCAL_BASED, label="Offset Based"
             ),
+            selector.SelectOptionDict(
+                value=CalibrationType.HYBRID, label="Hybrid"
+            ),
+        ],
+        mode=selector.SelectSelectorMode.DROPDOWN,
+    )
+)
+
+TEMP_STEP_SELECTOR = selector.SelectSelector(
         ],
         mode=selector.SelectSelectorMode.DROPDOWN,
     )

--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_WINDOW_TIMEOUT_AFTER,
     CONF_CALIBRATION_MODE,
     CONF_TOLERANCE,
+    CONF_TARGET_TEMP_STEP,
     CalibrationMode,
     CalibrationType,
 )
@@ -74,6 +75,23 @@ CALIBRATION_TYPE_ALL_SELECTOR = selector.SelectSelector(
 )
 
 TEMP_STEP_SELECTOR = selector.SelectSelector(
+    selector.SelectSelectorConfig(
+        options=[
+            selector.SelectOptionDict(
+                value="0.1", label="0.1 °C"
+                ),
+            selector.SelectOptionDict(
+                value="0.2", label="0.2 °C"
+            ),
+            selector.SelectOptionDict(
+                value="0.25", label="0.25 °C" 
+            ),
+            selector.SelectOptionDict(
+                value="0.5", label="0.5 °C"
+            ),
+            selector.SelectOptionDict(
+                value="1.0", label="1 °C"
+            )
         ],
         mode=selector.SelectSelectorMode.DROPDOWN,
     )
@@ -363,6 +381,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Optional(
                         CONF_TOLERANCE, default=user_input.get(CONF_TOLERANCE, 0.0)
                     ): vol.All(vol.Coerce(float), vol.Range(min=0)),
+                    vol.Optional(
+                        CONF_TARGET_TEMP_STEP, 
+                        default=str(user_input.get(CONF_TARGET_TEMP_STEP, 0.0))
+                    ): TEMP_STEP_SELECTOR,
                 }
             ),
             errors=errors,
@@ -565,6 +587,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self.updated_config[CONF_TOLERANCE] = float(
                 user_input.get(CONF_TOLERANCE, 0.0)
             )
+            self.updated_config[CONF_TARGET_TEMP_STEP] = float(
+                            user_input.get(CONF_TARGET_TEMP_STEP, 0.0)
+            )
 
             for trv in self.updated_config[CONF_HEATER]:
                 trv["adapter"] = None
@@ -692,6 +717,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_TOLERANCE, default=self.config_entry.data.get(CONF_TOLERANCE, 0.0)
             )
         ] = vol.All(vol.Coerce(float), vol.Range(min=0))
+        fields[
+            vol.Optional(
+                CONF_TARGET_TEMP_STEP,
+                default=str(self.config_entry.data.get(
+                    CONF_TARGET_TEMP_STEP, 0.0
+                )),
+            )
+        ] = TEMP_STEP_SELECTOR
 
         return self.async_show_form(
             step_id="user", data_schema=vol.Schema(fields), last_step=False

--- a/custom_components/better_thermostat/const.py
+++ b/custom_components/better_thermostat/const.py
@@ -53,6 +53,7 @@ CONF_HOMATICIP = "homaticip"
 CONF_INTEGRATION = "integration"
 CONF_NO_SYSTEM_MODE_OFF = "no_off_system_mode"
 CONF_TOLERANCE = "tolerance"
+CONF_TARGET_TEMP_STEP = "target_temp_step"
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
 
 ATTR_STATE_WINDOW_OPEN = "window_open"

--- a/custom_components/better_thermostat/const.py
+++ b/custom_components/better_thermostat/const.py
@@ -91,6 +91,7 @@ class CalibrationType(StrEnum):
 
     TARGET_TEMP_BASED = "target_temp_based"
     LOCAL_BASED = "local_calibration_based"
+    HYBRID = "hybrid_calibration"
 
 
 class CalibrationMode(StrEnum):

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -20,6 +20,14 @@ from ..utils.helpers import (
 )
 from custom_components.better_thermostat.utils.bridge import get_current_offset
 
+from ..const import (
+    CONF_HEAT_AUTO_SWAPPED,
+    CONF_HEATING_POWER_CALIBRATION,
+    CONF_FIX_CALIBRATION,
+    CONF_PROTECT_OVERHEATING,
+    CONF_NO_CALIBRATION
+)
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -79,7 +87,7 @@ async def trigger_trv_change(self, event):
             > _time_diff
             or (
                 self.real_trvs[entity_id]["calibration_received"] is False
-                and self.real_trvs[entity_id]["calibration"] == 0
+                and self.real_trvs[entity_id]["calibration"] != 1
             )
         )
     ):
@@ -100,7 +108,7 @@ async def trigger_trv_change(self, event):
             _main_change = False
             self.old_internal_temp = self.real_trvs[entity_id]["current_temperature"]
             self.old_external_temp = self.cur_temp
-            if self.real_trvs[entity_id]["calibration"] == 0:
+            if self.real_trvs[entity_id]["calibration"] != 1:
                 self.real_trvs[entity_id][
                     "last_calibration"
                 ] = await get_current_offset(self, entity_id)
@@ -154,7 +162,7 @@ async def trigger_trv_change(self, event):
         and self.bt_hvac_mode is not HVACMode.OFF
     ):
         _LOGGER.debug(
-            f"better_thermostat {self.name}: trigger_trv_change / _old_heating_setpoint: {_old_heating_setpoint} - _new_heating_setpoint: {_new_heating_setpoint} - _last_temperature: {self.real_trvs[entity_id]['last_temperature']}"
+            f"better_thermostat {self.name}: trigger_trv_change test / _old_heating_setpoint: {_old_heating_setpoint} - _new_heating_setpoint: {_new_heating_setpoint} - _last_temperature: {self.real_trvs[entity_id]['last_temperature']}"
         )
         if (
             _new_heating_setpoint < self.bt_min_temp
@@ -315,6 +323,13 @@ def convert_outbound_states(self, entity_id, hvac_mode) -> Union[dict, None]:
 
     try:
         _calibration_type = self.real_trvs[entity_id].get("calibration", 1)
+        _calibration_mode = self.real_trvs[entity_id]["advanced"].get(
+            "calibration_mode", "default"
+        )
+        
+        _LOGGER.debug(
+        f"better_thermostat {self.name}: {entity_id} /  - _calibration_type: {_calibration_type} - _calibration_mode: {_calibration_mode}"
+        )
 
         if _calibration_type is None:
             _LOGGER.warning(
@@ -323,7 +338,7 @@ def convert_outbound_states(self, entity_id, hvac_mode) -> Union[dict, None]:
             )
             _new_heating_setpoint = self.bt_target_temp
             _new_local_calibration = round_to_half_degree(
-                calculate_local_setpoint_delta(self, entity_id)
+                calculate_local_setpoint_delta(self, entity_id, _calibration_mode)
             )
             if _new_local_calibration is None:
                 return None
@@ -342,11 +357,11 @@ def convert_outbound_states(self, entity_id, hvac_mode) -> Union[dict, None]:
                     or _round_calibration is True
                 ):
                     _new_local_calibration = round_to_half_degree(
-                        calculate_local_setpoint_delta(self, entity_id)
+                        calculate_local_setpoint_delta(self, entity_id, _calibration_mode)
                     )
                 else:
                     _new_local_calibration = calculate_local_setpoint_delta(
-                        self, entity_id
+                        self, entity_id, _calibration_mode
                     )
 
                 _new_heating_setpoint = self.bt_target_temp
@@ -364,10 +379,34 @@ def convert_outbound_states(self, entity_id, hvac_mode) -> Union[dict, None]:
                     or _round_calibration is True
                 ):
                     _new_heating_setpoint = round_to_half_degree(
-                        calculate_setpoint_override(self, entity_id)
+                        calculate_setpoint_override(self, entity_id, _calibration_mode)
                     )
                 else:
-                    _new_heating_setpoint = calculate_setpoint_override(self, entity_id)
+                    _new_heating_setpoint = calculate_setpoint_override(self, entity_id, _calibration_mode)
+            elif _calibration_type == 2:
+                _round_calibration = self.real_trvs[entity_id]["advanced"].get(
+                    "calibration_round"
+                )
+
+                if _round_calibration is not None and (
+                    (
+                        isinstance(_round_calibration, str)
+                        and _round_calibration.lower() == "true"
+                    )
+                    or _round_calibration is True
+                ):
+                    _new_heating_setpoint = round_to_half_degree(
+                        calculate_setpoint_override(self, entity_id, CONF_FIX_CALIBRATION)
+                    )
+                    _new_local_calibration = round_to_half_degree(
+                        calculate_local_setpoint_delta(self, entity_id, CONF_NO_CALIBRATION)
+                    )
+                else:
+                    _new_heating_setpoint = calculate_setpoint_override(self, entity_id, CONF_FIX_CALIBRATION)
+                    _new_local_calibration = calculate_local_setpoint_delta(
+                        self, entity_id, CONF_NO_CALIBRATION
+                    )
+
 
             _system_modes = self.real_trvs[entity_id]["hvac_modes"]
             _has_system_mode = False


### PR DESCRIPTION
## Motivation:

## Changes:

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version:  
- Core 2023.11.3
- Supervisor 2023.11.6
- Operating System 11.1 
Zigbee2MQTT Version: 1.33.2-1
TRV Hardware: Moes BRT-100-TRV and Avatto ME167

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->

-----------------------------------

Hello,

Here are a few modifications that I applied to my local home assistant. 
Everything is not clean enough to be directly applied to your repo but I wanted to know if you are interested in the feature I added before oing further.

I added two features:

## Hybrid calibration mode

I added this feature because I was not happy with the way my TRV handles opening/closing its valve.  
Often, when the local temperature was close to the target temp, the valve closed itself to 25%. Because of that, the target temperature took a long time to be reached.  
This is annoying because my boiler is controled by HA and will be ON if any of my valves is open.

I also want the local temperature on my TRV to be as closed as possible as my temperature sensor.

Because of that I created a hybrid calibration mode.

The idea is simple:
- The calibration of my TRV is modified by BT to keep its local temperature close to the value reported by my temperature sensor. This is similar to the temperature calibration mode with a "no offset" mode.
- The target temperature set on the TRV is 3 degree **higher** that the temperature set to BT if the local temp is **lower** than the BT target temps. On the other hand, the target temperature set on the TRV is 3 degree **lower** that the temperature set to BT if the local temp is **higher** than the BT target temps. This is similar to the agressive temperature offset mode that already exists.

This allow me to have the desired behavior.

This addition is quite messy as I juste added a new value of 2 to `self.real_trvs[entity_id]["calibration"] ` while it was designed to be a boolean.

## Target temperature step option

My TRV target temperature step is 1°C.  
However, with my previous feature, the effective BT accuracy is the accuracy of the temperature sensor.

I added an option to override the temperature step of the TRV to have a better control on the desired temperature in a room.

## Error handling

I also added a error catch in the `set_hvac_mode` asI was experiencing some crashed in that function when using the Moes TRV with ZHA.

## Conclusion

Let me know what you think about those features.  
Maybe what I did is not interesting for anyone except me.