### PR TITLE
Update climate.py

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1093,6 +1093,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         return get_hvac_bt_mode(self, self.bt_hvac_mode)
 
     @property
+     @property
     def hvac_action(self):
         """Return the current HVAC action"""
         if (
@@ -1100,7 +1101,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             and self.bt_target_temp is not None
             and self.cur_temp is not None
         ):
-            if self.bt_target_temp > self.cur_temp and self.window_open is False:
+            if self.hvac_mode == HVACMode.OFF:
+                self.attr_hvac_action = HVACAction.OFF
+            elif self.bt_target_temp > self.cur_temp and self.window_open is False:
                 self.attr_hvac_action = HVACAction.HEATING
             else:
                 self.attr_hvac_action = HVACAction.IDLE

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1093,7 +1093,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         return get_hvac_bt_mode(self, self.bt_hvac_mode)
 
     @property
-     @property
     def hvac_action(self):
         """Return the current HVAC action"""
         if (


### PR DESCRIPTION
Fixed HVAC_ACTION Attribute to accomodate 'off' state

## Motivation:
Basing my automations on HVAC_Action but noticed it not working properly for the better thermostats.
Therefore implementing a fix accomodating OFF state.

## Changes:
added logic for off-state 

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2023.11.1
Zigbee2MQTT Version: ZHA
TRV Hardware: Aqara E1 TRV

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
