### PR TITLE
Increase check_target_temperature timeout

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -359,7 +359,7 @@ async def check_target_temperature(self, heater_entity_id=None):
         ):
             _timeout = 0
             break
-        if _timeout > 120:
+        if _timeout > 360:
             _LOGGER.debug(
                 f"better_thermostat {self.name}: {heater_entity_id} the real TRV did not respond to the target temperature change"
             )


### PR DESCRIPTION
This will consider some ZWave TRVs that will wake up only every 5 minutes.

## Motivation:
Apply target temperature to ZWave TRVs that will wake up every 5 minutes.

## Changes:
Increased the timeout in `check_target_temperature` from 120 to 360, which is the same timeout used in `check_system_mode`.

## Related issue (check one):

- [x] fixes #1171
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2023.12.4
Zigbee2MQTT Version: not relevant, hardware is a ZWave device
TRV Hardware:   Devolo MT02650 TRV

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
