### PR TITLE
fix: Detect regime change when all prediction errors are identical nonzero

### DIFF
--- a/custom_components/better_thermostat/utils/calibration/mpc.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc.py
@@ -400,7 +400,9 @@ def _detect_regime_change(recent_errors: list[float]) -> bool:
         return False
 
     if std_error == 0:
-        return False
+        # All errors are identical.  If mean is nonzero, the bias is
+        # perfectly consistent and should be treated as a regime change.
+        return mean_error != 0
 
     # t-statistic: how many std-devs is the mean away from 0?
     t_stat = abs(mean_error) / (std_error / (N**0.5))

--- a/tests/unit/test_mpc_regime_change.py
+++ b/tests/unit/test_mpc_regime_change.py
@@ -1,0 +1,73 @@
+"""Tests for _detect_regime_change bias detection."""
+
+from __future__ import annotations
+
+from custom_components.better_thermostat.utils.calibration.mpc import (
+    _detect_regime_change,
+)
+
+
+class TestDetectRegimeChange:
+    """Tests for _detect_regime_change."""
+
+    def test_too_few_samples_returns_false(self):
+        """Fewer than N samples should always return False."""
+        assert _detect_regime_change([0.1] * 5) is False
+
+    def test_zero_mean_zero_std_returns_false(self):
+        """All-zero errors (no bias, no variance) should return False."""
+        assert _detect_regime_change([0.0] * 10) is False
+
+    def test_constant_positive_bias_detected(self):
+        """Identical positive errors should be detected as regime change."""
+        errors = [0.05] * 10
+        assert _detect_regime_change(errors) is True
+
+    def test_constant_negative_bias_detected(self):
+        """Identical negative errors should be detected as regime change."""
+        errors = [-0.05] * 10
+        assert _detect_regime_change(errors) is True
+
+    def test_constant_small_bias_detected(self):
+        """Even very small but consistent bias should be detected."""
+        errors = [0.001] * 10
+        assert _detect_regime_change(errors) is True
+
+    def test_alternating_errors_not_detected(self):
+        """Alternating positive/negative errors with zero mean should not be detected."""
+        errors = [0.05, -0.05] * 5
+        assert _detect_regime_change(errors) is False
+
+    def test_high_variance_masks_small_bias(self):
+        """High variance relative to mean should not be detected as regime change."""
+        import random as rng
+
+        rng.seed(42)
+        errors = [rng.gauss(0.01, 0.5) for _ in range(10)]
+        result = _detect_regime_change(errors)
+        assert isinstance(result, bool)
+
+    def test_low_variance_with_bias_detected(self):
+        """Low variance with clear nonzero mean should be detected."""
+        errors = [0.04 + 0.001 * i for i in range(10)]
+        # mean ≈ 0.0445, std is tiny -> t-stat high
+        assert _detect_regime_change(errors) is True
+
+    def test_uses_only_last_n_samples(self):
+        """Only the last N samples should be considered."""
+        old = [0.1] * 10
+        new = [0.001, -0.001] * 5
+        errors = old + new
+        assert _detect_regime_change(errors) is False
+
+    def test_exactly_n_samples(self):
+        """Exactly N samples should work."""
+        errors = [0.1] * 10
+        assert _detect_regime_change(errors) is True
+
+    def test_more_than_n_samples(self):
+        """More than N samples should use last N only."""
+        neutral = [0.0] * 20
+        biased = [0.1] * 10
+        errors = neutral + biased
+        assert _detect_regime_change(errors) is True

--- a/tests/unit/test_mpc_regime_change.py
+++ b/tests/unit/test_mpc_regime_change.py
@@ -39,13 +39,14 @@ class TestDetectRegimeChange:
         assert _detect_regime_change(errors) is False
 
     def test_high_variance_masks_small_bias(self):
-        """High variance relative to mean should not be detected as regime change."""
-        import random as rng
+        """High variance relative to mean should not be detected as regime change.
 
-        rng.seed(42)
-        errors = [rng.gauss(0.01, 0.5) for _ in range(10)]
-        result = _detect_regime_change(errors)
-        assert isinstance(result, bool)
+        Fixed series with mean ≈ 0.01 and std ≈ 0.5 so the t-statistic
+        is too small for detection.
+        """
+        errors = [0.15, -0.42, 0.53, -0.31, 0.08, -0.47, 0.39, -0.18, 0.61, -0.28]
+        # mean ≈ 0.01, std ≈ 0.39 → t = 0.01 / (0.39/√10) ≈ 0.08
+        assert _detect_regime_change(errors) is False
 
     def test_low_variance_with_bias_detected(self):
         """Low variance with clear nonzero mean should be detected."""


### PR DESCRIPTION
## Problem

`_detect_regime_change` in `mpc.py` fails to detect a perfectly consistent bias when all recent prediction errors are identical and nonzero. When `std_error == 0`, the function returns `False` unconditionally because the t-test division by standard deviation is undefined. However, identical nonzero errors (e.g., `[0.05] * 10`) represent the strongest possible evidence of systematic bias — the model is consistently wrong by the same amount.

This means the MPC controller never triggers a regime change relearn when the thermal model has a constant offset error, allowing the bias to persist indefinitely.

## Impact

**Low to medium.** This bug only triggers under a specific condition: the last 10 prediction errors (`observed_rate - predicted_rate`) must be exactly identical and nonzero.

In practice this is uncommon, because `pred_error` is a floating-point difference between observed and predicted temperature rate of change. Having 10 consecutive values be bit-identical requires temperature, valve position, and outdoor temperature to behave exactly the same over 10 cycles. However, with quantized sensors (0.1°C/0.5°C steps), a stable system, and a constant `predicted_rate`, this scenario is plausible.

When it does occur, the consequence is: the `regime_boost` (3× faster adaptation) is not activated, and the model converges with the normal `adapt_alpha` instead of the boosted one. The model learns **more slowly**, not incorrectly — no total failure, but delayed reaction to changed conditions.

## History

- Discovered by the comprehensive MPC test suite in PR #1903
- No existing issues or PRs address this bug

## Solution

- When `std_error == 0`, return `mean_error != 0` instead of `False`
- If all errors are zero (no bias, no variance), still returns `False` — correct behavior
- If all errors are identical and nonzero, returns `True` — triggers regime change relearn
- Includes 11 unit tests covering: constant positive/negative bias, zero mean, small bias, high variance masking, last-N-samples windowing, and boundary conditions