### PR TITLE
Model quirk For Bosch BTH-RM230Z room thermostat

### DIFF
--- a/custom_components/better_thermostat/model_fixes/BTH-RM230Z.py
+++ b/custom_components/better_thermostat/model_fixes/BTH-RM230Z.py
@@ -1,0 +1,53 @@
+# Quirks for BTH-RM230Z
+import logging
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+_LOGGER = logging.getLogger(__name__)
+
+def fix_local_calibration(self, entity_id, offset):
+    return offset
+
+
+def fix_target_temperature_calibration(self, entity_id, temperature):
+    return temperature
+
+
+async def override_set_hvac_mode(self, entity_id, hvac_mode):
+    return False
+
+
+async def override_set_temperature(self, entity_id, temperature):
+    """Bosch room thermostat BTH-RM230Z has a quirk where it needs to set both high 
+    and low temperature, if heat and cool modes are available in newer Z2M versions.
+    """
+    model = self.real_trvs[entity_id]["model"]
+    if model == "BTH-RM230Z":
+        _LOGGER.debug(
+            f"better_thermostat {self.name}: TRV {entity_id} device quirk bth-rm230z for set_temperature active"
+        )
+        entity_reg = er.async_get(self.hass)
+        entry = entity_reg.async_get(entity_id)
+
+        hvac_modes = entry.capabilities.get("hvac_modes", [])
+
+        _LOGGER.debug(
+            f"better_thermostat {self.name}: TRV {entity_id} device quirk bth-rm230z found hvac_modes {hvac_modes}"
+        )
+
+        if entry.platform == "mqtt" and "cool" in hvac_modes and "heat" in hvac_modes:
+            await self.hass.services.async_call(
+                "climate",
+                "set_temperature",
+                {"entity_id": entity_id, "target_temp_high": temperature, "target_temp_low": temperature}, 
+                blocking=True,
+                context=self.context,
+            )
+        else:
+            await self.hass.services.async_call(
+                "climate",
+                "set_temperature",
+                {"entity_id": entity_id, "temperature": temperature},
+                blocking=True,
+                context=self.context,
+            )
+    return True

--- a/custom_components/better_thermostat/model_fixes/BTH-RM230Z.py
+++ b/custom_components/better_thermostat/model_fixes/BTH-RM230Z.py
@@ -4,6 +4,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 _LOGGER = logging.getLogger(__name__)
 
+
 def fix_local_calibration(self, entity_id, offset):
     return offset
 
@@ -17,7 +18,7 @@ async def override_set_hvac_mode(self, entity_id, hvac_mode):
 
 
 async def override_set_temperature(self, entity_id, temperature):
-    """Bosch room thermostat BTH-RM230Z has a quirk where it needs to set both high 
+    """Bosch room thermostat BTH-RM230Z has a quirk where it needs to set both high
     and low temperature, if heat and cool modes are available in newer Z2M versions.
     """
     model = self.real_trvs[entity_id]["model"]
@@ -38,7 +39,11 @@ async def override_set_temperature(self, entity_id, temperature):
             await self.hass.services.async_call(
                 "climate",
                 "set_temperature",
-                {"entity_id": entity_id, "target_temp_high": temperature, "target_temp_low": temperature}, 
+                {
+                    "entity_id": entity_id,
+                    "target_temp_high": temperature,
+                    "target_temp_low": temperature,
+                },
                 blocking=True,
                 context=self.context,
             )


### PR DESCRIPTION
This fixes handling of set_temperature, if device is used in newer Z2M, which requires to set target_temp_high and target_temp_low instead of temperature.
Backward compatiblity is ensured by checking model, platform (mqtt), and if heat/cool hvac_modes are present.
Fixes KartoffelToby/better_thermostat#1401

## Motivation:

Z2M has changed handling of hvac modes (https://github.com/Koenkk/zigbee-herdsman-converters/commit/2101914e85d864246694a1f8d334a92781ffe9bc) resulting mode heat and cool now present. This requires now to **set target_temp_low** and **target_temp_high** instead of **temperature** in action call. 

## Changes:

Add model quirk BTH-RM230Z.py

## Related issue (check one):

- [x] fixes #1401 
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2024.10.3
Zigbee2MQTT Version: 1.40.2
TRV Hardware: Bosch Room thermostat II 230V RBSH-RTH0-ZB-EU and model BTH-RM230Z

## New device mappings

- [ ] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

