### PR TITLE
Fix cooler entity min/max temp not considered in range calculation

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1008,6 +1008,20 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             self.bt_min_temp = reduce_attribute(states, ATTR_MIN_TEMP, reduce=max)
             self.bt_max_temp = reduce_attribute(states, ATTR_MAX_TEMP, reduce=min)
 
+            if (
+                self.bt_min_temp is not None
+                and self.bt_max_temp is not None
+                and self.bt_min_temp > self.bt_max_temp
+            ):
+                _LOGGER.warning(
+                    "better_thermostat %s: min temp (%.1f°) > max temp (%.1f°). "
+                    "This indicates non-overlapping temperature ranges between "
+                    "heater and cooler entities. Please check your configuration.",
+                    self.device_name,
+                    self.bt_min_temp,
+                    self.bt_max_temp,
+                )
+
             if self.bt_target_temp_step == 0.0:
                 self.bt_target_temp_step = reduce_attribute(
                     states, ATTR_TARGET_TEMP_STEP, reduce=max

--- a/tests/test_cooler_minmax.py
+++ b/tests/test_cooler_minmax.py
@@ -13,7 +13,6 @@ bt_min_temp = max of all min_temps and bt_max_temp = min of all max_temps.
 
 import pytest
 from unittest.mock import MagicMock
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
 
 def reduce_attribute(states, attribute, reduce):


### PR DESCRIPTION
## Summary

Fixes #1588

- Include cooler entity's state in min/max temperature calculation
- Ensures BT's temperature range is the intersection of all controlled devices' ranges
- Prevents `ServiceValidationError` when cooler has narrower range than TRV

## Problem

When a TRV has range 4-35°C and a cooler (AC) has range 18-30°C, BT only calculated `bt_min_temp`/`bt_max_temp` from TRV states. This allowed temperatures up to 35°C, but when BT tried to send 32°C to the cooler, Home Assistant raised `ServiceValidationError`.

## Solution

Include the cooler entity in the `states` list used for min/max calculation:
- `bt_min_temp` = max of all min_temps (ensures all devices can reach the minimum)
- `bt_max_temp` = min of all max_temps (ensures all devices can reach the maximum)

## Test plan

- [x] Added tests for cooler min/max handling in `tests/test_cooler_minmax.py`
- [ ] Test with TRV + AC setup where AC has narrower range