### PR TITLE
Remove hard coded 5° in debug message

### DIFF
--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -371,10 +371,11 @@ def convert_outbound_states(self, entity_id, hvac_mode) -> dict | None:
                 HVACMode.OFF not in _system_modes
                 or self.real_trvs[entity_id]["advanced"].get("no_off_system_mode")
             ):
+                _min_temp = self.real_trvs[entity_id]["min_temp"]
                 _LOGGER.debug(
-                    f"better_thermostat {self.device_name}: sending 5°C to the TRV because this device has no system mode off and heater should be off"
+                    f"better_thermostat {self.device_name}: sending {_min_temp}°C to the TRV because this device has no system mode off and heater should be off"
                 )
-                _new_heating_setpoint = self.real_trvs[entity_id]["min_temp"]
+                _new_heating_setpoint = _min_temp
                 hvac_mode = None
 
         return {


### PR DESCRIPTION
## Motivation:
Found this hard coded debug message and took it as an opportunity for first contribution

## Changes:
Replace hard-coded 5° by used min_temp value 

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [X] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.

## Test-Hardware list (for code changes)

Docker installation on amd64 Gentoo host.

HA Version: 2025.2.5
Zigbee2MQTT Version: - 
TRV Hardware: 
- Danfoss "Keemple smart radiator" (Z-Wave.js)
- Eurotronic "SPZB0001" (Zigbee)

## New device mappings
No