### PR TITLE
fix: Handle TypeError in check_float for None and invalid types

### DIFF
--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -364,7 +364,7 @@ def check_float(potential_float):
     try:
         float(potential_float)
         return True
-    except ValueError:
+    except (ValueError, TypeError):
         return False
 
 

--- a/tests/unit/test_check_float.py
+++ b/tests/unit/test_check_float.py
@@ -1,6 +1,5 @@
 """Tests for check_float function."""
 
-
 from custom_components.better_thermostat.utils.helpers import check_float
 
 

--- a/tests/unit/test_check_float.py
+++ b/tests/unit/test_check_float.py
@@ -4,7 +4,6 @@ This test file was extracted from the comprehensive helpers.py test suite
 in PR #1868 to accompany the bug fix for TypeError handling.
 """
 
-import pytest
 
 from custom_components.better_thermostat.utils.helpers import check_float
 

--- a/tests/unit/test_check_float.py
+++ b/tests/unit/test_check_float.py
@@ -1,8 +1,4 @@
-"""Tests for check_float function.
-
-This test file was extracted from the comprehensive helpers.py test suite
-in PR #1868 to accompany the bug fix for TypeError handling.
-"""
+"""Tests for check_float function."""
 
 
 from custom_components.better_thermostat.utils.helpers import check_float

--- a/tests/unit/test_check_float.py
+++ b/tests/unit/test_check_float.py
@@ -1,0 +1,47 @@
+"""Tests for check_float function.
+
+This test file was extracted from the comprehensive helpers.py test suite
+in PR #1868 to accompany the bug fix for TypeError handling.
+"""
+
+import pytest
+
+from custom_components.better_thermostat.utils.helpers import check_float
+
+
+class TestCheckFloat:
+    """Test check_float function."""
+
+    def test_returns_true_for_valid_float_string(self):
+        """Test that valid float strings return True."""
+        assert check_float("10.5") is True
+        assert check_float("20") is True
+        assert check_float("-5.5") is True
+        assert check_float("0.0") is True
+
+    def test_returns_true_for_scientific_notation(self):
+        """Test that scientific notation strings return True."""
+        assert check_float("1.5e-3") is True
+        assert check_float("1E10") is True
+        assert check_float("-2.5e+5") is True
+
+    def test_returns_true_for_float_number(self):
+        """Test that float numbers return True."""
+        assert check_float(10.5) is True
+        assert check_float(20) is True
+        assert check_float(-5.5) is True
+
+    def test_returns_false_for_invalid_string(self):
+        """Test that invalid strings return False."""
+        assert check_float("not_a_number") is False
+        assert check_float("10.5.5") is False
+        assert check_float("") is False
+
+    def test_returns_false_for_none(self):
+        """Test that None returns False."""
+        assert check_float(None) is False
+
+    def test_returns_false_for_invalid_types(self):
+        """Test that invalid types return False."""
+        assert check_float([]) is False
+        assert check_float({}) is False


### PR DESCRIPTION
## Summary

Fixes bug where `check_float()` raised `TypeError` instead of returning `False` when passed `None` or invalid types.

## Problem

The function only caught `ValueError` but not `TypeError`, which is raised when `float()` is called with incompatible types like `None`, lists, or dicts.

```python
# Before (crashes):
check_float(None)     # → TypeError
check_float([])       # → TypeError
check_float({})       # → TypeError

# After (returns False):
check_float(None)     # → False
check_float([])       # → False
check_float({})       # → False
```

## Changes

- Added `TypeError` to exception handling in `check_float()` (line 349)
- Added comprehensive tests extracted from #1868

## Related

- #1868 - Test coverage PR that discovered this bug
- Fixes bug #2 (HIGH severity) documented in #1868

## Testing

```bash
uv run pytest tests/unit/test_check_float.py -v
```

All 6 tests pass ✅

## Impact

- **Severity:** HIGH
- **Risk:** Minimal (only expands error handling)
- **Backward compatibility:** Full (only prevents crashes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric input validation improved to handle additional non-numeric/incompatible types more gracefully.

* **Tests**
  * Added comprehensive unit tests for numeric validation covering integers, negatives, scientific notation, floats, invalid strings, None, and other unsupported types.

* **Style**
  * Test formatting and layout adjusted for readability.

* **Chores**
  * Reserved an internal variable for future enhancement (no runtime behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->