### PR TITLE
Support Eurotronic Spirit Z-Wave valve

### DIFF
--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -101,13 +101,13 @@ def convert_to_float(
     """
     if value is None or value == "None":
         return None
-    try:
+        try:
         return round_by_steps(float(value), 10)
-    except (ValueError, TypeError, AttributeError, KeyError):
-        _LOGGER.debug(
-            f"better thermostat {instance_name}: Could not convert '{value}' to float in {context}"
-        )
-        return None
+        except (ValueError, TypeError, AttributeError, KeyError):
+            _LOGGER.debug(
+                f"better thermostat {instance_name}: Could not convert '{value}' to float in {context}"
+            )
+            return None
 
 
 class rounding(Enum):
@@ -222,7 +222,7 @@ async def find_valve_entity(self, entity_id):
         uid = entity.unique_id
         # Make sure we use the correct device entities
         if entity.device_id == reg_entity.device_id:
-            if "_valve_position" in uid or "_position" in uid:
+            if "_valve_position" in uid or "_position" in uid or "38-0-currentValue" in uid:
                 _LOGGER.debug(
                     f"better thermostat: Found valve position entity {entity.entity_id} for {entity_id}"
                 )


### PR DESCRIPTION
## Motivation:

For zwave_js, entity.unique_id is named differently: it is "XXXX-38-0-currentValue".
An other PR will come that add a adapters/zwave_js.py to fully support those devices.

## Changes:
Add "38-0-currentValue" pattern for valve detection
## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [X] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X ] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify the hardware/software which was used to test the code locally: -->

HA Version: Core 2024.12.5
Zigbee2MQTT Version: X
TRV Hardware: zwave_js

