### PR TITLE
Remove unused imports and variables

### DIFF
--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -7,7 +7,6 @@ convert thermostat states and prepare outbound payloads.
 
 from datetime import datetime
 import logging
-from typing import Any, Dict, cast
 from custom_components.better_thermostat.utils.const import CONF_HOMEMATICIP
 
 from homeassistant.components.climate.const import HVACMode
@@ -26,7 +25,6 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
     CalibrationMode,
 )
-from homeassistant.util import dt as dt_util
 
 from custom_components.better_thermostat.calibration import (
     calculate_calibration_local,

--- a/custom_components/better_thermostat/sensor.py
+++ b/custom_components/better_thermostat/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_state_change_event
 
-from .utils.const import CONF_HEATER, CONF_CALIBRATION_MODE, CalibrationMode
+from .utils.const import CONF_CALIBRATION_MODE, CalibrationMode
 
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = "better_thermostat"

--- a/custom_components/better_thermostat/utils/calibration/pid.py
+++ b/custom_components/better_thermostat/utils/calibration/pid.py
@@ -12,8 +12,8 @@ Notes:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Optional, Dict, Any
+from dataclasses import dataclass
+from typing import Dict, Any
 from time import monotonic
 import logging
 

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -5,7 +5,6 @@ import logging
 
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
-from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.better_thermostat.model_fixes.model_quirks import (
     override_set_hvac_mode,

--- a/custom_components/better_thermostat/utils/weather.py
+++ b/custom_components/better_thermostat/utils/weather.py
@@ -173,7 +173,7 @@ async def check_weather_prediction(self) -> bool:
             return bool(cond_cur or cond_fc)
         else:
             raise TypeError
-    except (TypeError, ServiceNotSupported, HomeAssistantError) as err:
+    except (TypeError, ServiceNotSupported, HomeAssistantError):
         _LOGGER.warning(
             "better_thermostat %s: no weather entity data found.", self.device_name
         )


### PR DESCRIPTION
## Summary
- **trv.py**: Remove unused typing imports (`Any`, `Dict`, `cast`) and `dt_util`
- **sensor.py**: Remove unused `CONF_HEATER` import
- **pid.py**: Remove unused `dataclasses.field` and `typing.Optional` imports
- **controlling.py**: Remove unused `HomeAssistantError` import
- **weather.py**: Remove unused exception variable