### PR TITLE
fix: Extend lock coverage to prevent race conditions in parallel TRV control

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 
-from homeassistant.components.climate.const import PRESET_BOOST, HVACMode
+from homeassistant.components.climate.const import HVACMode
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
 from custom_components.better_thermostat.adapters.delegate import (

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -413,175 +413,6 @@ async def control_trv(self, heater_entity_id=None):
             self.device_name,
             heater_entity_id,
         )
-
-        _remapped_states = convert_outbound_states(
-            self, heater_entity_id, self.bt_hvac_mode
-        )
-        if not isinstance(_remapped_states, dict):
-            _LOGGER.debug(
-                "better_thermostat %s: ERROR %s %s",
-                self.device_name,
-                heater_entity_id,
-                _remapped_states,
-            )
-            await asyncio.sleep(10)
-            self.ignore_states = False
-            self.real_trvs[heater_entity_id]["ignore_trv_states"] = False
-            return False
-
-        _temperature = _remapped_states.get("temperature", None)
-        _calibration = _remapped_states.get("local_temperature_calibration", None)
-        _calibration_mode = self.real_trvs[heater_entity_id]["advanced"].get(
-            "calibration_mode", CalibrationMode.MPC_CALIBRATION
-        )
-        _calibration_type = self.real_trvs[heater_entity_id]["advanced"].get(
-            "calibration", CalibrationType.TARGET_TEMP_BASED
-        )
-
-        # Boost mode: set max temperature
-        if _is_boost_heating_active(self):
-            _temperature = self.real_trvs[heater_entity_id].get("max_temp", 30.0)
-
-        # Determine and apply valve control (boost or calibration-based)
-        bal, _source = _get_valve_control(
-            self, heater_entity_id, _calibration_mode, _calibration_type
-        )
-        try:
-            await _apply_valve_control(self, heater_entity_id, bal, _source)
-        except Exception:
-            _LOGGER.debug(
-                "better_thermostat %s: set_valve not applied for %s (unsupported or failed)",
-                self.device_name,
-                heater_entity_id,
-            )
-
-        _new_hvac_mode = handle_window_open(self, _remapped_states)
-
-        # Cooler is handled by control_cooler() in control_queue
-
-        # if we don't need to heat, we force HVACMode to be off
-        if self.call_for_heat is False:
-            _new_hvac_mode = HVACMode.OFF
-
-        # Reset valve when safety overrides force HVAC OFF during boost mode
-        await _reset_valve_on_safety_override(
-            self, heater_entity_id, _new_hvac_mode, _source
-        )
-
-        # Manage TRVs with no HVACMode.OFF
-        _no_off_system_mode = (
-            HVACMode.OFF not in self.real_trvs[heater_entity_id]["hvac_modes"]
-        ) or (
-            self.real_trvs[heater_entity_id]["advanced"].get(
-                "no_off_system_mode", False
-            )
-            is True
-        )
-        if _no_off_system_mode is True and _new_hvac_mode == HVACMode.OFF:
-            _min_temp = self.real_trvs[heater_entity_id]["min_temp"]
-            _LOGGER.debug(
-                "better_thermostat %s: sending %s°C to the TRV because this device has no system mode off and heater should be off",
-                self.device_name,
-                _min_temp,
-            )
-            _temperature = _min_temp
-
-        # send new HVAC mode to TRV, if it changed
-        if (
-            _new_hvac_mode is not None
-            and _new_hvac_mode != _trv.state
-            and (
-                (_no_off_system_mode is True and _new_hvac_mode != HVACMode.OFF)
-                or (_no_off_system_mode is False)
-            )
-        ):
-            _LOGGER.debug(
-                "better_thermostat %s: TO TRV set_hvac_mode: %s from: %s to: %s",
-                self.device_name,
-                heater_entity_id,
-                _trv.state,
-                _new_hvac_mode,
-            )
-            self.real_trvs[heater_entity_id]["last_hvac_mode"] = _new_hvac_mode
-            _tvr_has_quirk = await override_set_hvac_mode(
-                self, heater_entity_id, _new_hvac_mode
-            )
-            if _tvr_has_quirk is False:
-                await set_hvac_mode(self, heater_entity_id, _new_hvac_mode)
-            if self.real_trvs[heater_entity_id]["system_mode_received"] is True:
-                self.real_trvs[heater_entity_id]["system_mode_received"] = False
-                self.task_manager.create_task(check_system_mode(self, heater_entity_id))
-
-        # set new calibration offset
-        if (
-            _calibration is not None
-            and _new_hvac_mode != HVACMode.OFF
-            and _calibration_mode != CalibrationMode.NO_CALIBRATION
-        ):
-            _current_calibration_s = await get_current_offset(self, heater_entity_id)
-
-            if _current_calibration_s is None:
-                _LOGGER.error(
-                    "better_thermostat %s: calibration fatal error %s",
-                    self.device_name,
-                    heater_entity_id,
-                )
-                # this should not be before, set_hvac_mode (because if it fails, the new hvac mode will never be sent)
-                self.ignore_states = False
-                self.real_trvs[heater_entity_id]["ignore_trv_states"] = False
-                return True
-
-            _current_calibration = convert_to_float(
-                str(_current_calibration_s), self.device_name, "controlling()"
-            )
-
-            _calibration = float(str(_calibration))
-
-            _old_calibration = self.real_trvs[heater_entity_id].get(
-                "last_calibration", _current_calibration
-            )
-
-            if self.real_trvs[heater_entity_id][
-                "calibration_received"
-            ] is True and float(_old_calibration) != float(_calibration):
-                _LOGGER.debug(
-                    "better_thermostat %s: TO TRV set_local_temperature_calibration: %s from: %s to: %s",
-                    self.device_name,
-                    heater_entity_id,
-                    _old_calibration,
-                    _calibration,
-                )
-                await set_offset(self, heater_entity_id, _calibration)
-                self.real_trvs[heater_entity_id]["calibration_received"] = False
-
-        # set new target temperature
-        if _temperature is not None and (
-            _new_hvac_mode != HVACMode.OFF or _no_off_system_mode
-        ):
-            _current_set_temperature = self.real_trvs[heater_entity_id].get(
-                "temperature"
-            )
-            if _temperature != _current_set_temperature:
-                old = self.real_trvs[heater_entity_id].get("last_temperature", "?")
-                _LOGGER.debug(
-                    "better_thermostat %s: TO TRV set_temperature: %s from: %s to: %s",
-                    self.device_name,
-                    heater_entity_id,
-                    old,
-                    _temperature,
-                )
-                self.real_trvs[heater_entity_id]["last_temperature"] = _temperature
-                await set_temperature(self, heater_entity_id, _temperature)
-                if self.real_trvs[heater_entity_id]["target_temp_received"] is True:
-                    self.real_trvs[heater_entity_id]["target_temp_received"] = False
-                    self.task_manager.create_task(
-                        check_target_temperature(self, heater_entity_id)
-                    )
-
-        await asyncio.sleep(3)
-        # Don't retry - the TRV state change event will trigger a new control
-        # cycle when the TRV becomes available again. This prevents infinite
-        # retry loops that can freeze Home Assistant.
         self.real_trvs[heater_entity_id]["ignore_trv_states"] = False
         return True
 
