### PR TITLE
#1553 - Fixed new rounding function for local_calibration

### DIFF
--- a/custom_components/better_thermostat/adapters/deconz.py
+++ b/custom_components/better_thermostat/adapters/deconz.py
@@ -34,8 +34,8 @@ async def get_current_offset(self, entity_id):
     return float(str(self.hass.states.get(entity_id).attributes.get("offset", 0)))
 
 
-async def get_offset_steps(self, entity_id):
-    """Get offset steps."""
+async def get_offset_step(self, entity_id):
+    """Get offset step."""
     return float(1.0)
 
 

--- a/custom_components/better_thermostat/adapters/delegate.py
+++ b/custom_components/better_thermostat/adapters/delegate.py
@@ -55,9 +55,9 @@ async def get_current_offset(self, entity_id):
     )
 
 
-async def get_offset_steps(self, entity_id):
+async def get_offset_step(self, entity_id):
     """get offset setps."""
-    return await self.real_trvs[entity_id]["adapter"].get_offset_steps(self, entity_id)
+    return await self.real_trvs[entity_id]["adapter"].get_offset_step(self, entity_id)
 
 
 async def get_min_offset(self, entity_id):

--- a/custom_components/better_thermostat/adapters/generic.py
+++ b/custom_components/better_thermostat/adapters/generic.py
@@ -64,8 +64,8 @@ async def get_current_offset(self, entity_id):
         return None
 
 
