### PR TITLE
Add retries to delegate.py

### DIFF
--- a/custom_components/better_thermostat/adapters/delegate.py
+++ b/custom_components/better_thermostat/adapters/delegate.py
@@ -1,5 +1,13 @@
 from homeassistant.helpers.importlib import async_import_module
+
 import logging
+import asyncio
+import functools
+import logging
+import random
+from typing import Callable, TypeVar, Any
+
+from ..utils.retry import async_retry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,15 +47,18 @@ async def load_adapter(self, integration, entity_id, get_name=False):
     return self.adapter
 
 
+@async_retry(retries=5)
 async def init(self, entity_id):
     """Init adapter."""
     return await self.real_trvs[entity_id]["adapter"].init(self, entity_id)
 
 
+@async_retry(retries=5)
 async def get_info(self, entity_id):
     return await self.real_trvs[entity_id]["adapter"].get_info(self, entity_id)
 
 
+@async_retry(retries=5)
 async def get_current_offset(self, entity_id):
     """Get current offset."""
     return await self.real_trvs[entity_id]["adapter"].get_current_offset(
@@ -55,21 +66,25 @@ async def get_current_offset(self, entity_id):
     )
 
 
+@async_retry(retries=5)
 async def get_offset_step(self, entity_id):
     """get offset setps."""
     return await self.real_trvs[entity_id]["adapter"].get_offset_step(self, entity_id)
 
 
+@async_retry(retries=5)
 async def get_min_offset(self, entity_id):
     """Get min offset."""
     return await self.real_trvs[entity_id]["adapter"].get_min_offset(self, entity_id)
 
 
+@async_retry(retries=5)
 async def get_max_offset(self, entity_id):
     """Get max offset."""
     return await self.real_trvs[entity_id]["adapter"].get_max_offset(self, entity_id)
 
 
+@async_retry(retries=5)
 async def set_temperature(self, entity_id, temperature):
     """Set new target temperature."""
     return await self.real_trvs[entity_id]["adapter"].set_temperature(
@@ -77,6 +92,7 @@ async def set_temperature(self, entity_id, temperature):
     )
 
 
+@async_retry(retries=5)
 async def set_hvac_mode(self, entity_id, hvac_mode):
     """Set new target hvac mode."""
     return await self.real_trvs[entity_id]["adapter"].set_hvac_mode(
@@ -84,6 +100,7 @@ async def set_hvac_mode(self, entity_id, hvac_mode):
     )
 
 
+@async_retry(retries=5)
 async def set_offset(self, entity_id, offset):
     """Set new target offset."""
     return await self.real_trvs[entity_id]["adapter"].set_offset(
@@ -91,6 +108,7 @@ async def set_offset(self, entity_id, offset):
     )
 
 
+@async_retry(retries=5)
 async def set_valve(self, entity_id, valve):
     """Set new target valve."""
     return await self.real_trvs[entity_id]["adapter"].set_valve(self, entity_id, valve)

--- a/custom_components/better_thermostat/utils/retry.py
+++ b/custom_components/better_thermostat/utils/retry.py
@@ -1,0 +1,84 @@
+import asyncio
+import functools
+import logging
+import random
+from typing import Callable, TypeVar, Optional, Any
+
+_LOGGER = logging.getLogger(__name__)
+
+T = TypeVar('T')
+
+def async_retry(
+    retries: int = 1,
+    base_delay: float = 1.0,
+    jitter: float = 0.2,
+    backoff_factor: float = 2.0,
+    max_delay: float = 60.0,
+    exceptions: tuple = (Exception,),
+    log_level: str = "exception",
+    identifier: str = ""
+):
+    """
+    Decorator for retrying async functions when exceptions occur.
+
+    Args:
+        retries: Number of retries before giving up
+        base_delay: Initial delay between retries in seconds
+        jitter: Random jitter factor as a percentage (0.2 = 20% variation)
+        backoff_factor: Exponential backoff multiplier (2.0 = double the delay each retry)
+        max_delay: Maximum delay in seconds, regardless of backoff calculation
+        exceptions: Tuple of exceptions to catch and retry on
+        log_level: Logging level to use ("debug", "info", "warning", "error", "exception")
+        identifier: Optional identifier string to include in log messages
+    """
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs):
+            last_exception = None
+
+            # Extract entity_id from args/kwargs if available for better logging
+            entity_id = kwargs.get('entity_id', None)
+            if entity_id is None and len(args) > 2:  # Assuming self and entity_id are first two args
+                entity_id = args[1]
+
+            log_prefix = f"better_thermostat{f' {identifier}' if identifier else ''}: "
+            entity_suffix = f" to entity {entity_id}" if entity_id else ""
+
+            for attempt in range(retries + 1):
+                try:
+                    return await func(*args, **kwargs)
+                except exceptions as e:
+                    last_exception = e
+
+                    # Only log and delay if we're going to retry
+                    if attempt < retries:
+                        # Calculate exponential backoff
+                        delay = min(base_delay * (backoff_factor ** attempt), max_delay)
+
+                        # Apply jitter
+                        jitter_range = delay * jitter
+                        actual_delay = delay + random.uniform(-jitter_range, jitter_range)
+                        actual_delay = max(0.1, actual_delay)  # Ensure minimum delay
+
+                        log_message = f"{log_prefix}{func.__name__} attempt {attempt+1}/{retries+1} failed: {e}{entity_suffix}, retrying in {actual_delay:.2f}s"
+
+                        if log_level == "debug":
+                            _LOGGER.debug(log_message)
+                        elif log_level == "info":
+                            _LOGGER.info(log_message)
+                        elif log_level == "warning":
+                            _LOGGER.warning(log_message)
+                        elif log_level == "error":
+                            _LOGGER.error(log_message)
+                        else:  # Default to exception level
+                            _LOGGER.exception(log_message)
+
+                        await asyncio.sleep(actual_delay)
+
+            # If we got here, we ran out of retries
+            log_message = f"{log_prefix}{func.__name__} failed after {retries+1} attempts: {last_exception}{entity_suffix}"
+            _LOGGER.exception(log_message)
+            raise last_exception
+
+        return wrapper
+    return decorator


### PR DESCRIPTION
## Motivation:

Helps when e.g. zigbee connection is flaky or the TRV itself has a difficult time at the moment.

## Changes:

- added a `retry` module with an `async_retry` decorator
- armed `delegate` adapter with retries

## Related issue (check one):

- [x] fixes #1614 (maybe)
- [ ] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify the hardware/software which was used to test the code locally: -->

HA Version: 2025.3.3
Zigbee2MQTT Version: -
TRV Hardware: Sonoff TRVZB sw_build_id 1.3.0

## New device mappings

<!-- If a new device mapping has been added, please make sure to fill in this checklist: -->

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

<!-- If you changed the `climate.py` please create a dedicated PR for this. -->
