### PR TITLE
Fix invalid JSON in strings.json file

### DIFF
--- a/custom_components/better_thermostat/strings.json
+++ b/custom_components/better_thermostat/strings.json
@@ -67,7 +67,7 @@
                                         "window_off_delay": "Delay before the thermostat should turn off when the window is opened",
                                         "window_off_delay_after": "Delay before the thermostat should turn on when the window is closed",
                                         "outdoor_sensor": "Outdoor temperature sensor",
-                                        "weather": "Weather entity to get the outdoor temperature"
+                                        "weather": "Weather entity to get the outdoor temperature",
                                         "valve_maintenance": "If your thermostat has no own maintenance mode, you can use this one",
                                         "calibration": "The sort of calibration https://better-thermostat.org/configuration#second-step",
                                         "heat_auto_swapped": "If the auto means heat for your TRV and you want to swap it",


### PR DESCRIPTION
## Motivation:

Within https://github.com/KartoffelToby/better_thermostat/pull/1488 a small mistake sneaked into the `strings.json` file.
Since then the JSON file is invalid, a simple comma is missing.

## Changes:

This cahnge will add the missing comma to make the JSON file valid again.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify the hardware/software which was used to test the code locally: -->

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

<!-- If a new device mapping has been added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you changed the `climate.py` please create a dedicated PR for this. -->
