### PR TITLE
Avoid blocking import warning

### DIFF
--- a/custom_components/better_thermostat/adapters/delegate.py
+++ b/custom_components/better_thermostat/adapters/delegate.py
@@ -1,10 +1,10 @@
-from importlib import import_module
+from homeassistant.helpers.importlib import async_import_module
 import logging
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def load_adapter(self, integration, entity_id, get_name=False):
+async def load_adapter(self, integration, entity_id, get_name=False):
     """Load adapter."""
     if get_name:
         self.name = "-"
@@ -13,9 +13,9 @@ def load_adapter(self, integration, entity_id, get_name=False):
         integration = "generic"
 
     try:
-        self.adapter = import_module(
+        self.adapter = await async_import_module(
+            self.hass,
             "custom_components.better_thermostat.adapters." + integration,
-            package="better_thermostat",
         )
         _LOGGER.debug(
             "better_thermostat %s: uses adapter %s for trv %s",
@@ -24,9 +24,9 @@ def load_adapter(self, integration, entity_id, get_name=False):
             entity_id,
         )
     except Exception:
-        self.adapter = import_module(
+        self.adapter = await async_import_module(
+            self.hass,
             "custom_components.better_thermostat.adapters.generic",
-            package="better_thermostat",
         )
         _LOGGER.info(
             "better_thermostat %s: integration: %s isn't native supported, feel free to open an issue, fallback adapter %s",

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -335,8 +335,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 _calibration = 0
             if trv["advanced"]["calibration"] == "hybrid_calibration":
                 _calibration = 2
-            _adapter = load_adapter(self, trv["integration"], trv["trv"])
-            _model_quirks = load_model_quirks(self, trv["model"], trv["trv"])
+            _adapter = await load_adapter(self, trv["integration"], trv["trv"])
+            _model_quirks = await load_model_quirks(self, trv["model"], trv["trv"])
             self.real_trvs[trv["trv"]] = {
                 "calibration": _calibration,
                 "integration": trv["integration"],

--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -309,7 +309,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             "trv": trv,
                             "integration": _intigration,
                             "model": await get_device_model(self, trv),
-                            "adapter": load_adapter(self, _intigration, trv),
+                            "adapter": await load_adapter(self, _intigration, trv),
                         }
                     )
                 self.data[CONF_MODEL] = "/".join([x["model"] for x in self.trv_bundle])
@@ -438,7 +438,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         _default_calibration = "target_temp_based"
         self.name = user_input.get(CONF_NAME, "-")
 
-        _adapter = load_adapter(
+        _adapter = await load_adapter(
             self, _trv_config.get("integration"), _trv_config.get("trv")
         )
         if _adapter is not None:

--- a/custom_components/better_thermostat/diagnostics.py
+++ b/custom_components/better_thermostat/diagnostics.py
@@ -19,7 +19,9 @@ async def async_get_config_entry_diagnostics(
         trv = hass.states.get(trv_id["trv"])
         if trv is None:
             continue
-        _adapter_name = await load_adapter(hass, trv_id["integration"], trv_id["trv"], True)
+        _adapter_name = await load_adapter(
+            hass, trv_id["integration"], trv_id["trv"], True
+        )
         trv_id["adapter"] = _adapter_name
         trvs[trv_id["trv"]] = {
             "name": trv.name,

--- a/custom_components/better_thermostat/diagnostics.py
+++ b/custom_components/better_thermostat/diagnostics.py
@@ -19,7 +19,7 @@ async def async_get_config_entry_diagnostics(
         trv = hass.states.get(trv_id["trv"])
         if trv is None:
             continue
-        _adapter_name = load_adapter(hass, trv_id["integration"], trv_id["trv"], True)
+        _adapter_name = await load_adapter(hass, trv_id["integration"], trv_id["trv"], True)
         trv_id["adapter"] = _adapter_name
         trvs[trv_id["trv"]] = {
             "name": trv.name,

--- a/custom_components/better_thermostat/model_fixes/model_quirks.py
+++ b/custom_components/better_thermostat/model_fixes/model_quirks.py
@@ -1,19 +1,19 @@
-from importlib import import_module
+from homeassistant.helpers.importlib import async_import_module
 import logging
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def load_model_quirks(self, model, entity_id):
+async def load_model_quirks(self, model, entity_id):
     """Load model."""
 
     # remove / from model
     model = model.replace("/", "_")
 
     try:
-        self.model_quirks = import_module(
+        self.model_quirks = await async_import_module(
+            self.hass,
             "custom_components.better_thermostat.model_fixes." + model,
-            package="better_thermostat",
         )
         _LOGGER.debug(
             "better_thermostat %s: uses quirks fixes for model %s for trv %s",
@@ -22,9 +22,9 @@ def load_model_quirks(self, model, entity_id):
             entity_id,
         )
     except Exception:
-        self.model_quirks = import_module(
+        self.model_quirks = await async_import_module(
+            self.hass,
             "custom_components.better_thermostat.model_fixes.default",
-            package="better_thermostat",
         )
         pass
 


### PR DESCRIPTION
## Motivation:
Resolves warnings about blocking imports

## Changes:
Made use of HA async import helper and made surrounding functions async.

## Related issue (check one):

- [x] fixes #1363
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: core-2024.7.3
Zigbee2MQTT Version: [1.39.0](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.39.0) commit: [0326926](https://github.com/Koenkk/zigbee2mqtt/commit/0326926)
TRV Hardware: Sonoff TRVZB

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
