### PR TITLE
refactor: Make compute_pid() and compute_tpi() return state in tuple

### DIFF
--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -355,7 +355,7 @@ def _compute_tpi_balance(self, entity_id: str):
     params = TpiParams()
 
     try:
-        tpi_output = compute_tpi(
+        tpi_output, _tpi_state = compute_tpi(
             TpiInput(
                 key=build_tpi_key(self, entity_id),
                 current_temp_C=self.cur_temp,
@@ -451,7 +451,7 @@ def _compute_pid_balance(self, entity_id: str):
     )
 
     try:
-        percent, debug = compute_pid(
+        percent, debug, _pid_state = compute_pid(
             params,
             self.bt_target_temp,
             self.cur_temp,
@@ -461,8 +461,6 @@ def _compute_pid_balance(self, entity_id: str):
             inp_current_temp_ema_C=self.cur_temp_filtered,
             max_opening_pct=_get_trv_max_opening(self, entity_id),
         )
-        # Schedule saving of updated PID states
-        self.schedule_save_pid_state()
     except (ValueError, TypeError, ZeroDivisionError) as err:
         _LOGGER.debug(
             "better_thermostat %s: PID calibration compute failed for %s: %s",

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -409,7 +409,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.cur_temp = None
         self._current_humidity = 0
         self.window_open = None
-        self.bt_target_temp_step = float(target_temp_step) if target_temp_step and target_temp_step != "0.0" else None
+        self.bt_target_temp_step = (
+            float(target_temp_step)
+            if target_temp_step and target_temp_step != "0.0"
+            else None
+        )
         self.bt_min_temp = 0
         self.bt_max_temp = 30
         self.bt_target_temp = 5.0

--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -59,8 +59,10 @@ _LOGGER = logging.getLogger(__name__)
 TEMP_STEP_SELECTOR = selector.SelectSelector(
     selector.SelectSelectorConfig(
         options=[
-            selector.SelectOptionDict(value="0.0", label="Auto"),  # Keep for backwards compatibility
-            selector.SelectOptionDict(value="", label="Auto (New)"), 
+            selector.SelectOptionDict(
+                value="0.0", label="Auto"
+            ),  # Keep for backwards compatibility
+            selector.SelectOptionDict(value="", label="Auto (New)"),
             selector.SelectOptionDict(value="0.1", label="0.1 °C"),
             selector.SelectOptionDict(value="0.2", label="0.2 °C"),
             selector.SelectOptionDict(value="0.25", label="0.25 °C"),

--- a/custom_components/better_thermostat/utils/calibration/tpi.py
+++ b/custom_components/better_thermostat/utils/calibration/tpi.py
@@ -58,7 +58,8 @@ class _TpiState:
     last_update_ts: float = 0.0
 
 
-# Public alias so that StateManager can reference the type.
+# Public alias so callers can reference the state type without
+# importing a private name.
 TpiState = _TpiState
 
 _TPI_STATES: dict[str, _TpiState] = {}
@@ -118,14 +119,35 @@ def _round_dbg(v: float | int | None, d: int = 3) -> float | int | None:
         return v
 
 
-def compute_tpi(inp: TpiInput, params: TpiParams) -> TpiOutput | None:
+def compute_tpi(
+    inp: TpiInput, params: TpiParams, state: _TpiState | None = None
+) -> tuple[TpiOutput | None, _TpiState]:
     """Compute TPI duty cycle and on/off durations.
 
-    Returns None if inputs are insufficient. Emits extensive debug logs.
-    """
+    Parameters
+    ----------
+    inp:
+        Current measurements and context.
+    params:
+        Controller configuration.
+    state:
+        Mutable controller state.  When ``None`` the function falls back
+        to the module-level ``_TPI_STATES`` dict for backwards
+        compatibility, but callers are encouraged to pass state explicitly.
 
+    Returns
+    -------
+    tuple[TpiOutput | None, _TpiState]
+        The duty-cycle recommendation (or ``None`` on early exit) **and**
+        the updated state object.
+    """
     now = monotonic()
-    state = _TPI_STATES.setdefault(inp.key, _TpiState())
+
+    # --- Resolve state ---
+    if state is None:
+        state = _TPI_STATES.setdefault(inp.key, _TpiState())
+    else:
+        _TPI_STATES[inp.key] = state
 
     name = inp.bt_name or "BT"
     entity = inp.entity_id or "unknown"
@@ -191,7 +213,7 @@ def _finalize_output(
     duty_pct_raw: float,
     error_K: float | None,
     debug: dict[str, Any],
-) -> TpiOutput:
+) -> tuple[TpiOutput, _TpiState]:
     # Clamp
     duty_pct = max(params.clamp_min_pct, min(params.clamp_max_pct, duty_pct_raw))
 
@@ -215,7 +237,7 @@ def _finalize_output(
         debug,
     )
 
-    return TpiOutput(duty_cycle_pct=duty_pct, debug=debug)
+    return TpiOutput(duty_cycle_pct=duty_pct, debug=debug), state
 
 
 def build_tpi_key(bt, entity_id: str) -> str:

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -236,7 +236,9 @@ def _deserialize(raw: dict[str, Any]) -> RuntimeState:
         except (TypeError, ValueError):
             heating_power = None
         try:
-            heat_loss_rate = float(heat_loss_rate) if heat_loss_rate is not None else None
+            heat_loss_rate = (
+                float(heat_loss_rate) if heat_loss_rate is not None else None
+            )
         except (TypeError, ValueError):
             heat_loss_rate = None
         state.thermal = ThermalStats(

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -22,7 +22,7 @@ class TestPIDController:
     def test_no_temperatures(self):
         """Test behavior when temperatures are missing."""
         params = PIDParams()
-        percent, debug = compute_pid(
+        percent, debug, _ = compute_pid(
             params=params,
             inp_target_temp_C=None,
             inp_current_temp_C=20.0,
@@ -41,7 +41,7 @@ class TestPIDController:
             auto_tune=False, kp=10.0, ki=1.0, kd=5.0, min_hold_time_s=0.0
         )
         # First call to initialize
-        percent1, _ = compute_pid(
+        percent1, _, _ = compute_pid(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,
@@ -53,7 +53,7 @@ class TestPIDController:
         assert percent1 > 0
 
         # Second call with same error; integer rounding may mask tiny increments
-        percent2, _ = compute_pid(
+        percent2, _, _ = compute_pid(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,
@@ -66,7 +66,7 @@ class TestPIDController:
         # After a few iterations the integral term should raise the output
         percent_last = percent2
         for _ in range(6):
-            percent_last, _ = compute_pid(
+            percent_last, _, _ = compute_pid(
                 params=params,
                 inp_target_temp_C=22.0,
                 inp_current_temp_C=20.0,
@@ -80,7 +80,7 @@ class TestPIDController:
         """Test anti-windup clamping."""
         params = PIDParams(auto_tune=False, kp=100.0, ki=10.0, i_min=-10.0, i_max=10.0)
         # Large error to cause windup
-        percent, _ = compute_pid(
+        percent, _, _ = compute_pid(
             params=params,
             inp_target_temp_C=30.0,
             inp_current_temp_C=20.0,
@@ -391,7 +391,7 @@ class TestPIDController:
             key="test_deriv",
         )
         # Second call to have dt > 0
-        _, debug = compute_pid(
+        _, debug, _ = compute_pid(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,
@@ -418,7 +418,7 @@ class TestPIDController:
         key = "test_hold_block"
 
         # First call establishes baseline
-        percent1, _ = compute_pid(
+        percent1, _, _ = compute_pid(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,  # Error = 2.0, P = 20%
@@ -429,7 +429,7 @@ class TestPIDController:
         assert percent1 == 20.0  # P-term only: 10 * 2.0 = 20
 
         # Second call with slightly different error (small change < 33%)
-        percent2, _ = compute_pid(
+        percent2, _, _ = compute_pid(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.5,  # Error = 1.5, P = 15%
@@ -453,7 +453,7 @@ class TestPIDController:
         key = "test_hold_big"
 
         # First call establishes baseline
-        percent1, _ = compute_pid(
+        percent1, _, _ = compute_pid(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,  # Error = 2.0, P = 20%
@@ -464,7 +464,7 @@ class TestPIDController:
         assert percent1 == 20.0
 
         # Second call with large error change (big change >= 33%)
-        percent2, _ = compute_pid(
+        percent2, _, _ = compute_pid(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=15.0,  # Error = 7.0, P = 70%
@@ -488,7 +488,7 @@ class TestPIDController:
         key = "test_hold_target"
 
         # First call establishes baseline
-        percent1, _ = compute_pid(
+        percent1, _, _ = compute_pid(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,  # Error = 2.0, P = 20%
@@ -499,7 +499,7 @@ class TestPIDController:
         assert percent1 == 20.0
 
         # Second call with changed target temperature
-        percent2, _ = compute_pid(
+        percent2, _, _ = compute_pid(
             params=params,
             inp_target_temp_C=23.0,  # Target changed by 1.0°C (> 0.05)
             inp_current_temp_C=20.0,  # Error = 3.0, P = 30%
@@ -523,7 +523,7 @@ class TestPIDController:
         key = "test_hold_disabled"
 
         # First call
-        percent1, _ = compute_pid(
+        percent1, _, _ = compute_pid(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,
@@ -534,7 +534,7 @@ class TestPIDController:
         assert percent1 == 20.0
 
         # Second call with small change - should NOT be blocked
-        percent2, _ = compute_pid(
+        percent2, _, _ = compute_pid(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.5,  # Small change

--- a/tests/test_tpi.py
+++ b/tests/test_tpi.py
@@ -21,13 +21,13 @@ class TestTpiController:
             window_open=True,
             heating_allowed=True,
         )
-        result = compute_tpi(inp, params)
+        result, _ = compute_tpi(inp, params)
         assert result.duty_cycle_pct == 0.0
         assert result.debug["reason"] == "blocked"
 
         inp.heating_allowed = False
         inp.window_open = False
-        result = compute_tpi(inp, params)
+        result, _ = compute_tpi(inp, params)
         assert result.duty_cycle_pct == 0.0
         assert result.debug["reason"] == "blocked"
 
@@ -35,13 +35,13 @@ class TestTpiController:
         """Test behavior when temperatures are missing."""
         params = TpiParams()
         inp = TpiInput(key="test", current_temp_C=None, target_temp_C=22.0)
-        result = compute_tpi(inp, params)
+        result, _ = compute_tpi(inp, params)
         assert result.duty_cycle_pct == 0.0  # No last_percent, so 0
         assert result.debug["reason"] == "missing_temps"
 
         # Now with last_percent
         inp.current_temp_C = 20.0
-        result = compute_tpi(inp, params)
+        result, _ = compute_tpi(inp, params)
         # Should calculate normally, clamped to 100
         assert result.duty_cycle_pct == 100.0
 
@@ -51,7 +51,7 @@ class TestTpiController:
         inp = TpiInput(
             key="test", current_temp_C=20.0, target_temp_C=22.0, outdoor_temp_C=15.0
         )
-        result = compute_tpi(inp, params)
+        result, _ = compute_tpi(inp, params)
         assert result.duty_cycle_pct == 100.0  # clamped
         assert result.debug["error_K"] == 2.0
         assert result.debug["raw_pct"] == 114.0
@@ -64,7 +64,7 @@ class TestTpiController:
             current_temp_C=22.6,
             target_temp_C=22.0,  # error = -0.6
         )
-        result = compute_tpi(inp, params)
+        result, _ = compute_tpi(inp, params)
         assert result.duty_cycle_pct == 0.0
         assert result.debug["reason"] == "threshold_high"
 
@@ -76,11 +76,11 @@ class TestTpiController:
             current_temp_C=20.0,
             target_temp_C=25.0,  # error=5, duty=500, clamped to 90
         )
-        result = compute_tpi(inp, params)
+        result, _ = compute_tpi(inp, params)
         assert result.duty_cycle_pct == 90.0
 
         inp.target_temp_C = 19.0  # error=-1, duty=-100, clamped to 10
-        result = compute_tpi(inp, params)
+        result, _ = compute_tpi(inp, params)
         assert result.duty_cycle_pct == 10.0
 
     def test_build_tpi_key(self):

--- a/tests/unit/test_mpc_comprehensive.py
+++ b/tests/unit/test_mpc_comprehensive.py
@@ -105,10 +105,16 @@ def _default_params(
     overrides = {
         k: local[k]
         for k in base_field_names
-        if k in local and local[k] is not _UNSET and k not in {
-            "min_update_interval_s", "min_percent_hold_time_s",
-            "percent_hysteresis_pts", "mpc_du_max_pct",
-            "use_virtual_temp", "enable_min_effective_percent",
+        if k in local
+        and local[k] is not _UNSET
+        and k
+        not in {
+            "min_update_interval_s",
+            "min_percent_hold_time_s",
+            "percent_hysteresis_pts",
+            "mpc_du_max_pct",
+            "use_virtual_temp",
+            "enable_min_effective_percent",
         }
     }
     return replace(base, **overrides) if overrides else base


### PR DESCRIPTION
> Part 3 of 5 — Unified state persistence (#1919)

## Problem

`compute_pid()` and `compute_tpi()` read and write implicitly into module-global dicts, same issue as `compute_mpc()` (#1915). See #1919 for the full motivation.

## Solution

Same pattern as #1915: add an optional explicit `state` parameter and return the updated state as part of the result tuple.

**PID:**
- `compute_pid(...)` now returns `(percent, debug, PIDState)` instead of `(percent, debug)`
- Optional `state: PIDState | None` parameter added

**TPI:**
- `compute_tpi(...)` now returns `(TpiOutput | None, TpiState)` instead of `TpiOutput | None`
- Optional `state: TpiState | None` parameter added

Both fully backwards compatible: without the `state` parameter, functions fall back to their global dicts.

## Changed files

| File | Change |
|---|---|
| `utils/calibration/pid.py` | New signature, optional `state` param, 3-tuple return |
| `utils/calibration/tpi.py` | New signature, optional `state` param, tuple return |
| `calibration.py` | Unpack tuples at PID + TPI call sites |
| `tests/test_pid.py` | Adapt tests for 3-tuple return |
| `tests/test_tpi.py` | Adapt tests for tuple return |

## PR series (#1919)

| | PR | Status |
|---|---|---|
| 1 | #1914 — StateManager module | merged into this branch |
| 2 | #1915 — MPC stateless compute | merged into this branch |
| **3** | **#1916 — PID/TPI stateless compute** | **this PR** |
| 4 | #1917 — Wire into climate.py | depends on this |
| 5 | #1918 — Extract v0 migration | depends on #1917 |