### PR TITLE
Replace deprecated weather forecast with new service call

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -396,7 +396,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         _check = await check_all_entities(self)
         if _check is False:
             return
-        check_weather(self)
+        await check_weather(self)
         if self._last_call_for_heat != self.call_for_heat:
             self._last_call_for_heat = self.call_for_heat
             await self.async_update_ha_state(force_refresh=True)

--- a/custom_components/better_thermostat/utils/weather.py
+++ b/custom_components/better_thermostat/utils/weather.py
@@ -17,7 +17,7 @@ from statistics import median
 _LOGGER = logging.getLogger(__name__)
 
 
-def check_weather(self) -> bool:
+async def check_weather(self) -> bool:
     """check weather predictions or ambient air temperature if available
 
     Parameters
@@ -37,7 +37,7 @@ def check_weather(self) -> bool:
     self.call_for_heat = True
 
     if self.weather_entity is not None:
-        _call_for_heat_weather = check_weather_prediction(self)
+        _call_for_heat_weather = await check_weather_prediction(self)
         self.call_for_heat = _call_for_heat_weather
 
     if self.outdoor_sensor is not None:
@@ -63,7 +63,7 @@ def check_weather(self) -> bool:
         return False
 
 
-def check_weather_prediction(self) -> bool:
+async def check_weather_prediction(self) -> bool:
     """Checks configured weather entity for next two days of temperature predictions.
 
     Returns
@@ -84,7 +84,14 @@ def check_weather_prediction(self) -> bool:
         return None
 
     try:
-        forecast = self.hass.states.get(self.weather_entity).attributes.get("forecast")
+        forecasts = await self.hass.services.async_call(
+            "weather",
+            "get_forecasts",
+            {"type": "daily", "entity_id": self.weather_entity},
+            blocking=True,
+            return_response=True,
+        )
+        forecast = forecasts.get(self.weather_entity).get("forecast")
         if len(forecast) > 0:
             cur_outside_temp = convert_to_float(
                 str(


### PR DESCRIPTION
## Motivation:
In HA Update 2024.04 the old way of retrieving the forecast data got removed and only the new get_forecasts service remains. This PR utilizes the new service to retrieve the forecast data. The service is supported since 2023.12.
## Changes:
Changes the way retrieving forecast data: Instead of entity attribute use weather.get_forecasts service
## Related issue (check one):

- [x] fixes #1331
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2024.2.1 and 2024.4.1
Zigbee2MQTT Version: - devcontainer
TRV Hardware: simulated - devcontainer

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
