### PR TITLE
hvac_action attribute stays in "heating" state even if Better Thermostat is turned off

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1123,8 +1123,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
     def hvac_action(self):
         """Return the current HVAC action"""
         if (
-            self.attr_hvac_action is None
-            and self.bt_target_temp is not None
+            self.bt_target_temp is not None
             and self.cur_temp is not None
         ):
             if self.hvac_mode == HVACMode.OFF:


### PR DESCRIPTION
Remove check for an empty hvac_action

## Motivation:

This is in relation to #1193 , after the changes made previously in this thread were made and 1.5 was released. I still have HVAC_action staying as heating, when the device state is off and the set temp is higher than current temp.

## Changes:

Remove a check for the current hvac_action to be none before the rest of the normal logic kicks in.

## Related issue (check one):

- [x] fixes #1193 
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
