### PR TITLE
Fix possibly invalid target_temp_high in trv.py

### DIFF
--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -142,7 +142,7 @@ async def trigger_trv_change(self, event):
 
     _main_key = "temperature"
     if "temperature" not in old_state.attributes:
-        _main_key = "target_temp_high"
+        _main_key = "target_temp_low"
 
     _old_heating_setpoint = convert_to_float(
         str(old_state.attributes.get(_main_key, None)),


### PR DESCRIPTION
## Motivation:

Bosch Thermostat having attributes target_temp_high and target_temp_low (and no temperature) having issues when changing the temperature locally. Changes were not communicated back properly.

Reference: https://github.com/KartoffelToby/better_thermostat/pull/1422#issuecomment-2456680355

Changing target_temp_high to target_temp_low in trv.py fixed this.

On deeper investigation it seems that Zigbee occupied_heating_temperature is converted to target_temp_low. 

Inspecting https://github.com/KartoffelToby/better_thermostat/commit/1797332908695a795a9201b4fd9af9affa586dfd reveals that in cooler.py and trv.py the temperature is set using target_temp_high. This should be correct for cooler.py, but most propably not in trv.py

## Changes:

Changes target_temp_high to target_temp_low in trv.py.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2024.11.0
Zigbee2MQTT Version: 1.41.0
TRV Hardware: Bosch Thermostat II
