### PR TITLE
test: Test suite for events/trv.py – 3 bugs found

### DIFF
--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -563,6 +563,32 @@ class TestHvacModeUpdate:
 
         assert mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] == "heat"
 
+    @pytest.mark.asyncio
+    async def test_child_lock_none_blocks_mode_propagation(self, mock_bt):
+        """Mode cache updates but bt_hvac_mode does not propagate when child_lock is None."""
+        mock_bt.real_trvs[ENTITY_ID]["advanced"].pop("child_lock", None)
+        trv_state = _make_state(
+            state_str="off",
+            attributes={"current_temperature": 18.0, "temperature": 19.0},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] = "heat"
+        mock_bt.real_trvs[ENTITY_ID]["system_mode_received"] = True
+        mock_bt.real_trvs[ENTITY_ID]["last_hvac_mode"] = "heat"
+
+        event = _make_event(
+            mock_bt, new_state=trv_state, old_state=_make_state(state_str="heat")
+        )
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.OFF,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] == "off"
+        assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+
 
 # ---------------------------------------------------------------------------
 # 5. Target temperature adoption


### PR DESCRIPTION
## Problem

`events/trv.py` is the central event handler for TRV state changes – completely untested. A code review identified several suspicious patterns that needed verification through tests.

## Solution

52 unit tests covering all functions in `events/trv.py`:

| Test class | Tests | Covers |
|------------|-------|--------|
| `TestTriggerTrvChangeGuards` | 9 | Guard clauses (lines 39–71) |
| `TestInternalTemperatureChange` | 6 | Temp sensor updates (lines 111–160) |
| `TestHvacActionAndValvePosition` | 4 | Action/valve cache (lines 175–202) |
| `TestHvacModeUpdate` | 5 | Mode synchronisation (lines 204–225) |
| `TestTargetTempAdoption` | 11 | Setpoint adoption (lines 229–321) |
| `TestControlQueueTrigger` | 2 | Final action (lines 323–328) |
| `TestConvertInboundStates` | 6 | Inbound conversion (lines 331–356) |
| `TestConvertOutboundStates` | 8 | Outbound payload (lines 359–462) |

### Confirmed bugs

**1. Guard clause crash (line 52)** — `AttributeError` when `new_state` is `None`
```python
if None in (new_state, old_state, new_state.attributes):
#                                  ^^^^^^^^^^^^^^^^^ crashes before None check
```
Fix: #1926

**2. Cooler-sync logic always overwrites (lines 302–309)** — Two `if` conditions (`<=` and `>=`) cover ALL cases, so `bt_target_cooltemp` is always set to `bt_target_temp - step` regardless of initial value. Second `if` should likely be `elif`.
```python
if self.bt_target_temp <= self.bt_target_cooltemp:   # case A
    self.bt_target_cooltemp = self.bt_target_temp - self.bt_target_temp_step
if self.bt_target_temp >= self.bt_target_cooltemp:   # case B (always true after A)
    self.bt_target_cooltemp = self.bt_target_temp - self.bt_target_temp_step
```
Fix: #1927

**3. `no_off_system_mode` unreachable when OFF (line 313 inside line 246 guard)** — Critical: When BT is in OFF state and user turns the TRV dial up from `min_temp`, the `no_off_system_mode` logic at line 313 is inside the `bt_hvac_mode is not HVACMode.OFF` guard at line 246, so it never executes → BT stays OFF instead of switching to HEAT.

Fix: #1928

### Status

- [x] Tests written and passing (51 passed, 1 xfail for bug #3)
- [x] Fix bug #1: Guard clause crash → #1926
- [x] Fix bug #2: Cooler-sync invariant → #1927
- [x] Fix bug #3: no_off_system_mode unreachable when OFF → #1928
- [ ] Remove xfail markers after fixes are merged

## Test plan

```bash
pytest tests/unit/test_trv_events.py -v -p no:homeassistant
```