### PR TITLE
Fix hvac_action attribute behavior to go to "idle" when the Better Thermostat is "off"

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1100,7 +1100,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             and self.bt_target_temp is not None
             and self.cur_temp is not None
         ):
-            if self.bt_target_temp > self.cur_temp and self.window_open is False:
+            if (
+                self.bt_target_temp > self.cur_temp
+                and self.window_open is False
+                and self.bt_hvac_mode is not HVACMode.OFF
+            ):
                 self.attr_hvac_action = HVACAction.HEATING
             else:
                 self.attr_hvac_action = HVACAction.IDLE


### PR DESCRIPTION
With this fix, the hvac_action attribute is correctly set to "idle" state when the thermostat is turned off.

## Motivation:
hvac_action stays in "heating" state even if the thermostat is turned off.

## Changes:

## Related issue (check one):

- [x] fixes #1193
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2023.12.1
Zigbee2MQTT Version: 1.34.0
TRV Hardware: Aqara Smart Radiator Thermostat E1

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
