### PR TITLE
Fix failing climate.turn_on issue introduced in version 1.5.0-beta6

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1267,7 +1267,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         await self.async_set_hvac_mode(HVACMode.OFF)
 
     async def async_turn_on(self) -> None:
-        await self.async_set_hvac_mode(HVACMode.HEATING)
+        await self.async_set_hvac_mode(HVACMode.HEAT)
 
     @property
     def min_temp(self):


### PR DESCRIPTION
The commit b53b564 that went into BT version 1.5.0-beta6 introduced an issue causing the climate.turn_on operation to consistently fail.

The problem is due to the fact that HVACMode.HEATING is used in the call of self.async_set_hvac_mode() inside async_turn_on() function instead of HVACMode.HEAT.

## Motivation: climate.turn_on operation called on BT fails because of a recent commit (b53b564) to 1.5.0-beta6.

## Changes: HVACMode.HEAT is now used in the call of self.async_set_hvac_mode() inside async_turn_on() function, instead of the wrong  HVACMode.HEATING.

## Related issue (check one): #1295 

- [ ] fixes #<issue number goes here>
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2024.3.2
Zigbee2MQTT Version: 1.36.0
TRV Hardware: Aqara Smart radiator thermostat E1

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
