### PR TITLE
Fix NoneType AttributeError when entities are unavailable

### DIFF
--- a/custom_components/better_thermostat/adapters/deconz.py
+++ b/custom_components/better_thermostat/adapters/deconz.py
@@ -16,7 +16,10 @@ _LOGGER = logging.getLogger(__name__)
 
 async def get_info(self, entity_id):
     """Get info from TRV."""
-    _offset = self.hass.states.get(entity_id).attributes.get("offset", None)
+    state = self.hass.states.get(entity_id)
+    if state is None:
+        return {"support_offset": False, "support_valve": False}
+    _offset = state.attributes.get("offset", None)
     if _offset is None:
         return {"support_offset": False, "support_valve": False}
     return {"support_offset": True, "support_valve": False}

--- a/custom_components/better_thermostat/adapters/delegate.py
+++ b/custom_components/better_thermostat/adapters/delegate.py
@@ -100,11 +100,8 @@ async def set_temperature(self, entity_id, temperature):
         global_cfg_step = getattr(self, "bt_target_temp_step", None)
         if global_cfg_step in (0, 0.0):
             global_cfg_step = None
-        device_step = (
-            self.hass.states.get(entity_id).attributes.get("target_temp_step")
-            if self.hass.states.get(entity_id)
-            else None
-        )
+        state = self.hass.states.get(entity_id)
+        device_step = state.attributes.get("target_temp_step") if state else None
         step = per_trv_step or global_cfg_step or device_step or 0.5
         rounded = round_by_step(float(t), float(step))
     except Exception:

--- a/custom_components/better_thermostat/adapters/generic.py
+++ b/custom_components/better_thermostat/adapters/generic.py
@@ -77,13 +77,12 @@ async def get_current_offset(self, entity_id):
 async def get_offset_step(self, entity_id):
     """Get offset step."""
     if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is not None:
