### PR TITLE
Add minimum Home Assistant version to manifest

### DIFF
--- a/custom_components/better_thermostat/manifest.json
+++ b/custom_components/better_thermostat/manifest.json
@@ -14,6 +14,7 @@
     "recorder"
   ],
   "documentation": "https://github.com/KartoffelToby/better_thermostat",
+  "homeassistant": "2024.12.0",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/KartoffelToby/better_thermostat/issues",
   "requirements": [],


### PR DESCRIPTION
## Summary
- Closes #1530
- Adds `homeassistant: "2024.12.0"` to manifest.json
- PR #1557 fixed the deprecated `config_entry` pattern but requires HA 2024.12+
- Without this field, users with older HA versions may get runtime errors

## Test plan
- [x] Verified manifest.json is valid JSON