### PR TITLE
Skip calibration calculation for 'NO_CALIBRATION' mode

### DIFF
--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -17,7 +17,10 @@ from custom_components.better_thermostat.utils.helpers import (
 )
 from custom_components.better_thermostat.adapters.delegate import get_current_offset
 
-from custom_components.better_thermostat.utils.const import CalibrationType
+from custom_components.better_thermostat.utils.const import (
+    CalibrationType,
+    CalibrationMode,
+)
 
 from custom_components.better_thermostat.calibration import (
     calculate_calibration_local,
@@ -317,6 +320,7 @@ def convert_outbound_states(self, entity_id, hvac_mode) -> Union[dict, None]:
 
     try:
         _calibration_type = self.real_trvs[entity_id]["advanced"].get("calibration")
+        _calibration_mode = self.real_trvs[entity_id]["advanced"].get("calibration_mode")
 
         if _calibration_type is None:
             _LOGGER.warning(
@@ -336,7 +340,10 @@ def convert_outbound_states(self, entity_id, hvac_mode) -> Union[dict, None]:
                 _new_heating_setpoint = self.bt_target_temp
 
             elif _calibration_type == CalibrationType.TARGET_TEMP_BASED:
-                _new_heating_setpoint = calculate_calibration_setpoint(self, entity_id)
+                if _calibration_mode == CalibrationMode.NO_CALIBRATION:
+                    _new_heating_setpoint = self.bt_target_temp
+                else:
+                    _new_heating_setpoint = calculate_calibration_setpoint(self, entity_id)
 
             _system_modes = self.real_trvs[entity_id]["hvac_modes"]
             _has_system_mode = False

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -264,9 +264,7 @@ async def control_trv(self, heater_entity_id=None):
         # set new target temperature
         if (
             _temperature is not None
-            and _calibration_mode != CalibrationMode.NO_CALIBRATION
-            and _new_hvac_mode != HVACMode.OFF
-            or _no_off_system_mode
+            and (_new_hvac_mode != HVACMode.OFF or _no_off_system_mode)
         ):
             if _temperature != _current_set_temperature:
                 old = self.real_trvs[heater_entity_id].get("last_temperature", "?")


### PR DESCRIPTION
## Motivation:
I am using Devolo Connect (MT02650) thermostat recognized by BT as generic thermostat. As there is already a calibration running in Devolo HC gateway, I set BT to use CalibrationMode NO_CALIBRATION. This did not work at all and wrong values were set to the TRV (mainly as the TRV does not provide measured temperature).
However if CalibrationMode is set to NO_CALIBRATION, no calibration value shall be calculated and temperature set in BT should be applied as entered as target temperature (normal, eco or off temperature).

## Changes:
Skip calibration calculation in trv.py for 'NO_CALIBRATION' mode and use target temperature instead.
Fixed if statement in controlling.py for target temperature setting

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2023.12.4
Zigbee2MQTT Version: - 
TRV Hardware: Devolo Connect (MT02650)

## New device mappings

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

