### PR TITLE
Switch to enum.StrEnum

### DIFF
--- a/custom_components/better_thermostat/utils/const.py
+++ b/custom_components/better_thermostat/utils/const.py
@@ -2,8 +2,7 @@
 
 import os
 import json
-from enum import IntEnum
-from homeassistant.backports.enum import StrEnum
+from enum import IntEnum, StrEnum
 
 import logging
 import voluptuous as vol


### PR DESCRIPTION
## Motivation:
Just avoiding future deprecation and logging warning of old alias as per https://developers.home-assistant.io/blog/2024/04/08/deprecated-backports-and-typing-aliases/

## Changes:
import enum.StrEnum rather than homeassistant.backports.enum.StrEnum

## Related issue (check one):

- [x] fixes #1351
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2024.5.3
Zigbee2MQTT Version: 1.37.1
TRV Hardware: Sonoff TRVs 1.1.5

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
