### PR TITLE
Bugfix - Support devices only having mode heat_cool instead of heat (#1322)

### DIFF
--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -354,34 +354,28 @@ def convert_outbound_states(self, entity_id, hvac_mode) -> dict | None:
                     )
 
             _system_modes = self.real_trvs[entity_id]["hvac_modes"]
-            _has_system_mode = False
-            if _system_modes is not None:
-                _has_system_mode = True
+            _has_system_mode = _system_modes is not None
 
             # Handling different devices with or without system mode reported or contained in the device config
 
             hvac_mode = mode_remap(self, entity_id, str(hvac_mode), False)
 
-            if _has_system_mode is False:
+            if not _has_system_mode:
                 _LOGGER.debug(
                     f"better_thermostat {self.device_name}: device config expects no system mode, while the device has one. Device system mode will be ignored"
                 )
                 if hvac_mode == HVACMode.OFF:
                     _new_heating_setpoint = self.real_trvs[entity_id]["min_temp"]
                 hvac_mode = None
-            if (
-                HVACMode.OFF not in _system_modes
-                or self.real_trvs[entity_id]["advanced"].get(
-                    "no_off_system_mode", False
-                )
-                is True
+            if hvac_mode == HVACMode.OFF and (
+                HVACMode.OFF not in _system_modes or
+                self.real_trvs[entity_id]["advanced"].get("no_off_system_mode")
             ):
-                if hvac_mode == HVACMode.OFF:
-                    _LOGGER.debug(
-                        f"better_thermostat {self.device_name}: sending 5°C to the TRV because this device has no system mode off and heater should be off"
-                    )
-                    _new_heating_setpoint = self.real_trvs[entity_id]["min_temp"]
-                    hvac_mode = None
+                _LOGGER.debug(
+                    f"better_thermostat {self.device_name}: sending 5°C to the TRV because this device has no system mode off and heater should be off"
+                )
+                _new_heating_setpoint = self.real_trvs[entity_id]["min_temp"]
+                hvac_mode = None
 
         return {
             "temperature": _new_heating_setpoint,

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -45,20 +45,19 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str:
     )
 
     if _heat_auto_swapped:
-        if hvac_mode == HVACMode.HEAT and inbound is False:
+        if hvac_mode == HVACMode.HEAT and not inbound:
             return HVACMode.AUTO
-        elif hvac_mode == HVACMode.AUTO and inbound is True:
+        if hvac_mode == HVACMode.AUTO and inbound:
             return HVACMode.HEAT
-        else:
-            return hvac_mode
-    else:
-        if hvac_mode != HVACMode.AUTO:
-            return hvac_mode
-        else:
-            _LOGGER.error(
-                f"better_thermostat {self.device_name}: {entity_id} HVAC mode {hvac_mode} is not supported by this device, is it possible that you forgot to set the heat auto swapped option?"
-            )
-            return HVACMode.OFF
+        return hvac_mode
+
+    if hvac_mode != HVACMode.AUTO:
+        return hvac_mode
+
+    _LOGGER.error(
+        f"better_thermostat {self.device_name}: {entity_id} HVAC mode {hvac_mode} is not supported by this device, is it possible that you forgot to set the heat auto swapped option?"
+    )
+    return HVACMode.OFF
 
 
 def heating_power_valve_position(self, entity_id):

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -51,6 +51,14 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str:
             return HVACMode.HEAT
         return hvac_mode
 
+    trv_modes = self.real_trvs[entity_id]["hvac_modes"]
+    if not HVACMode.HEAT in trv_modes and HVACMode.HEAT_COOL in trv_modes:
+        # entity only supports HEAT_COOL, but not HEAT - need to translate
+        if not inbound and hvac_mode = HVACMode.HEAT:
+            return HVACMode.HEAT_COOL
+        if inbound and hvac_mode = HVACMode.HEAT_COOL:
+            return HVACMode.HEAT
+
     if hvac_mode != HVACMode.AUTO:
         return hvac_mode
 


### PR DESCRIPTION
## Motivation:
Fix #1322 - Support devices only having mode `heat_cool`, but not `heat`

## Changes:
- Cleaned up some overly nested if's while scrolling through the code
- Remap HEAT -> HEAT_COOL (outbound) and HEAT_COOL -> HEAT (inbound), like the swap-auto feature
  (this seemed to be easiest and fastest solution for now)

## Related issue (check one):

- [X] fixes #1322; duplicates:
#1336
#1396
#1409
#1531
- [ ] there is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify your hardware/software which was used to test the code locally: -->

HA Version: 2024.12.1
Zigbee2MQTT Version:
TRV Hardware:
