### PR TITLE
Fix device_model parsing for multiple braces

### DIFF
--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -456,8 +456,9 @@ async def get_device_model(self, entity_id):
             _LOGGER.debug(device)
             try:
                 # Z2M reports the device name as a long string with the actual model name in braces, we need to extract it
-                return re.search("\\((.+?)\\)", device.model).group(1)
-            except AttributeError:
+                matches = re.findall(r"\((.+?)\)", device.model)
+                return matches[-1]
+            except IndexError:
                 # Other climate integrations might report the model name plainly, need more infos on this
                 return device.model
         except (


### PR DESCRIPTION
only get last value in braces. 

model description can also contain braces. Example Bosch: Room thermostat II (Battery model) (BTH-RM)

## Motivation:

Devices can have multiple braces due to vendor having something like (Battery model) appended. See device info in comment: https://github.com/KartoffelToby/better_thermostat/pull/1422#issuecomment-2461629069

## Changes:

Fix regexp to extract value within last braces and return that value.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2024.11.0
Zigbee2MQTT Version: 1.41.0
TRV Hardware: Bosch Room Thermostat II

