### PR TITLE
Add Italian translations for Better Thermostat

### DIFF
--- a/custom_components/better_thermostat/translations/it.json
+++ b/custom_components/better_thermostat/translations/it.json
@@ -1,0 +1,162 @@
+{
+  "title": "Better Thermostat",
+  "config": {
+    "step": {
+      "user": {
+        "description": "Configura il tuo Better Thermostat per integrarlo con Home Assistant\n**Per maggiori informazioni: https://better-thermostat.org/configuration#first-step**",
+        "data": {
+          "name": "Nome",
+          "thermostat": "Il termostato reale",
+          "cooler": "Il dispositivo di raffreddamento (opzionale)",
+          "temperature_sensor": "Sensore di temperatura",
+          "humidity_sensor": "Sensore di umidità",
+          "window_sensors": "Sensore finestra",
+          "off_temperature": "Temperatura esterna alla quale il termostato si spegne",
+          "tolerance": "Tolleranza, per evitare che il termostato si accenda e spenga troppo spesso.",
+          "window_off_delay": "Ritardo prima che il termostato si spenga quando la finestra viene aperta",
+          "window_off_delay_after": "Ritardo prima che il termostato si riaccenda quando la finestra viene chiusa",
+          "outdoor_sensor": "Se hai un sensore esterno, puoi usarlo per ottenere la temperatura esterna",
+          "weather": "La tua entità meteo per ottenere la temperatura esterna"
+        }
+      },
+      "advanced": {
+        "description": "Configurazione avanzata {trv}\n***Informazioni sui tipi di calibrazione: https://better-thermostat.org/configuration#second-step***",
+        "data": {
+          "balance_mode": "Modalità di bilanciamento idraulico (Sperimentale)",
+          "trend_mix_trv": "Mix temperatura (peso esterno, 0–1)",
+          "percent_hysteresis_pts": "Isteresi (punti percentuali)",
+          "min_update_interval_s": "Intervallo minimo di aggiornamento (secondi)",
+          "pid_auto_tune": "Auto-taratura PID",
+          "pid_kp": "PID Kp",
+          "pid_ki": "PID Ki",
+          "pid_kd": "PID Kd",
+          "protect_overheating": "Protezione dal surriscaldamento?",
+          "heat_auto_swapped": "Se 'auto' indica riscaldamento per il tuo TRV e vuoi invertirlo",
+          "child_lock": "Ignora tutti gli input sul TRV come un blocco bambini",
+          "homematicip": "Se usi HomematicIP, abilita questa opzione per rallentare le richieste e prevenire il ciclo di lavoro eccessivo",
+          "valve_maintenance": "Se il tuo termostato non ha una modalità di manutenzione propria, puoi usare questa",
+          "calibration": "Tipo di calibrazione",
+          "calibration_mode": "Modalità di calibrazione",
+          "no_off_system_mode": "Se il tuo TRV non può gestire la modalità 'off', puoi abilitare questa opzione per usare 5°C come temperatura target"
+        },
+        "data_description": {
+          "balance_mode": "Scegli come Better Thermostat adatta l’apertura della valvola tra le stanze.\n***Nessuno / Off***: Nessun bilanciamento; i TRV funzionano normalmente.\n***Euristico (Sperimentale)***: Bilanciamento basato su regole semplici.\n***PID (Sperimentale)***: Controllo avanzato che richiede taratura.\n\nNota: Il bilanciamento idraulico è in Beta e può cambiare.",
+          "trend_mix_trv": "Peso della temperatura esterna rispetto a quella interna del TRV per il mix derivato. 0.0 = solo interna, 1.0 = solo esterna. Predefinito: 0.7.",
+          "percent_hysteresis_pts": "Zona morta intorno al target per evitare aperture/chiusure continue della valvola. Tipico: 1.0–3.0",
+          "min_update_interval_s": "Non inviare aggiornamenti della valvola più frequentemente di questo intervallo per risparmiare batteria e radio.",
+          "pid_auto_tune": "Permette al controllore di dedurre nel tempo valori PID stabili.",
+          "pid_kp": "Guadagno proporzionale (reattività all’errore).",
+          "pid_ki": "Guadagno integrale (elimina errori permanenti).",
+          "pid_kd": "Guadagno derivativo (smorza il superamento).",
+          "protect_overheating": "Alcuni TRV non chiudono completamente la valvola quando si raggiunge la temperatura. Oppure il radiatore mantiene molto calore residuo. Questa opzione può evitare il surriscaldamento.",
+          "calibration_mode": "Modalità di calcolo della calibrazione\n***Normale***: Il sensore interno di temperatura del TRV è corretto da quello esterno.\n***Aggressiva***: Il sensore interno del TRV è corretto da quello esterno ma impostato molto più basso/alto per ottenere una risposta più rapida.\n***Basata sul tempo AI***: Il sensore interno del TRV è corretto da quello esterno, ma un algoritmo personalizzato calcola il valore per migliorare l’algoritmo interno del TRV.",
+          "calibration": "Come deve essere applicata la calibrazione sul TRV (temperatura target o offset)\n***Basata sulla temperatura target***: Applica la calibrazione alla temperatura impostata.\n***Basata su offset***: Applica la calibrazione come offset."
+        }
+      },
+      "confirm": {
+        "title": "Conferma l’aggiunta di un Better Thermostat",
+        "description": "Stai per aggiungere `{name}` a Home Assistant.\nCon {trv} come termostato reale"
+      }
+    },
+    "error": {
+      "failed": "Qualcosa è andato storto.",
+      "no_name": "Per favore inserisci un nome.",
+      "no_off_mode": "Il tuo dispositivo è particolare e non ha una modalità 'off' :(\nBetter Thermostat userà invece la temperatura target minima.",
+      "no_outside_temp": "Non hai un sensore di temperatura esterna. Better Thermostat userà l’entità meteo al suo posto."
+    },
+    "abort": {
+      "single_instance_allowed": "È consentito un solo termostato per ogni dispositivo reale.",
+      "no_devices_found": "Nessuna entità termostato trovata. Assicurati di avere un’entità climate nel tuo Home Assistant"
+    }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "description": "Aggiorna le impostazioni del tuo Better Thermostat",
+        "data": {
+          "name": "Nome",
+          "thermostat": "Il termostato reale",
+          "temperature_sensor": "Sensore di temperatura",
+          "humidity_sensor": "Sensore di umidità",
+          "window_sensors": "Sensore finestra",
+          "off_temperature": "Temperatura esterna alla quale il termostato si spegne",
+          "tolerance": "Tolleranza, per evitare che il termostato si accenda e spenga troppo spesso.",
+          "window_off_delay": "Ritardo prima che il termostato si spenga quando la finestra viene aperta",
+          "window_off_delay_after": "Ritardo prima che il termostato si riaccenda quando la finestra viene chiusa",
+          "outdoor_sensor": "Se hai un sensore esterno, puoi usarlo per ottenere la temperatura esterna",
+          "valve_maintenance": "Se il tuo termostato non ha una modalità di manutenzione propria, puoi usare questa",
+          "calibration": "Tipo di calibrazione https://better-thermostat.org/configuration#second-step",
+          "weather": "La tua entità meteo per ottenere la temperatura esterna",
+          "heat_auto_swapped": "Se 'auto' indica riscaldamento per il tuo TRV e vuoi invertirlo",
+          "child_lock": "Ignora tutti gli input sul TRV come un blocco bambini",
+          "homematicip": "Se usi HomematicIP, abilita questa opzione per rallentare le richieste e prevenire il ciclo di lavoro"
+        }
+      },
+      "advanced": {
+        "description": "Configurazione avanzata {trv}\n***Informazioni sui tipi di calibrazione: https://better-thermostat.org/configuration#second-step***",
+        "data": {
+          "balance_mode": "Modalità di bilanciamento idraulico (Sperimentale)",
+          "trend_mix_trv": "Mix temperatura (peso esterno, 0–1)",
+          "percent_hysteresis_pts": "Isteresi (punti percentuali)",
+          "min_update_interval_s": "Intervallo minimo di aggiornamento (secondi)",
+          "pid_auto_tune": "Auto-taratura PID",
+          "pid_kp": "PID Kp",
+          "pid_ki": "PID Ki",
+          "pid_kd": "PID Kd",
+          "protect_overheating": "Protezione dal surriscaldamento?",
+          "heat_auto_swapped": "Se 'auto' indica riscaldamento per il tuo TRV e vuoi invertirlo",
+          "child_lock": "Ignora tutti gli input sul TRV come un blocco bambini",
+          "homematicip": "Se usi HomematicIP, abilita questa opzione per rallentare le richieste e prevenire il ciclo di lavoro",
+          "valve_maintenance": "Se il tuo termostato non ha una modalità di manutenzione propria, puoi usare questa",
+          "calibration": "Tipo di calibrazione che vuoi usare",
+          "calibration_mode": "Modalità di calibrazione",
+          "no_off_system_mode": "Se il tuo TRV non può gestire la modalità 'off', puoi abilitare questa opzione per usare 5°C come temperatura target"
+        },
+        "data_description": {
+          "balance_mode": "Scegli come Better Thermostat adatta l’apertura della valvola tra le stanze.\n***Nessuno / Off***: Nessun bilanciamento; i TRV funzionano normalmente.\n***Euristico (Sperimentale)***: Bilanciamento basato su regole semplici.\n***PID (Sperimentale)***: Controllo avanzato che richiede taratura.\n\nNota: Il bilanciamento idraulico è in Beta e può cambiare.",
+          "trend_mix_trv": "Peso della temperatura esterna rispetto a quella interna del TRV per il mix derivato. 0.0 = solo interna, 1.0 = solo esterna. Predefinito: 0.7.",
+          "percent_hysteresis_pts": "Zona morta intorno al target per evitare aperture/chiusure continue della valvola. Tipico: 1.0–3.0",
+          "min_update_interval_s": "Non inviare aggiornamenti della valvola più frequentemente di questo intervallo per risparmiare batteria e radio.",
+          "pid_auto_tune": "Permette al controllore di dedurre nel tempo valori PID stabili.",
+          "pid_kp": "Guadagno proporzionale (reattività all’errore).",
+          "pid_ki": "Guadagno integrale (elimina errori permanenti).",
+          "pid_kd": "Guadagno derivativo (smorza il superamento).",
+          "protect_overheating": "Alcuni TRV non chiudono completamente la valvola quando si raggiunge la temperatura. Oppure il radiatore mantiene molto calore residuo. Questa opzione può evitare il surriscaldamento.",
+          "calibration_mode": "Modalità di calcolo della calibrazione\n***Normale***: Il sensore interno di temperatura del TRV è corretto da quello esterno.\n***Aggressiva***: Il sensore interno del TRV è corretto da quello esterno ma impostato molto più basso/alto per ottenere una risposta più rapida.\n***Basata sul tempo AI***: Il sensore interno del TRV è corretto da quello esterno, ma un algoritmo personalizzato calcola il valore per migliorare l’algoritmo interno del TRV.",
+          "calibration": "Come deve essere applicata la calibrazione sul TRV (temperatura target o offset)\n***Basata sulla temperatura target***: Applica la calibrazione alla temperatura impostata.\n***Basata su offset***: Applica la calibrazione come offset."
+        }
+      }
+    }
+  },
+  "issues": {
+    "missing_entity": {
+      "title": "BT: {name} - entità collegata mancante",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "L’entità collegata {entity} è mancante",
+            "description": "La causa è che l’entità ({entity}) non è disponibile in Home Assistant.\n\nPuoi risolvere controllando che la batteria del dispositivo sia carica o riconnettendolo a HA. Assicurati che l’entità sia di nuovo presente in HA prima di continuare."
+          }
+        }
+      }
+    }
+  },
+  "services": {
+    "save_current_target_temperature": {
+      "name": "Salva temperatura attuale",
+      "description": "Salva la temperatura target corrente per poterla ripristinare in seguito."
+    },
+    "restore_saved_target_temperature": {
+      "name": "Ripristina temperatura",
+      "description": "Ripristina la temperatura target salvata."
+    },
+    "reset_heating_power": {
+      "name": "Reimposta potenza riscaldamento",
+      "description": "Reimposta la potenza di riscaldamento al valore predefinito."
+    },
+    "set_temp_target_temperature": {
+      "name": "Imposta temperatura eco",
+      "description": "Imposta la temperatura target su una modalità temporanea (come quella notturna) e salva la precedente."
+    }
+  }
+}


### PR DESCRIPTION
Added Italian translations for Better Thermostat configuration and options.

## Motivation:
Added missing italian translation
## Changes:
add it.json
## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [ ] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify the hardware/software which was used to test the code locally: -->

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

<!-- If a new device mapping has been added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you changed the `climate.py` please create a dedicated PR for this. -->
