### PR TITLE
potential fix for duplicated instances on update

### DIFF
--- a/custom_components/better_thermostat/__init__.py
+++ b/custom_components/better_thermostat/__init__.py
@@ -1,5 +1,6 @@
 """The better_thermostat component."""
 import logging
+from asyncio import Lock
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, Config
 from homeassistant.config_entries import ConfigEntry
@@ -19,6 +20,8 @@ DOMAIN = "better_thermostat"
 PLATFORMS = [Platform.CLIMATE]
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
+config_entry_update_listener_lock = Lock()
+
 
 async def async_setup(hass: HomeAssistant, config: Config):
     """Set up this integration using YAML is not supported."""
@@ -35,9 +38,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
-    await hass.config_entries.async_reload(entry.entry_id)
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    async with config_entry_update_listener_lock:
+        await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass, entry):

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -298,6 +298,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             asyncio.create_task(window_queue(self))
         self.heating_power = 0.01
         self.last_heating_power_stats = []
+        self.is_removed = False
 
     async def async_added_to_hass(self):
         """Run when entity about to be added.
@@ -356,6 +357,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 "last_current_temperature": None,
                 "last_calibration": None,
             }
+
+        def on_remove():
+            self.is_removed = True
+        self.async_on_remove(on_remove)
 
         await super().async_added_to_hass()
 
@@ -859,6 +864,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                             "battery": None,
                         }
 
+            if self.is_removed:
+                return
+
             # update_hvac_action(self)
             # Add listener
             if self.outdoor_sensor is not None:
@@ -868,6 +876,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 )
 
             await check_all_entities(self)
+
+            if self.is_removed:
+                return
 
             self.async_on_remove(
                 async_track_time_interval(


### PR DESCRIPTION
## Motivation:
After updating a Better Thermostat instance, two instances of the control logic seem to be running. That creates problems like target temperature updates on the original TRV being recognized as external input and therefore used as new target temperature for BT. Hard to say if this is the only cause for all those "Target temperature changes randomly" issues, but at least that's what's causing it for me.

After adding more debug logs, I found out that the `config_entry_update_listener` callback is actually called twice in quick succession. No idea why this is, some Home Assistant logic triggers this I guess. I could reliably observe this chain of events:
1. Update config in the UI
2. `config_entry_update_listener` is called
3. `async_unload_entry` is called
4. `config_entry_update_listener` is called
5. `async_setup_entry` is called
6. `async_unload_entry` is called
7. `async_unload_entry` is called
8. "ValueError: Config entry was never loaded!"
9. `async_setup_entry` is called
10. `async_setup_entry` is called
11. "ValueError: Config entry has already been setup!"
12. "startup completed"
13. "startup completed"

As you can see, some beautiful race conditions right there.

## Changes:
1. Use a lock in `config_entry_update_listener` to prevent to updates overlapping. That was why unload and setup were wildly mixed, causing exceptions.
2. Removed the `async_unload_entry` and `async_setup_entry` calls from `config_entry_update_listener`. They are already called during `hass.config_entries.async_reload`. That gets rid of some duplicate unloads/setups.
3. The `startup` function is running asynchronously. That means, if the entify is removed during its execution, a bunch of listeners could be attached after removal. The listeners are then not removed anymore, because `async_on_remove` has no effect, because the entity is already removed. To solve this, I added a check for removal before attaching the listeners.

I tested the changes and they do solve the problem. I am a noob with Python and HA however, so my testing was a bit hacky with me changing files directly in my running HA instance. I have extracted the changes into this PR, but did/could not test them in context of the newest version of the code.
There might be better or cleaner ways to achieve what I did, so feel free to use my changes as inspiration and implement them properly. 😉 

## Related issue (check one):

- [x] fixes #1097
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2023.12.1
Zigbee2MQTT Version: None, I use ZHA
TRV Hardware: FRITZ!DECT 301

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
