### PR TITLE
refactor: Make compute_mpc() return (output, state) tuple

### DIFF
--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -253,7 +253,7 @@ def _compute_mpc_balance(self, entity_id: str):
         mpc_key = build_mpc_key(self, entity_id)
 
     try:
-        mpc_output = compute_mpc(
+        mpc_output, _mpc_state = compute_mpc(
             MpcInput(
                 key=mpc_key,
                 target_temp_C=self.bt_target_temp,

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -409,7 +409,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.cur_temp = None
         self._current_humidity = 0
         self.window_open = None
-        self.bt_target_temp_step = float(target_temp_step) if target_temp_step and target_temp_step != "0.0" else None
+        self.bt_target_temp_step = (
+            float(target_temp_step)
+            if target_temp_step and target_temp_step != "0.0"
+            else None
+        )
         self.bt_min_temp = 0
         self.bt_max_temp = 30
         self.bt_target_temp = 5.0

--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -59,8 +59,10 @@ _LOGGER = logging.getLogger(__name__)
 TEMP_STEP_SELECTOR = selector.SelectSelector(
     selector.SelectSelectorConfig(
         options=[
-            selector.SelectOptionDict(value="0.0", label="Auto"),  # Keep for backwards compatibility
-            selector.SelectOptionDict(value="", label="Auto (New)"), 
+            selector.SelectOptionDict(
+                value="0.0", label="Auto"
+            ),  # Keep for backwards compatibility
+            selector.SelectOptionDict(value="", label="Auto (New)"),
             selector.SelectOptionDict(value="0.1", label="0.1 °C"),
             selector.SelectOptionDict(value="0.2", label="0.2 °C"),
             selector.SelectOptionDict(value="0.25", label="0.25 °C"),

--- a/custom_components/better_thermostat/utils/calibration/mpc.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc.py
@@ -148,7 +148,9 @@ class _MpcState:
     tolerance_hold_active: bool = False
 
 
-# Public alias so that StateManager can reference the type.
+# Public alias so callers can reference the state type without
+# importing a private name.  The underscore-prefixed original is kept
+# for backwards compatibility within this module.
 MpcState = _MpcState
 
 _MPC_STATES: dict[str, _MpcState] = {}
@@ -365,7 +367,12 @@ def _split_mpc_key(key: str) -> tuple[str | None, str | None, str | None]:
         return None, None, None
 
 
-def _seed_state_from_siblings(key: str, state: _MpcState, params: MpcParams) -> None:
+def _seed_state_from_siblings(
+    key: str,
+    state: _MpcState,
+    params: MpcParams,
+    all_states: dict[str, _MpcState] | None = None,
+) -> None:
     if not bool(getattr(params, "enable_min_effective_percent", True)):
         return
     if state.min_effective_percent is not None:
@@ -373,7 +380,8 @@ def _seed_state_from_siblings(key: str, state: _MpcState, params: MpcParams) -> 
     uid, entity, _ = _split_mpc_key(key)
     if not uid or not entity:
         return
-    for other_key, other_state in _MPC_STATES.items():
+    states = all_states if all_states is not None else _MPC_STATES
+    for other_key, other_state in states.items():
         if other_key == key:
             continue
         ouid, oentity, _ = _split_mpc_key(other_key)
@@ -547,11 +555,47 @@ def _round_for_debug(value: float | int | None, digits: int = 3) -> float | int 
         return value
 
 
-def compute_mpc(inp: MpcInput, params: MpcParams) -> MpcOutput | None:
-    """Run the predictive controller and emit a valve recommendation."""
+def compute_mpc(
+    inp: MpcInput,
+    params: MpcParams,
+    state: _MpcState | None = None,
+    *,
+    all_states: dict[str, _MpcState] | None = None,
+) -> tuple[MpcOutput | None, _MpcState]:
+    """Run the predictive controller and emit a valve recommendation.
+
+    Parameters
+    ----------
+    inp:
+        Current measurements and context.
+    params:
+        Controller configuration (tuning knobs).
+    state:
+        Mutable controller state for this key.  When ``None`` the function
+        falls back to the module-level ``_MPC_STATES`` dict for backwards
+        compatibility, but callers are encouraged to pass state explicitly.
+    all_states:
+        Mapping of *all* MPC states (used for sibling seeding).  When
+        ``None`` the module-level ``_MPC_STATES`` dict is used.
+
+    Returns
+    -------
+    tuple[MpcOutput | None, _MpcState]
+        The valve recommendation (or ``None`` on early exit) **and** the
+        updated state object.  The caller owns persistence.
+    """
 
     now = time()
-    state = _MPC_STATES.setdefault(inp.key, _MpcState())
+
+    # --- Resolve state ---
+    if state is None:
+        # Legacy path: use the module-level global dict.
+        state = _MPC_STATES.setdefault(inp.key, _MpcState())
+    else:
+        # Explicit state path: also store in global dict so that
+        # export_mpc_state_map() still works during the transition period.
+        _MPC_STATES[inp.key] = state
+
     if state.created_ts == 0.0:
         # For existing trained models, backdate the creation timestamp
         # to avoid "Training" status if we already have confidence.
@@ -560,7 +604,7 @@ def compute_mpc(inp: MpcInput, params: MpcParams) -> MpcOutput | None:
         else:
             state.created_ts = time()
 
-    _seed_state_from_siblings(inp.key, state, params)
+    _seed_state_from_siblings(inp.key, state, params, all_states=all_states)
 
     if inp.window_open:
         state.last_window_open_ts = now
@@ -878,7 +922,7 @@ def compute_mpc(inp: MpcInput, params: MpcParams) -> MpcOutput | None:
         _round_for_debug(summary_perf_rate, 4),
     )
 
-    return MpcOutput(valve_percent=percent_out, debug=debug)
+    return MpcOutput(valve_percent=percent_out, debug=debug), state
 
 
 def _compute_predictive_percent(

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -236,7 +236,9 @@ def _deserialize(raw: dict[str, Any]) -> RuntimeState:
         except (TypeError, ValueError):
             heating_power = None
         try:
-            heat_loss_rate = float(heat_loss_rate) if heat_loss_rate is not None else None
+            heat_loss_rate = (
+                float(heat_loss_rate) if heat_loss_rate is not None else None
+            )
         except (TypeError, ValueError):
             heat_loss_rate = None
         state.thermal = ThermalStats(

--- a/tests/unit/test_mpc_comprehensive.py
+++ b/tests/unit/test_mpc_comprehensive.py
@@ -105,10 +105,16 @@ def _default_params(
     overrides = {
         k: local[k]
         for k in base_field_names
-        if k in local and local[k] is not _UNSET and k not in {
-            "min_update_interval_s", "min_percent_hold_time_s",
-            "percent_hysteresis_pts", "mpc_du_max_pct",
-            "use_virtual_temp", "enable_min_effective_percent",
+        if k in local
+        and local[k] is not _UNSET
+        and k
+        not in {
+            "min_update_interval_s",
+            "min_percent_hold_time_s",
+            "percent_hysteresis_pts",
+            "mpc_du_max_pct",
+            "use_virtual_temp",
+            "enable_min_effective_percent",
         }
     }
     return replace(base, **overrides) if overrides else base

--- a/tests/unit/test_mpc_comprehensive.py
+++ b/tests/unit/test_mpc_comprehensive.py
@@ -114,44 +114,27 @@ def _default_params(
     return replace(base, **overrides) if overrides else base
 
 
-def _inp(
-    key: str = "test",
-    *,
-    target_temp_C: float | None = 22.0,
-    current_temp_C: float | None = 20.0,
-    heating_allowed: bool = True,
-    window_open: bool = False,
-    filtered_temp_C: float | None = None,
-    trv_temp_C: float | None = None,
-    tolerance_K: float = 0.0,
-    temp_slope_K_per_min: float | None = None,
-    bt_name: str | None = None,
-    entity_id: str | None = None,
-    outdoor_temp_C: float | None = None,
-    is_day: bool = True,
-    other_heat_power: float = 0.0,
-    solar_intensity: float = 0.0,
-    max_opening_pct: float | None = None,
-) -> MpcInput:
+def _compute(inp: MpcInput, params: MpcParams) -> MpcOutput | None:
+    """Call compute_mpc and return only the MpcOutput (discard state).
+
+    Most tests only need the output; the few that inspect the returned
+    state can call ``compute_mpc`` directly.
+    """
+    output, _state = compute_mpc(inp, params)
+    return output
+
+
+def _inp(key: str = "test", **overrides) -> MpcInput:
     """Shortcut for creating MpcInput with defaults."""
-    return MpcInput(
-        key=key,
-        target_temp_C=target_temp_C,
-        current_temp_C=current_temp_C,
-        heating_allowed=heating_allowed,
-        window_open=window_open,
-        filtered_temp_C=filtered_temp_C,
-        trv_temp_C=trv_temp_C,
-        tolerance_K=tolerance_K,
-        temp_slope_K_per_min=temp_slope_K_per_min,
-        bt_name=bt_name,
-        entity_id=entity_id,
-        outdoor_temp_C=outdoor_temp_C,
-        is_day=is_day,
-        other_heat_power=other_heat_power,
-        solar_intensity=solar_intensity,
-        max_opening_pct=max_opening_pct,
-    )
+    defaults = {
+        "key": key,
+        "target_temp_C": 22.0,
+        "current_temp_C": 20.0,
+        "heating_allowed": True,
+        "window_open": False,
+    }
+    defaults.update(overrides)
+    return MpcInput(**defaults)
 
 
 # ===================================================================
@@ -398,41 +381,41 @@ class TestComputeMpcBasic:
 
     def test_returns_mpc_output(self):
         """Test that compute_mpc returns a valid MpcOutput."""
-        result = compute_mpc(_inp(), _default_params())
+        result = _compute(_inp(), _default_params())
         assert isinstance(result, MpcOutput)
         assert 0 <= result.valve_percent <= 100
 
     def test_window_open_returns_zero(self):
         """Test that window_open forces valve to 0%."""
-        result = compute_mpc(_inp(window_open=True), _default_params())
+        result = _compute(_inp(window_open=True), _default_params())
         assert result.valve_percent == 0
 
     def test_heating_not_allowed_returns_zero(self):
         """Test that heating_allowed=False forces valve to 0%."""
-        result = compute_mpc(_inp(heating_allowed=False), _default_params())
+        result = _compute(_inp(heating_allowed=False), _default_params())
         assert result.valve_percent == 0
 
     def test_missing_target_temp(self):
         """Test that None target temp produces 0% valve."""
-        result = compute_mpc(_inp(target_temp_C=None), _default_params())
+        result = _compute(_inp(target_temp_C=None), _default_params())
         assert result is not None
         assert result.valve_percent == 0
 
     def test_missing_current_temp(self):
         """Test that None current temp does not crash."""
-        result = compute_mpc(_inp(current_temp_C=None), _default_params())
+        result = _compute(_inp(current_temp_C=None), _default_params())
         assert result is not None
 
     def test_both_temps_none(self):
         """Test that both temps None does not crash."""
-        result = compute_mpc(
+        result = _compute(
             _inp(target_temp_C=None, current_temp_C=None), _default_params()
         )
         assert result is not None
 
     def test_large_positive_error_gives_high_valve(self):
         """4K below target -> valve should be high."""
-        result = compute_mpc(
+        result = _compute(
             _inp(current_temp_C=18.0, target_temp_C=22.0), _default_params()
         )
         assert result.valve_percent >= 50
@@ -440,20 +423,20 @@ class TestComputeMpcBasic:
     def test_at_target_gives_base_load(self):
         """At target -> valve should be around u0 (base load), not zero."""
         params = _default_params(mpc_adapt=False)
-        result = compute_mpc(_inp(current_temp_C=22.0, target_temp_C=22.0), params)
+        result = _compute(_inp(current_temp_C=22.0, target_temp_C=22.0), params)
         # At target, optimizer should find u0 as optimal (compensate losses)
         assert result.valve_percent >= 0
 
     def test_above_target_gives_zero_or_low(self):
         """0.5K above target -> valve should be low or zero."""
         params = _default_params(mpc_adapt=False)
-        result = compute_mpc(_inp(current_temp_C=22.5, target_temp_C=22.0), params)
+        result = _compute(_inp(current_temp_C=22.5, target_temp_C=22.0), params)
         assert result.valve_percent <= 30
 
     def test_far_above_target_shutoff(self):
         """1K above target -> should shut off."""
         params = _default_params(mpc_adapt=False)
-        result = compute_mpc(_inp(current_temp_C=23.0, target_temp_C=22.0), params)
+        result = _compute(_inp(current_temp_C=23.0, target_temp_C=22.0), params)
         assert result.valve_percent == 0
 
     def test_valve_monotonically_increases_with_error(self):
@@ -462,7 +445,7 @@ class TestComputeMpcBasic:
         temps = [21.5, 21.0, 20.5, 20.0, 19.0, 18.0]
         results = []
         for current in temps:
-            r = compute_mpc(_inp(key=f"mono_{current}", current_temp_C=current), params)
+            r = _compute(_inp(key=f"mono_{current}", current_temp_C=current), params)
             results.append(r.valve_percent)
         # Each should be >= previous (or equal for saturation)
         for i in range(1, len(results)):
@@ -474,8 +457,8 @@ class TestComputeMpcBasic:
     def test_filtered_temp_reduces_valve_demand(self):
         """filtered_temp_C closer to target should lower the cost-optimized valve."""
         params = _default_params(mpc_adapt=False)
-        raw = compute_mpc(_inp(key="filt_raw", current_temp_C=20.5), params)
-        filt = compute_mpc(
+        raw = _compute(_inp(key="filt_raw", current_temp_C=20.5), params)
+        filt = _compute(
             _inp(key="filt_filt", current_temp_C=20.5, filtered_temp_C=21.8), params
         )
         assert filt.valve_percent <= raw.valve_percent
@@ -483,13 +466,13 @@ class TestComputeMpcBasic:
     def test_window_open_resets_control_state(self):
         """Test that window_open resets integrals and control state."""
         params = _default_params(mpc_adapt=True)
-        compute_mpc(_inp(key="win"), params)
+        _compute(_inp(key="win"), params)
         state = mpc_mod._MPC_STATES["win"]
         state.last_percent = 50.0
         state.u_integral = 1000.0
         state.time_integral = 100.0
 
-        compute_mpc(_inp(key="win", window_open=True), params)
+        _compute(_inp(key="win", window_open=True), params)
         state = mpc_mod._MPC_STATES["win"]
         assert state.last_percent == 0.0
         assert state.u_integral == 0.0
@@ -500,21 +483,21 @@ class TestComputeMpcBasic:
     def test_calibration_aborted_on_window_open(self):
         """Active calibration should be aborted when window opens."""
         params = _default_params()
-        compute_mpc(_inp(key="cal_abort"), params)
+        _compute(_inp(key="cal_abort"), params)
         mpc_mod._MPC_STATES["cal_abort"].is_calibration_active = True
 
-        compute_mpc(_inp(key="cal_abort", window_open=True), params)
+        _compute(_inp(key="cal_abort", window_open=True), params)
         assert mpc_mod._MPC_STATES["cal_abort"].is_calibration_active is False
 
     def test_valve_integration_accumulates(self):
         """u_integral should accumulate valve position over time."""
         params = _default_params()
-        compute_mpc(_inp(key="integ"), params)
+        _compute(_inp(key="integ"), params)
         state = mpc_mod._MPC_STATES["integ"]
         state.last_percent = 50.0
         old_integral = state.u_integral
 
-        compute_mpc(_inp(key="integ"), params)
+        _compute(_inp(key="integ"), params)
         # Integration should have increased (last_percent * dt)
         # dt might be tiny in tests, but integral shouldn't decrease
         assert state.u_integral >= old_integral
@@ -530,7 +513,7 @@ class TestAdaptiveLearning:
 
     def _setup_learning_state(self, key: str, params: MpcParams, **state_overrides):
         """Initialize MPC state and set up for learning."""
-        compute_mpc(_inp(key=key), params)
+        _compute(_inp(key=key), params)
         state = mpc_mod._MPC_STATES[key]
         for k, v in state_overrides.items():
             setattr(state, k, v)
@@ -539,21 +522,21 @@ class TestAdaptiveLearning:
     def test_gain_initialized_on_first_call(self):
         """Test that gain_est is seeded from mpc_thermal_gain on first call."""
         params = _default_params(mpc_adapt=True, mpc_thermal_gain=0.08)
-        compute_mpc(_inp(key="ginit"), params)
+        _compute(_inp(key="ginit"), params)
         state = mpc_mod._MPC_STATES["ginit"]
         assert state.gain_est == pytest.approx(0.08)
 
     def test_loss_initialized_on_first_call(self):
         """Test that loss_est is seeded from mpc_loss_coeff on first call."""
         params = _default_params(mpc_adapt=True, mpc_loss_coeff=0.012)
-        compute_mpc(_inp(key="linit"), params)
+        _compute(_inp(key="linit"), params)
         state = mpc_mod._MPC_STATES["linit"]
         assert state.loss_est == pytest.approx(0.012)
 
     def test_no_adaptation_when_disabled(self):
         """Test that gain_est and loss_est stay None when mpc_adapt=False."""
         params = _default_params(mpc_adapt=False)
-        compute_mpc(_inp(key="noadapt"), params)
+        _compute(_inp(key="noadapt"), params)
         state = mpc_mod._MPC_STATES["noadapt"]
         assert state.gain_est is None
         assert state.loss_est is None
@@ -580,7 +563,7 @@ class TestAdaptiveLearning:
         loss_before = state.loss_est
 
         # Room cooled from 21.0 to 20.5 in 5 min = -0.1 °C/min
-        compute_mpc(_inp(key="loss_cool", current_temp_C=20.5), params)
+        _compute(_inp(key="loss_cool", current_temp_C=20.5), params)
         # Loss should have increased (room is cooling faster than model predicted)
         assert state.loss_est >= loss_before
 
@@ -606,7 +589,7 @@ class TestAdaptiveLearning:
         )
 
         # Room warmed from 20.0 to 20.5 in 5 min
-        compute_mpc(_inp(key="gain_warm", current_temp_C=20.5), params)
+        _compute(_inp(key="gain_warm", current_temp_C=20.5), params)
         # gain_est should have been updated
         assert state.gain_est is not None
 
@@ -626,7 +609,7 @@ class TestAdaptiveLearning:
         gain_before = state.gain_est
         loss_before = state.loss_est
 
-        compute_mpc(_inp(key="win_block", current_temp_C=20.5), params)
+        _compute(_inp(key="win_block", current_temp_C=20.5), params)
         # Should NOT adapt (within window block period)
         assert state.gain_est == pytest.approx(gain_before)
         assert state.loss_est == pytest.approx(loss_before)
@@ -649,7 +632,7 @@ class TestAdaptiveLearning:
         gain_before = state.gain_est
 
         # Change target by >= 0.05
-        compute_mpc(
+        _compute(
             _inp(key="tgt_change", target_temp_C=23.0, current_temp_C=20.5), params
         )
         # target_changed should block adaptation
@@ -672,7 +655,7 @@ class TestAdaptiveLearning:
         gain_before = state.gain_est
 
         # Temperature jumped from 20.0 to 22.0 in 3 min = 0.67 °C/min
-        compute_mpc(_inp(key="extreme", current_temp_C=22.0), params)
+        _compute(_inp(key="extreme", current_temp_C=22.0), params)
         # Should NOT update gain (rate > 0.35 °C/min)
         assert state.gain_est == pytest.approx(gain_before)
 
@@ -694,7 +677,7 @@ class TestAdaptiveLearning:
         )
 
         # Room warmed a lot -> gain candidate could be very high
-        compute_mpc(_inp(key="gclamp", current_temp_C=20.8), params)
+        _compute(_inp(key="gclamp", current_temp_C=20.8), params)
         assert state.gain_est <= params.mpc_gain_max
         assert state.gain_est >= params.mpc_gain_min
 
@@ -720,7 +703,7 @@ class TestAdaptiveLearning:
         )
 
         # Room cooled fast -> loss candidate high
-        compute_mpc(_inp(key="lclamp", current_temp_C=20.0), params)
+        _compute(_inp(key="lclamp", current_temp_C=20.0), params)
         assert state.loss_est <= params.mpc_loss_max
         assert state.loss_est >= params.mpc_loss_min
 
@@ -748,13 +731,13 @@ class TestAdaptiveLearning:
         # Room dropped 1.5K in 5 min = 0.3 °C/min >> 1.5 * 0.03 = 0.045
         # But max rate is 0.35, so we need a smaller drop: 1K in 5min = 0.2 °C/min
         # 0.2 > 0.045 → should be skipped
-        compute_mpc(_inp(key="loss_ow", current_temp_C=20.0), params)
+        _compute(_inp(key="loss_ow", current_temp_C=20.0), params)
         assert state.loss_est == pytest.approx(loss_before)
 
     def test_ka_est_initialized_with_outdoor_temp(self):
         """ka_est should be calculated when outdoor_temp is provided."""
         params = _default_params(mpc_adapt=True, mpc_loss_coeff=0.01)
-        compute_mpc(_inp(key="ka", current_temp_C=20.0, outdoor_temp_C=5.0), params)
+        _compute(_inp(key="ka", current_temp_C=20.0, outdoor_temp_C=5.0), params)
         state = mpc_mod._MPC_STATES["ka"]
         assert state.ka_est is not None
         # ka = loss / (indoor - outdoor) = 0.01 / 15 ≈ 0.000667
@@ -783,7 +766,7 @@ class TestAdaptiveLearning:
         gain_before = state.gain_est
 
         # Room is 1K below target, temp unchanged (steady state -> rate ≈ 0)
-        compute_mpc(_inp(key="insuff", current_temp_C=21.0, target_temp_C=22.0), params)
+        _compute(_inp(key="insuff", current_temp_C=21.0, target_temp_C=22.0), params)
         # With residual learning: loss_candidate = gain*u - rate ≈ 0.06*0.167 - 0 ≈ 0.01
         # If loss_candidate > loss_est AND target-current > 0.2 -> insufficient heat
         # -> gain should be reduced
@@ -801,14 +784,14 @@ class TestVirtualTemperature:
     def test_virtual_temp_initialized_from_sensor(self):
         """Test that virtual_temp starts at the sensor reading."""
         params = _default_params(use_virtual_temp=True)
-        compute_mpc(_inp(key="vinit", current_temp_C=20.5), params)
+        _compute(_inp(key="vinit", current_temp_C=20.5), params)
         state = mpc_mod._MPC_STATES["vinit"]
         assert state.virtual_temp == pytest.approx(20.5)
 
     def test_virtual_temp_corrects_large_drift(self):
         """Kalman filter should correct virtual_temp when it drifts far from sensor."""
         params = _default_params(use_virtual_temp=True)
-        compute_mpc(_inp(key="vreset", current_temp_C=20.0), params)
+        _compute(_inp(key="vreset", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["vreset"]
         # Artificially drift virtual temp far from sensor
         state.virtual_temp = 21.0  # 1K off from sensor at 20.0
@@ -816,38 +799,38 @@ class TestVirtualTemperature:
         state.last_percent = 50.0
         state.kalman_P = 1.0  # High uncertainty → Kalman gain ≈ 1.0
 
-        compute_mpc(_inp(key="vreset", current_temp_C=20.0), params)
+        _compute(_inp(key="vreset", current_temp_C=20.0), params)
         # Kalman should correct most of the 1K drift
         assert abs(state.virtual_temp - 20.0) < 0.5
 
     def test_virtual_temp_stays_close_to_sensor(self):
         """Kalman update should keep virtual_temp close to sensor value."""
         params = _default_params(use_virtual_temp=True)
-        compute_mpc(_inp(key="vclamp", current_temp_C=20.0), params)
+        _compute(_inp(key="vclamp", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["vclamp"]
         state.virtual_temp = 20.3  # slightly drifted
         state.last_sensor_temp_C = 19.9  # different so update fires
         state.last_percent = 50.0
 
-        compute_mpc(_inp(key="vclamp", current_temp_C=20.0), params)
+        _compute(_inp(key="vclamp", current_temp_C=20.0), params)
         # After Kalman update, virtual_temp should be closer to sensor
         assert abs(state.virtual_temp - 20.0) < 0.3
 
     def test_virtual_temp_not_synced_when_sensor_unchanged(self):
         """Sync should be skipped when sensor value hasn't changed."""
         params = _default_params(use_virtual_temp=True)
-        compute_mpc(_inp(key="vsame", current_temp_C=20.0), params)
+        _compute(_inp(key="vsame", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["vsame"]
         state.last_sensor_temp_C = 20.0  # same as current
         state.last_percent = 50.0
 
-        compute_mpc(_inp(key="vsame", current_temp_C=20.0), params)
+        _compute(_inp(key="vsame", current_temp_C=20.0), params)
         assert state.virtual_temp is not None
 
     def test_virtual_temp_used_for_delta_t(self):
         """When virtual temp is enabled, delta_t should use virtual temp, not sensor."""
         params = _default_params(use_virtual_temp=True)
-        compute_mpc(_inp(key="vdelta", current_temp_C=20.0, target_temp_C=22.0), params)
+        _compute(_inp(key="vdelta", current_temp_C=20.0, target_temp_C=22.0), params)
         state = mpc_mod._MPC_STATES["vdelta"]
         # Virtual temp should be close to sensor on first call
         assert state.virtual_temp is not None
@@ -855,10 +838,10 @@ class TestVirtualTemperature:
     def test_window_open_clears_virtual_temp(self):
         """Test that window_open resets virtual_temp to None."""
         params = _default_params(use_virtual_temp=True)
-        compute_mpc(_inp(key="vwin", current_temp_C=20.0), params)
+        _compute(_inp(key="vwin", current_temp_C=20.0), params)
         assert mpc_mod._MPC_STATES["vwin"].virtual_temp is not None
 
-        compute_mpc(_inp(key="vwin", window_open=True), params)
+        _compute(_inp(key="vwin", window_open=True), params)
         assert mpc_mod._MPC_STATES["vwin"].virtual_temp is None
 
 
@@ -922,7 +905,7 @@ class TestRegimeBoostIntegration:
     def test_regime_boost_activates_on_sustained_bias(self):
         """Test that regime boost triggers when recent_errors show sustained bias."""
         params = _default_params(mpc_adapt=True, mpc_adapt_alpha=0.1)
-        compute_mpc(_inp(key="rboost"), params)
+        _compute(_inp(key="rboost"), params)
         state = mpc_mod._MPC_STATES["rboost"]
         # Inject biased errors to trigger regime change
         state.recent_errors = [0.05] * 15
@@ -1029,11 +1012,11 @@ class TestPostProcessing:
         """Small changes should be suppressed by hysteresis."""
         params = _default_params(percent_hysteresis_pts=3.0)
         # First call establishes baseline
-        r1 = compute_mpc(_inp(key="hyst", current_temp_C=20.0), params)
+        r1 = _compute(_inp(key="hyst", current_temp_C=20.0), params)
         pct1 = r1.valve_percent
 
         # Second call with tiny temperature change
-        r2 = compute_mpc(_inp(key="hyst", current_temp_C=20.05), params)
+        r2 = _compute(_inp(key="hyst", current_temp_C=20.05), params)
         # Should be same due to hysteresis
         assert r2.valve_percent == pct1
 
@@ -1042,13 +1025,13 @@ class TestPostProcessing:
         params = _default_params(
             percent_hysteresis_pts=5.0, min_percent_hold_time_s=300.0
         )
-        r1 = compute_mpc(
+        r1 = _compute(
             _inp(key="tgt_bypass", current_temp_C=20.0, target_temp_C=22.0), params
         )
         pct1 = r1.valve_percent
 
         # Change target significantly
-        r2 = compute_mpc(
+        r2 = _compute(
             _inp(key="tgt_bypass", current_temp_C=20.0, target_temp_C=18.0), params
         )
         # Should produce a different result (not blocked)
@@ -1060,15 +1043,13 @@ class TestPostProcessing:
         params = _default_params(mpc_du_max_pct=5.0)
 
         # First call: cold room -> high valve
-        compute_mpc(_inp(key="dumax", current_temp_C=18.0), params)
+        _compute(_inp(key="dumax", current_temp_C=18.0), params)
         state = mpc_mod._MPC_STATES["dumax"]
         state.last_percent = 50.0  # Force a known starting point
         state.last_update_ts = time()
 
         # Second call: want to go to 0 (warm room)
-        r = compute_mpc(
-            _inp(key="dumax", current_temp_C=25.0, target_temp_C=22.0), params
-        )
+        r = _compute(_inp(key="dumax", current_temp_C=25.0, target_temp_C=22.0), params)
         # Change should be limited to ±5%
         assert r.valve_percent >= 45  # 50 - 5
 
@@ -1076,23 +1057,23 @@ class TestPostProcessing:
         """min_percent_hold_time_s should block updates that come too fast."""
         params = _default_params(min_percent_hold_time_s=300.0)
 
-        r1 = compute_mpc(_inp(key="hold", current_temp_C=20.0), params)
+        r1 = _compute(_inp(key="hold", current_temp_C=20.0), params)
         pct1 = r1.valve_percent
 
         # Immediate second call (too soon)
-        r2 = compute_mpc(_inp(key="hold", current_temp_C=19.0), params)
+        r2 = _compute(_inp(key="hold", current_temp_C=19.0), params)
         # Should be blocked (same as last)
         assert r2.valve_percent == pct1
 
     def test_min_effective_percent_clamp(self):
         """If min_effective_percent is set, low nonzero outputs should be clamped up."""
         params = _default_params(enable_min_effective_percent=True)
-        compute_mpc(_inp(key="mineff"), params)
+        _compute(_inp(key="mineff"), params)
         state = mpc_mod._MPC_STATES["mineff"]
         state.min_effective_percent = 15.0
 
         # Request a small valve opening
-        r = compute_mpc(
+        r = _compute(
             _inp(key="mineff", current_temp_C=21.9, target_temp_C=22.0), params
         )
         # If valve > 0, should be >= 15
@@ -1171,22 +1152,22 @@ class TestForcedCalibration:
     def test_calibration_ends_when_temp_drops_below_threshold(self):
         """Active calibration should end when temp < target - hysteresis."""
         params = _default_params()
-        compute_mpc(_inp(key="calend", current_temp_C=22.5, target_temp_C=22.0), params)
+        _compute(_inp(key="calend", current_temp_C=22.5, target_temp_C=22.0), params)
         state = mpc_mod._MPC_STATES["calend"]
         state.is_calibration_active = True
 
         # Temp drops to 21.7 (< 22.0 - 0.2 = 21.8)
-        compute_mpc(_inp(key="calend", current_temp_C=21.7, target_temp_C=22.0), params)
+        _compute(_inp(key="calend", current_temp_C=21.7, target_temp_C=22.0), params)
         assert state.is_calibration_active is False
 
     def test_calibration_keeps_valve_at_zero(self):
         """During active calibration, valve should be forced to 0."""
         params = _default_params()
-        compute_mpc(_inp(key="cal0", current_temp_C=22.1, target_temp_C=22.0), params)
+        _compute(_inp(key="cal0", current_temp_C=22.1, target_temp_C=22.0), params)
         state = mpc_mod._MPC_STATES["cal0"]
         state.is_calibration_active = True
 
-        result = compute_mpc(
+        result = _compute(
             _inp(key="cal0", current_temp_C=22.1, target_temp_C=22.0), params
         )
         assert result.valve_percent == 0
@@ -1197,7 +1178,7 @@ class TestForcedCalibration:
         triggered = False
         for i in range(50):
             key = f"cal_stoch_{i}"
-            compute_mpc(_inp(key=key, current_temp_C=22.5, target_temp_C=22.0), params)
+            _compute(_inp(key=key, current_temp_C=22.5, target_temp_C=22.0), params)
             state = mpc_mod._MPC_STATES[key]
             if state.is_calibration_active:
                 triggered = True
@@ -1208,7 +1189,7 @@ class TestForcedCalibration:
     def test_calibration_chance_decays_with_experience(self):
         """Calibration chance should decay as loss_learn_count increases."""
         params = _default_params()
-        compute_mpc(_inp(key="cal_decay"), params)
+        _compute(_inp(key="cal_decay"), params)
         state = mpc_mod._MPC_STATES["cal_decay"]
         state.loss_learn_count = 100
         # chance = max(0.05, 1/(100+1)) ≈ 0.01 -> clamped to 0.05
@@ -1228,13 +1209,13 @@ class TestStaleStateDetection:
     def test_stale_state_resets_learning(self):
         """Test that stale state (>15min) resets learning anchors."""
         params = _default_params(mpc_adapt=True)
-        compute_mpc(_inp(key="stale"), params)
+        _compute(_inp(key="stale"), params)
         state = mpc_mod._MPC_STATES["stale"]
         state.last_time = time() - 1000  # 16+ min ago
         state.last_learn_temp = 19.0
         state.u_integral = 5000.0
 
-        compute_mpc(_inp(key="stale", current_temp_C=21.0), params)
+        _compute(_inp(key="stale", current_temp_C=21.0), params)
         # u_integral should be reset
         assert state.u_integral == 0.0
 
@@ -1255,7 +1236,7 @@ class TestSeedFromSiblings:
         mpc_mod._MPC_STATES["uid1:climate.trv:t21.0"] = sibling_state
 
         # New key same uid+entity, different bucket
-        compute_mpc(_inp(key="uid1:climate.trv:t22.0", current_temp_C=20.0), params)
+        _compute(_inp(key="uid1:climate.trv:t22.0", current_temp_C=20.0), params)
         new_state = mpc_mod._MPC_STATES["uid1:climate.trv:t22.0"]
         assert new_state.min_effective_percent == 15.0
 
@@ -1265,7 +1246,7 @@ class TestSeedFromSiblings:
         sibling_state = _MpcState(min_effective_percent=15.0)
         mpc_mod._MPC_STATES["uid2:climate.trv:t21.0"] = sibling_state
 
-        compute_mpc(_inp(key="uid2:climate.trv:t22.0", current_temp_C=20.0), params)
+        _compute(_inp(key="uid2:climate.trv:t22.0", current_temp_C=20.0), params)
         new_state = mpc_mod._MPC_STATES["uid2:climate.trv:t22.0"]
         assert new_state.min_effective_percent is None
 
@@ -1275,7 +1256,7 @@ class TestSeedFromSiblings:
         sibling_state = _MpcState(min_effective_percent=15.0)
         mpc_mod._MPC_STATES["uid3:climate.trv_A:t21.0"] = sibling_state
 
-        compute_mpc(_inp(key="uid3:climate.trv_B:t22.0", current_temp_C=20.0), params)
+        _compute(_inp(key="uid3:climate.trv_B:t22.0", current_temp_C=20.0), params)
         new_state = mpc_mod._MPC_STATES["uid3:climate.trv_B:t22.0"]
         assert new_state.min_effective_percent is None
 
@@ -1291,20 +1272,20 @@ class TestEdgeCases:
     def test_very_large_temperature_error(self):
         """20K error should not crash and should give 100%."""
         params = _default_params()
-        result = compute_mpc(_inp(current_temp_C=2.0, target_temp_C=22.0), params)
+        result = _compute(_inp(current_temp_C=2.0, target_temp_C=22.0), params)
         assert result.valve_percent == 100
 
     def test_negative_temperature(self):
         """Negative temperatures (e.g., frost) should work."""
         params = _default_params()
-        result = compute_mpc(_inp(current_temp_C=-5.0, target_temp_C=5.0), params)
+        result = _compute(_inp(current_temp_C=-5.0, target_temp_C=5.0), params)
         assert result is not None
         assert result.valve_percent == 100
 
     def test_zero_gain_does_not_crash(self):
         """gain=0 should not cause ZeroDivisionError."""
         params = _default_params(mpc_thermal_gain=0.0, mpc_adapt=False)
-        result = compute_mpc(_inp(), params)
+        result = _compute(_inp(), params)
         assert result is not None
 
     def test_identical_consecutive_calls_are_stable(self):
@@ -1312,7 +1293,7 @@ class TestEdgeCases:
         params = _default_params()
         results = []
         for _ in range(5):
-            r = compute_mpc(_inp(key="stable"), params)
+            r = _compute(_inp(key="stable"), params)
             results.append(r.valve_percent)
         # After settling, values should be the same
         assert results[-1] == results[-2]
@@ -1321,7 +1302,7 @@ class TestEdgeCases:
         """Rapid target temp changes should not crash."""
         params = _default_params()
         for target in [18, 22, 15, 25, 20, 23, 17]:
-            result = compute_mpc(
+            result = _compute(
                 _inp(key="rapid", current_temp_C=20.0, target_temp_C=float(target)),
                 params,
             )
@@ -1332,11 +1313,11 @@ class TestEdgeCases:
         """With outdoor temp and ka_est, loss should be dynamic."""
         params = _default_params(mpc_adapt=True)
         # Cold outside -> higher loss
-        r_cold = compute_mpc(
+        r_cold = _compute(
             _inp(key="out_cold", current_temp_C=20.0, outdoor_temp_C=-10.0), params
         )
         # Warm outside -> lower loss
-        r_warm = compute_mpc(
+        r_warm = _compute(
             _inp(key="out_warm", current_temp_C=20.0, outdoor_temp_C=15.0), params
         )
         # Cold outside should need more valve
@@ -1345,8 +1326,8 @@ class TestEdgeCases:
     def test_other_heat_power_reduces_valve(self):
         """Specifying other_heat_power should reduce valve demand."""
         params = _default_params(mpc_adapt=False)
-        r_no_other = compute_mpc(_inp(key="ohp_no", current_temp_C=20.0), params)
-        r_with_other = compute_mpc(
+        r_no_other = _compute(_inp(key="ohp_no", current_temp_C=20.0), params)
+        r_with_other = _compute(
             _inp(key="ohp_yes", current_temp_C=20.0, other_heat_power=0.05), params
         )
         # other heat power should reduce (or equal) valve demand
@@ -1359,11 +1340,11 @@ class TestEdgeCases:
         )
         params_overshoot = _default_params(mpc_adapt=False, mpc_overshoot_penalty=5.0)
 
-        r_no_overshoot = compute_mpc(
+        r_no_overshoot = _compute(
             _inp(key="over_no", current_temp_C=22.1, target_temp_C=22.0),
             params_no_overshoot,
         )
-        r_overshoot = compute_mpc(
+        r_overshoot = _compute(
             _inp(key="over_yes", current_temp_C=22.1, target_temp_C=22.0),
             params_overshoot,
         )
@@ -1372,13 +1353,13 @@ class TestEdgeCases:
     def test_slope_ema_updated_in_debug(self):
         """When temp_slope_K_per_min is provided, EMA slope should be tracked."""
         params = _default_params()
-        compute_mpc(_inp(key="slope_ema", temp_slope_K_per_min=0.05), params)
+        _compute(_inp(key="slope_ema", temp_slope_K_per_min=0.05), params)
         state = mpc_mod._MPC_STATES["slope_ema"]
         assert state.ema_slope is not None
         assert state.ema_slope == pytest.approx(0.05)
 
         # Second call with different slope -> EMA blend
-        compute_mpc(_inp(key="slope_ema", temp_slope_K_per_min=0.10), params)
+        _compute(_inp(key="slope_ema", temp_slope_K_per_min=0.10), params)
         # ema = 0.6 * 0.05 + 0.4 * 0.10 = 0.07
         assert state.ema_slope == pytest.approx(0.07, abs=0.001)
 
@@ -1519,7 +1500,7 @@ class TestKalmanFilter:
         Init: P=R=0.04, then update: K=P/(P+R)=0.5, P_new=(1-0.5)*0.04=0.02.
         """
         params = _default_params(use_virtual_temp=True, kalman_R=0.04)
-        compute_mpc(_inp(key="kp_init", current_temp_C=20.0), params)
+        _compute(_inp(key="kp_init", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["kp_init"]
         # Init sets P=R=0.04, then sensor_changed triggers update:
         # K = P/(P+R) = 0.04/(0.04+0.04) = 0.5
@@ -1529,7 +1510,7 @@ class TestKalmanFilter:
     def test_kalman_p_grows_during_predict(self):
         """P should increase after predict step (uncertainty grows with time)."""
         params = _default_params(use_virtual_temp=True, kalman_Q=0.001)
-        compute_mpc(_inp(key="kp_grow", current_temp_C=20.0), params)
+        _compute(_inp(key="kp_grow", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["kp_grow"]
         state.last_percent = 50.0
         P_after_init = state.kalman_P
@@ -1537,33 +1518,33 @@ class TestKalmanFilter:
         # Advance virtual_temp_ts backward to force a predict step
         state.virtual_temp_ts = time() - 60  # 60s ago
 
-        compute_mpc(_inp(key="kp_grow", current_temp_C=20.0), params)
+        _compute(_inp(key="kp_grow", current_temp_C=20.0), params)
         # P should have grown by Q * dt_s
         assert state.kalman_P > P_after_init
 
     def test_kalman_p_shrinks_on_update(self):
         """P should decrease after update step (measurement reduces uncertainty)."""
         params = _default_params(use_virtual_temp=True, kalman_Q=0.001, kalman_R=0.04)
-        compute_mpc(_inp(key="kp_shrink", current_temp_C=20.0), params)
+        _compute(_inp(key="kp_shrink", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["kp_shrink"]
         state.last_percent = 50.0
         state.kalman_P = 1.0  # High uncertainty
         state.last_sensor_temp_C = 19.5  # Different from current → triggers update
 
-        compute_mpc(_inp(key="kp_shrink", current_temp_C=20.0), params)
+        _compute(_inp(key="kp_shrink", current_temp_C=20.0), params)
         # After update: P_new = (1 - K) * P, so it must be smaller
         assert state.kalman_P < 1.0
 
     def test_kalman_gain_high_P(self):
         """With high P (relative to R), Kalman gain K → 1, trusting sensor more."""
         params = _default_params(use_virtual_temp=True, kalman_R=0.04)
-        compute_mpc(_inp(key="kg_high", current_temp_C=20.0), params)
+        _compute(_inp(key="kg_high", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["kg_high"]
         state.kalman_P = 100.0  # Very high uncertainty
         state.last_sensor_temp_C = 19.0  # Force update
         state.virtual_temp = 21.0  # Far from sensor
 
-        compute_mpc(_inp(key="kg_high", current_temp_C=20.0), params)
+        _compute(_inp(key="kg_high", current_temp_C=20.0), params)
         # K ≈ 100 / (100 + 0.04) ≈ 0.9996
         # virtual_temp should be very close to 20.0
         assert abs(state.virtual_temp - 20.0) < 0.01
@@ -1571,13 +1552,13 @@ class TestKalmanFilter:
     def test_kalman_gain_low_P(self):
         """With low P (relative to R), Kalman gain K → 0, trusting model more."""
         params = _default_params(use_virtual_temp=True, kalman_R=0.04)
-        compute_mpc(_inp(key="kg_low", current_temp_C=20.0), params)
+        _compute(_inp(key="kg_low", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["kg_low"]
         state.kalman_P = 0.0001  # Very low uncertainty
         state.last_sensor_temp_C = 19.0  # Force update
         state.virtual_temp = 21.0  # Far from sensor
 
-        compute_mpc(_inp(key="kg_low", current_temp_C=20.0), params)
+        _compute(_inp(key="kg_low", current_temp_C=20.0), params)
         # K ≈ 0.0001 / (0.0001 + 0.04) ≈ 0.0025
         # virtual_temp should barely change
         assert abs(state.virtual_temp - 21.0) < 0.1
@@ -1590,7 +1571,7 @@ class TestKalmanFilter:
             mpc_loss_coeff=0.01,
             mpc_adapt=True,
         )
-        compute_mpc(_inp(key="kpred", current_temp_C=20.0), params)
+        _compute(_inp(key="kpred", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["kpred"]
         state.last_percent = 100.0  # Full open
         state.gain_est = 0.06
@@ -1601,7 +1582,7 @@ class TestKalmanFilter:
         # Set sensor same as current to skip update
         state.last_sensor_temp_C = 20.0
 
-        compute_mpc(_inp(key="kpred", current_temp_C=20.0), params)
+        _compute(_inp(key="kpred", current_temp_C=20.0), params)
         # predicted_dT = gain * u * dt_min - loss * dt_min
         # = 0.06 * 1.0 * 1.0 - 0.01 * 1.0 = 0.05
         # virtual_temp should have increased (gain > loss at u=1)
@@ -1621,7 +1602,7 @@ class TestAnalyticalSolver:
         params = _default_params(
             mpc_thermal_gain=0.0, mpc_loss_coeff=0.0, mpc_adapt=False
         )
-        result = compute_mpc(
+        result = _compute(
             _inp(key="zg_solver", current_temp_C=20.0, target_temp_C=22.0), params
         )
         # u0 = loss/gain = 0/0 → 0.0, so solver should return u0=0%
@@ -1634,7 +1615,7 @@ class TestAnalyticalSolver:
             mpc_thermal_gain=0.06, mpc_loss_coeff=0.01, mpc_adapt=False
         )
         # 2K error → should demand significant heating
-        result = compute_mpc(
+        result = _compute(
             _inp(key="anal_reas", current_temp_C=20.0, target_temp_C=22.0), params
         )
         assert result.valve_percent > 0
@@ -1646,7 +1627,7 @@ class TestAnalyticalSolver:
         params = _default_params(
             mpc_thermal_gain=0.06, mpc_loss_coeff=0.01, mpc_adapt=False
         )
-        result = compute_mpc(
+        result = _compute(
             _inp(key="anal_neg", current_temp_C=23.0, target_temp_C=22.0), params
         )
         assert result.valve_percent <= 20  # Should be low/zero
@@ -1654,7 +1635,7 @@ class TestAnalyticalSolver:
     def test_cost_at_optimum_in_debug(self):
         """Debug dict should contain the cost at the analytical optimum."""
         params = _default_params(mpc_adapt=False)
-        result = compute_mpc(
+        result = _compute(
             _inp(key="anal_cost", current_temp_C=20.0, target_temp_C=22.0), params
         )
         assert "mpc_cost" in result.debug
@@ -1672,7 +1653,7 @@ class TestMaxOpeningPct:
     def test_max_opening_clamps_output(self):
         """Output should be clamped to max_opening_pct."""
         params = _default_params()
-        result = compute_mpc(
+        result = _compute(
             _inp(
                 key="maxop",
                 current_temp_C=18.0,
@@ -1686,7 +1667,7 @@ class TestMaxOpeningPct:
     def test_max_opening_none_no_clamp(self):
         """When max_opening_pct is None, no clamping should occur."""
         params = _default_params()
-        result = compute_mpc(
+        result = _compute(
             _inp(
                 key="maxop_none",
                 current_temp_C=18.0,
@@ -1701,7 +1682,7 @@ class TestMaxOpeningPct:
     def test_max_opening_debug_flag(self):
         """Debug should indicate when max_opening clamping occurred."""
         params = _default_params()
-        result = compute_mpc(
+        result = _compute(
             _inp(
                 key="maxop_dbg",
                 current_temp_C=18.0,
@@ -1731,7 +1712,7 @@ class TestGainLearnCountGuard:
             mpc_loss_coeff=0.02,
             enable_min_effective_percent=False,
         )
-        compute_mpc(_inp(key=key, current_temp_C=20.0), params)
+        _compute(_inp(key=key, current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES[key]
         state.gain_est = 0.06
         state.loss_est = 0.02
@@ -1750,7 +1731,7 @@ class TestGainLearnCountGuard:
         params, state = self._setup_warm_low_u("wlu_blocked", gain_learn_count=1)
         loss_before = state.loss_est
 
-        compute_mpc(_inp(key="wlu_blocked", current_temp_C=20.0), params)
+        _compute(_inp(key="wlu_blocked", current_temp_C=20.0), params)
         # With gain_learn_count=1, warm_low_u should NOT fire
         # Loss should remain unchanged (or updated via another path)
         # The key assertion: if loss changed, it was NOT via warm_low_u
@@ -1763,7 +1744,7 @@ class TestGainLearnCountGuard:
         params, state = self._setup_warm_low_u("wlu_allowed", gain_learn_count=2)
         loss_before = state.loss_est
 
-        compute_mpc(_inp(key="wlu_allowed", current_temp_C=20.0), params)
+        _compute(_inp(key="wlu_allowed", current_temp_C=20.0), params)
         # With gain_learn_count=2 and warming below u0, loss should decrease
         assert state.loss_est <= loss_before
 
@@ -1781,7 +1762,7 @@ class TestGainRecovery:
         params = _default_params(
             mpc_adapt=True, mpc_adapt_alpha=0.1, enable_min_effective_percent=False
         )
-        compute_mpc(_inp(key="grecov", current_temp_C=20.0), params)
+        _compute(_inp(key="grecov", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["grecov"]
         state.gain_est = 0.02  # Artificially low gain
         state.loss_est = 0.005
@@ -1795,7 +1776,7 @@ class TestGainRecovery:
         # Room warmed 0.5K in 5min = 0.1 °C/min
         # gain_implied = (0.1 + 0.005) / 0.5 = 0.21
         # 0.21 > 0.02 * 1.1 = 0.022 → should recover
-        compute_mpc(_inp(key="grecov", current_temp_C=20.0), params)
+        _compute(_inp(key="grecov", current_temp_C=20.0), params)
         assert state.gain_est > gain_before
 
     def test_no_recovery_when_warming_matches_model(self):
@@ -1803,7 +1784,7 @@ class TestGainRecovery:
         params = _default_params(
             mpc_adapt=True, mpc_adapt_alpha=0.1, enable_min_effective_percent=False
         )
-        compute_mpc(_inp(key="gnorec", current_temp_C=20.0), params)
+        _compute(_inp(key="gnorec", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["gnorec"]
         state.gain_est = 0.10
         state.loss_est = 0.01
@@ -1818,7 +1799,7 @@ class TestGainRecovery:
         state.time_integral = 300.0
         gain_before = state.gain_est
 
-        compute_mpc(_inp(key="gnorec", current_temp_C=20.0), params)
+        _compute(_inp(key="gnorec", current_temp_C=20.0), params)
         # gain_implied = (0.02 + 0.01) / 0.5 = 0.06 < 0.11 → no recovery
         assert (
             state.gain_est == pytest.approx(gain_before)
@@ -1839,7 +1820,7 @@ class TestHighUSteadyStateGain:
         params = _default_params(
             mpc_adapt=True, mpc_adapt_alpha=0.1, enable_min_effective_percent=False
         )
-        compute_mpc(_inp(key="huss", current_temp_C=20.0), params)
+        _compute(_inp(key="huss", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["huss"]
         state.gain_est = 0.10
         state.loss_est = 0.01
@@ -1856,7 +1837,7 @@ class TestHighUSteadyStateGain:
         # temp unchanged → not temp_changed ✓
         # observed_rate ≈ 0 ✓
         # dt_residual=400 → within [300, 3600] ✓
-        compute_mpc(_inp(key="huss", current_temp_C=20.0, target_temp_C=21.0), params)
+        _compute(_inp(key="huss", current_temp_C=20.0, target_temp_C=21.0), params)
         assert state.gain_est <= gain_before
 
 
@@ -1875,17 +1856,13 @@ class TestKaEstDynamicLoss:
         """
         params = _default_params(mpc_adapt=True, mpc_loss_coeff=0.01)
         # Cold outside: delta = 20 - (-10) = 30
-        compute_mpc(
-            _inp(key="ka_cold", current_temp_C=20.0, outdoor_temp_C=-10.0), params
-        )
+        _compute(_inp(key="ka_cold", current_temp_C=20.0, outdoor_temp_C=-10.0), params)
         state_cold = mpc_mod._MPC_STATES["ka_cold"]
         assert state_cold.ka_est is not None
         assert state_cold.ka_est == pytest.approx(0.01 / 30.0, rel=0.01)
 
         # Warm outside: delta = max(5.0, 20 - 15) = 5
-        compute_mpc(
-            _inp(key="ka_warm", current_temp_C=20.0, outdoor_temp_C=15.0), params
-        )
+        _compute(_inp(key="ka_warm", current_temp_C=20.0, outdoor_temp_C=15.0), params)
         state_warm = mpc_mod._MPC_STATES["ka_warm"]
         assert state_warm.ka_est is not None
         assert state_warm.ka_est == pytest.approx(0.01 / 5.0, rel=0.01)
@@ -1901,7 +1878,7 @@ class TestKaEstDynamicLoss:
             mpc_loss_coeff=0.01,
             enable_min_effective_percent=False,
         )
-        compute_mpc(_inp(key="ka_upd", current_temp_C=21.0, outdoor_temp_C=5.0), params)
+        _compute(_inp(key="ka_upd", current_temp_C=21.0, outdoor_temp_C=5.0), params)
         state = mpc_mod._MPC_STATES["ka_upd"]
         state.last_percent = 0.0
         state.last_learn_temp = 21.0
@@ -1913,7 +1890,7 @@ class TestKaEstDynamicLoss:
         ka_before = state.ka_est
 
         # Room cooled from 21.0 to 20.5 → loss learning should fire and update ka_est
-        compute_mpc(_inp(key="ka_upd", current_temp_C=20.5, outdoor_temp_C=5.0), params)
+        _compute(_inp(key="ka_upd", current_temp_C=20.5, outdoor_temp_C=5.0), params)
         # ka should have been updated
         if state.loss_est != pytest.approx(0.01):
             assert state.ka_est != ka_before
@@ -1933,7 +1910,7 @@ class TestResidualRateLimiting:
             mpc_adapt=True, mpc_adapt_alpha=0.1, enable_min_effective_percent=False
         )
         now = time()
-        compute_mpc(_inp(key=key, current_temp_C=20.0), params)
+        _compute(_inp(key=key, current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES[key]
         state.gain_est = 0.06
         state.loss_est = 0.01
@@ -1951,9 +1928,7 @@ class TestResidualRateLimiting:
         params, state = self._setup_residual("res_below", dt_residual=200)
         loss_before = state.loss_est
 
-        compute_mpc(
-            _inp(key="res_below", current_temp_C=20.0, target_temp_C=22.0), params
-        )
+        _compute(_inp(key="res_below", current_temp_C=20.0, target_temp_C=22.0), params)
         # Residual should be rate-limited; loss should not change via residual path
         assert state.loss_est == pytest.approx(loss_before)
 
@@ -1962,9 +1937,7 @@ class TestResidualRateLimiting:
         params, state = self._setup_residual("res_above", dt_residual=4000)
         loss_before = state.loss_est
 
-        compute_mpc(
-            _inp(key="res_above", current_temp_C=20.0, target_temp_C=22.0), params
-        )
+        _compute(_inp(key="res_above", current_temp_C=20.0, target_temp_C=22.0), params)
         assert state.loss_est == pytest.approx(loss_before)
 
 
@@ -1984,15 +1957,13 @@ class TestBigChangeHoldBypass:
             big_change_force_close_pct=10.0,
         )
         # First call: set low valve
-        compute_mpc(
-            _inp(key="bigopen", current_temp_C=22.0, target_temp_C=22.0), params
-        )
+        _compute(_inp(key="bigopen", current_temp_C=22.0, target_temp_C=22.0), params)
         state = mpc_mod._MPC_STATES["bigopen"]
         state.last_percent = 10.0
         state.last_update_ts = time()  # just updated
 
         # Sudden large demand (cold room)
-        result = compute_mpc(
+        result = _compute(
             _inp(key="bigopen", current_temp_C=16.0, target_temp_C=22.0), params
         )
         # The valve should jump up despite hold-time (raw ≈ 100%, change ≈ 90% > 33%)
@@ -2005,15 +1976,13 @@ class TestBigChangeHoldBypass:
             big_change_force_open_pct=33.0,
             big_change_force_close_pct=10.0,
         )
-        compute_mpc(
-            _inp(key="bigclose", current_temp_C=18.0, target_temp_C=22.0), params
-        )
+        _compute(_inp(key="bigclose", current_temp_C=18.0, target_temp_C=22.0), params)
         state = mpc_mod._MPC_STATES["bigclose"]
         state.last_percent = 80.0
         state.last_update_ts = time()  # just updated
 
         # Warm room → wants to go to 0%
-        result = compute_mpc(
+        result = _compute(
             _inp(key="bigclose", current_temp_C=23.0, target_temp_C=22.0), params
         )
         # Closing should bypass hold-time if drop exceeds close threshold
@@ -2026,7 +1995,7 @@ class TestBigChangeHoldBypass:
             big_change_force_open_pct=33.0,
             big_change_force_close_pct=10.0,
         )
-        compute_mpc(
+        _compute(
             _inp(key="smallclose", current_temp_C=18.0, target_temp_C=22.0), params
         )
         state = mpc_mod._MPC_STATES["smallclose"]
@@ -2034,7 +2003,7 @@ class TestBigChangeHoldBypass:
         state.last_update_ts = time()
 
         # Nearly on target -> small closing request likely below 10%
-        result = compute_mpc(
+        result = _compute(
             _inp(key="smallclose", current_temp_C=21.95, target_temp_C=22.0), params
         )
         assert result.valve_percent == 25
@@ -2074,7 +2043,7 @@ class TestStaleStateAnchorReset:
     def test_stale_resets_learn_time_and_temp(self):
         """Stale detection should reset learn_time and learn_temp, not just u_integral."""
         params = _default_params(mpc_adapt=True)
-        compute_mpc(_inp(key="stale_full", current_temp_C=20.0), params)
+        _compute(_inp(key="stale_full", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["stale_full"]
         state.last_time = time() - 1000  # 16+ min ago
         state.last_learn_temp = 18.0
@@ -2082,7 +2051,7 @@ class TestStaleStateAnchorReset:
         state.u_integral = 5000.0
         state.time_integral = 500.0
 
-        compute_mpc(_inp(key="stale_full", current_temp_C=21.0), params)
+        _compute(_inp(key="stale_full", current_temp_C=21.0), params)
         # After stale detection, anchors should be reset
         assert state.u_integral == 0.0
         assert state.time_integral == 0.0
@@ -2101,9 +2070,7 @@ class TestTargetChangeBoundary:
     def test_target_change_exactly_0_05_detected(self):
         """A target change of exactly 0.05K should be detected."""
         params = _default_params(mpc_adapt=True, mpc_adapt_alpha=0.5)
-        compute_mpc(
-            _inp(key="tgt_exact", current_temp_C=20.0, target_temp_C=22.0), params
-        )
+        _compute(_inp(key="tgt_exact", current_temp_C=20.0, target_temp_C=22.0), params)
         state = mpc_mod._MPC_STATES["tgt_exact"]
         state.last_target_C = 22.0
         state.last_learn_temp = 20.0
@@ -2116,7 +2083,7 @@ class TestTargetChangeBoundary:
         gain_before = state.gain_est
 
         # Change target by exactly 0.05 → should be detected as target_changed
-        compute_mpc(
+        _compute(
             _inp(key="tgt_exact", current_temp_C=20.5, target_temp_C=22.05), params
         )
         # With target_changed=True, adaptation is blocked
@@ -2125,9 +2092,7 @@ class TestTargetChangeBoundary:
     def test_target_change_below_0_05_not_detected(self):
         """A target change of less than 0.05K should NOT be detected."""
         params = _default_params(mpc_adapt=True, mpc_adapt_alpha=0.5)
-        compute_mpc(
-            _inp(key="tgt_sub", current_temp_C=20.0, target_temp_C=22.0), params
-        )
+        _compute(_inp(key="tgt_sub", current_temp_C=20.0, target_temp_C=22.0), params)
         state = mpc_mod._MPC_STATES["tgt_sub"]
         state.last_target_C = 22.0
         state.last_learn_temp = 20.0
@@ -2139,9 +2104,7 @@ class TestTargetChangeBoundary:
         state.last_percent = 50.0
 
         # Change target by only 0.04 → should NOT block adaptation
-        compute_mpc(
-            _inp(key="tgt_sub", current_temp_C=20.5, target_temp_C=22.04), params
-        )
+        _compute(_inp(key="tgt_sub", current_temp_C=20.5, target_temp_C=22.04), params)
         # target_changed should be False, so adaptation can proceed
         # (gain may or may not change depending on conditions,
         # but the key is that target_changed didn't block it)
@@ -2177,7 +2140,7 @@ class TestSolarGainInit:
     def test_solar_gain_initialized_on_adapt(self):
         """solar_gain_est should be initialized when mpc_adapt=True."""
         params = _default_params(mpc_adapt=True)
-        compute_mpc(_inp(key="solar_init", current_temp_C=20.0), params)
+        _compute(_inp(key="solar_init", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["solar_init"]
         assert state.solar_gain_est is not None
         assert state.solar_gain_est == pytest.approx(
@@ -2187,7 +2150,7 @@ class TestSolarGainInit:
     def test_solar_gain_not_initialized_without_adapt(self):
         """solar_gain_est should stay None when mpc_adapt=False."""
         params = _default_params(mpc_adapt=False)
-        compute_mpc(_inp(key="solar_noinit", current_temp_C=20.0), params)
+        _compute(_inp(key="solar_noinit", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["solar_noinit"]
         assert state.solar_gain_est is None
 
@@ -2203,12 +2166,12 @@ class TestIntegrationAccumulation:
     def test_integration_accumulates_correctly(self):
         """u_integral and time_integral should track valve usage over time."""
         params = _default_params()
-        compute_mpc(_inp(key="integ_prec", current_temp_C=20.0), params)
+        _compute(_inp(key="integ_prec", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["integ_prec"]
         state.last_percent = 50.0
         state.last_integration_ts = time() - 60  # 60s ago
 
-        compute_mpc(_inp(key="integ_prec", current_temp_C=20.0), params)
+        _compute(_inp(key="integ_prec", current_temp_C=20.0), params)
         # u_integral should have accumulated: 50.0 * ~60 ≈ 3000
         assert state.u_integral > 0
         assert state.time_integral > 0
@@ -2216,11 +2179,11 @@ class TestIntegrationAccumulation:
     def test_integration_reset_on_window_open(self):
         """Window open should reset u_integral and time_integral."""
         params = _default_params()
-        compute_mpc(_inp(key="integ_win", current_temp_C=20.0), params)
+        _compute(_inp(key="integ_win", current_temp_C=20.0), params)
         state = mpc_mod._MPC_STATES["integ_win"]
         state.u_integral = 5000.0
         state.time_integral = 300.0
 
-        compute_mpc(_inp(key="integ_win", window_open=True), params)
+        _compute(_inp(key="integ_win", window_open=True), params)
         assert state.u_integral == 0.0
         assert state.time_integral == 0.0

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -28,11 +28,11 @@ from custom_components.better_thermostat.utils.state_manager import (
     ThermalStats,
     TpiState,
     _deserialize,
+    _migrate_v0_to_v1,
+    _serialize,
     deserialize_mpc,
     deserialize_pid,
     deserialize_tpi,
-    _migrate_v0_to_v1,
-    _serialize,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -28,11 +28,11 @@ from custom_components.better_thermostat.utils.state_manager import (
     ThermalStats,
     TpiState,
     _deserialize,
-    _migrate_v0_to_v1,
-    _serialize,
     deserialize_mpc,
     deserialize_pid,
     deserialize_tpi,
+    _migrate_v0_to_v1,
+    _serialize,
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> Part 2 of 5 — Unified state persistence (#1919)

## Problem

`compute_mpc()` reads and writes implicitly into a module-global `_MPC_STATES` dict. This makes the function hard to test in isolation and prevents clean persistence via a centralized `StateManager`. See #1919 for the full motivation.

## Solution

Make `compute_mpc()` accept an optional explicit `state` parameter and return a `(MpcOutput | None, MpcState)` tuple so the caller owns persistence:

- **New signature**: `compute_mpc(inp, params, state=None, *, all_states=None) -> (MpcOutput | None, MpcState)`
- **Fully backwards compatible**: without the `state` parameter the function falls back to `_MPC_STATES` internally
- Caller in `calibration.py` updated to unpack the tuple: `mpc_output, _mpc_state = compute_mpc(...)`

## Changed files

| File | Change |
|---|---|
| `utils/calibration/mpc.py` | New signature, optional `state`/`all_states` params, tuple return |
| `calibration.py` | Unpack tuple at MPC call site |
| `tests/test_mpc.py` | Adapt all tests for tuple return |
| `tests/unit/test_mpc_comprehensive.py` | Adapt all tests for tuple return |

## PR series (#1919)

| | PR | Status |
|---|---|---|
| 1 | #1914 — StateManager module | merged into this branch |
| **2** | **#1915 — MPC stateless compute** | **this PR** |
| 3 | #1916 — PID/TPI stateless compute | depends on this |
| 4 | #1917 — Wire into climate.py | depends on #1916 |
| 5 | #1918 — Extract v0 migration | depends on #1917 |