@@ -614,16 +445,78 @@ async def control_trv(self, heater_entity_id=None):
         "calibration", CalibrationType.TARGET_TEMP_BASED
     )
 
-    # Boost mode: set max temperature
-    if _is_boost_heating_active(self):
-        _temperature = self.real_trvs[heater_entity_id].get("max_temp", 30.0)
-
-    # Determine and apply valve control (boost or calibration-based)
-    bal, _source = _get_valve_control(
-        self, heater_entity_id, _calibration_mode, _calibration_type
-    )
+    # Optional: set valve position if supported (e.g., MQTT/Z2M)
     try:
-        await _apply_valve_control(self, heater_entity_id, bal, _source)
+        _source = None
+        bal = None
+        if _calibration_type == CalibrationType.DIRECT_VALVE_BASED:
+            if _calibration_mode == CalibrationMode.MPC_CALIBRATION:
+                cal_bal = self.real_trvs[heater_entity_id].get("calibration_balance")
+                if (
+                    isinstance(cal_bal, dict)
+                    and cal_bal.get("apply_valve")
+                    and cal_bal.get("valve_percent") is not None
+                ):
+                    bal = cal_bal
+                    _source = "mpc_calibration"
+            elif _calibration_mode == CalibrationMode.TPI_CALIBRATION:
+                cal_bal = self.real_trvs[heater_entity_id].get("calibration_balance")
+                if (
+                    isinstance(cal_bal, dict)
+                    and cal_bal.get("apply_valve")
+                    and cal_bal.get("valve_percent") is not None
+                ):
+                    bal = cal_bal
+                    _source = "tpi_calibration"
+            elif _calibration_mode == CalibrationMode.HEATING_POWER_CALIBRATION:
+                cal_bal = self.real_trvs[heater_entity_id].get("calibration_balance")
+                if (
+                    isinstance(cal_bal, dict)
+                    and cal_bal.get("apply_valve")
+                    and cal_bal.get("valve_percent") is not None
+                ):
+                    bal = cal_bal
+                    _source = "heating_power_calibration"
+            elif _calibration_mode == CalibrationMode.PID_CALIBRATION:
+                cal_bal = self.real_trvs[heater_entity_id].get("calibration_balance")
+                if (
+                    isinstance(cal_bal, dict)
+                    and cal_bal.get("apply_valve")
+                    and cal_bal.get("valve_percent") is not None
+                ):
+                    bal = cal_bal
+                    _source = "pid_calibration"
+
+            if bal is None:
+                raw_balance = self.real_trvs[heater_entity_id].get("balance")
+                if raw_balance and raw_balance.get("valve_percent") is not None:
+                    bal = raw_balance
+                    _source = "balance"
+            if bal is not None:
+                target_pct = int(round(bal.get("valve_percent", 0)))
+                _LOGGER.debug(
+                    "better_thermostat %s: TO TRV set_valve: %s to: %s%% (source=%s)",
+                    self.device_name,
+                    heater_entity_id,
+                    target_pct,
+                    _source,
+                )
+                ok = await set_valve(self, heater_entity_id, target_pct)
+                if not ok:
+                    _LOGGER.debug(
+                        "better_thermostat %s: delegate.set_valve returned False (target=%s%%, entity=%s, source=%s)",
+                        self.device_name,
+                        target_pct,
+                        heater_entity_id,
+                        _source,
+                    )
+        else:
+            _LOGGER.debug(
+                "better_thermostat %s: TRV %s does not support direct valve control due to calibration type %s",
+                self.device_name,
+                heater_entity_id,
+                _calibration_type,
+            )
     except Exception:
         _LOGGER.debug(
             "better_thermostat %s: set_valve not applied for %s (unsupported or failed)",
@@ -633,14 +526,15 @@ async def control_trv(self, heater_entity_id=None):
 
     _new_hvac_mode = handle_window_open(self, _remapped_states)
 
-    # if we don't need to heat, we force HVACMode to be off
+    # wtom: disabled for now, switches off the trv all the time
+    # if not self.window_open:
+    # _new_hvac_mode = handle_hvac_mode_tolerance(self, _remapped_states)
+
+    # Removed cooler section from here, moved to control_queue/control_cooler
+
+    # if we don't need ot heat, we force HVACMode to be off
     if self.call_for_heat is False:
         _new_hvac_mode = HVACMode.OFF
-
-    # Reset valve when safety overrides force HVAC OFF during boost mode
-    await _reset_valve_on_safety_override(
-        self, heater_entity_id, _new_hvac_mode, _source
-    )
 
     # Manage TRVs with no HVACMode.OFF
     _no_off_system_mode = (

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -425,7 +425,7 @@ async def control_trv(self, heater_entity_id=None):
     # Extended lock scope to protect all critical operations including
     # set_valve(), set_hvac_mode(), set_offset(), set_temperature()
     # This prevents race conditions when control_queue runs control_trv()
-    # in parallel for multiple TRVs (Issue #1839, #1145, #875, #1733, #1849)
+    # in parallel for multiple TRVs
     async with self._temp_lock:
         self.real_trvs[heater_entity_id]["ignore_trv_states"] = True
         # Formerly update_hvac_action(self) (removed / centralized in climate entity)

--- a/tests/unit/test_race_condition_lock_coverage.py
+++ b/tests/unit/test_race_condition_lock_coverage.py
@@ -118,6 +118,7 @@ async def test_parallel_trv_control_no_race_condition():
     original_lock_acquire = mock_self._temp_lock.acquire
 
     async def tracked_acquire(*args, **kwargs):
+        """Track lock acquisition events for race condition detection."""
         nonlocal lock_acquired_count
         lock_acquired_count += 1
         execution_log.append(f"lock_acquire_{lock_acquired_count}")
@@ -160,21 +161,25 @@ async def test_parallel_trv_control_no_race_condition():
 
         # Simulate network delay in critical operations
         async def delayed_set_valve(*args, **kwargs):
+            """Mock set_valve with delay to detect interleaving."""
             execution_log.append(f"set_valve_start_{args[1]}")
             await asyncio.sleep(0.01)  # Simulate network delay
             execution_log.append(f"set_valve_end_{args[1]}")
 
         async def delayed_set_hvac_mode(*args, **kwargs):
+            """Mock set_hvac_mode with delay to detect interleaving."""
             execution_log.append(f"set_hvac_mode_start_{args[1]}")
             await asyncio.sleep(0.01)
             execution_log.append(f"set_hvac_mode_end_{args[1]}")
 
         async def delayed_set_offset(*args, **kwargs):
+            """Mock set_offset with delay to detect interleaving."""
             execution_log.append(f"set_offset_start_{args[1]}")
             await asyncio.sleep(0.01)
             execution_log.append(f"set_offset_end_{args[1]}")
 
         async def delayed_set_temp(*args, **kwargs):
+            """Mock set_temperature with delay to detect interleaving."""
             execution_log.append(f"set_temp_start_{args[1]}")
             await asyncio.sleep(0.01)
             execution_log.append(f"set_temp_end_{args[1]}")
@@ -440,21 +445,25 @@ async def test_lock_protects_critical_sections():
         }
 
         async def check_lock_on_set_valve(*args, **kwargs):
+            """Record lock state when set_valve is called."""
             lock_state_during_operations.append(
                 ("set_valve", mock_self._temp_lock.locked())
             )
 
         async def check_lock_on_set_hvac_mode(*args, **kwargs):
+            """Record lock state when set_hvac_mode is called."""
             lock_state_during_operations.append(
                 ("set_hvac_mode", mock_self._temp_lock.locked())
             )
 
         async def check_lock_on_set_offset(*args, **kwargs):
+            """Record lock state when set_offset is called."""
             lock_state_during_operations.append(
                 ("set_offset", mock_self._temp_lock.locked())
             )
 
         async def check_lock_on_set_temp(*args, **kwargs):
+            """Record lock state when set_temperature is called."""
             lock_state_during_operations.append(
                 ("set_temperature", mock_self._temp_lock.locked())
             )

--- a/tests/unit/test_race_condition_lock_coverage.py
+++ b/tests/unit/test_race_condition_lock_coverage.py
@@ -223,14 +223,12 @@ async def test_parallel_trv_control_no_race_condition():
 
                         # If multiple operations started before this one ended, we have interleaving
                         if starts_before > ends_before + 1:
-                            # This is expected with current bug!
-                            print(f"\nRace condition detected: {starts_before} operations started before this one ended")
-                            print(f"  Event: {event}")
-                            print(f"  Events before: {operation_events[:i]}")
-                            # Don't fail - this is the bug we're documenting!
-                            return
-
-            print("\nNo interleaving detected - operations ran sequentially")
+                            raise AssertionError(
+                                f"Race condition detected: {starts_before} operations started "
+                                f"before this one ended.\n"
+                                f"  Event: {event}\n"
+                                f"  Events before: {operation_events[:i]}"
+                            )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_race_condition_lock_coverage.py
+++ b/tests/unit/test_race_condition_lock_coverage.py
@@ -1,0 +1,432 @@
+"""Test race conditions in parallel TRV control (Bug #5).
+
+This test verifies that parallel execution of control_trv() for grouped TRVs
+doesn't cause race conditions due to incomplete lock coverage.
+
+Problem (Bug #5):
+- control_queue() runs control_trv() in parallel for all TRVs (asyncio.gather)
+- _temp_lock only protects lines 240-257
+- Critical operations outside lock: set_valve, set_hvac_mode, set_offset, set_temperature
+- Shared state access without protection: ignore_states, cur_temp, bt_target_temp
+
+Related Issues:
+- #1839: Automation stuck on climate.set_temperature (2 grouped TRVs)
+- #1145: Grouped TRVs automatically turn off
+- #875: Grouped thermostats turned to 30°C
+- #1733: BT changes Target Temp with no input from user
+- #1849: Random target temperature changes
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from homeassistant.components.climate.const import HVACMode
+
+from custom_components.better_thermostat.utils.const import (
+    CalibrationMode,
+    CalibrationType,
+)
+from custom_components.better_thermostat.utils.controlling import control_trv
+
+
+@pytest.mark.asyncio
+async def test_parallel_trv_control_no_race_condition():
+    """Test that parallel control_trv() calls don't cause race conditions.
+
+    Scenario: 2 grouped TRVs controlled simultaneously (like in Issue #1839)
+    Expected: Both TRVs complete successfully without state corruption
+    """
+    # Mock TRV states
+    mock_state_trv1 = Mock()
+    mock_state_trv1.state = HVACMode.HEAT
+    mock_state_trv1.attributes = {
+        "temperature": 22.0,
+        "current_temperature": 20.0,
+        "hvac_modes": [HVACMode.HEAT, HVACMode.OFF],
+    }
+
+    mock_state_trv2 = Mock()
+    mock_state_trv2.state = HVACMode.HEAT
+    mock_state_trv2.attributes = {
+        "temperature": 22.0,
+        "current_temperature": 20.0,
+        "hvac_modes": [HVACMode.HEAT, HVACMode.OFF],
+    }
+
+    mock_hass = Mock()
+    mock_hass.states.get.side_effect = lambda entity_id: (
+        mock_state_trv1 if entity_id == "climate.trv1" else mock_state_trv2
+    )
+
+    # Shared BetterThermostat instance (like in grouped TRVs scenario)
+    mock_self = Mock()
+    mock_self.hass = mock_hass
+    mock_self.device_name = "test_grouped_thermostat"
+    mock_self._temp_lock = asyncio.Lock()
+    mock_self.calculate_heating_power = AsyncMock()
+    mock_self.task_manager = Mock(create_task=Mock())
+    mock_self.cur_temp = 20.0
+    mock_self.bt_target_temp = 22.0
+    mock_self.bt_hvac_mode = HVACMode.HEAT
+
+    # Two TRVs sharing the same Better Thermostat instance
+    mock_self.real_trvs = {
+        "climate.trv1": {
+            "ignore_trv_states": False,
+            "hvac_modes": [HVACMode.HEAT, HVACMode.OFF],
+            "min_temp": 5.0,
+            "max_temp": 30.0,
+            "temperature": 22.0,
+            "last_hvac_mode": HVACMode.HEAT,
+            "system_mode_received": False,
+            "target_temp_received": False,
+            "calibration_received": False,
+            "model_quirks": Mock(override_set_hvac_mode=AsyncMock(return_value=False)),
+            "advanced": {
+                "calibration_mode": CalibrationMode.MPC_CALIBRATION,
+                "calibration": CalibrationType.TARGET_TEMP_BASED,
+            },
+        },
+        "climate.trv2": {
+            "ignore_trv_states": False,
+            "hvac_modes": [HVACMode.HEAT, HVACMode.OFF],
+            "min_temp": 5.0,
+            "max_temp": 30.0,
+            "temperature": 22.0,
+            "last_hvac_mode": HVACMode.HEAT,
+            "system_mode_received": False,
+            "target_temp_received": False,
+            "calibration_received": False,
+            "model_quirks": Mock(override_set_hvac_mode=AsyncMock(return_value=False)),
+            "advanced": {
+                "calibration_mode": CalibrationMode.MPC_CALIBRATION,
+                "calibration": CalibrationType.TARGET_TEMP_BASED,
+            },
+        },
+    }
+
+    # Track concurrent execution
+    execution_log = []
+    lock_acquired_count = 0
+
+    original_lock_acquire = mock_self._temp_lock.acquire
+
+    async def tracked_acquire(*args, **kwargs):
+        nonlocal lock_acquired_count
+        lock_acquired_count += 1
+        execution_log.append(f"lock_acquire_{lock_acquired_count}")
+        result = await original_lock_acquire(*args, **kwargs)
+        execution_log.append(f"lock_acquired_{lock_acquired_count}")
+        return result
+
+    mock_self._temp_lock.acquire = tracked_acquire
+
+    with patch(
+        "custom_components.better_thermostat.utils.controlling.convert_outbound_states"
+    ) as mock_convert, patch(
+        "custom_components.better_thermostat.utils.controlling.set_valve"
+    ) as mock_set_valve, patch(
+        "custom_components.better_thermostat.utils.controlling.set_hvac_mode"
+    ) as mock_set_hvac_mode, patch(
+        "custom_components.better_thermostat.utils.controlling.set_offset"
+    ) as mock_set_offset, patch(
+        "custom_components.better_thermostat.utils.controlling.set_temperature"
+    ) as mock_set_temp:
+
+        mock_convert.return_value = {
+            "temperature": 22.0,
+            "local_temperature_calibration": 0.0,
+            "system_mode": HVACMode.HEAT,
+        }
+
+        # Simulate network delay in critical operations
+        async def delayed_set_valve(*args, **kwargs):
+            execution_log.append(f"set_valve_start_{args[1]}")
+            await asyncio.sleep(0.01)  # Simulate network delay
+            execution_log.append(f"set_valve_end_{args[1]}")
+
+        async def delayed_set_hvac_mode(*args, **kwargs):
+            execution_log.append(f"set_hvac_mode_start_{args[1]}")
+            await asyncio.sleep(0.01)
+            execution_log.append(f"set_hvac_mode_end_{args[1]}")
+
+        async def delayed_set_offset(*args, **kwargs):
+            execution_log.append(f"set_offset_start_{args[1]}")
+            await asyncio.sleep(0.01)
+            execution_log.append(f"set_offset_end_{args[1]}")
+
+        async def delayed_set_temp(*args, **kwargs):
+            execution_log.append(f"set_temp_start_{args[1]}")
+            await asyncio.sleep(0.01)
+            execution_log.append(f"set_temp_end_{args[1]}")
+
+        mock_set_valve.side_effect = delayed_set_valve
+        mock_set_hvac_mode.side_effect = delayed_set_hvac_mode
+        mock_set_offset.side_effect = delayed_set_offset
+        mock_set_temp.side_effect = delayed_set_temp
+
+        # Run both TRVs in parallel (like control_queue does)
+        results = await asyncio.gather(
+            control_trv(mock_self, "climate.trv1"),
+            control_trv(mock_self, "climate.trv2"),
+            return_exceptions=True,
+        )
+
+        # Both should succeed
+        assert results[0] is True
+        assert results[1] is True
+
+        # At least one operation should have been called
+        total_calls = (
+            mock_set_temp.call_count
+            + mock_set_hvac_mode.call_count
+            + mock_set_offset.call_count
+            + mock_set_valve.call_count
+        )
+        assert total_calls >= 2, f"Expected at least 2 operation calls, got {total_calls}"
+
+        # CRITICAL TEST: Operations should NOT interleave
+        # If lock coverage is incomplete, we'll see interleaving like:
+        #   set_temp_start_trv1
+        #   set_temp_start_trv2  <- BAD! Started before trv1 finished
+        #   set_temp_end_trv1
+        #   set_temp_end_trv2
+        #
+        # With proper lock coverage, we should see:
+        #   set_temp_start_trv1
+        #   set_temp_end_trv1
+        #   set_temp_start_trv2  <- GOOD! Started after trv1 finished
+        #   set_temp_end_trv2
+
+        print("\nExecution log:")
+        for event in execution_log:
+            print(f"  {event}")
+
+        # Check for interleaving of ANY operation (not just set_temp)
+        # Look for set_hvac_mode since that's what actually gets called
+        operation_events = [e for e in execution_log if "set_hvac_mode" in e or "set_temp" in e]
+
+        if len(operation_events) >= 4:
+            # Find all starts and ends
+            starts = [e for e in operation_events if "start" in e]
+            ends = [e for e in operation_events if "end" in e]
+
+            if len(starts) >= 2 and len(ends) >= 2:
+                # Check for interleaving: any end before all starts
+                # This would indicate operations running concurrently
+                for i, event in enumerate(operation_events):
+                    if "end" in event:
+                        # Find how many starts came before this end
+                        starts_before = sum(1 for e in operation_events[:i] if "start" in e)
+                        ends_before = sum(1 for e in operation_events[:i] if "end" in e)
+
+                        # If multiple operations started before this one ended, we have interleaving
+                        if starts_before > ends_before + 1:
+                            # This is expected with current bug!
+                            print(f"\nRace condition detected: {starts_before} operations started before this one ended")
+                            print(f"  Event: {event}")
+                            print(f"  Events before: {operation_events[:i]}")
+                            # Don't fail - this is the bug we're documenting!
+                            return
+
+            print("\nNo interleaving detected - operations ran sequentially")
+
+
+@pytest.mark.asyncio
+async def test_shared_state_corruption_in_parallel_execution():
+    """Test that shared state doesn't get corrupted during parallel execution.
+
+    This tests the specific scenario from Issue #1839 where automation gets stuck.
+    """
+    mock_state = Mock()
+    mock_state.state = HVACMode.HEAT
+    mock_state.attributes = {
+        "temperature": 22.0,
+        "current_temperature": 20.0,
+        "hvac_modes": [HVACMode.HEAT, HVACMode.OFF],
+    }
+
+    mock_hass = Mock()
+    mock_hass.states.get.return_value = mock_state
+
+    mock_self = Mock()
+    mock_self.hass = mock_hass
+    mock_self.device_name = "test_thermostat"
+    mock_self._temp_lock = asyncio.Lock()
+    mock_self.calculate_heating_power = AsyncMock()
+    mock_self.task_manager = Mock(create_task=Mock())
+    mock_self.cur_temp = 20.0
+    mock_self.bt_target_temp = 22.0
+    mock_self.bt_hvac_mode = HVACMode.HEAT
+
+    # Track ignore_states changes
+    ignore_states_log = []
+
+    def track_ignore_states(entity_id, value):
+        ignore_states_log.append((entity_id, value, asyncio.current_task().get_name()))
+
+    mock_self.real_trvs = {
+        "climate.trv1": {
+            "ignore_trv_states": False,
+            "hvac_modes": [HVACMode.HEAT, HVACMode.OFF],
+            "min_temp": 5.0,
+            "max_temp": 30.0,
+            "temperature": 22.0,
+            "last_hvac_mode": HVACMode.HEAT,
+            "system_mode_received": False,
+            "target_temp_received": False,
+            "calibration_received": False,
+            "model_quirks": Mock(override_set_hvac_mode=AsyncMock(return_value=False)),
+            "advanced": {
+                "calibration_mode": CalibrationMode.MPC_CALIBRATION,
+                "calibration": CalibrationType.TARGET_TEMP_BASED,
+            },
+        },
+        "climate.trv2": {
+            "ignore_trv_states": False,
+            "hvac_modes": [HVACMode.HEAT, HVACMode.OFF],
+            "min_temp": 5.0,
+            "max_temp": 30.0,
+            "temperature": 22.0,
+            "last_hvac_mode": HVACMode.HEAT,
+            "system_mode_received": False,
+            "target_temp_received": False,
+            "calibration_received": False,
+            "model_quirks": Mock(override_set_hvac_mode=AsyncMock(return_value=False)),
+            "advanced": {
+                "calibration_mode": CalibrationMode.MPC_CALIBRATION,
+                "calibration": CalibrationType.TARGET_TEMP_BASED,
+            },
+        },
+    }
+
+    with patch(
+        "custom_components.better_thermostat.utils.controlling.convert_outbound_states"
+    ) as mock_convert, patch(
+        "custom_components.better_thermostat.utils.controlling.set_temperature"
+    ):
+
+        mock_convert.return_value = {
+            "temperature": 22.0,
+            "local_temperature_calibration": 0.0,
+            "system_mode": HVACMode.HEAT,
+        }
+
+        # Run both TRVs in parallel
+        results = await asyncio.gather(
+            control_trv(mock_self, "climate.trv1"),
+            control_trv(mock_self, "climate.trv2"),
+            return_exceptions=True,
+        )
+
+        # Both should complete
+        assert results[0] is True
+        assert results[1] is True
+
+        # Both ignore_trv_states should be reset to False
+        assert mock_self.real_trvs["climate.trv1"]["ignore_trv_states"] is False
+        assert mock_self.real_trvs["climate.trv2"]["ignore_trv_states"] is False
+
+        # With proper lock coverage, state should not be corrupted
+        # This test documents expected behavior; current code may fail
+
+
+@pytest.mark.asyncio
+async def test_lock_protects_critical_sections():
+    """Test that lock actually protects all critical operations.
+
+    This is a documentation test showing what SHOULD happen with proper lock coverage.
+    """
+    mock_state = Mock()
+    mock_state.state = HVACMode.HEAT
+    mock_state.attributes = {
+        "temperature": 22.0,
+        "current_temperature": 20.0,
+        "hvac_modes": [HVACMode.HEAT, HVACMode.OFF],
+    }
+
+    mock_hass = Mock()
+    mock_hass.states.get.return_value = mock_state
+
+    mock_self = Mock()
+    mock_self.hass = mock_hass
+    mock_self.device_name = "test_thermostat"
+    mock_self._temp_lock = asyncio.Lock()
+    mock_self.calculate_heating_power = AsyncMock()
+    mock_self.task_manager = Mock(create_task=Mock())
+    mock_self.cur_temp = 20.0
+    mock_self.bt_target_temp = 22.0
+    mock_self.bt_hvac_mode = HVACMode.HEAT
+    mock_self.real_trvs = {
+        "climate.trv1": {
+            "ignore_trv_states": False,
+            "hvac_modes": [HVACMode.HEAT, HVACMode.OFF],
+            "min_temp": 5.0,
+            "max_temp": 30.0,
+            "temperature": 22.0,
+            "last_hvac_mode": HVACMode.HEAT,
+            "system_mode_received": False,
+            "target_temp_received": False,
+            "calibration_received": False,
+            "model_quirks": Mock(override_set_hvac_mode=AsyncMock(return_value=False)),
+            "advanced": {
+                "calibration_mode": CalibrationMode.MPC_CALIBRATION,
+                "calibration": CalibrationType.TARGET_TEMP_BASED,
+            },
+        },
+    }
+
+    # Track lock state during critical operations
+    lock_state_during_operations = []
+
+    with patch(
+        "custom_components.better_thermostat.utils.controlling.convert_outbound_states"
+    ) as mock_convert, patch(
+        "custom_components.better_thermostat.utils.controlling.set_valve"
+    ) as mock_set_valve, patch(
+        "custom_components.better_thermostat.utils.controlling.set_hvac_mode"
+    ) as mock_set_hvac_mode, patch(
+        "custom_components.better_thermostat.utils.controlling.set_offset"
+    ) as mock_set_offset, patch(
+        "custom_components.better_thermostat.utils.controlling.set_temperature"
+    ) as mock_set_temp:
+
+        mock_convert.return_value = {
+            "temperature": 22.0,
+            "local_temperature_calibration": 0.0,
+            "system_mode": HVACMode.HEAT,
+        }
+
+        async def check_lock_on_set_valve(*args, **kwargs):
+            lock_state_during_operations.append(("set_valve", mock_self._temp_lock.locked()))
+
+        async def check_lock_on_set_hvac_mode(*args, **kwargs):
+            lock_state_during_operations.append(("set_hvac_mode", mock_self._temp_lock.locked()))
+
+        async def check_lock_on_set_offset(*args, **kwargs):
+            lock_state_during_operations.append(("set_offset", mock_self._temp_lock.locked()))
+
+        async def check_lock_on_set_temp(*args, **kwargs):
+            lock_state_during_operations.append(("set_temperature", mock_self._temp_lock.locked()))
+
+        mock_set_valve.side_effect = check_lock_on_set_valve
+        mock_set_hvac_mode.side_effect = check_lock_on_set_hvac_mode
+        mock_set_offset.side_effect = check_lock_on_set_offset
+        mock_set_temp.side_effect = check_lock_on_set_temp
+
+        result = await control_trv(mock_self, "climate.trv1")
+
+        assert result is True
+
+        # CRITICAL: All operations should run while lock is held
+        # With current code (bug), this will FAIL because lock is released before operations
+        print("\nLock state during critical operations:")
+        for operation, locked in lock_state_during_operations:
+            print(f"  {operation}: locked={locked}")
+
+        for operation, locked in lock_state_during_operations:
+            assert locked is True, (
+                f"Operation {operation} ran WITHOUT lock protection! "
+                f"This causes race conditions in parallel execution."
+            )

--- a/tests/unit/test_race_condition_lock_coverage.py
+++ b/tests/unit/test_race_condition_lock_coverage.py
@@ -20,8 +20,8 @@ Related Issues:
 import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
-import pytest
 from homeassistant.components.climate.const import HVACMode
+import pytest
 
 from custom_components.better_thermostat.utils.const import (
     CalibrationMode,

--- a/tests/unit/test_unavailable_trv_no_operations.py
+++ b/tests/unit/test_unavailable_trv_no_operations.py
@@ -1,0 +1,71 @@
+"""Test that unavailable TRVs don't execute control operations.
+
+This test verifies the fix for the incomplete PR #1813 implementation.
+
+Problem: After PR #1813, the code logged "skipping control" for unavailable TRVs
+but still executed all control operations (Lines 271-582):
+- convert_outbound_states()
+- set_valve()
+- set_hvac_mode()
+- set_offset()
+- set_temperature()
+
+Fix: Return True immediately after detecting unavailable TRV, without executing
+any operations.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import STATE_UNAVAILABLE
+
+from custom_components.better_thermostat.utils.const import CalibrationMode
+from custom_components.better_thermostat.utils.controlling import control_trv
+
+
+@pytest.mark.asyncio
+async def test_unavailable_trv_no_operations_called():
+    """Test that unavailable TRVs don't execute any control operations."""
+    mock_state = Mock()
+    mock_state.state = STATE_UNAVAILABLE
+
+    mock_hass = Mock()
+    mock_hass.states.get.return_value = mock_state
+
+    mock_self = Mock()
+    mock_self.hass = mock_hass
+    mock_self.device_name = "test_thermostat"
+    mock_self._temp_lock = asyncio.Lock()
+    mock_self.calculate_heating_power = AsyncMock()
+    mock_self.real_trvs = {
+        "climate.trv1": {
+            "ignore_trv_states": False,
+            "advanced": {
+                "calibration_mode": CalibrationMode.MPC_CALIBRATION,
+            },
+        }
+    }
+
+    with patch(
+        "custom_components.better_thermostat.utils.controlling.convert_outbound_states"
+    ) as mock_convert, patch(
+        "custom_components.better_thermostat.utils.controlling.set_valve"
+    ) as mock_set_valve, patch(
+        "custom_components.better_thermostat.utils.controlling.set_hvac_mode"
+    ) as mock_set_hvac_mode, patch(
+        "custom_components.better_thermostat.utils.controlling.set_offset"
+    ) as mock_set_offset, patch(
+        "custom_components.better_thermostat.utils.controlling.set_temperature"
+    ) as mock_set_temp:
+        result = await control_trv(mock_self, "climate.trv1")
+
+        assert result is True
+
+        # Verify no operations were called
+        mock_convert.assert_not_called()
+        mock_set_valve.assert_not_called()
+        mock_set_hvac_mode.assert_not_called()
+        mock_set_offset.assert_not_called()
+        mock_set_temp.assert_not_called()

--- a/tests/unit/test_unavailable_trv_no_operations.py
+++ b/tests/unit/test_unavailable_trv_no_operations.py
@@ -36,23 +36,27 @@ async def test_unavailable_trv_no_operations_called():
     mock_self.real_trvs = {
         "climate.trv1": {
             "ignore_trv_states": False,
-            "advanced": {
-                "calibration_mode": CalibrationMode.MPC_CALIBRATION,
-            },
+            "advanced": {"calibration_mode": CalibrationMode.MPC_CALIBRATION},
         }
     }
 
-    with patch(
-        "custom_components.better_thermostat.utils.controlling.convert_outbound_states"
-    ) as mock_convert, patch(
-        "custom_components.better_thermostat.utils.controlling.set_valve"
-    ) as mock_set_valve, patch(
-        "custom_components.better_thermostat.utils.controlling.set_hvac_mode"
-    ) as mock_set_hvac_mode, patch(
-        "custom_components.better_thermostat.utils.controlling.set_offset"
-    ) as mock_set_offset, patch(
-        "custom_components.better_thermostat.utils.controlling.set_temperature"
-    ) as mock_set_temp:
+    with (
+        patch(
+            "custom_components.better_thermostat.utils.controlling.convert_outbound_states"
+        ) as mock_convert,
+        patch(
+            "custom_components.better_thermostat.utils.controlling.set_valve"
+        ) as mock_set_valve,
+        patch(
+            "custom_components.better_thermostat.utils.controlling.set_hvac_mode"
+        ) as mock_set_hvac_mode,
+        patch(
+            "custom_components.better_thermostat.utils.controlling.set_offset"
+        ) as mock_set_offset,
+        patch(
+            "custom_components.better_thermostat.utils.controlling.set_temperature"
+        ) as mock_set_temp,
+    ):
         result = await control_trv(mock_self, "climate.trv1")
 
         assert result is True

--- a/tests/unit/test_unavailable_trv_no_operations.py
+++ b/tests/unit/test_unavailable_trv_no_operations.py
@@ -1,17 +1,12 @@
 """Test that unavailable TRVs don't execute control operations.
 
-This test verifies the fix for the incomplete PR #1813 implementation.
-
-Problem: After PR #1813, the code logged "skipping control" for unavailable TRVs
-but still executed all control operations (Lines 271-582):
+Verifies that control_trv() returns True immediately when a TRV is
+unavailable, without calling any control functions:
 - convert_outbound_states()
 - set_valve()
 - set_hvac_mode()
 - set_offset()
 - set_temperature()
-
-Fix: Return True immediately after detecting unavailable TRV, without executing
-any operations.
 """
 
 import asyncio

--- a/tests/unit/test_unavailable_trv_no_operations.py
+++ b/tests/unit/test_unavailable_trv_no_operations.py
@@ -17,9 +17,8 @@ any operations.
 import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
-import pytest
-from homeassistant.components.climate.const import HVACMode
 from homeassistant.const import STATE_UNAVAILABLE
+import pytest
 
 from custom_components.better_thermostat.utils.const import CalibrationMode
 from custom_components.better_thermostat.utils.controlling import control_trv


### PR DESCRIPTION
## Problem

`control_queue()` runs `control_trv()` in parallel for all TRVs via `asyncio.gather()`. But `_temp_lock` in `control_trv()` only protected a small block at the top — the state fetch and `ignore_trv_states` flag — while all actual TRV operations ran **outside** the lock:

```
async def control_trv(self, heater_entity_id=None):
    async with self._temp_lock:                          # Lock acquired
        self.real_trvs[...]["ignore_trv_states"] = True
        ...
        _trv = self.hass.states.get(heater_entity_id)
                                                         # Lock released here!
    _trv = self.hass.states.get(heater_entity_id)        # Duplicate fetch (outside lock)
    ...
    _remapped_states = convert_outbound_states(...)       # No lock
    await set_valve(...)                                  # No lock
    await set_hvac_mode(...)                              # No lock
    await set_offset(...)                                 # No lock
    await set_temperature(...)                            # No lock
    await asyncio.sleep(3)                                # No lock
```

This means two parallel `control_trv()` calls (e.g., for TRV1 and TRV2) could interleave their operations:

```
TRV1: set_hvac_mode(HEAT)
TRV2: set_hvac_mode(HEAT)     ← interleaved
TRV1: set_temperature(22)
TRV2: set_temperature(22)     ← interleaved
```

Symptoms:
- Automations stuck on `climate.set_temperature` (#1839)
- Grouped TRVs turning off unexpectedly (#1145)
- Random temperature jumps to 30°C (#875)
- Unexplained target temperature changes (#1733, #1849)

## Solution

### 1. Extended `_temp_lock` to cover all critical operations

```
async def control_trv(self, heater_entity_id=None):
    if not heater_entity_id or heater_entity_id not in self.real_trvs:
        return False                                     # Guard clause (new)

    async with self._temp_lock:                          # Lock acquired
        self.real_trvs[...]["ignore_trv_states"] = True
        _trv = self.hass.states.get(heater_entity_id)    # Single fetch (deduplicated)
        ...
        _remapped_states = convert_outbound_states(...)   # Protected
        await set_valve(...)                              # Protected
        await set_hvac_mode(...)                          # Protected
        await set_offset(...)                             # Protected
        await set_temperature(...)                        # Protected
                                                         # Lock released here
    await asyncio.sleep(3)                               # Outside lock (intentional)
```

The 3-second sleep stays **outside** the lock so TRVs can be controlled in parallel — only the actual operations are serialized.

### 2. Fixed `calibration_received` getting stuck

When `ignore_trv_states` is True during control, TRV state change events are suppressed. If the TRV confirms a calibration change during this window, `calibration_received` stays False forever, blocking future calibration updates. Now checks if current calibration already matches target and resets the flag.

### 3. Replaced `self.ignore_states` with per-TRV `ignore_trv_states`

The old code set the global `self.ignore_states = False` in error paths inside `control_trv()`. This flag is managed by `control_queue()` and should not be touched by individual TRV control. Replaced with per-TRV `ignore_trv_states` to avoid one TRV's error prematurely re-enabling state events for all TRVs.

### 4. Other fixes

- Guard clause for missing/invalid `heater_entity_id`
- Unavailable check for TRVs in `check_target_temperature()` polling loop
- Removed duplicate `_trv = self.hass.states.get()` call
- Moved `calculate_heating_power()` to `control_queue()` (once per cycle, not per TRV)
- Reduced error sleep from 10s to 2s
- Removed boost mode override (handled elsewhere)
- Moved cooler control to dedicated `control_cooler()` function
- Fixed swapped `_source` labels for PID/HEATING_POWER calibration

## Test coverage

- `test_parallel_trv_control_no_race_condition` — verifies no interleaving of operations
- `test_shared_state_corruption_in_parallel_execution` — verifies state consistency after parallel execution
- `test_lock_protects_critical_sections` — verifies lock is held during all delegate calls
- `test_unavailable_trv_no_operations_called` — verifies unavailable TRVs skip all operations