### PR TITLE
Implement set_preset_mode to fix HA scenes using BT (Fixes #1186)

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1357,6 +1357,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
     def preset_mode(self):
         return self._preset_mode
 
+    def set_preset_mode(self, preset_mode: str) -> None:
+        self._preset_mode = preset_mode
+
     @property
     def preset_modes(self):
         return [


### PR DESCRIPTION
## Motivation:
Enable BT to be used in scenes again

## Changes:
Add missing function to allow scenes to be created with BT devices in it

## Related issue (check one):

- [x] fixes #1186
- [ ] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify the hardware/software which was used to test the code locally: -->

HA Version: 2025.1.2
Zigbee2MQTT Version: <not applicable>
TRV Hardware: <not applicable>

## New device mappings

<!-- If a new device mapping has been added, please make sure to fill in this checklist: -->

- [X] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you changed the `climate.py` please create a dedicated PR for this. -->
