### PR TITLE
fix: translate HEAT_COOL mode on TRVs when AC entity is connected

### DIFF
--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -163,6 +163,12 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str:
             return HVACMode.HEAT_COOL
         if inbound and hvac_mode == HVACMode.HEAT_COOL:
             return HVACMode.HEAT
+    if HVACMode.HEAT_COOL not in trv_modes and HVACMode.HEAT in trv_modes:
+        # entity only supports HEAT, but not HEAT_COOL - need to translate                                                                                                                                                                             
+        if not inbound and hvac_mode == HVACMode.HEAT_COOL:
+            return HVACMode.HEAT
+        if inbound and hvac_mode == HVACMode.HEAT:
+            return HVACMode.HEAT_COOL
 
     if hvac_mode != HVACMode.AUTO:
         return hvac_mode


### PR DESCRIPTION
## Motivation:

When Better Thermostat is configured with both TRVs and a separate AC unit, the available HVAC modes are `OFF` and `HEAT_COOL`. This causes an error on TRVs that do not support the `HEAT_COOL` mode:
```
2026-01-25 10:54:31.328 DEBUG (MainThread) [custom_components.better_thermostat.utils.controlling] better_thermostat Thermostat: TO TRV set_hvac_mode: climate.living_room_radiator from: heat to: heat_cool                                          
2026-01-25 10:54:31.329 ERROR (MainThread) [custom_components.better_thermostat.climate] better_thermostat Thermostat: Error controlling TRV climate.living_room_radiator: not_valid_hvac_mode
```

## Changes:

Implements an additional check which translates the HVAC mode.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [X] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [X] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify the hardware/software which was used to test the code locally: -->

HA Version: 2026.1.3
Zigbee2MQTT Version: -
TRV Hardware: TRVZB

## New device mappings

<!-- If a new device mapping has been added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [X] There are no changes in `climate.py`

<!-- If you changed the `climate.py` please create a dedicated PR for this. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compatibility with thermostats and radiator valves that support either HEAT or HEAT_COOL modes exclusively. The app now properly handles mode translation and mapping for these devices, ensuring seamless operation regardless of supported heating modes. This improvement increases overall system compatibility and reliability across a wider range of thermostat models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->