### PR TITLE
fixed typo in de.json

### DIFF
--- a/custom_components/better_thermostat/translations/de.json
+++ b/custom_components/better_thermostat/translations/de.json
@@ -7,7 +7,7 @@
         "data": {
           "name": "Name",
           "thermostat": "Das reale Thermostat",
-          "cooler": "Klimmagerät AC (optional)",
+          "cooler": "Klimagerät AC (optional)",
           "temperature_sensor": "Externer Temperatursensor",
           "humidity_sensor": "Luftfeuchtigkeitssensor",
           "window_sensors": "Fenstersensor(en)",


### PR DESCRIPTION
Klimagerät instead of Klimmagerät

## Motivation:

There was a typo in the german translation

## Changes:

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [x] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.