### PR TITLE
Hotfix diagnostic data export - #1469

### DIFF
--- a/custom_components/better_thermostat/diagnostics.py
+++ b/custom_components/better_thermostat/diagnostics.py
@@ -19,16 +19,18 @@ async def async_get_config_entry_diagnostics(
         trv = hass.states.get(trv_id["trv"])
         if trv is None:
             continue
-        _adapter_name = await load_adapter(
-            hass, trv_id["integration"], trv_id["trv"], True
-        )
-        trv_id["adapter"] = _adapter_name
+        # TODO: this does nothing but return trv_id["integration"] as adapter_name
+        # -> removing this for now, to fix diagnostic export
+        # _adapter_name = await load_adapter(
+        #     hass, trv_id["integration"], trv_id["trv"], True
+        # )
+        # trv_id["adapter"] = _adapter_name
         trvs[trv_id["trv"]] = {
             "name": trv.name,
             "state": trv.state,
             "attributes": trv.attributes,
             "bt_config": trv_id["advanced"],
-            "bt_adapter": trv_id["adapter"],
+            # "bt_adapter": trv_id["adapter"],
             "bt_integration": trv_id["integration"],
             "model": trv_id["model"],
         }


### PR DESCRIPTION
## Motivation:
Fix #1469

The issue was introduced in #1371, where in _load_adapter the import was changed to use async_import_module instead, which needs hass as an object (which wasn't required/used before). All other calls to load_adapter pass "self" als the first object, while only diagnostic.py calls it with hass as the first object -> Therefore getting self.hass in load_adapter fails, since self = hass already

## Changes:
Idk what the original intention of calling load_adapter with "get_name=True" in diagnostic.py was, but in the current version it does nothing more but return `trv_id["integration"]`, which is already stored in "bt_integration" (no need to call load_adapter for this).
-> I commented out the problematic code for now, since it wouldn't provide any additional atm anyway. At least the diagostic export won't be completely broken anymore.
I'm sure this used to do something more useful in the past, but to properly fix the "bt_adapter" output, I need to figure out first when what it was supposed to actually contain. 

## Related issue (check one):

- [X] fixes #1469
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2024.12.1
Zigbee2MQTT Version: N/A
TRV Hardware: Demo