### PR TITLE
Quickfix: revert unsupported homeassistant key in manifest.json

### DIFF
--- a/custom_components/better_thermostat/manifest.json
+++ b/custom_components/better_thermostat/manifest.json
@@ -14,7 +14,6 @@
     "recorder"
   ],
   "documentation": "https://github.com/KartoffelToby/better_thermostat",
-  "homeassistant": "2024.12.0",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/KartoffelToby/better_thermostat/issues",
   "requirements": [],


### PR DESCRIPTION
Reverts the `homeassistant` key added in #1807 as it's not supported by hassfest.

The minimum HA version is already specified in `hacs.json`.