-        return float(
-            str(
-                self.hass.states.get(
-                    self.real_trvs[entity_id]["local_temperature_calibration_entity"]
-                ).attributes.get("step", 1)
-            )
+        state = self.hass.states.get(
+            self.real_trvs[entity_id]["local_temperature_calibration_entity"]
         )
+        if state is None:
+            return None
+        return float(str(state.attributes.get("step", 1)))
     else:
         return None
 
@@ -91,13 +90,12 @@ async def get_offset_step(self, entity_id):
 async def get_min_offset(self, entity_id):
     """Get min offset."""
     if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is not None:
-        return float(
-            str(
-                self.hass.states.get(
-                    self.real_trvs[entity_id]["local_temperature_calibration_entity"]
-                ).attributes.get("min", -10)
-            )
+        state = self.hass.states.get(
+            self.real_trvs[entity_id]["local_temperature_calibration_entity"]
         )
+        if state is None:
+            return -6.0
+        return float(str(state.attributes.get("min", -10)))
     else:
         return -6
 
@@ -105,13 +103,12 @@ async def get_min_offset(self, entity_id):
 async def get_max_offset(self, entity_id):
     """Get max offset."""
     if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is not None:
-        return float(
-            str(
-                self.hass.states.get(
-                    self.real_trvs[entity_id]["local_temperature_calibration_entity"]
-                ).attributes.get("max", 10)
-            )
+        state = self.hass.states.get(
+            self.real_trvs[entity_id]["local_temperature_calibration_entity"]
         )
+        if state is None:
+            return 6.0
+        return float(str(state.attributes.get("max", 10)))
     else:
         return 6
 

--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -70,9 +70,8 @@ async def init(self, entity_id):
             self.real_trvs[entity_id]["local_temperature_calibration_entity"],
         )
 
-        _has_preset = self.hass.states.get(entity_id).attributes.get(
-            "preset_modes", None
-        )
+        state = self.hass.states.get(entity_id)
+        _has_preset = state.attributes.get("preset_modes", None) if state else None
         if _has_preset is not None:
             await self.hass.services.async_call(
                 "climate",
@@ -114,35 +113,32 @@ async def get_current_offset(self, entity_id):
 
 async def get_offset_step(self, entity_id):
     """Get offset step."""
-    return float(
-        str(
-            self.hass.states.get(
-                self.real_trvs[entity_id]["local_temperature_calibration_entity"]
-            ).attributes.get("step", 1)
-        )
+    state = self.hass.states.get(
+        self.real_trvs[entity_id]["local_temperature_calibration_entity"]
     )
+    if state is None:
+        return 1.0
+    return float(str(state.attributes.get("step", 1)))
 
 
 async def get_min_offset(self, entity_id):
     """Get min offset."""
-    return float(
-        str(
-            self.hass.states.get(
-                self.real_trvs[entity_id]["local_temperature_calibration_entity"]
-            ).attributes.get("min", -10)
-        )
+    state = self.hass.states.get(
+        self.real_trvs[entity_id]["local_temperature_calibration_entity"]
     )
+    if state is None:
+        return -10.0
+    return float(str(state.attributes.get("min", -10)))
 
 
 async def get_max_offset(self, entity_id):
     """Get max offset."""
-    return float(
-        str(
-            self.hass.states.get(
-                self.real_trvs[entity_id]["local_temperature_calibration_entity"]
-            ).attributes.get("max", 10)
-        )
+    state = self.hass.states.get(
+        self.real_trvs[entity_id]["local_temperature_calibration_entity"]
     )
+    if state is None:
+        return 10.0
+    return float(str(state.attributes.get("max", 10)))
 
 
 async def set_offset(self, entity_id, offset):

--- a/tests/test_adapters_none_handling.py
+++ b/tests/test_adapters_none_handling.py
@@ -1,0 +1,179 @@
+"""Tests for adapter None handling.
+
+Tests that adapters properly handle None states when entities are unavailable.
+"""
+
+import pytest
+from unittest.mock import MagicMock, AsyncMock
+
+
+@pytest.fixture
+def anyio_backend():
+    """Configure anyio to use asyncio backend for async tests."""
+    return "asyncio"
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = MagicMock()
+    hass.states = MagicMock()
+    return hass
+
+
+@pytest.fixture
+def mock_bt_instance(mock_hass):
+    """Create a mock BetterThermostat instance."""
+    bt = MagicMock()
+    bt.hass = mock_hass
+    bt.device_name = "Test Thermostat"
+    bt.real_trvs = {
+        "climate.test_trv": {
+            "local_temperature_calibration_entity": "number.test_calibration"
+        }
+    }
+    return bt
+
+
+class TestDeconzAdapter:
+    """Tests for deCONZ adapter None handling."""
+
+    @pytest.mark.anyio
+    async def test_get_info_returns_false_when_state_is_none(self, mock_bt_instance):
+        """Test that get_info returns support_offset=False when state is None."""
+        from custom_components.better_thermostat.adapters.deconz import get_info
+
+        mock_bt_instance.hass.states.get.return_value = None
+
+        result = await get_info(mock_bt_instance, "climate.missing_entity")
+
+        assert result == {"support_offset": False, "support_valve": False}
+
+    @pytest.mark.anyio
+    async def test_get_info_returns_true_when_offset_exists(self, mock_bt_instance):
+        """Test that get_info returns support_offset=True when offset attribute exists."""
+        from custom_components.better_thermostat.adapters.deconz import get_info
+
+        mock_state = MagicMock()
+        mock_state.attributes = {"offset": 0.0}
+        mock_bt_instance.hass.states.get.return_value = mock_state
+
+        result = await get_info(mock_bt_instance, "climate.test_trv")
+
+        assert result == {"support_offset": True, "support_valve": False}
+
+
+class TestMqttAdapter:
+    """Tests for MQTT adapter None handling."""
+
+    @pytest.mark.anyio
+    async def test_get_offset_step_returns_default_when_state_is_none(
+        self, mock_bt_instance
+    ):
+        """Test that get_offset_step returns 1.0 when state is None."""
+        from custom_components.better_thermostat.adapters.mqtt import get_offset_step
+
+        mock_bt_instance.hass.states.get.return_value = None
+
+        result = await get_offset_step(mock_bt_instance, "climate.test_trv")
+
+        assert result == 1.0
+
+    @pytest.mark.anyio
+    async def test_get_min_offset_returns_default_when_state_is_none(
+        self, mock_bt_instance
+    ):
+        """Test that get_min_offset returns -10.0 when state is None."""
+        from custom_components.better_thermostat.adapters.mqtt import get_min_offset
+
+        mock_bt_instance.hass.states.get.return_value = None
+
+        result = await get_min_offset(mock_bt_instance, "climate.test_trv")
+
+        assert result == -10.0
+
+    @pytest.mark.anyio
+    async def test_get_max_offset_returns_default_when_state_is_none(
+        self, mock_bt_instance
+    ):
+        """Test that get_max_offset returns 10.0 when state is None."""
+        from custom_components.better_thermostat.adapters.mqtt import get_max_offset
+
+        mock_bt_instance.hass.states.get.return_value = None
+
+        result = await get_max_offset(mock_bt_instance, "climate.test_trv")
+
+        assert result == 10.0
+
+    @pytest.mark.anyio
+    async def test_get_offset_step_returns_attribute_when_state_exists(
+        self, mock_bt_instance
+    ):
+        """Test that get_offset_step returns attribute value when state exists."""
+        from custom_components.better_thermostat.adapters.mqtt import get_offset_step
+
+        mock_state = MagicMock()
+        mock_state.attributes = {"step": 0.5}
+        mock_bt_instance.hass.states.get.return_value = mock_state
+
+        result = await get_offset_step(mock_bt_instance, "climate.test_trv")
+
+        assert result == 0.5
+
+
+class TestGenericAdapter:
+    """Tests for generic adapter None handling."""
+
+    @pytest.mark.anyio
+    async def test_get_offset_step_returns_none_when_state_is_none(
+        self, mock_bt_instance
+    ):
+        """Test that get_offset_step returns None when state is None."""
+        from custom_components.better_thermostat.adapters.generic import get_offset_step
+
+        mock_bt_instance.hass.states.get.return_value = None
+
+        result = await get_offset_step(mock_bt_instance, "climate.test_trv")
+
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_get_min_offset_returns_default_when_state_is_none(
+        self, mock_bt_instance
+    ):
+        """Test that get_min_offset returns -6.0 when state is None."""
+        from custom_components.better_thermostat.adapters.generic import get_min_offset
+
+        mock_bt_instance.hass.states.get.return_value = None
+
+        result = await get_min_offset(mock_bt_instance, "climate.test_trv")
+
+        assert result == -6.0
+
+    @pytest.mark.anyio
+    async def test_get_max_offset_returns_default_when_state_is_none(
+        self, mock_bt_instance
+    ):
+        """Test that get_max_offset returns 6.0 when state is None."""
+        from custom_components.better_thermostat.adapters.generic import get_max_offset
+
+        mock_bt_instance.hass.states.get.return_value = None
+
+        result = await get_max_offset(mock_bt_instance, "climate.test_trv")
+
+        assert result == 6.0
+
+    @pytest.mark.anyio
+    async def test_get_offset_step_returns_none_when_no_calibration_entity(
+        self, mock_bt_instance
+    ):
+        """Test that get_offset_step returns None when no calibration entity configured."""
+        from custom_components.better_thermostat.adapters.generic import get_offset_step
+
+        mock_bt_instance.real_trvs = {
+            "climate.test_trv": {"local_temperature_calibration_entity": None}
+        }
+
+        result = await get_offset_step(mock_bt_instance, "climate.test_trv")
+
+        assert result is None


### PR DESCRIPTION
## Summary

Fixes crashes when TRV or calibration entities become temporarily unavailable. The adapters were accessing `.attributes` on state objects without first checking if the state was `None`.

### Changes:
- **deconz.py**: Add None check in `get_info()` before accessing attributes
- **mqtt.py**: Add None checks in `init()`, `get_offset_step()`, `get_min_offset()`, `get_max_offset()`
- **generic.py**: Add None checks in `get_offset_step()`, `get_min_offset()`, `get_max_offset()`
- **delegate.py**: Fix order of operations - check for None before accessing attributes

### Added Tests:
- 10 new tests for None handling in adapters

## Related Issues

- https://github.com/KartoffelToby/better_thermostat/issues/1460 - `Unavailable traceback when re-configured` (exact error in `adapters/generic.py`)
- https://github.com/KartoffelToby/better_thermostat/issues/1114 - `unsupported operand type(s) for -: 'NoneType' and 'float'`