### PR TITLE
Helpers rework - rounding

### DIFF
--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -43,6 +43,9 @@ def calculate_calibration_local(self, entity_id) -> Union[float, None]:
     """
     _context = "_calculate_calibration_local()"
 
+    def _convert_to_float(value):
+        return convert_to_float(value, self.name, _context)
+
     if None in (self.cur_temp, self.bt_target_temp):
         return None
 
@@ -51,11 +54,9 @@ def calculate_calibration_local(self, entity_id) -> Union[float, None]:
     _cur_external_temp = self.cur_temp
     _cur_target_temp = self.bt_target_temp
 
-    _cur_trv_temp_f = convert_to_float(str(_cur_trv_temp_s), self.name, _context)
+    _cur_trv_temp_f = _convert_to_float(_cur_trv_temp_s)
 
-    _current_trv_calibration = convert_to_float(
-        str(self.real_trvs[entity_id]["last_calibration"]), self.name, _context
-    )
+    _current_trv_calibration = _convert_to_float(self.real_trvs[entity_id]["last_calibration"])
 
     if None in (
         _current_trv_calibration,
@@ -109,17 +110,12 @@ def calculate_calibration_local(self, entity_id) -> Union[float, None]:
     # Adjust based on the steps allowed by the local calibration entity
     _new_trv_calibration = round_by_steps(_new_trv_calibration, _calibration_steps)
 
-    # Compare against min/max
-    if _new_trv_calibration > float(self.real_trvs[entity_id]["local_calibration_max"]):
-        _new_trv_calibration = float(self.real_trvs[entity_id]["local_calibration_max"])
-    elif _new_trv_calibration < float(
-        self.real_trvs[entity_id]["local_calibration_min"]
-    ):
-        _new_trv_calibration = float(self.real_trvs[entity_id]["local_calibration_min"])
+    # limit new setpoint within min/max of the TRV's range
+    t_min = float(self.real_trvs[entity_id]["local_calibration_min"])
+    t_max = float(self.real_trvs[entity_id]["local_calibration_max"])
+    _new_trv_calibration = max(t_min, min(_new_trv_calibration, t_max))
 
-    _new_trv_calibration = convert_to_float(
-        str(_new_trv_calibration), self.name, _context
-    )
+    _new_trv_calibration = _convert_to_float(_new_trv_calibration)
 
     _logmsg = (
         "better_thermostat %s: %s - new local calibration: %s | external_temp: %s, "
@@ -203,11 +199,10 @@ def calculate_calibration_setpoint(self, entity_id) -> Union[float, None]:
 
     _calibrated_setpoint = round_down_to_half_degree(_calibrated_setpoint)
 
-    # check if new setpoint is inside the TRV's range, else set to min or max
-    if _calibrated_setpoint < self.real_trvs[entity_id]["min_temp"]:
-        _calibrated_setpoint = self.real_trvs[entity_id]["min_temp"]
-    if _calibrated_setpoint > self.real_trvs[entity_id]["max_temp"]:
-        _calibrated_setpoint = self.real_trvs[entity_id]["max_temp"]
+    # limit new setpoint within min/max of the TRV's range
+    t_min = self.real_trvs[entity_id]["min_temp"]
+    t_max = self.real_trvs[entity_id]["max_temp"]
+    _calibrated_setpoint = max(t_min, min(_calibrated_setpoint, t_max))
 
     _logmsg = (
         "better_thermostat %s: %s - new setpoint calibration: %s | external_temp: %s, "

--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -157,6 +157,7 @@ def calculate_calibration_setpoint(self, entity_id) -> Union[float, None]:
 
     _cur_external_temp = self.cur_temp
     _cur_target_temp = self.bt_target_temp
+    _trv_temp_steps = 1 / ( self.real_trvs[entity_id]["target_temp_step"] or 0.5 )
 
     if None in (_cur_target_temp, _cur_external_temp, _cur_trv_temp_s):
         return None
@@ -196,8 +197,7 @@ def calculate_calibration_setpoint(self, entity_id) -> Union[float, None]:
         if _cur_external_temp >= _cur_target_temp:
             _calibrated_setpoint -= (_cur_external_temp - _cur_target_temp) * 10.0
 
-    # TODO: round down to half degree step -> replace with rounding to step size
-    _calibrated_setpoint =  round_by_steps(_calibrated_setpoint, 2)
+    _calibrated_setpoint = round_by_steps(_calibrated_setpoint, _trv_temp_steps)
 
     # limit new setpoint within min/max of the TRV's range
     t_min = self.real_trvs[entity_id]["min_temp"]

--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -12,7 +12,7 @@ from custom_components.better_thermostat.utils.const import (
 
 from custom_components.better_thermostat.utils.helpers import (
     convert_to_float,
-    round_down_to_half_degree,
+    rounding,
     round_by_steps,
     heating_power_valve_position,
 )
@@ -197,7 +197,8 @@ def calculate_calibration_setpoint(self, entity_id) -> Union[float, None]:
         if _cur_external_temp >= _cur_target_temp:
             _calibrated_setpoint -= (_cur_external_temp - _cur_target_temp) * 10.0
 
-    _calibrated_setpoint = round_down_to_half_degree(_calibrated_setpoint)
+    # TODO: round down to half degree step -> replace with normal rounding to step size
+    _calibrated_setpoint =  round_by_steps(_calibrated_setpoint, 2, rounding.down)
 
     # limit new setpoint within min/max of the TRV's range
     t_min = self.real_trvs[entity_id]["min_temp"]

--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -12,7 +12,6 @@ from custom_components.better_thermostat.utils.const import (
 
 from custom_components.better_thermostat.utils.helpers import (
     convert_to_float,
-    rounding,
     round_by_steps,
     heating_power_valve_position,
 )
@@ -197,8 +196,8 @@ def calculate_calibration_setpoint(self, entity_id) -> Union[float, None]:
         if _cur_external_temp >= _cur_target_temp:
             _calibrated_setpoint -= (_cur_external_temp - _cur_target_temp) * 10.0
 
-    # TODO: round down to half degree step -> replace with normal rounding to step size
-    _calibrated_setpoint =  round_by_steps(_calibrated_setpoint, 2, rounding.down)
+    # TODO: round down to half degree step -> replace with rounding to step size
+    _calibrated_setpoint =  round_by_steps(_calibrated_setpoint, 2)
 
     # limit new setpoint within min/max of the TRV's range
     t_min = self.real_trvs[entity_id]["min_temp"]

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1073,7 +1073,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         Returns
         -------
         float
-                Steps of target temperature.
+                Step size of target temperature.
         """
         if self.bt_target_temp_step is not None:
             return self.bt_target_temp_step

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -827,7 +827,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 )
                 self.real_trvs[trv]["target_temp_step"] = convert_to_float(
                     str(
-                        self.hass.states.get(trv).attributes.get("target_temp_step", 1)
+                        self.hass.states.get(trv).attributes.get("target_temp_step", 0.5)
                     ),
                     self.device_name,
                     "startup",

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -77,7 +77,7 @@ def heating_power_valve_position(self, entity_id):
 
 
 def convert_to_float(
-    value: Union[str, int, float], instance_name: str, context: str
+    value: Union[str, float], instance_name: str, context: str
 ) -> Union[float, None]:
     """Convert value to float or print error message.
 
@@ -111,7 +111,7 @@ def convert_to_float(
             return None
 
 
-def calibration_round(value: Union[int, float, None]) -> Union[float, int, None]:
+def calibration_round(value: Union[float, None]) -> Union[float, None]:
     """Round the calibration value to the nearest 0.5.
 
     Parameters
@@ -135,8 +135,8 @@ def calibration_round(value: Union[int, float, None]) -> Union[float, int, None]
 
 
 def round_by_steps(
-    value: Union[int, float, None], steps: Union[int, float, None]
-) -> Union[float, int, None]:
+    value: Union[float, None], steps: Union[float, None]
+) -> Union[float, None]:
     """Round the value based on the allowed decimal 'steps'.
 
     Parameters
@@ -162,8 +162,8 @@ def round_by_steps(
 
 
 def round_down_to_half_degree(
-    value: Union[int, float, None]
-) -> Union[float, int, None]:
+    value: Union[float, None]
+) -> Union[float, None]:
     """Round the value down to the nearest 0.5.
 
     Parameters
