### PR TITLE
Fix preset modes not available when config has empty list

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -414,7 +414,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             None  # Temperature saved before entering any preset mode
         )
         self._enabled_presets = enabled_presets
-        if self._enabled_presets is None:
+        if not self._enabled_presets:
             self._enabled_presets = [
                 PRESET_AWAY,
                 PRESET_BOOST,


### PR DESCRIPTION
## Summary

Fixes the preset availability issue reported in #1500.

**Problem:**
When no presets were explicitly configured during setup, `config_flow.py` saves an empty list `[]`. The check in `climate.py` only tested for `None`:

```python
if self._enabled_presets is None:
    self._enabled_presets = [PRESET_AWAY, PRESET_ECO, ...]
```

Since `[]` is not `None`, the default presets were never applied, resulting in:
- No preset modes in dropdown
- Automation errors like "Preset mode away is not valid"

**Fix:**
Changed to `if not self._enabled_presets:` which handles both `None` and empty list `[]`.

## Test plan
- [ ] Create a new BT entity without explicitly selecting presets
- [ ] Verify preset modes (away, eco, etc.) appear in the UI dropdown
- [ ] Verify automations can set preset modes without errors