### PR TITLE
Fix retrieving history when the entity was unavailable

### DIFF
--- a/custom_components/better_thermostat/utils/weather.py
+++ b/custom_components/better_thermostat/utils/weather.py
@@ -170,10 +170,10 @@ async def check_ambient_air_temperature(self):
         )
 
         for item in history_list.get(lower_entity_id):
-            # filter out all None, NaN and "unknown" states
+            # filter out all None, NaN, "unknown" and "unavailable" states.
             # only keep real values
             with suppress(ValueError):
-                if item.state != "unknown":
+                if item.state not in ("unknown", "unavailable"):
                     _temp_history.add_measurement(
                         convert_to_float(
                             item.state, self.name, "check_ambient_air_temperature()"


### PR DESCRIPTION
If the entity was unavailable at some point, it seems we get `unavailable` returned in its history. Currently, we'll try to progress this value as if it were a number, and we get:

> Could not convert 'unavailable' to float in check_ambient_air_temperature()

in the logs. We can suppress this by filtering out such values before trying to process them.

- [ ] fixes #1204 (maybe)