-async def get_offset_steps(self, entity_id):
-    """Get offset steps."""
+async def get_offset_step(self, entity_id):
+    """Get offset step."""
     if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is not None:
         return float(
             str(

--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -90,8 +90,8 @@ async def get_current_offset(self, entity_id):
     )
 
 
-async def get_offset_steps(self, entity_id):
-    """Get offset steps."""
+async def get_offset_step(self, entity_id):
+    """Get offset step."""
     return float(
         str(
             self.hass.states.get(

--- a/custom_components/better_thermostat/adapters/tado.py
+++ b/custom_components/better_thermostat/adapters/tado.py
@@ -33,8 +33,8 @@ async def get_current_offset(self, entity_id):
     )
 
 
-async def get_offset_steps(self, entity_id):
-    """Get offset steps."""
+async def get_offset_step(self, entity_id):
+    """Get offset step."""
     return float(0.01)
 
 

--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -11,7 +11,7 @@ from custom_components.better_thermostat.utils.const import (
 
 from custom_components.better_thermostat.utils.helpers import (
     convert_to_float,
-    round_by_steps,
+    round_by_step,
     heating_power_valve_position,
 )
 
@@ -57,7 +57,7 @@ def calculate_calibration_local(self, entity_id) -> float | None:
         return self.real_trvs[entity_id]["last_calibration"]
 
     _cur_trv_temp_s = self.real_trvs[entity_id]["current_temperature"]
-    _calibration_steps = self.real_trvs[entity_id]["local_calibration_steps"]
+    _calibration_step = self.real_trvs[entity_id]["local_calibration_step"]
     _cur_external_temp = self.cur_temp
     _cur_target_temp = self.bt_target_temp
 
@@ -71,12 +71,12 @@ def calculate_calibration_local(self, entity_id) -> float | None:
         _current_trv_calibration,
         _cur_external_temp,
         _cur_trv_temp_f,
-        _calibration_steps,
+        _calibration_step,
     ):
         _LOGGER.warning(
             f"better thermostat {self.device_name}: {entity_id} Could not calculate local calibration in {_context}:"
             f" trv_calibration: {_current_trv_calibration}, trv_temp: {_cur_trv_temp_f}, external_temp: {_cur_external_temp}"
-            f" calibration_steps: {_calibration_steps}"
+            f" calibration_step: {_calibration_step}"
         )
         return None
 
@@ -125,8 +125,8 @@ def calculate_calibration_local(self, entity_id) -> float | None:
                 _cur_external_temp - (_cur_target_temp + self.tolerance)
             ) * 8.0  # Reduced from 10.0 since we already add 2.0
 
-    # Adjust based on the steps allowed by the local calibration entity
-    _new_trv_calibration = round_by_steps(_new_trv_calibration, _calibration_steps)
+    # Adjust based on the step size allowed by the local calibration entity
+    _new_trv_calibration = round_by_step(_new_trv_calibration, _calibration_step)
 
     # limit new setpoint within min/max of the TRV's range
     t_min = float(self.real_trvs[entity_id]["local_calibration_min"])
@@ -185,7 +185,7 @@ def calculate_calibration_setpoint(self, entity_id) -> float | None:
 
     _cur_external_temp = self.cur_temp
     _cur_target_temp = self.bt_target_temp
-    _trv_temp_steps = 1 / (self.real_trvs[entity_id]["target_temp_step"] or 0.5)
+    _trv_temp_step = self.real_trvs[entity_id]["target_temp_step"] or 0.5
 
     if None in (_cur_target_temp, _cur_external_temp, _cur_trv_temp_s):
         return None
@@ -234,7 +234,7 @@ def calculate_calibration_setpoint(self, entity_id) -> float | None:
                 _cur_external_temp - (_cur_target_temp + self.tolerance)
             ) * 8.0  # Reduced from 10.0 since we already subtract 2.0
 
-    _calibrated_setpoint = round_by_steps(_calibrated_setpoint, _trv_temp_steps)
+    _calibrated_setpoint = round_by_step(_calibrated_setpoint, _trv_temp_step)
 
     # limit new setpoint within min/max of the TRV's range
     t_min = self.real_trvs[entity_id]["min_temp"]

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -46,7 +46,7 @@ from .adapters.delegate import (
     get_current_offset,
     get_max_offset,
     get_min_offset,
-    get_offset_steps,
+    get_offset_step,
     init,
     load_adapter,
 )
@@ -834,8 +834,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     self.real_trvs[trv]["local_calibration_max"] = await get_max_offset(
                         self, trv
                     )
-                    self.real_trvs[trv]["local_calibration_steps"] = (
-                        await get_offset_steps(self, trv)
+                    self.real_trvs[trv]["local_calibration_step"] = (
+                        await get_offset_step(self, trv)
                     )
                 else:
                     self.real_trvs[trv]["last_calibration"] = 0

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -108,7 +108,7 @@ def convert_to_float(
     if value is None or value == "None":
         return None
     try:
-        return round_by_steps(float(value), 10)
+        return round_by_step(float(value), 0.1)
     except (ValueError, TypeError, AttributeError, KeyError):
         _LOGGER.debug(
             f"better thermostat {instance_name}: Could not convert '{value}' to float in {context}"
@@ -129,15 +129,17 @@ class rounding(Enum):
         return round(x - 0.0001)
 
 
-def round_by_steps(
-    value: float | None, steps: float | None, f_rounding: rounding = rounding.nearest
+def round_by_step(
+    value: float | None, step: float | None, f_rounding: rounding = rounding.nearest
 ) -> float | None:
-    """Round the value based on the allowed decimal 'steps'.
+    """Round the value based on the allowed decimal 'step' size.
 
     Parameters
     ----------
     value : float
             the value to round
+    step : float
+            size of one step
 
     Returns
     -------
@@ -145,9 +147,10 @@ def round_by_steps(
             the rounded value
     """
 
-    if value is None or steps is None:
+    if value is None or step is None:
         return None
-    return f_rounding(value * steps) / steps
+    # convert to integer number of steps for rounding, then convert back to decimal
+    return f_rounding(value / step) * step
 
 
 def check_float(potential_float):


### PR DESCRIPTION
Seems "local_calibration_steps" is bad naming in our code, and actually refering to the step (size), not the number of step**s**. Therefore the new round_by_steps is "wrong" in local calibration mode, as the opposite was assumed. Issue wasn't apparent in my test, since I didn't have a TRV with local calibration yet.

## Motivation:
Fix bug - right now we round by the inverse of step size - e.g. 0.1° step = 10°C steps 😅 

## Changes:
Renamed "steps" to "step" (target_temp_step also was already a *step* and not *steps*, even though apparently they're both supposed to be the same thing) and corrected new rounding code, and made sure the function documentation is clear now.

## Related issue (check one):

- [X] fixes #1553
- [ ] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify the hardware/software which was used to test the code locally: -->

HA Version: 2024.12
Zigbee2MQTT Version: N/A (ZHA)
TRV Hardware: Bosch RBSH-TRV0-ZB-EU (Radiator Thermostat II)
