### PR TITLE
Fix Config import

### DIFF
--- a/custom_components/better_thermostat/__init__.py
+++ b/custom_components/better_thermostat/__init__.py
@@ -3,8 +3,9 @@
 import logging
 from asyncio import Lock
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant, Config
+from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.typing import ConfigType
 import voluptuous as vol
 
 from .utils.const import (
@@ -24,7 +25,7 @@ CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 config_entry_update_listener_lock = Lock()
 
 
-async def async_setup(hass: HomeAssistant, config: Config):
+async def async_setup(hass: HomeAssistant, config: ConfigType):
     """Set up this integration using YAML is not supported."""
     hass.data[DOMAIN] = {}
     return True


### PR DESCRIPTION
## Motivation:
ConfigType to be used instead

## Changes:

## Related issue (check one):

- [x] fixes #1428 
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2024.11.0b0
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
