### PR TITLE
add "temperatur_offset" as a possible offset entity

### DIFF
--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -330,7 +330,7 @@ async def find_local_calibration_entity(self, entity_id):
         uid = entity.unique_id + " " + entity.entity_id
         # Make sure we use the correct device entities
         if entity.device_id == reg_entity.device_id:
-            if "temperature_calibration" in uid or "temperature_offset" in uid:
+            if "temperature_calibration" in uid or "temperature_offset" in uid or "temperatur_offset" in uid:
                 _LOGGER.debug(
                     f"better thermostat: Found local calibration entity {
                         entity.entity_id} for {entity_id}"


### PR DESCRIPTION
## Motivation:

I would like my Eve Thermo devices to be controlled using offset calibration.

## Changes:

The offset entity is written "temperatur_offset", this has been added to the list.

## Related issue (check one):

- [x] fixes #1279

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify the hardware/software which was used to test the code locally: -->

HA Version: 2025.3.4
Zigbee2MQTT Version: NONE
TRV Hardware: Eve Thermo 20EBP1701 (v3.5.1)
