### PR TITLE
TS0601_thermostat remove not working fixes

### DIFF
--- a/custom_components/better_thermostat/model_fixes/TS0601_thermostat.py
+++ b/custom_components/better_thermostat/model_fixes/TS0601_thermostat.py
@@ -1,22 +1,11 @@
 def fix_local_calibration(self, entity_id, offset):
-    _cur_external_temp = self.cur_temp
-    _target_temp = self.bt_target_temp
-
-    if (_cur_external_temp + 0.1) >= _target_temp:
-        offset = round(offset + 0.5, 1)
-    elif (_cur_external_temp + 0.5) >= _target_temp:
-        offset -= 2.5
-
     return offset
-
 
 def fix_target_temperature_calibration(self, entity_id, temperature):
     return temperature
 
-
 async def override_set_hvac_mode(self, entity_id, hvac_mode):
     return False
-
 
 async def override_set_temperature(self, entity_id, temperature):
     return False

--- a/custom_components/better_thermostat/model_fixes/TS0601_thermostat.py
+++ b/custom_components/better_thermostat/model_fixes/TS0601_thermostat.py
@@ -11,17 +11,6 @@ def fix_local_calibration(self, entity_id, offset):
 
 
 def fix_target_temperature_calibration(self, entity_id, temperature):
-    _cur_trv_temp = float(
-        self.hass.states.get(entity_id).attributes["current_temperature"]
-    )
-    if _cur_trv_temp is None:
-        return temperature
-    if (
-        round(temperature, 1) > round(_cur_trv_temp, 1)
-        and temperature - _cur_trv_temp < 1.5
-    ):
-        temperature += 1.5
-
     return temperature
 
 


### PR DESCRIPTION
- removes "fix" which leads too high set points and significant overheating of rooms

## Motivation:

- Not transparent to the user, why Better Thermostat calculates "wrong" values.
- Does lead to overheating of rooms.

## Changes:

Removes not working fix.

## Related issue (check one):

- [x] fixes #1471
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2024.11.1
Zigbee2MQTT Version: 1.41.0
TRV Hardware: TS0601_thermostat

## New device mappings

<!-- If there was a new device mapping added, please make sure to fill in this checklist: -->

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

<!-- If you did change the `climate.py` please create a dedicated PR for this. -->
