### PR TITLE
fix: resolve ruff lint errors on master

### DIFF
--- a/custom_components/better_thermostat/utils/calibration/mpc.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc.py
@@ -1375,7 +1375,7 @@ def _compute_predictive_percent(
     #     if state.solar_gain_est is not None
     #     else getattr(params, "mpc_solar_gain_initial", 0.01)
     # )
-    solar_gain_factor = 0.0
+    _solar_gain_factor = 0.0  # reserved for future solar gain
 
     gain_step = gain * step_minutes
     loss_step = loss * step_minutes

--- a/tests/test_off_temperature_attribute.py
+++ b/tests/test_off_temperature_attribute.py
@@ -67,7 +67,9 @@ def mock_bt_without_off_temperature():
 class TestOffTemperatureAttribute:
     """Tests for off_temperature attribute exposure in extra_state_attributes."""
 
-    def test_off_temperature_exposed_when_configured(self, mock_bt_with_off_temperature):
+    def test_off_temperature_exposed_when_configured(
+        self, mock_bt_with_off_temperature
+    ):
         """Test that off_temperature is exposed when configured.
 
         The off_temperature attribute should be present in extra_state_attributes
@@ -75,7 +77,7 @@ class TestOffTemperatureAttribute:
         """
         # Verify the constant is available
         assert ATTR_STATE_OFF_TEMPERATURE == "off_temperature"
-        
+
         # Verify the mock has the correct value
         bt = mock_bt_with_off_temperature
         assert bt.off_temperature == 20.0
@@ -91,7 +93,7 @@ class TestOffTemperatureAttribute:
         """
         # Verify the constant is defined
         assert ATTR_STATE_OFF_TEMPERATURE == "off_temperature"
-        
+
         # Verify the mock has None when not configured
         bt = mock_bt_without_off_temperature
         assert bt.off_temperature is None
@@ -103,11 +105,11 @@ class TestOffTemperatureAttribute:
         that users might configure (e.g., 15°C, 18°C, 22°C, etc.).
         """
         test_values = [15.0, 18.0, 20.0, 22.0, 25.0, 0.0]
-        
+
         for temp_value in test_values:
             bt = MagicMock()
             bt.off_temperature = temp_value
-            
+
             # Verify the value is stored correctly
             assert bt.off_temperature == temp_value
             assert isinstance(bt.off_temperature, float)
@@ -119,7 +121,7 @@ class TestOffTemperatureAttribute:
         """
         # Verify the constant matches the expected attribute name
         assert ATTR_STATE_OFF_TEMPERATURE == "off_temperature"
-        
+
         # Verify it's a string
         assert isinstance(ATTR_STATE_OFF_TEMPERATURE, str)
 
@@ -132,12 +134,10 @@ class TestOffTemperatureAttribute:
         # Simulate the extra_state_attributes dict pattern
         mock_bt = MagicMock()
         mock_bt.off_temperature = 20.0
-        
+
         # Simulate building the attributes dict as done in climate.py
-        test_attributes = {
-            ATTR_STATE_OFF_TEMPERATURE: mock_bt.off_temperature,
-        }
-        
+        test_attributes = {ATTR_STATE_OFF_TEMPERATURE: mock_bt.off_temperature}
+
         # Verify the attribute is in the dict with the correct key and value
         assert "off_temperature" in test_attributes
         assert test_attributes["off_temperature"] == 20.0
@@ -150,12 +150,10 @@ class TestOffTemperatureAttribute:
         """
         mock_bt = MagicMock()
         mock_bt.off_temperature = None
-        
+
         # Simulate building the attributes dict
-        test_attributes = {
-            ATTR_STATE_OFF_TEMPERATURE: mock_bt.off_temperature,
-        }
-        
+        test_attributes = {ATTR_STATE_OFF_TEMPERATURE: mock_bt.off_temperature}
+
         # Verify the attribute is in the dict with None value
         assert "off_temperature" in test_attributes
         assert test_attributes["off_temperature"] is None


### PR DESCRIPTION
## Problem

The `master` branch has two ruff lint errors that cause CI failures on all PR branches:

1. **F841**: `solar_gain_factor` assigned but never used in `mpc.py:1378`
2. **W293**: Trailing whitespace on blank lines in `test_off_temperature_attribute.py` (9 occurrences)

These pre-existing errors propagate to every PR branch, causing unnecessary ruff CI failures.

## Solution

- Rename `solar_gain_factor` to `_solar_gain_factor` (underscore prefix signals intentionally unused, reserved for future solar gain feature)
- Remove trailing whitespace from blank lines in test file
- Run `ruff check --fix` and `ruff format` to ensure zero remaining issues