@@ -189,7 +189,7 @@ def round_down_to_half_degree(
         return float(str(split[0]))
 
 
-def round_to_half_degree(value: Union[int, float, None]) -> Union[float, int, None]:
+def round_to_half_degree(value: Union[float, None]) -> Union[float, None]:
     """Rounds numbers to the nearest n.5/n.0
 
     Parameters
@@ -212,8 +212,8 @@ def round_to_half_degree(value: Union[int, float, None]) -> Union[float, int, No
 
 
 def round_to_hundredth_degree(
-    value: Union[int, float, None]
-) -> Union[float, int, None]:
+    value: Union[float, None]
+) -> Union[float, None]:
     """Rounds numbers to the nearest n.nn0
 
     Parameters

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -177,7 +177,7 @@ def round_down_to_half_degree(
     float
             the rounded value
     """
-    return round_by_steps(value, 2, "down")
+    return round_by_steps(value, 2, rounding.down)
 
 
 def round_to_half_degree(value: Union[float, None]) -> Union[float, None]:

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -110,25 +110,6 @@ def convert_to_float(
         return None
 
 
-def calibration_round(value: Union[float, None]) -> Union[float, None]:
-    """Round the calibration value up if > *.8, else down
-
-    Parameters
-    ----------
-    value : float
-            the value to round
-
-    Returns
-    -------
-    float
-            the rounded value
-    """
-    # FIXME: Had a wrong description! Why are we doing it this way - bug?
-    # Was supposed to "round to the nearest 0.5" (what 'round_to_half_degree' does),
-    # but actually we were rounding up at 0.9, and everything else down (to the next int, not even .5)
-    return round_by_steps(value + 0.1, 1, rounding.down)
-
-
 class rounding(Enum):
     # rounding functions that avoid errors due to using floats
 
@@ -160,60 +141,6 @@ def round_by_steps(
     if value is None or steps is None:
         return None
     return f_rounding(value * steps) / steps
-
-
-def round_down_to_half_degree(
-    value: Union[float, None]
-) -> Union[float, None]:
-    """Round the value down to the nearest 0.5.
-
-    Parameters
-    ----------
-    value : float
-            the value to round
-
-    Returns
-    -------
-    float
-            the rounded value
-    """
-    return round_by_steps(value, 2, rounding.down)
-
-
-def round_to_half_degree(value: Union[float, None]) -> Union[float, None]:
-    """Rounds numbers to the nearest n.5/n.0
-
-    Parameters
-    ----------
-    value : int, float
-            input value
-
-    Returns
-    -------
-    float
-            float rounded to n.5/n.0
-
-    """
-    return round_by_steps(value, 2)
-
-
-def round_to_hundredth_degree(
-    value: Union[float, None]
-) -> Union[float, None]:
-    """Rounds numbers to two digits
-
-    Parameters
-    ----------
-    value : int, float
-            input value
-
-    Returns
-    -------
-    float
-            a float rounded to n.nn
-
-    """
-    return round_by_steps(value, 100)
 
 
 def check_float(potential_float):


### PR DESCRIPTION
## Motivation:
A lot of code is unused and redundant, so cleaned this up before fixing #1475. I know a lot of these conversions back and forth were done to avoid the rounding error from floating point arithmetic, but I'm proposing easier ways to achieve this.

The 0.0001 offset for correcting this error is a bit of a hack as well, but I think it's the simplest solution, given that we do not need arbitrary precision or working with extremly large numbers.

## Changes:
- [X] removed "int" from type defs - redundant according to [PEP-0484](https://peps.python.org/pep-0484/#the-numeric-tower)
- [X] converted "round_by_step" to be a generic function for all usecases
- [X] Replaced all other rounding functions with a call to round_by_step
- [X] removed all unused rounding functions (so the previous change is useless, but in case you wanna keep some functions for some reason...)
- [X] Changed rounding method for target temperature calibration from down to nearest (#1475)
- [x] Changed rounding method for target temperature calibration from fixed 0.5°C to actual step size (#1475)

## Related issue (check one):

- [X] fixes #1475
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2024.12.1
Zigbee2MQTT Version: N/A (ZHA)
TRV Hardware: Demo and HmIP
