### PR TITLE
refactor: Add unified StateManager for runtime state persistence

### DIFF
--- a/custom_components/better_thermostat/utils/calibration/mpc.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc.py
@@ -148,6 +148,9 @@ class _MpcState:
     tolerance_hold_active: bool = False
 
 
+# Public alias so that StateManager can reference the type.
+MpcState = _MpcState
+
 _MPC_STATES: dict[str, _MpcState] = {}
 
 _STATE_EXPORT_FIELDS = (

--- a/custom_components/better_thermostat/utils/calibration/tpi.py
+++ b/custom_components/better_thermostat/utils/calibration/tpi.py
@@ -58,6 +58,9 @@ class _TpiState:
     last_update_ts: float = 0.0
 
 
+# Public alias so that StateManager can reference the type.
+TpiState = _TpiState
+
 _TPI_STATES: dict[str, _TpiState] = {}
 
 _STATE_EXPORT_FIELDS = ("last_percent",)

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -1,0 +1,414 @@
+"""Unified runtime state persistence for Better Thermostat.
+
+Replaces four separate HA Store files with a single versioned store per
+config entry. The StateManager owns all runtime state that must survive
+a Home Assistant restart (calibration models, thermal stats, learned
+presets).
+
+Usage in climate.py
+-------------------
+::
+
+    async def async_added_to_hass(self) -> None:
+        self.state_mgr = StateManager(self.hass, self.config_entry.entry_id)
+        await self.state_mgr.load()
+
+    # After calibration updates:
+    self.state_mgr.mark_dirty()
+
+    async def async_will_remove_from_hass(self) -> None:
+        await self.state_mgr.flush()
+
+Schema migration
+----------------
+When ``load()`` reads a store file without a ``"version"`` key it applies
+``_migrate_v0_to_v1`` which fills in schema defaults.  Future schema
+changes bump ``CURRENT_VERSION`` and add a new migration function.
+
+One-time data migration from the four legacy Store files is handled
+during ``async_added_to_hass`` in ``climate.py``.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .calibration.mpc import MpcState
+from .calibration.pid import PIDState
+from .calibration.tpi import TpiState
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "better_thermostat"
+CURRENT_VERSION = 1
+
+# ---------------------------------------------------------------------------
+# State dataclasses (only those NOT owned by a controller module)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ThermalStats:
+    """Learned thermal characteristics of the room."""
+
+    heating_power: float | None = None
+    heat_loss_rate: float | None = None
+
+
+@dataclass
+class RuntimeState:
+    """Complete runtime state for one BetterThermostat config entry.
+
+    This is the top-level structure that gets serialized to a single
+    HA Store file.
+    """
+
+    version: int = CURRENT_VERSION
+    mpc: dict[str, MpcState] = field(default_factory=dict)
+    pid: dict[str, PIDState] = field(default_factory=dict)
+    tpi: dict[str, TpiState] = field(default_factory=dict)
+    thermal: ThermalStats = field(default_factory=ThermalStats)
+    presets: dict[str, float] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Serialization helpers
+# ---------------------------------------------------------------------------
+
+# Fields that should be coerced to int during deserialization.
+_INT_FIELDS = frozenset(
+    {
+        "dead_zone_hits",
+        "loss_learn_count",
+        "gain_learn_count",
+        "profile_samples",
+        "consecutive_insufficient_heat",
+        "last_delta_sign",
+        "last_error_sign",
+    }
+)
+
+# Fields that should be coerced to bool during deserialization.
+_BOOL_FIELDS = frozenset(
+    {
+        "is_calibration_active",
+        "regime_boost_active",
+        "tolerance_hold_active",
+        "auto_tune",
+    }
+)
+
+# Fields that should be coerced to str during deserialization.
+_STR_FIELDS = frozenset({"trv_profile"})
+
+
+def _make_json_safe(obj: Any) -> Any:
+    """Recursively convert non-JSON-serializable types.
+
+    ``dataclasses.asdict`` does **not** convert ``deque`` to ``list``,
+    so we walk the resulting dict and fix up anything that ``json.dumps``
+    would choke on.
+    """
+    if isinstance(obj, deque):
+        return [_make_json_safe(v) for v in obj]
+    if isinstance(obj, dict):
+        return {k: _make_json_safe(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_make_json_safe(v) for v in obj]
+    return obj
+
+
+def _serialize(state: RuntimeState) -> dict[str, Any]:
+    """Convert RuntimeState to a JSON-serializable dict.
+
+    The ``deque`` used by MPC's ``recent_errors`` is converted to a plain
+    list so that ``json.dumps`` can handle it.
+    """
+    data = asdict(state)
+    return _make_json_safe(data)
+
+
+def deserialize_mpc(raw: dict[str, Any]) -> MpcState:
+    """Deserialize a single MPC state dict into an MpcState dataclass."""
+    state = MpcState()
+    for attr in MpcState.__dataclass_fields__:
+        if attr not in raw:
+            continue
+        value = raw[attr]
+        if value is None:
+            setattr(state, attr, None)
+            continue
+        if attr == "perf_curve" and isinstance(value, Mapping):
+            setattr(state, attr, dict(value))
+            continue
+        if attr == "recent_errors" and isinstance(value, (list, tuple)):
+            # MpcState.recent_errors is a deque(maxlen=20).
+            setattr(state, attr, deque(value, maxlen=20))
+            continue
+        try:
+            if attr in _INT_FIELDS:
+                setattr(state, attr, int(value))
+            elif attr in _BOOL_FIELDS:
+                setattr(state, attr, bool(value))
+            elif attr in _STR_FIELDS:
+                setattr(state, attr, str(value))
+            else:
+                setattr(state, attr, float(value))
+        except (TypeError, ValueError):
+            continue
+    return state
+
+
+def deserialize_pid(raw: dict[str, Any]) -> PIDState:
+    """Deserialize a single PID state dict into a PIDState dataclass."""
+    state = PIDState()
+    for attr in PIDState.__dataclass_fields__:
+        if attr not in raw:
+            continue
+        value = raw[attr]
+        if value is None:
+            setattr(state, attr, None)
+            continue
+        try:
+            if attr in _INT_FIELDS:
+                setattr(state, attr, int(value))
+            elif attr in _BOOL_FIELDS:
+                setattr(state, attr, bool(value))
+            else:
+                setattr(state, attr, float(value))
+        except (TypeError, ValueError):
+            continue
+    return state
+
+
+def deserialize_tpi(raw: dict[str, Any]) -> TpiState:
+    """Deserialize a single TPI state dict into a TpiState dataclass."""
+    state = TpiState()
+    for attr in TpiState.__dataclass_fields__:
+        if attr not in raw:
+            continue
+        value = raw[attr]
+        if value is None:
+            setattr(state, attr, None)
+            continue
+        try:
+            setattr(state, attr, float(value))
+        except (TypeError, ValueError):
+            continue
+    return state
+
+
+def _deserialize(raw: dict[str, Any]) -> RuntimeState:
+    """Reconstruct a RuntimeState from a raw dict (loaded from Store)."""
+    state = RuntimeState(version=raw.get("version", CURRENT_VERSION))
+
+    for key, state_dict in raw.get("mpc", {}).items():
+        if isinstance(state_dict, dict):
+            state.mpc[key] = deserialize_mpc(state_dict)
+
+    for key, state_dict in raw.get("pid", {}).items():
+        if isinstance(state_dict, dict):
+            state.pid[key] = deserialize_pid(state_dict)
+
+    for key, state_dict in raw.get("tpi", {}).items():
+        if isinstance(state_dict, dict):
+            state.tpi[key] = deserialize_tpi(state_dict)
+
+    thermal_raw = raw.get("thermal", {})
+    if isinstance(thermal_raw, dict):
+        heating_power = thermal_raw.get("heating_power")
+        heat_loss_rate = thermal_raw.get("heat_loss_rate")
+        state.thermal = ThermalStats(
+            heating_power=float(heating_power) if heating_power is not None else None,
+            heat_loss_rate=(
+                float(heat_loss_rate) if heat_loss_rate is not None else None
+            ),
+        )
+
+    presets_raw = raw.get("presets", {})
+    if isinstance(presets_raw, dict):
+        for name, temp in presets_raw.items():
+            try:
+                state.presets[str(name)] = float(temp)
+            except (TypeError, ValueError):
+                continue
+
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+
+def _migrate_v0_to_v1(raw: dict[str, Any]) -> dict[str, Any]:
+    """Migrate from unversioned (v0) format to v1.
+
+    v0 is the legacy format where MPC/PID/TPI/thermal data lived in
+    separate Store files.  If loading from a unified store that already
+    has the v1 schema, this is a no-op.
+    """
+    raw.setdefault("version", 1)
+    raw.setdefault("mpc", {})
+    raw.setdefault("pid", {})
+    raw.setdefault("tpi", {})
+    raw.setdefault("thermal", {})
+    raw.setdefault("presets", {})
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# StateManager
+# ---------------------------------------------------------------------------
+
+
+class StateManager:
+    """Manages unified runtime state persistence for one BetterThermostat instance.
+
+    Parameters
+    ----------
+    hass : HomeAssistant
+        The Home Assistant instance.
+    entry_id : str
+        The config entry ID (stable across restarts).
+    """
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        self._store: Store[dict[str, Any]] = Store(
+            hass, CURRENT_VERSION, f"{DOMAIN}_{entry_id}_state"
+        )
+        self._entry_id = entry_id
+        self._state = RuntimeState()
+        self._dirty = False
+
+    # -- Public properties ---------------------------------------------------
+
+    @property
+    def state(self) -> RuntimeState:
+        """Return the current runtime state (read-only access)."""
+        return self._state
+
+    @property
+    def dirty(self) -> bool:
+        """Return whether unsaved changes exist."""
+        return self._dirty
+
+    # -- State access --------------------------------------------------------
+
+    def get_mpc(self, key: str) -> MpcState:
+        """Get or create MPC state for a key."""
+        if key not in self._state.mpc:
+            self._state.mpc[key] = MpcState()
+            self._dirty = True
+        return self._state.mpc[key]
+
+    def set_mpc(self, key: str, mpc: MpcState) -> None:
+        """Set MPC state for a key and mark dirty."""
+        self._state.mpc[key] = mpc
+        self._dirty = True
+
+    def get_pid(self, key: str) -> PIDState:
+        """Get or create PID state for a key."""
+        if key not in self._state.pid:
+            self._state.pid[key] = PIDState()
+            self._dirty = True
+        return self._state.pid[key]
+
+    def set_pid(self, key: str, pid: PIDState) -> None:
+        """Set PID state for a key and mark dirty."""
+        self._state.pid[key] = pid
+        self._dirty = True
+
+    def get_tpi(self, key: str) -> TpiState:
+        """Get or create TPI state for a key."""
+        if key not in self._state.tpi:
+            self._state.tpi[key] = TpiState()
+            self._dirty = True
+        return self._state.tpi[key]
+
+    def set_tpi(self, key: str, tpi: TpiState) -> None:
+        """Set TPI state for a key and mark dirty."""
+        self._state.tpi[key] = tpi
+        self._dirty = True
+
+    @property
+    def thermal(self) -> ThermalStats:
+        """Return thermal stats."""
+        return self._state.thermal
+
+    @thermal.setter
+    def thermal(self, value: ThermalStats) -> None:
+        """Set thermal stats and mark dirty."""
+        self._state.thermal = value
+        self._dirty = True
+
+    @property
+    def presets(self) -> dict[str, float]:
+        """Return learned preset temperatures."""
+        return self._state.presets
+
+    @presets.setter
+    def presets(self, value: dict[str, float]) -> None:
+        """Set learned preset temperatures and mark dirty."""
+        self._state.presets = value
+        self._dirty = True
+
+    def mark_dirty(self) -> None:
+        """Manually mark state as needing persistence."""
+        self._dirty = True
+
+    # -- Load / Save ---------------------------------------------------------
+
+    async def load(self) -> None:
+        """Load state from HA Store.  Applies migrations if needed."""
+        raw = await self._store.async_load()
+        if not raw or not isinstance(raw, dict):
+            _LOGGER.debug(
+                "better_thermostat [%s]: No persisted state found, starting fresh",
+                self._entry_id,
+            )
+            return
+
+        version = raw.get("version", 0)
+        if version < 1:
+            raw = _migrate_v0_to_v1(raw)
+
+        self._state = _deserialize(raw)
+        self._dirty = False
+        _LOGGER.debug(
+            "better_thermostat [%s]: Loaded state v%d (%d mpc, %d pid, %d tpi keys)",
+            self._entry_id,
+            self._state.version,
+            len(self._state.mpc),
+            len(self._state.pid),
+            len(self._state.tpi),
+        )
+
+    async def save(self) -> None:
+        """Persist current state to HA Store unconditionally."""
+        data = _serialize(self._state)
+        await self._store.async_save(data)
+        self._dirty = False
+        _LOGGER.debug(
+            "better_thermostat [%s]: Saved state (%d mpc, %d pid, %d tpi keys)",
+            self._entry_id,
+            len(self._state.mpc),
+            len(self._state.pid),
+            len(self._state.tpi),
+        )
+
+    async def save_if_dirty(self) -> None:
+        """Persist current state only if it has been modified since last save."""
+        if self._dirty:
+            await self.save()
+
+    async def flush(self) -> None:
+        """Flush unsaved changes -- call from async_will_remove_from_hass."""
+        await self.save_if_dirty()

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -209,27 +209,38 @@ def _deserialize(raw: dict[str, Any]) -> RuntimeState:
     """Reconstruct a RuntimeState from a raw dict (loaded from Store)."""
     state = RuntimeState(version=raw.get("version", CURRENT_VERSION))
 
-    for key, state_dict in raw.get("mpc", {}).items():
-        if isinstance(state_dict, dict):
-            state.mpc[key] = deserialize_mpc(state_dict)
+    mpc_raw = raw.get("mpc", {})
+    if isinstance(mpc_raw, Mapping):
+        for key, state_dict in mpc_raw.items():
+            if isinstance(state_dict, dict):
+                state.mpc[key] = deserialize_mpc(state_dict)
 
-    for key, state_dict in raw.get("pid", {}).items():
-        if isinstance(state_dict, dict):
-            state.pid[key] = deserialize_pid(state_dict)
+    pid_raw = raw.get("pid", {})
+    if isinstance(pid_raw, Mapping):
+        for key, state_dict in pid_raw.items():
+            if isinstance(state_dict, dict):
+                state.pid[key] = deserialize_pid(state_dict)
 
-    for key, state_dict in raw.get("tpi", {}).items():
-        if isinstance(state_dict, dict):
-            state.tpi[key] = deserialize_tpi(state_dict)
+    tpi_raw = raw.get("tpi", {})
+    if isinstance(tpi_raw, Mapping):
+        for key, state_dict in tpi_raw.items():
+            if isinstance(state_dict, dict):
+                state.tpi[key] = deserialize_tpi(state_dict)
 
     thermal_raw = raw.get("thermal", {})
     if isinstance(thermal_raw, dict):
         heating_power = thermal_raw.get("heating_power")
         heat_loss_rate = thermal_raw.get("heat_loss_rate")
+        try:
+            heating_power = float(heating_power) if heating_power is not None else None
+        except (TypeError, ValueError):
+            heating_power = None
+        try:
+            heat_loss_rate = float(heat_loss_rate) if heat_loss_rate is not None else None
+        except (TypeError, ValueError):
+            heat_loss_rate = None
         state.thermal = ThermalStats(
-            heating_power=float(heating_power) if heating_power is not None else None,
-            heat_loss_rate=(
-                float(heat_loss_rate) if heat_loss_rate is not None else None
-            ),
+            heating_power=heating_power, heat_loss_rate=heat_loss_rate
         )
 
     presets_raw = raw.get("presets", {})

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -1,0 +1,635 @@
+"""Tests for the unified StateManager and its serialization layer.
+
+Covers:
+- Dataclass defaults and field types
+- Serialization roundtrip (_serialize / _deserialize)
+- Type coercion during deserialization (int, bool, str, float)
+- Graceful handling of missing, extra, and invalid fields
+- Migration from v0 (unversioned) to v1
+- StateManager dirty tracking
+- StateManager get-or-create semantics
+- StateManager load / save / flush lifecycle
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import asdict
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.utils.state_manager import (
+    CURRENT_VERSION,
+    MpcState,
+    PIDState,
+    RuntimeState,
+    StateManager,
+    ThermalStats,
+    TpiState,
+    _deserialize,
+    _migrate_v0_to_v1,
+    _serialize,
+    deserialize_mpc,
+    deserialize_pid,
+    deserialize_tpi,
+)
+
+# ---------------------------------------------------------------------------
+# Dataclass defaults
+# ---------------------------------------------------------------------------
+
+
+class TestMpcStateDefaults:
+    """MpcState should initialize with sensible defaults."""
+
+    def test_numeric_defaults(self):
+        """Nullable floats default to None, counters to 0, kalman_P to 1."""
+        s = MpcState()
+        assert s.last_percent is None
+        assert s.last_update_ts == 0.0
+        assert s.dead_zone_hits == 0
+        assert s.kalman_P == 1.0
+
+    def test_bool_defaults(self):
+        """All boolean fields default to False."""
+        s = MpcState()
+        assert s.is_calibration_active is False
+        assert s.regime_boost_active is False
+        assert s.tolerance_hold_active is False
+
+    def test_str_defaults(self):
+        """trv_profile defaults to 'unknown'."""
+        s = MpcState()
+        assert s.trv_profile == "unknown"
+
+    def test_collection_defaults(self):
+        """Mutable collection fields default to empty."""
+        s = MpcState()
+        assert s.perf_curve == {}
+        assert len(s.recent_errors) == 0
+
+    def test_collection_defaults_are_independent(self):
+        """Each instance should get its own mutable collections."""
+        a = MpcState()
+        b = MpcState()
+        a.recent_errors.append(1.0)
+        assert len(b.recent_errors) == 0
+
+
+class TestPIDStateDefaults:
+    """PIDState should initialize with sensible defaults."""
+
+    def test_defaults(self):
+        """Numeric fields default to 0.0, nullable fields to None."""
+        s = PIDState()
+        assert s.pid_integral == 0.0
+        assert s.pid_last_meas is None
+        assert s.auto_tune is None
+        assert s.last_delta_sign is None
+
+
+class TestTpiStateDefaults:
+    """TpiState should initialize with sensible defaults."""
+
+    def test_defaults(self):
+        """last_percent is None, last_update_ts is 0.0."""
+        s = TpiState()
+        assert s.last_percent is None
+        assert s.last_update_ts == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Serialization roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeDeserializeRoundtrip:
+    """_serialize then _deserialize should produce equivalent state."""
+
+    def test_empty_state_roundtrip(self):
+        """Fresh RuntimeState survives a serialize/deserialize cycle."""
+        original = RuntimeState()
+        raw = _serialize(original)
+        restored = _deserialize(raw)
+        assert asdict(restored) == asdict(original)
+
+    def test_mpc_roundtrip(self):
+        """MPC state with various field types survives roundtrip."""
+        original = RuntimeState()
+        mpc = MpcState(
+            last_percent=42.5,
+            dead_zone_hits=3,
+            is_calibration_active=True,
+            trv_profile="linear",
+            recent_errors=deque([0.1, -0.2, 0.05], maxlen=20),
+            perf_curve={"20.0": {"gain": 1.5, "count": 10}},
+        )
+        original.mpc["trv1__20"] = mpc
+
+        raw = _serialize(original)
+        restored = _deserialize(raw)
+
+        r_mpc = restored.mpc["trv1__20"]
+        assert r_mpc.last_percent == 42.5
+        assert r_mpc.dead_zone_hits == 3
+        assert r_mpc.is_calibration_active is True
+        assert r_mpc.trv_profile == "linear"
+        assert list(r_mpc.recent_errors) == [0.1, -0.2, 0.05]
+        assert r_mpc.perf_curve == {"20.0": {"gain": 1.5, "count": 10}}
+
+    def test_pid_roundtrip(self):
+        """PID state with int, bool, and float fields survives roundtrip."""
+        original = RuntimeState()
+        pid = PIDState(pid_integral=1.5, auto_tune=True, last_delta_sign=-1)
+        original.pid["trv1"] = pid
+
+        raw = _serialize(original)
+        restored = _deserialize(raw)
+
+        r_pid = restored.pid["trv1"]
+        assert r_pid.pid_integral == 1.5
+        assert r_pid.auto_tune is True
+        assert r_pid.last_delta_sign == -1
+
+    def test_tpi_roundtrip(self):
+        """TPI state survives roundtrip."""
+        original = RuntimeState()
+        original.tpi["trv1"] = TpiState(last_percent=65.0, last_update_ts=1000.0)
+
+        raw = _serialize(original)
+        restored = _deserialize(raw)
+
+        r_tpi = restored.tpi["trv1"]
+        assert r_tpi.last_percent == 65.0
+        assert r_tpi.last_update_ts == 1000.0
+
+    def test_thermal_roundtrip(self):
+        """ThermalStats survive roundtrip."""
+        original = RuntimeState(
+            thermal=ThermalStats(heating_power=1200.0, heat_loss_rate=0.03)
+        )
+
+        raw = _serialize(original)
+        restored = _deserialize(raw)
+
+        assert restored.thermal.heating_power == 1200.0
+        assert restored.thermal.heat_loss_rate == 0.03
+
+    def test_presets_roundtrip(self):
+        """Preset temperatures survive roundtrip."""
+        original = RuntimeState(presets={"comfort": 22.0, "eco": 18.5})
+
+        raw = _serialize(original)
+        restored = _deserialize(raw)
+
+        assert restored.presets == {"comfort": 22.0, "eco": 18.5}
+
+    def test_full_state_roundtrip(self):
+        """Complete state with all sections populated."""
+        original = RuntimeState(
+            mpc={"k1": MpcState(gain_est=0.5, loss_est=0.02)},
+            pid={"k1": PIDState(pid_kp=2.0)},
+            tpi={"k1": TpiState(last_percent=30.0)},
+            thermal=ThermalStats(heating_power=800.0),
+            presets={"away": 16.0},
+        )
+
+        raw = _serialize(original)
+        restored = _deserialize(raw)
+
+        assert restored.mpc["k1"].gain_est == 0.5
+        assert restored.pid["k1"].pid_kp == 2.0
+        assert restored.tpi["k1"].last_percent == 30.0
+        assert restored.thermal.heating_power == 800.0
+        assert restored.presets["away"] == 16.0
+
+
+# ---------------------------------------------------------------------------
+# Type coercion during deserialization
+# ---------------------------------------------------------------------------
+
+
+class TestDeserializeMpcTypeCoercion:
+    """deserialize_mpc should coerce types correctly."""
+
+    def test_int_field_from_float(self):
+        """Float values in int fields are truncated to int."""
+        raw = {"dead_zone_hits": 3.0, "loss_learn_count": 5.7}
+        mpc = deserialize_mpc(raw)
+        assert mpc.dead_zone_hits == 3
+        assert isinstance(mpc.dead_zone_hits, int)
+        assert mpc.loss_learn_count == 5
+        assert isinstance(mpc.loss_learn_count, int)
+
+    def test_bool_field_from_int(self):
+        """Integer values in bool fields are coerced to bool."""
+        raw = {"is_calibration_active": 1, "regime_boost_active": 0}
+        mpc = deserialize_mpc(raw)
+        assert mpc.is_calibration_active is True
+        assert mpc.regime_boost_active is False
+
+    def test_str_field_from_number(self):
+        """Numeric values in str fields are coerced to str."""
+        raw = {"trv_profile": 123}
+        mpc = deserialize_mpc(raw)
+        assert mpc.trv_profile == "123"
+        assert isinstance(mpc.trv_profile, str)
+
+    def test_float_field_from_int(self):
+        """Integer values in float fields are coerced to float."""
+        raw = {"last_percent": 50, "kalman_P": 2}
+        mpc = deserialize_mpc(raw)
+        assert mpc.last_percent == 50.0
+        assert isinstance(mpc.last_percent, float)
+
+    def test_none_preserved(self):
+        """None values are preserved for nullable fields."""
+        raw = {"gain_est": None, "loss_est": None}
+        mpc = deserialize_mpc(raw)
+        assert mpc.gain_est is None
+        assert mpc.loss_est is None
+
+    def test_invalid_value_skipped(self):
+        """Non-numeric strings and wrong types fall back to defaults."""
+        raw = {"last_percent": "not_a_number", "gain_est": [1, 2]}
+        mpc = deserialize_mpc(raw)
+        assert mpc.last_percent is None  # default
+        assert mpc.gain_est is None  # default
+
+    def test_extra_fields_ignored(self):
+        """Unknown fields in the raw dict are silently ignored."""
+        raw = {"nonexistent_field": 42, "last_percent": 10.0}
+        mpc = deserialize_mpc(raw)
+        assert mpc.last_percent == 10.0
+        assert not hasattr(mpc, "nonexistent_field")
+
+    def test_empty_dict(self):
+        """Empty dict produces a default MpcState."""
+        mpc = deserialize_mpc({})
+        assert mpc == MpcState()
+
+
+class TestDeserializePidTypeCoercion:
+    """deserialize_pid should coerce types correctly."""
+
+    def test_int_field_from_float(self):
+        """Float values in int fields are truncated to int."""
+        raw = {"last_delta_sign": -1.0, "last_error_sign": 1.9}
+        pid = deserialize_pid(raw)
+        assert pid.last_delta_sign == -1
+        assert pid.last_error_sign == 1
+
+    def test_bool_field(self):
+        """Integer value in auto_tune is coerced to bool."""
+        raw = {"auto_tune": 1}
+        pid = deserialize_pid(raw)
+        assert pid.auto_tune is True
+
+    def test_none_preserved(self):
+        """None values are preserved for nullable fields."""
+        raw = {"pid_kp": None}
+        pid = deserialize_pid(raw)
+        assert pid.pid_kp is None
+
+
+class TestDeserializeTpi:
+    """deserialize_tpi should coerce all fields to float."""
+
+    def test_basic(self):
+        """Integer values are coerced to float."""
+        raw = {"last_percent": 80, "last_update_ts": 12345}
+        tpi = deserialize_tpi(raw)
+        assert tpi.last_percent == 80.0
+        assert tpi.last_update_ts == 12345.0
+
+    def test_invalid_skipped(self):
+        """Non-numeric values fall back to defaults."""
+        raw = {"last_percent": "bad"}
+        tpi = deserialize_tpi(raw)
+        assert tpi.last_percent is None
+
+
+# ---------------------------------------------------------------------------
+# Deserialization edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestDeserializeEdgeCases:
+    """Edge cases in full _deserialize function."""
+
+    def test_missing_sections(self):
+        """Missing top-level sections produce empty collections."""
+        raw = {"version": 1}
+        state = _deserialize(raw)
+        assert state.mpc == {}
+        assert state.pid == {}
+        assert state.tpi == {}
+        assert state.presets == {}
+
+    def test_non_dict_mpc_payload_skipped(self):
+        """Non-dict payloads inside mpc section are skipped."""
+        raw = {"version": 1, "mpc": {"key1": "not_a_dict", "key2": 42}}
+        state = _deserialize(raw)
+        assert "key1" not in state.mpc
+        assert "key2" not in state.mpc
+
+    def test_non_dict_thermal_ignored(self):
+        """Non-dict thermal section falls through to defaults."""
+        raw = {"version": 1, "thermal": "garbage"}
+        state = _deserialize(raw)
+        assert state.thermal.heating_power is None
+
+    def test_invalid_preset_skipped(self):
+        """Non-numeric preset values are skipped, valid ones kept."""
+        raw = {"version": 1, "presets": {"good": 21.0, "bad": "not_a_number"}}
+        state = _deserialize(raw)
+        assert state.presets["good"] == 21.0
+        assert "bad" not in state.presets
+
+    def test_non_dict_presets_ignored(self):
+        """Non-dict presets section produces empty dict."""
+        raw = {"version": 1, "presets": [1, 2, 3]}
+        state = _deserialize(raw)
+        assert state.presets == {}
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationV0ToV1:
+    """v0 to v1 migration adds missing top-level keys."""
+
+    def test_adds_missing_keys(self):
+        """Empty dict gets all required v1 keys."""
+        raw: dict = {}
+        result = _migrate_v0_to_v1(raw)
+        assert result["version"] == 1
+        assert result["mpc"] == {}
+        assert result["pid"] == {}
+        assert result["tpi"] == {}
+        assert result["thermal"] == {}
+        assert result["presets"] == {}
+
+    def test_preserves_existing_data(self):
+        """Existing data is preserved during migration."""
+        raw = {"mpc": {"k": {"gain_est": 0.5}}, "thermal": {"heating_power": 1000}}
+        result = _migrate_v0_to_v1(raw)
+        assert result["version"] == 1
+        assert result["mpc"]["k"]["gain_est"] == 0.5
+        assert result["thermal"]["heating_power"] == 1000
+
+    def test_does_not_overwrite_existing_version(self):
+        """Setdefault does not overwrite an existing version key."""
+        raw = {"version": 99}
+        result = _migrate_v0_to_v1(raw)
+        assert result["version"] == 99
+
+
+# ---------------------------------------------------------------------------
+# StateManager — dirty tracking
+# ---------------------------------------------------------------------------
+
+
+class TestStateManagerDirtyTracking:
+    """Dirty flag tracks whether unsaved changes exist."""
+
+    def _make_manager(self) -> StateManager:
+        """Create a StateManager with a mocked Store."""
+        mock_hass = AsyncMock()
+        with patch("custom_components.better_thermostat.utils.state_manager.Store"):
+            return StateManager(mock_hass, "test_entry")
+
+    def test_starts_clean(self):
+        """Fresh StateManager is not dirty."""
+        mgr = self._make_manager()
+        assert mgr.dirty is False
+
+    def test_mark_dirty(self):
+        """mark_dirty() sets the dirty flag."""
+        mgr = self._make_manager()
+        mgr.mark_dirty()
+        assert mgr.dirty is True
+
+    def test_get_mpc_creates_and_dirties(self):
+        """get_mpc for a new key creates state and sets dirty."""
+        mgr = self._make_manager()
+        mpc = mgr.get_mpc("key1")
+        assert isinstance(mpc, MpcState)
+        assert mgr.dirty is True
+
+    def test_get_mpc_existing_not_dirty(self):
+        """get_mpc for an existing key does not set dirty."""
+        mgr = self._make_manager()
+        mgr.get_mpc("key1")
+        mgr._dirty = False  # Reset
+        mpc2 = mgr.get_mpc("key1")
+        assert mgr.dirty is False
+        assert isinstance(mpc2, MpcState)
+
+    def test_set_mpc_dirties(self):
+        """set_mpc always sets dirty."""
+        mgr = self._make_manager()
+        mgr.set_mpc("key1", MpcState(gain_est=1.0))
+        assert mgr.dirty is True
+        assert mgr.get_mpc("key1").gain_est == 1.0
+
+    def test_get_pid_creates_and_dirties(self):
+        """get_pid for a new key creates state and sets dirty."""
+        mgr = self._make_manager()
+        pid = mgr.get_pid("key1")
+        assert isinstance(pid, PIDState)
+        assert mgr.dirty is True
+
+    def test_set_pid_dirties(self):
+        """set_pid always sets dirty."""
+        mgr = self._make_manager()
+        mgr.set_pid("key1", PIDState(pid_kp=3.0))
+        assert mgr.dirty is True
+
+    def test_get_tpi_creates_and_dirties(self):
+        """get_tpi for a new key creates state and sets dirty."""
+        mgr = self._make_manager()
+        tpi = mgr.get_tpi("key1")
+        assert isinstance(tpi, TpiState)
+        assert mgr.dirty is True
+
+    def test_set_tpi_dirties(self):
+        """set_tpi always sets dirty."""
+        mgr = self._make_manager()
+        mgr.set_tpi("key1", TpiState(last_percent=50.0))
+        assert mgr.dirty is True
+
+    def test_thermal_setter_dirties(self):
+        """Assigning thermal property sets dirty."""
+        mgr = self._make_manager()
+        mgr.thermal = ThermalStats(heating_power=500.0)
+        assert mgr.dirty is True
+        assert mgr.thermal.heating_power == 500.0
+
+    def test_presets_setter_dirties(self):
+        """Assigning presets property sets dirty."""
+        mgr = self._make_manager()
+        mgr.presets = {"eco": 18.0}
+        assert mgr.dirty is True
+        assert mgr.presets == {"eco": 18.0}
+
+
+# ---------------------------------------------------------------------------
+# StateManager — load / save lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestStateManagerLoadSave:
+    """Load, save, save_if_dirty, and flush lifecycle."""
+
+    def _make_manager_with_store(self):
+        """Create a StateManager with a capturable mock Store."""
+        mock_hass = AsyncMock()
+        mock_store = AsyncMock()
+        with patch(
+            "custom_components.better_thermostat.utils.state_manager.Store",
+            return_value=mock_store,
+        ):
+            mgr = StateManager(mock_hass, "test_entry")
+        return mgr, mock_store
+
+    @pytest.mark.asyncio
+    async def test_load_empty_store(self):
+        """Loading from an empty store keeps default state."""
+        mgr, mock_store = self._make_manager_with_store()
+        mock_store.async_load.return_value = None
+
+        await mgr.load()
+
+        assert mgr.state.mpc == {}
+        assert mgr.dirty is False
+
+    @pytest.mark.asyncio
+    async def test_load_valid_state(self):
+        """Loading valid v1 data populates all sections."""
+        mgr, mock_store = self._make_manager_with_store()
+        mock_store.async_load.return_value = {
+            "version": 1,
+            "mpc": {"k1": {"gain_est": 0.5, "dead_zone_hits": 2}},
+            "pid": {},
+            "tpi": {},
+            "thermal": {"heating_power": 1000.0},
+            "presets": {"comfort": 22.0},
+        }
+
+        await mgr.load()
+
+        assert mgr.state.mpc["k1"].gain_est == 0.5
+        assert mgr.state.mpc["k1"].dead_zone_hits == 2
+        assert mgr.state.thermal.heating_power == 1000.0
+        assert mgr.state.presets["comfort"] == 22.0
+        assert mgr.dirty is False
+
+    @pytest.mark.asyncio
+    async def test_load_triggers_migration(self):
+        """Loading v0 data (no version key) triggers migration to v1."""
+        mgr, mock_store = self._make_manager_with_store()
+        mock_store.async_load.return_value = {"mpc": {"k1": {"gain_est": 0.3}}}
+
+        await mgr.load()
+
+        assert mgr.state.version == 1
+        assert mgr.state.mpc["k1"].gain_est == pytest.approx(0.3)
+
+    @pytest.mark.asyncio
+    async def test_save_writes_to_store(self):
+        """save() serializes state and calls async_save on the Store."""
+        mgr, mock_store = self._make_manager_with_store()
+        mgr.set_mpc("k1", MpcState(last_percent=75.0))
+
+        await mgr.save()
+
+        mock_store.async_save.assert_called_once()
+        saved_data = mock_store.async_save.call_args[0][0]
+        assert saved_data["version"] == CURRENT_VERSION
+        assert saved_data["mpc"]["k1"]["last_percent"] == 75.0
+        assert mgr.dirty is False
+
+    @pytest.mark.asyncio
+    async def test_save_if_dirty_skips_when_clean(self):
+        """save_if_dirty() does nothing when state is clean."""
+        mgr, mock_store = self._make_manager_with_store()
+        assert mgr.dirty is False
+
+        await mgr.save_if_dirty()
+
+        mock_store.async_save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_save_if_dirty_saves_when_dirty(self):
+        """save_if_dirty() saves when dirty flag is set."""
+        mgr, mock_store = self._make_manager_with_store()
+        mgr.mark_dirty()
+
+        await mgr.save_if_dirty()
+
+        mock_store.async_save.assert_called_once()
+        assert mgr.dirty is False
+
+    @pytest.mark.asyncio
+    async def test_flush_delegates_to_save_if_dirty(self):
+        """flush() saves dirty state."""
+        mgr, mock_store = self._make_manager_with_store()
+        mgr.set_mpc("k1", MpcState())
+
+        await mgr.flush()
+
+        mock_store.async_save.assert_called_once()
+        assert mgr.dirty is False
+
+    @pytest.mark.asyncio
+    async def test_flush_noop_when_clean(self):
+        """flush() does nothing when state is clean."""
+        mgr, mock_store = self._make_manager_with_store()
+
+        await mgr.flush()
+
+        mock_store.async_save.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# StateManager — state property
+# ---------------------------------------------------------------------------
+
+
+class TestStateManagerStateAccess:
+    """Public property access on StateManager."""
+
+    def _make_manager(self) -> StateManager:
+        """Create a StateManager with a mocked Store."""
+        mock_hass = AsyncMock()
+        with patch("custom_components.better_thermostat.utils.state_manager.Store"):
+            return StateManager(mock_hass, "test_entry")
+
+    def test_state_returns_runtime_state(self):
+        """State property returns a RuntimeState with current version."""
+        mgr = self._make_manager()
+        assert isinstance(mgr.state, RuntimeState)
+        assert mgr.state.version == CURRENT_VERSION
+
+    def test_thermal_getter(self):
+        """Thermal property returns ThermalStats."""
+        mgr = self._make_manager()
+        assert isinstance(mgr.thermal, ThermalStats)
+
+    def test_presets_getter(self):
+        """Presets property returns empty dict by default."""
+        mgr = self._make_manager()
+        assert mgr.presets == {}
+
+    def test_multiple_keys_independent(self):
+        """Different MPC keys store independent state."""
+        mgr = self._make_manager()
+        mgr.set_mpc("trv1__20", MpcState(gain_est=0.5))
+        mgr.set_mpc("trv1__22", MpcState(gain_est=0.8))
+
+        assert mgr.get_mpc("trv1__20").gain_est == 0.5
+        assert mgr.get_mpc("trv1__22").gain_est == 0.8


### PR DESCRIPTION
> Part 1 of 5 — Unified state persistence (#1919)

## Problem

Runtime state is split across four separate shared HA Store files with 12 load/save/schedule methods in `climate.py`. Calibration modules use module-global dicts for in-memory state. See #1919 for the full problem description.

## Solution

Add a new `utils/state_manager.py` module that consolidates all runtime state into a single versioned store per config entry:

- **Typed dataclasses**: `RuntimeState` container referencing `MpcState`, `PIDState`, `TpiState`, `ThermalStats`
- **Public type aliases**: `MpcState = _MpcState` and `TpiState = _TpiState` added to `mpc.py` / `tpi.py` so the StateManager can reference them (`PIDState` was already public)
- **Safe serialization**: Type-coercing deserializers that gracefully skip invalid values instead of crashing on corrupt store data
- **Migration framework**: Versioned schema with `_migrate_v0_to_v1()` — future schema changes add a new migration function and bump `CURRENT_VERSION`
- **Dirty tracking**: `mark_dirty()` / `save_if_dirty()` / `flush()` to avoid unnecessary writes
- **58 unit tests**: Roundtrip serialization, type coercion edge cases, migration, dirty tracking, load/save lifecycle

This PR adds the module **alongside** existing stores without changing any current behavior. Wiring into `climate.py` happens in #1917.

## Changed files

| File | Change |
|---|---|
| `utils/state_manager.py` | New: StateManager, RuntimeState, serialization, migration |
| `utils/calibration/mpc.py` | Add `MpcState = _MpcState` alias |
| `utils/calibration/tpi.py` | Add `TpiState = _TpiState` alias |
| `tests/unit/test_state_manager.py` | 58 unit tests |

## PR series (#1919)

| | PR | Status |
|---|---|---|
| **1** | **#1914 — StateManager module** | **this PR** |
| 2 | #1915 — MPC stateless compute | depends on this |
| 3 | #1916 — PID/TPI stateless compute | depends on #1915 |
| 4 | #1917 — Wire into climate.py | depends on #1916 |
| 5 | #1918 — Extract v0 migration | depends on #1917 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced unified runtime state persistence system for improved reliability and data integrity.
  * Added automatic state migration support with versioning for seamless upgrades.

* **Refactor**
  * Consolidated legacy state management into a single, centralized system with robust serialization and dirty-tracking.

* **Tests**
  * Comprehensive test coverage for state management, serialization, and migration logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->