### PR TITLE
Fix service "reset_heating_power"

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -110,7 +110,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
         elif data.service == SERVICE_SET_TEMP_TARGET_TEMPERATURE:
             await self.set_temp_temperature(data.data[ATTR_TEMPERATURE])
         elif data.service == SERVICE_RESET_HEATING_POWER:
-            await self.reset_heating_power
+            await self.reset_heating_power()
 
     platform = entity_platform.async_get_current_platform()
     platform.async_register_entity_service(


### PR DESCRIPTION
## Motivation:
Calling `service: better_thermostat.reset_heating_power` failed with the following debug log entry:
```
2023-12-06 22:47:02.206 DEBUG (MainThread) [custom_components.better_thermostat.climate] Service call: <entity climate.buro_heizung_betterthermostat=heat> » reset_heating_power
  File "/config/custom_components/better_thermostat/climate.py", line 113, in async_service_handler
  File "/config/custom_components/better_thermostat/climate.py", line 113, in async_service_handler
```

## Changes:
Added missing parentheses to function call.

## Related issue (check one):

- [x] fixes #939
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2023.11.0
Zigbee2MQTT Version:
TRV Hardware: