### PR TITLE
#1530: fix deprecation warning - config_entry set in base class

### DIFF
--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -118,6 +118,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.trv_bundle = []
         self.integration = None
         self.i = 0
+        super().__init__()
 
     @staticmethod
     @callback
@@ -390,13 +391,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
-        self.options = dict(config_entry.options)
         self.i = 0
         self.trv_bundle = []
         self.device_name = ""
         self._last_step = False
         self.updated_config = {}
+        super().__init__()
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""


### PR DESCRIPTION
Seems to be already handled in base-base class, see https://developers.home-assistant.io/blog/2024/11/12/options-flow/
(not in https://github.com/home-assistant/core/blob/dev/homeassistant/config_entries.py#L3169 - this is also deprecated/not needed anymore)

## Changes:
Fixed override of __init__ properly calling the base-class with super(), which also means the related lines here are now redundant and can be removed.

## Related issue (check one):

- [X] fixes #1530
- [ ] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify the hardware/software which was used to test the code locally: -->

HA Version: 2024.12
Zigbee2MQTT Version: N/A (ZHA)
TRV Hardware: