### PR TITLE
Direct Valve Control of Sonoff TRVZB using ZHA on German translated HA

### DIFF
--- a/custom_components/better_thermostat/adapters/generic.py
+++ b/custom_components/better_thermostat/adapters/generic.py
@@ -39,9 +39,7 @@ async def init(self, entity_id):
     """
     # Try to discover valve position entity early
     try:
-        from ..utils.helpers import find_valve_entity as _find_valve
-
-        valve = await _find_valve(self, entity_id)
+        valve = await find_valve_entity(self, entity_id)
         if valve is not None:
             self.real_trvs[entity_id]["valve_position_entity"] = valve.get("entity_id")
             self.real_trvs[entity_id]["valve_position_writable"] = bool(

--- a/custom_components/better_thermostat/model_fixes/TRVZB.py
+++ b/custom_components/better_thermostat/model_fixes/TRVZB.py
@@ -89,6 +89,7 @@ async def maybe_set_sonoff_valve_percent(self, entity_id, percent: int) -> bool:
             # Prefer explicit Sonoff names first
             if (
                 "valve_opening_degree" in en
+                or "ventiloffnungswinkel" in en
                 or "valve_opening_degree" in uid
                 or "valve opening degree" in name
             ):
@@ -96,6 +97,7 @@ async def maybe_set_sonoff_valve_percent(self, entity_id, percent: int) -> bool:
                 continue
             if (
                 "valve_closing_degree" in en
+                or "ventilschliesswinkel" in en
                 or "valve_closing_degree" in uid
                 or "valve closing degree" in name
             ):
@@ -258,6 +260,7 @@ async def maybe_set_external_temperature(self, entity_id, temperature: float) ->
             name = (getattr(ent, "original_name", None) or "").lower()
             if (
                 "external_temperature_input" in en
+                or "wert_des_externen_temperatursensors" in en
                 or "external_temperature_input" in uid
                 or "external temperature input" in name
             ):

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -434,9 +434,9 @@ async def find_valve_entity(self, entity_id):
     def _classify(uid: str, ent_id: str, original_name: str) -> str | None:
         descriptor = f"{uid} {ent_id} {original_name}".lower()
         # Sonoff TRVZB (and some others) expose explicit valve degree entities
-        if "valve_opening_degree" in descriptor:
+        if "valve_opening_degree" in descriptor or "ventiloffnungswinkel" in descriptor:
             return "valve_opening_degree"
-        if "valve_closing_degree" in descriptor:
+        if "valve_closing_degree" in descriptor or "ventilschliesswinkel" in descriptor:
             return "valve_closing_degree"
 
         # Existing patterns


### PR DESCRIPTION
## Motivation:
Sonoff TRVZB using ZHA in german translated home assistant does not use direct valve control and the external temperature sensor also does not work.

## Changes:

## Related issue (check one):

- [x] fixes #1837 
- [x] fixes #1836  but only partly because you still need to enable the external temperature switch
- [ ] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify the hardware/software which was used to test the code locally: -->

Home Assistant: Core: 2026.1.0 Frontend: 20260107.0
Better Thermostat: Version 1.8.0-Beta-9

TRV(s): TRVZB SONOFF Firmware: 0x00001300

## New device mappings

<!-- If a new device mapping has been added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

<!-- If you changed the `climate.py` please create a dedicated PR for this. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic valve detection and optional valve control so the thermostat can discover writable valve devices and set valve positions.
  * Improved language support: recognizes German naming for valve position and external temperature entities to broaden device compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->