### PR TITLE
fix: prevent AttributeError crash when TRV event delivers None state

### DIFF
--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -49,7 +49,7 @@ async def trigger_trv_change(self, event):
     new_state = event.data.get("new_state")
     entity_id = event.data.get("entity_id")
 
-    if None in (new_state, old_state, new_state.attributes):
+    if new_state is None or old_state is None or new_state.attributes is None:
         _LOGGER.debug(
             "better_thermostat %s: TRV %s update contained not all necessary data for processing, skipping",
             self.device_name,

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -1,0 +1,1124 @@
+"""Tests for events/trv.py – TRV event handlers and conversion helpers.
+
+Covers guard clauses, internal temperature changes, HVAC action/valve caching,
+mode synchronisation, target-temperature adoption, control-queue triggering,
+and the convert_inbound_states / convert_outbound_states helpers.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.climate.const import HVACMode
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.events.trv import (
+    convert_inbound_states,
+    convert_outbound_states,
+    trigger_trv_change,
+)
+from custom_components.better_thermostat.utils.const import (
+    CalibrationMode,
+    CalibrationType,
+    CONF_HOMEMATICIP,
+)
+
+ENTITY_ID = "climate.test_trv"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_bt():
+    """Create a mock BetterThermostat instance with sensible defaults."""
+    bt = MagicMock()
+    bt.hass = MagicMock()
+    bt.device_name = "Test Thermostat"
+    bt.bt_hvac_mode = HVACMode.HEAT
+    bt.bt_target_temp = 19.0
+    bt.bt_min_temp = 5.0
+    bt.bt_max_temp = 30.0
+    bt.bt_target_cooltemp = 25.0
+    bt.bt_target_temp_step = 0.5
+    bt.cur_temp = 18.0
+    bt.window_open = False
+    bt.tolerance = 0.3
+    bt.startup_running = False
+    bt.control_queue_task = AsyncMock()
+    bt.bt_update_lock = False
+    bt.cooler_entity_id = None
+    bt.ignore_states = False
+    bt.context = MagicMock()  # unique context so != event.context
+    bt.last_internal_sensor_change = datetime.now() - timedelta(seconds=60)
+    bt.async_write_ha_state = MagicMock()
+
+    bt.all_trvs = [
+        {"advanced": {CONF_HOMEMATICIP: False}},
+    ]
+
+    bt.real_trvs = {
+        ENTITY_ID: {
+            "hvac_mode": HVACMode.HEAT,
+            "hvac_modes": [HVACMode.OFF, HVACMode.HEAT],
+            "min_temp": 5.0,
+            "max_temp": 30.0,
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+            "last_temperature": 19.0,
+            "last_hvac_mode": "heat",
+            "target_temp_received": True,
+            "system_mode_received": True,
+            "calibration_received": True,
+            "calibration": 1,
+            "last_calibration": 0.0,
+            "ignore_trv_states": False,
+            "model": "SomeModel",
+            "model_quirks": None,
+            "hvac_action": "heating",
+            "valve_position": 50,
+            "advanced": {
+                "calibration": CalibrationType.LOCAL_BASED,
+                "calibration_mode": CalibrationMode.DEFAULT,
+                "no_off_system_mode": False,
+                "heat_auto_swapped": False,
+                "child_lock": False,
+            },
+        }
+    }
+    return bt
+
+
+def _make_state(state_str="heat", attributes=None):
+    """Build a minimal HA State object."""
+    attrs = {"current_temperature": 18.0, "temperature": 19.0}
+    if attributes is not None:
+        attrs.update(attributes)
+    return State(ENTITY_ID, state_str, attributes=attrs)
+
+
+def _make_event(bt, new_state=None, old_state=None, entity_id=ENTITY_ID):
+    """Build a mock event whose context differs from bt.context."""
+    if old_state is None:
+        old_state = _make_state()
+    if new_state is None:
+        new_state = _make_state()
+
+    event = MagicMock()
+    event.data = {
+        "old_state": old_state,
+        "new_state": new_state,
+        "entity_id": entity_id,
+    }
+    event.context = MagicMock()  # differs from bt.context
+    return event
+
+
+# ---------------------------------------------------------------------------
+# 1. Guard clauses
+# ---------------------------------------------------------------------------
+
+class TestTriggerTrvChangeGuards:
+    """Guard-clause tests for trigger_trv_change()."""
+
+    @pytest.mark.asyncio
+    async def test_returns_early_during_startup(self, mock_bt):
+        mock_bt.startup_running = True
+        event = _make_event(mock_bt)
+        await trigger_trv_change(mock_bt, event)
+        mock_bt.async_write_ha_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_early_no_queue(self, mock_bt):
+        mock_bt.control_queue_task = None
+        event = _make_event(mock_bt)
+        await trigger_trv_change(mock_bt, event)
+        mock_bt.async_write_ha_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_early_none_temps(self, mock_bt):
+        mock_bt.bt_target_temp = None
+        event = _make_event(mock_bt)
+        await trigger_trv_change(mock_bt, event)
+        mock_bt.async_write_ha_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_early_none_cur_temp(self, mock_bt):
+        mock_bt.cur_temp = None
+        event = _make_event(mock_bt)
+        await trigger_trv_change(mock_bt, event)
+        mock_bt.async_write_ha_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_early_none_tolerance(self, mock_bt):
+        mock_bt.tolerance = None
+        event = _make_event(mock_bt)
+        await trigger_trv_change(mock_bt, event)
+        mock_bt.async_write_ha_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_early_update_lock(self, mock_bt):
+        mock_bt.bt_update_lock = True
+        event = _make_event(mock_bt)
+        await trigger_trv_change(mock_bt, event)
+        mock_bt.async_write_ha_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_early_new_state_none(self, mock_bt):
+        """new_state=None should return early without crashing."""
+        event = _make_event(mock_bt)
+        event.data["new_state"] = None
+        await trigger_trv_change(mock_bt, event)
+        mock_bt.control_queue_task.put.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_early_old_state_none(self, mock_bt):
+        event = _make_event(mock_bt)
+        event.data["old_state"] = None
+        # new_state is valid so new_state.attributes doesn't crash.
+        # None in (new_state, old_state, new_state.attributes) → True → return
+        await trigger_trv_change(mock_bt, event)
+        mock_bt.control_queue_task.put.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_own_context(self, mock_bt):
+        event = _make_event(mock_bt)
+        event.context = mock_bt.context  # same context → BT's own update
+        await trigger_trv_change(mock_bt, event)
+        mock_bt.control_queue_task.put.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2. Internal temperature change
+# ---------------------------------------------------------------------------
+
+class TestInternalTemperatureChange:
+    """Tests for TRV internal-temperature-sensor updates."""
+
+    @pytest.mark.asyncio
+    async def test_temp_change_updates_cache(self, mock_bt):
+        """A new TRV temperature reading should update the cache."""
+        new_temp = 20.0
+        trv_state = _make_state(attributes={"current_temperature": new_temp})
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+        mock_bt.real_trvs[ENTITY_ID]["calibration_received"] = True
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID]["current_temperature"] == new_temp
+
+    @pytest.mark.asyncio
+    async def test_temp_change_respects_time_diff(self, mock_bt):
+        """Changes within 5 s of the last internal sensor change are skipped."""
+        mock_bt.last_internal_sensor_change = datetime.now() - timedelta(seconds=2)
+        trv_state = _make_state(attributes={"current_temperature": 20.0})
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+        mock_bt.real_trvs[ENTITY_ID]["calibration_received"] = True
+        mock_bt.real_trvs[ENTITY_ID]["calibration"] = 1
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        # Temperature NOT updated because <5 s elapsed and calibration_received=True
+        assert mock_bt.real_trvs[ENTITY_ID]["current_temperature"] == 18.0
+
+    @pytest.mark.asyncio
+    async def test_temp_change_homematicip_600s(self, mock_bt):
+        """HomematicIP uses a 600 s guard instead of 5 s."""
+        mock_bt.all_trvs = [{"advanced": {CONF_HOMEMATICIP: True}}]
+        mock_bt.last_internal_sensor_change = datetime.now() - timedelta(seconds=30)
+        trv_state = _make_state(attributes={"current_temperature": 20.0})
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+        mock_bt.real_trvs[ENTITY_ID]["calibration_received"] = True
+        mock_bt.real_trvs[ENTITY_ID]["calibration"] = 1
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        # 30 s elapsed < 600 s → blocked
+        assert mock_bt.real_trvs[ENTITY_ID]["current_temperature"] == 18.0
+
+    @pytest.mark.asyncio
+    async def test_calibration_received_flag_set(self, mock_bt):
+        """calibration_received should be set True on first temp change."""
+        mock_bt.real_trvs[ENTITY_ID]["calibration_received"] = False
+        mock_bt.real_trvs[ENTITY_ID]["calibration"] = 1
+        trv_state = _make_state(attributes={"current_temperature": 20.0})
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID]["calibration_received"] is True
+
+    @pytest.mark.asyncio
+    async def test_calibration_received_resets_main_change(self, mock_bt):
+        """When calibration is first received, _main_change should become False."""
+        mock_bt.real_trvs[ENTITY_ID]["calibration_received"] = False
+        mock_bt.real_trvs[ENTITY_ID]["calibration"] = 1
+        trv_state = _make_state(attributes={"current_temperature": 20.0})
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        # _main_change was reset to False → no control_queue_task.put()
+        mock_bt.control_queue_task.put.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_calibration_zero_fetches_offset(self, mock_bt):
+        """When calibration==0, get_current_offset() should be called."""
+        mock_bt.real_trvs[ENTITY_ID]["calibration_received"] = False
+        mock_bt.real_trvs[ENTITY_ID]["calibration"] = 0
+        trv_state = _make_state(attributes={"current_temperature": 20.0})
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with (
+            patch(
+                "custom_components.better_thermostat.events.trv.get_current_offset",
+                new_callable=AsyncMock,
+                return_value=2.5,
+            ) as mock_offset,
+            patch(
+                "custom_components.better_thermostat.events.trv.convert_inbound_states",
+                return_value=HVACMode.HEAT,
+            ),
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        mock_offset.assert_awaited_once_with(mock_bt, ENTITY_ID)
+        assert mock_bt.real_trvs[ENTITY_ID]["last_calibration"] == 2.5
+
+
+# ---------------------------------------------------------------------------
+# 3. HVAC action and valve position
+# ---------------------------------------------------------------------------
+
+class TestHvacActionAndValvePosition:
+    """Tests for hvac_action / valve_position cache updates."""
+
+    @pytest.mark.asyncio
+    async def test_hvac_action_updated_from_attribute(self, mock_bt):
+        trv_state = _make_state(attributes={
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+            "hvac_action": "idle",
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["hvac_action"] = "heating"
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID]["hvac_action"] == "idle"
+
+    @pytest.mark.asyncio
+    async def test_hvac_action_fallback_to_action(self, mock_bt):
+        """Fallback: use 'action' attribute when 'hvac_action' is absent."""
+        trv_state = _make_state(attributes={
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+            "action": "Heating",
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["hvac_action"] = "idle"
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID]["hvac_action"] == "heating"
+
+    @pytest.mark.asyncio
+    async def test_hvac_action_change_triggers_main_change(self, mock_bt):
+        """A changed hvac_action value should trigger _main_change."""
+        trv_state = _make_state(attributes={
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+            "hvac_action": "idle",
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["hvac_action"] = "heating"
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        mock_bt.control_queue_task.put.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_valve_position_updated(self, mock_bt):
+        trv_state = _make_state(attributes={
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+            "valve_position": "75",
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID]["valve_position"] == 75.0
+
+
+# ---------------------------------------------------------------------------
+# 4. HVAC mode update
+# ---------------------------------------------------------------------------
+
+class TestHvacModeUpdate:
+    """Tests for HVAC mode synchronisation."""
+
+    @pytest.mark.asyncio
+    async def test_mode_change_updates_cache(self, mock_bt):
+        """New mode from TRV is written to real_trvs cache."""
+        trv_state = _make_state(state_str="off", attributes={
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] = "heat"
+
+        event = _make_event(
+            mock_bt,
+            new_state=trv_state,
+            old_state=_make_state(state_str="heat"),
+        )
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.OFF,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] == "off"
+
+    @pytest.mark.asyncio
+    async def test_mode_change_blocked_by_child_lock(self, mock_bt):
+        """Child lock prevents mode cache update."""
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["child_lock"] = True
+        trv_state = _make_state(state_str="off", attributes={
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] = "heat"
+
+        event = _make_event(
+            mock_bt,
+            new_state=trv_state,
+            old_state=_make_state(state_str="heat"),
+        )
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.OFF,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        # Should remain "heat" because child_lock blocks update
+        assert mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] == "heat"
+
+    @pytest.mark.asyncio
+    async def test_mode_propagates_to_bt_hvac_mode(self, mock_bt):
+        """Mode change propagates to bt_hvac_mode when conditions are met."""
+        trv_state = _make_state(state_str="off", attributes={
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] = "heat"
+        mock_bt.real_trvs[ENTITY_ID]["system_mode_received"] = True
+        mock_bt.real_trvs[ENTITY_ID]["last_hvac_mode"] = "heat"
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["child_lock"] = False
+
+        event = _make_event(
+            mock_bt,
+            new_state=trv_state,
+            old_state=_make_state(state_str="heat"),
+        )
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.OFF,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_hvac_mode == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_mode_not_propagated_before_system_mode_received(self, mock_bt):
+        """No propagation to bt_hvac_mode if system_mode_received is False."""
+        trv_state = _make_state(state_str="off", attributes={
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] = "heat"
+        mock_bt.real_trvs[ENTITY_ID]["system_mode_received"] = False
+
+        event = _make_event(
+            mock_bt,
+            new_state=trv_state,
+            old_state=_make_state(state_str="heat"),
+        )
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.OFF,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        # bt_hvac_mode stays at HEAT (original)
+        assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+
+    @pytest.mark.asyncio
+    async def test_unmapped_mode_ignored(self, mock_bt):
+        """Mode outside (OFF, HEAT, HEAT_COOL) doesn't update cache."""
+        trv_state = _make_state(state_str="cool", attributes={
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] = "heat"
+
+        event = _make_event(
+            mock_bt,
+            new_state=trv_state,
+            old_state=_make_state(state_str="heat"),
+        )
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=None,  # unmapped
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] == "heat"
+
+
+# ---------------------------------------------------------------------------
+# 5. Target temperature adoption
+# ---------------------------------------------------------------------------
+
+class TestTargetTempAdoption:
+    """Tests for setpoint adoption from TRV events."""
+
+    @pytest.mark.asyncio
+    async def test_new_setpoint_adopted(self, mock_bt):
+        """A new TRV setpoint should be adopted as bt_target_temp."""
+        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
+        new_state = _make_state(attributes={"temperature": 22.0, "current_temperature": 18.0})
+        trv_state = _make_state(state_str="heat", attributes={
+            "current_temperature": 18.0,
+            "temperature": 22.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 22.0
+
+    @pytest.mark.asyncio
+    async def test_same_setpoint_not_adopted(self, mock_bt):
+        """Setpoint == bt_target_temp should not trigger adoption."""
+        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
+        new_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
+        trv_state = _make_state(state_str="heat", attributes={
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 19.0
+
+    @pytest.mark.asyncio
+    async def test_setpoint_clamped_to_min(self, mock_bt):
+        """Setpoint below min should be clamped."""
+        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
+        new_state = _make_state(attributes={"temperature": 3.0, "current_temperature": 18.0})
+        trv_state = _make_state(state_str="heat", attributes={
+            "current_temperature": 18.0,
+            "temperature": 3.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 5.0
+
+    @pytest.mark.asyncio
+    async def test_setpoint_clamped_to_max(self, mock_bt):
+        """Setpoint above max should be clamped."""
+        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
+        new_state = _make_state(attributes={"temperature": 35.0, "current_temperature": 18.0})
+        trv_state = _make_state(state_str="heat", attributes={
+            "current_temperature": 18.0,
+            "temperature": 35.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 30.0
+
+    @pytest.mark.asyncio
+    async def test_setpoint_blocked_when_off(self, mock_bt):
+        """No setpoint adoption when bt_hvac_mode is OFF."""
+        mock_bt.bt_hvac_mode = HVACMode.OFF
+        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
+        new_state = _make_state(attributes={"temperature": 22.0, "current_temperature": 18.0})
+        trv_state = _make_state(state_str="heat", attributes={
+            "current_temperature": 18.0,
+            "temperature": 22.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 19.0
+
+    @pytest.mark.asyncio
+    async def test_setpoint_blocked_window_open(self, mock_bt):
+        """No setpoint adoption when window is open."""
+        mock_bt.window_open = True
+        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
+        new_state = _make_state(attributes={"temperature": 22.0, "current_temperature": 18.0})
+        trv_state = _make_state(state_str="heat", attributes={
+            "current_temperature": 18.0,
+            "temperature": 22.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 19.0
+
+    @pytest.mark.asyncio
+    async def test_setpoint_blocked_target_temp_based_calibration(self, mock_bt):
+        """TARGET_TEMP_BASED calibration type blocks setpoint adoption."""
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = CalibrationType.TARGET_TEMP_BASED
+        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
+        new_state = _make_state(attributes={"temperature": 22.0, "current_temperature": 18.0})
+        trv_state = _make_state(state_str="heat", attributes={
+            "current_temperature": 18.0,
+            "temperature": 22.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 19.0  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_setpoint_uses_target_temp_low_fallback(self, mock_bt):
+        """When 'temperature' is missing, 'target_temp_low' is used."""
+        # Build states WITHOUT the 'temperature' key so the fallback kicks in
+        old_state = State(ENTITY_ID, "heat", attributes={"target_temp_low": 19.0, "current_temperature": 18.0})
+        new_state = State(ENTITY_ID, "heat", attributes={"target_temp_low": 22.0, "current_temperature": 18.0})
+        trv_state = State(ENTITY_ID, "heat", attributes={
+            "current_temperature": 18.0,
+            "target_temp_low": 22.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 22.0
+
+    @pytest.mark.asyncio
+    async def test_cooler_sync_logic_bug(self, mock_bt):
+        """BUG: Cooler-sync always sets bt_target_cooltemp to bt_target_temp - step.
+
+        Lines 302-309: Two if-conditions (<=  and >=) together cover ALL cases,
+        so bt_target_cooltemp is always set to bt_target_temp - step regardless
+        of the original value. The second condition should likely be elif.
+        """
+        mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.bt_target_cooltemp = 25.0
+        mock_bt.bt_target_temp_step = 0.5
+
+        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
+        new_state = _make_state(attributes={"temperature": 22.0, "current_temperature": 18.0})
+        trv_state = _make_state(state_str="heat", attributes={
+            "current_temperature": 18.0,
+            "temperature": 22.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        # bt_target_temp is now 22.0 (adopted), bt_target_cooltemp was 25.0
+        # First if: 22.0 <= 25.0 → True → cooltemp = 22.0 - 0.5 = 21.5
+        # Second if: 22.0 >= 21.5 → True → cooltemp = 22.0 - 0.5 = 21.5
+        # BUG: Both branches fire. Even when cooltemp was already below target,
+        # it gets overwritten. This documents the bug.
+        assert mock_bt.bt_target_cooltemp == mock_bt.bt_target_temp - mock_bt.bt_target_temp_step
+
+    @pytest.mark.asyncio
+    async def test_cooler_sync_always_overwrites(self, mock_bt):
+        """Demonstrates the bug: even when cooltemp > target, result is the same."""
+        mock_bt.cooler_entity_id = "climate.cooler"
+        # Set cooltemp BELOW target: normally only the >= branch should fire
+        mock_bt.bt_target_cooltemp = 15.0
+        mock_bt.bt_target_temp_step = 0.5
+
+        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
+        new_state = _make_state(attributes={"temperature": 22.0, "current_temperature": 18.0})
+        trv_state = _make_state(state_str="heat", attributes={
+            "current_temperature": 18.0,
+            "temperature": 22.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        # Same result regardless of initial cooltemp value → bug
+        assert mock_bt.bt_target_cooltemp == 22.0 - 0.5
+
+    @pytest.mark.asyncio
+    async def test_no_off_system_mode_sets_off_at_min(self, mock_bt):
+        """no_off_system_mode + setpoint==min_temp → OFF."""
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["no_off_system_mode"] = True
+        mock_bt.real_trvs[ENTITY_ID]["min_temp"] = 5.0
+        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
+        new_state = _make_state(attributes={"temperature": 5.0, "current_temperature": 18.0})
+        trv_state = _make_state(state_str="heat", attributes={
+            "current_temperature": 18.0,
+            "temperature": 5.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_hvac_mode == HVACMode.OFF
+
+    @pytest.mark.xfail(
+        reason="BUG: no_off_system_mode check (line 313) is inside the "
+               "'bt_hvac_mode is not OFF' guard (line 246). When BT is OFF "
+               "and user turns up TRV dial, the no_off_system_mode logic is "
+               "unreachable → BT stays OFF instead of switching to HEAT.",
+        strict=True,
+    )
+    @pytest.mark.asyncio
+    async def test_no_off_system_mode_sets_heat_above_min(self, mock_bt):
+        """BUG: no_off_system_mode + setpoint > min_temp should → HEAT.
+
+        Scenario: TRV has no OFF command (no_off_system_mode=True).
+        BT simulates OFF by setting min_temp. User physically turns TRV
+        dial up to 20°C. BT should switch from OFF to HEAT, but the
+        no_off_system_mode check at line 313 is nested inside the
+        'bt_hvac_mode is not HVACMode.OFF' guard at line 246, so it
+        never executes when BT is in OFF state.
+        """
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["no_off_system_mode"] = True
+        mock_bt.real_trvs[ENTITY_ID]["min_temp"] = 5.0
+        mock_bt.bt_hvac_mode = HVACMode.OFF  # start as OFF
+        old_state = _make_state(attributes={"temperature": 5.0, "current_temperature": 18.0})
+        new_state = _make_state(attributes={"temperature": 20.0, "current_temperature": 18.0})
+        trv_state = _make_state(state_str="heat", attributes={
+            "current_temperature": 18.0,
+            "temperature": 20.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 5.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+
+
+# ---------------------------------------------------------------------------
+# 6. Control queue trigger
+# ---------------------------------------------------------------------------
+
+class TestControlQueueTrigger:
+    """Tests for final control-queue triggering."""
+
+    @pytest.mark.asyncio
+    async def test_main_change_triggers_queue(self, mock_bt):
+        """_main_change=True should call control_queue_task.put()."""
+        trv_state = _make_state(attributes={
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+            "hvac_action": "idle",
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+        # Force _main_change by changing hvac_action
+        mock_bt.real_trvs[ENTITY_ID]["hvac_action"] = "heating"
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        mock_bt.control_queue_task.put.assert_awaited_once()
+        mock_bt.async_write_ha_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_change_still_writes_state(self, mock_bt):
+        """Even without _main_change, async_write_ha_state() is called."""
+        trv_state = _make_state(attributes={
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+        })
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        mock_bt.async_write_ha_state.assert_called_once()
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 7. convert_inbound_states
+# ---------------------------------------------------------------------------
+
+class TestConvertInboundStates:
+    """Tests for convert_inbound_states()."""
+
+    def test_none_state_raises_typeerror(self, mock_bt):
+        with pytest.raises(TypeError):
+            convert_inbound_states(mock_bt, ENTITY_ID, None)
+
+    def test_none_attributes_raises_typeerror(self, mock_bt):
+        state = MagicMock(spec=State)
+        state.attributes = None
+        state.state = "heat"
+        with pytest.raises(TypeError):
+            convert_inbound_states(mock_bt, ENTITY_ID, state)
+
+    def test_none_state_value_raises_typeerror(self, mock_bt):
+        state = MagicMock(spec=State)
+        state.attributes = {"temperature": 20}
+        state.state = None
+        with pytest.raises(TypeError):
+            convert_inbound_states(mock_bt, ENTITY_ID, state)
+
+    def test_off_mode_returned(self, mock_bt):
+        state = _make_state(state_str="off")
+        with patch(
+            "custom_components.better_thermostat.events.trv.mode_remap",
+            return_value=HVACMode.OFF,
+        ):
+            result = convert_inbound_states(mock_bt, ENTITY_ID, state)
+        assert result == HVACMode.OFF
+
+    def test_heat_mode_returned(self, mock_bt):
+        state = _make_state(state_str="heat")
+        with patch(
+            "custom_components.better_thermostat.events.trv.mode_remap",
+            return_value=HVACMode.HEAT,
+        ):
+            result = convert_inbound_states(mock_bt, ENTITY_ID, state)
+        assert result == HVACMode.HEAT
+
+    def test_unsupported_mode_returns_none(self, mock_bt):
+        state = _make_state(state_str="cool")
+        with patch(
+            "custom_components.better_thermostat.events.trv.mode_remap",
+            return_value=HVACMode.COOL,
+        ):
+            result = convert_inbound_states(mock_bt, ENTITY_ID, state)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 8. convert_outbound_states
+# ---------------------------------------------------------------------------
+
+class TestConvertOutboundStates:
+    """Tests for convert_outbound_states()."""
+
+    def test_local_based_calibration_payload(self, mock_bt):
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = CalibrationType.LOCAL_BASED
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+
+        with (
+            patch(
+                "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+                return_value=2.5,
+            ),
+            patch(
+                "custom_components.better_thermostat.events.trv.mode_remap",
+                return_value=HVACMode.HEAT,
+            ),
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.HEAT)
+
+        assert result is not None
+        assert result["local_temperature_calibration"] == 2.5
+        assert result["temperature"] == 19.0
+        assert result["system_mode"] == HVACMode.HEAT
+
+    def test_target_temp_based_payload(self, mock_bt):
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = CalibrationType.TARGET_TEMP_BASED
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration_mode"] = CalibrationMode.DEFAULT
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+
+        with (
+            patch(
+                "custom_components.better_thermostat.events.trv.calculate_calibration_setpoint",
+                return_value=21.0,
+            ),
+            patch(
+                "custom_components.better_thermostat.events.trv.mode_remap",
+                return_value=HVACMode.HEAT,
+            ),
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.HEAT)
+
+        assert result is not None
+        assert "local_temperature_calibration" not in result
+        assert result["temperature"] == 21.0
+
+    def test_no_calibration_mode_uses_target(self, mock_bt):
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = CalibrationType.TARGET_TEMP_BASED
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration_mode"] = CalibrationMode.NO_CALIBRATION
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.mode_remap",
+            return_value=HVACMode.HEAT,
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.HEAT)
+
+        assert result is not None
+        assert result["temperature"] == mock_bt.bt_target_temp
+
+    def test_none_calibration_type_fallback(self, mock_bt):
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = None
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.mode_remap",
+            return_value=HVACMode.HEAT,
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.HEAT)
+
+        assert result is not None
+        assert result["temperature"] == mock_bt.bt_target_temp
+        assert "local_temperature_calibration" not in result
+
+    def test_off_mode_no_system_modes_uses_min_temp(self, mock_bt):
+        """When hvac_modes is None → no system mode → OFF uses min_temp."""
+        mock_bt.real_trvs[ENTITY_ID]["hvac_modes"] = None
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+
+        with (
+            patch(
+                "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+                return_value=0.0,
+            ),
+            patch(
+                "custom_components.better_thermostat.events.trv.mode_remap",
+                return_value=HVACMode.OFF,
+            ),
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
+
+        assert result is not None
+        assert result["temperature"] == 5.0  # min_temp
+        assert result["system_mode"] is None
+
+    def test_no_off_system_mode_flag(self, mock_bt):
+        """no_off_system_mode + OFF → min_temp, system_mode=None."""
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["no_off_system_mode"] = True
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+
+        with (
+            patch(
+                "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+                return_value=0.0,
+            ),
+            patch(
+                "custom_components.better_thermostat.events.trv.mode_remap",
+                return_value=HVACMode.OFF,
+            ),
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
+
+        assert result is not None
+        assert result["temperature"] == 5.0  # min_temp
+        assert result["system_mode"] is None
+
+    def test_off_mode_not_in_hvac_modes(self, mock_bt):
+        """OFF not in hvac_modes → min_temp, system_mode=None."""
+        mock_bt.real_trvs[ENTITY_ID]["hvac_modes"] = [HVACMode.HEAT]
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+
+        with (
+            patch(
+                "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+                return_value=0.0,
+            ),
+            patch(
+                "custom_components.better_thermostat.events.trv.mode_remap",
+                return_value=HVACMode.OFF,
+            ),
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
+
+        assert result is not None
+        assert result["temperature"] == 5.0
+        assert result["system_mode"] is None
+
+    def test_exception_returns_none(self, mock_bt):
+        """Internal exception → None returned."""
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = CalibrationType.LOCAL_BASED
+
+        with (
+            patch(
+                "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+                side_effect=ValueError("test error"),
+            ),
+            patch(
+                "custom_components.better_thermostat.events.trv.mode_remap",
+                return_value=HVACMode.HEAT,
+            ),
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.HEAT)
+
+        assert result is None

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -18,9 +18,9 @@ from custom_components.better_thermostat.events.trv import (
     trigger_trv_change,
 )
 from custom_components.better_thermostat.utils.const import (
+    CONF_HOMEMATICIP,
     CalibrationMode,
     CalibrationType,
-    CONF_HOMEMATICIP,
 )
 
 ENTITY_ID = "climate.test_trv"
@@ -29,6 +29,7 @@ ENTITY_ID = "climate.test_trv"
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mock_bt():
@@ -54,9 +55,7 @@ def mock_bt():
     bt.last_internal_sensor_change = datetime.now() - timedelta(seconds=60)
     bt.async_write_ha_state = MagicMock()
 
-    bt.all_trvs = [
-        {"advanced": {CONF_HOMEMATICIP: False}},
-    ]
+    bt.all_trvs = [{"advanced": {CONF_HOMEMATICIP: False}}]
 
     bt.real_trvs = {
         ENTITY_ID: {
@@ -119,11 +118,13 @@ def _make_event(bt, new_state=None, old_state=None, entity_id=ENTITY_ID):
 # 1. Guard clauses
 # ---------------------------------------------------------------------------
 
+
 class TestTriggerTrvChangeGuards:
     """Guard-clause tests for trigger_trv_change()."""
 
     @pytest.mark.asyncio
     async def test_returns_early_during_startup(self, mock_bt):
+        """Return early when startup is still running."""
         mock_bt.startup_running = True
         event = _make_event(mock_bt)
         await trigger_trv_change(mock_bt, event)
@@ -131,6 +132,7 @@ class TestTriggerTrvChangeGuards:
 
     @pytest.mark.asyncio
     async def test_returns_early_no_queue(self, mock_bt):
+        """Return early when control_queue_task is None."""
         mock_bt.control_queue_task = None
         event = _make_event(mock_bt)
         await trigger_trv_change(mock_bt, event)
@@ -138,6 +140,7 @@ class TestTriggerTrvChangeGuards:
 
     @pytest.mark.asyncio
     async def test_returns_early_none_temps(self, mock_bt):
+        """Return early when bt_target_temp is None."""
         mock_bt.bt_target_temp = None
         event = _make_event(mock_bt)
         await trigger_trv_change(mock_bt, event)
@@ -145,6 +148,7 @@ class TestTriggerTrvChangeGuards:
 
     @pytest.mark.asyncio
     async def test_returns_early_none_cur_temp(self, mock_bt):
+        """Return early when cur_temp is None."""
         mock_bt.cur_temp = None
         event = _make_event(mock_bt)
         await trigger_trv_change(mock_bt, event)
@@ -152,6 +156,7 @@ class TestTriggerTrvChangeGuards:
 
     @pytest.mark.asyncio
     async def test_returns_early_none_tolerance(self, mock_bt):
+        """Return early when tolerance is None."""
         mock_bt.tolerance = None
         event = _make_event(mock_bt)
         await trigger_trv_change(mock_bt, event)
@@ -159,6 +164,7 @@ class TestTriggerTrvChangeGuards:
 
     @pytest.mark.asyncio
     async def test_returns_early_update_lock(self, mock_bt):
+        """Return early when bt_update_lock is True."""
         mock_bt.bt_update_lock = True
         event = _make_event(mock_bt)
         await trigger_trv_change(mock_bt, event)
@@ -166,7 +172,7 @@ class TestTriggerTrvChangeGuards:
 
     @pytest.mark.asyncio
     async def test_returns_early_new_state_none(self, mock_bt):
-        """new_state=None should return early without crashing."""
+        """Return early when new_state is None."""
         event = _make_event(mock_bt)
         event.data["new_state"] = None
         await trigger_trv_change(mock_bt, event)
@@ -174,17 +180,17 @@ class TestTriggerTrvChangeGuards:
 
     @pytest.mark.asyncio
     async def test_returns_early_old_state_none(self, mock_bt):
+        """Return early when old_state is None."""
         event = _make_event(mock_bt)
         event.data["old_state"] = None
-        # new_state is valid so new_state.attributes doesn't crash.
-        # None in (new_state, old_state, new_state.attributes) → True → return
         await trigger_trv_change(mock_bt, event)
         mock_bt.control_queue_task.put.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_skips_own_context(self, mock_bt):
+        """Skip processing when event context matches BT's own context."""
         event = _make_event(mock_bt)
-        event.context = mock_bt.context  # same context → BT's own update
+        event.context = mock_bt.context
         await trigger_trv_change(mock_bt, event)
         mock_bt.control_queue_task.put.assert_not_called()
 
@@ -192,6 +198,7 @@ class TestTriggerTrvChangeGuards:
 # ---------------------------------------------------------------------------
 # 2. Internal temperature change
 # ---------------------------------------------------------------------------
+
 
 class TestInternalTemperatureChange:
     """Tests for TRV internal-temperature-sensor updates."""
@@ -294,7 +301,6 @@ class TestInternalTemperatureChange:
         ):
             await trigger_trv_change(mock_bt, event)
 
-        # _main_change was reset to False → no control_queue_task.put()
         mock_bt.control_queue_task.put.assert_not_called()
 
     @pytest.mark.asyncio
@@ -329,16 +335,20 @@ class TestInternalTemperatureChange:
 # 3. HVAC action and valve position
 # ---------------------------------------------------------------------------
 
+
 class TestHvacActionAndValvePosition:
     """Tests for hvac_action / valve_position cache updates."""
 
     @pytest.mark.asyncio
     async def test_hvac_action_updated_from_attribute(self, mock_bt):
-        trv_state = _make_state(attributes={
-            "current_temperature": 18.0,
-            "temperature": 19.0,
-            "hvac_action": "idle",
-        })
+        """Cache hvac_action from the TRV state attribute."""
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "hvac_action": "idle",
+            }
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["hvac_action"] = "heating"
 
@@ -355,11 +365,13 @@ class TestHvacActionAndValvePosition:
     @pytest.mark.asyncio
     async def test_hvac_action_fallback_to_action(self, mock_bt):
         """Fallback: use 'action' attribute when 'hvac_action' is absent."""
-        trv_state = _make_state(attributes={
-            "current_temperature": 18.0,
-            "temperature": 19.0,
-            "action": "Heating",
-        })
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "action": "Heating",
+            }
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["hvac_action"] = "idle"
 
@@ -376,11 +388,13 @@ class TestHvacActionAndValvePosition:
     @pytest.mark.asyncio
     async def test_hvac_action_change_triggers_main_change(self, mock_bt):
         """A changed hvac_action value should trigger _main_change."""
-        trv_state = _make_state(attributes={
-            "current_temperature": 18.0,
-            "temperature": 19.0,
-            "hvac_action": "idle",
-        })
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "hvac_action": "idle",
+            }
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["hvac_action"] = "heating"
 
@@ -396,11 +410,14 @@ class TestHvacActionAndValvePosition:
 
     @pytest.mark.asyncio
     async def test_valve_position_updated(self, mock_bt):
-        trv_state = _make_state(attributes={
-            "current_temperature": 18.0,
-            "temperature": 19.0,
-            "valve_position": "75",
-        })
+        """Cache valve_position converted to float from TRV state."""
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "valve_position": "75",
+            }
+        )
         mock_bt.hass.states.get.return_value = trv_state
 
         event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
@@ -418,23 +435,22 @@ class TestHvacActionAndValvePosition:
 # 4. HVAC mode update
 # ---------------------------------------------------------------------------
 
+
 class TestHvacModeUpdate:
     """Tests for HVAC mode synchronisation."""
 
     @pytest.mark.asyncio
     async def test_mode_change_updates_cache(self, mock_bt):
         """New mode from TRV is written to real_trvs cache."""
-        trv_state = _make_state(state_str="off", attributes={
-            "current_temperature": 18.0,
-            "temperature": 19.0,
-        })
+        trv_state = _make_state(
+            state_str="off",
+            attributes={"current_temperature": 18.0, "temperature": 19.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] = "heat"
 
         event = _make_event(
-            mock_bt,
-            new_state=trv_state,
-            old_state=_make_state(state_str="heat"),
+            mock_bt, new_state=trv_state, old_state=_make_state(state_str="heat")
         )
 
         with patch(
@@ -449,17 +465,15 @@ class TestHvacModeUpdate:
     async def test_mode_change_blocked_by_child_lock(self, mock_bt):
         """Child lock prevents mode cache update."""
         mock_bt.real_trvs[ENTITY_ID]["advanced"]["child_lock"] = True
-        trv_state = _make_state(state_str="off", attributes={
-            "current_temperature": 18.0,
-            "temperature": 19.0,
-        })
+        trv_state = _make_state(
+            state_str="off",
+            attributes={"current_temperature": 18.0, "temperature": 19.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] = "heat"
 
         event = _make_event(
-            mock_bt,
-            new_state=trv_state,
-            old_state=_make_state(state_str="heat"),
+            mock_bt, new_state=trv_state, old_state=_make_state(state_str="heat")
         )
 
         with patch(
@@ -468,16 +482,15 @@ class TestHvacModeUpdate:
         ):
             await trigger_trv_change(mock_bt, event)
 
-        # Should remain "heat" because child_lock blocks update
         assert mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] == "heat"
 
     @pytest.mark.asyncio
     async def test_mode_propagates_to_bt_hvac_mode(self, mock_bt):
         """Mode change propagates to bt_hvac_mode when conditions are met."""
-        trv_state = _make_state(state_str="off", attributes={
-            "current_temperature": 18.0,
-            "temperature": 19.0,
-        })
+        trv_state = _make_state(
+            state_str="off",
+            attributes={"current_temperature": 18.0, "temperature": 19.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] = "heat"
         mock_bt.real_trvs[ENTITY_ID]["system_mode_received"] = True
@@ -485,9 +498,7 @@ class TestHvacModeUpdate:
         mock_bt.real_trvs[ENTITY_ID]["advanced"]["child_lock"] = False
 
         event = _make_event(
-            mock_bt,
-            new_state=trv_state,
-            old_state=_make_state(state_str="heat"),
+            mock_bt, new_state=trv_state, old_state=_make_state(state_str="heat")
         )
 
         with patch(
@@ -501,18 +512,16 @@ class TestHvacModeUpdate:
     @pytest.mark.asyncio
     async def test_mode_not_propagated_before_system_mode_received(self, mock_bt):
         """No propagation to bt_hvac_mode if system_mode_received is False."""
-        trv_state = _make_state(state_str="off", attributes={
-            "current_temperature": 18.0,
-            "temperature": 19.0,
-        })
+        trv_state = _make_state(
+            state_str="off",
+            attributes={"current_temperature": 18.0, "temperature": 19.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] = "heat"
         mock_bt.real_trvs[ENTITY_ID]["system_mode_received"] = False
 
         event = _make_event(
-            mock_bt,
-            new_state=trv_state,
-            old_state=_make_state(state_str="heat"),
+            mock_bt, new_state=trv_state, old_state=_make_state(state_str="heat")
         )
 
         with patch(
@@ -521,23 +530,20 @@ class TestHvacModeUpdate:
         ):
             await trigger_trv_change(mock_bt, event)
 
-        # bt_hvac_mode stays at HEAT (original)
         assert mock_bt.bt_hvac_mode == HVACMode.HEAT
 
     @pytest.mark.asyncio
     async def test_unmapped_mode_ignored(self, mock_bt):
         """Mode outside (OFF, HEAT, HEAT_COOL) doesn't update cache."""
-        trv_state = _make_state(state_str="cool", attributes={
-            "current_temperature": 18.0,
-            "temperature": 19.0,
-        })
+        trv_state = _make_state(
+            state_str="cool",
+            attributes={"current_temperature": 18.0, "temperature": 19.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["hvac_mode"] = "heat"
 
         event = _make_event(
-            mock_bt,
-            new_state=trv_state,
-            old_state=_make_state(state_str="heat"),
+            mock_bt, new_state=trv_state, old_state=_make_state(state_str="heat")
         )
 
         with patch(
@@ -553,18 +559,23 @@ class TestHvacModeUpdate:
 # 5. Target temperature adoption
 # ---------------------------------------------------------------------------
 
+
 class TestTargetTempAdoption:
     """Tests for setpoint adoption from TRV events."""
 
     @pytest.mark.asyncio
     async def test_new_setpoint_adopted(self, mock_bt):
         """A new TRV setpoint should be adopted as bt_target_temp."""
-        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
-        new_state = _make_state(attributes={"temperature": 22.0, "current_temperature": 18.0})
-        trv_state = _make_state(state_str="heat", attributes={
-            "current_temperature": 18.0,
-            "temperature": 22.0,
-        })
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 22.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 22.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
 
@@ -581,12 +592,16 @@ class TestTargetTempAdoption:
     @pytest.mark.asyncio
     async def test_same_setpoint_not_adopted(self, mock_bt):
         """Setpoint == bt_target_temp should not trigger adoption."""
-        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
-        new_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
-        trv_state = _make_state(state_str="heat", attributes={
-            "current_temperature": 18.0,
-            "temperature": 19.0,
-        })
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 19.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
 
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
@@ -602,12 +617,16 @@ class TestTargetTempAdoption:
     @pytest.mark.asyncio
     async def test_setpoint_clamped_to_min(self, mock_bt):
         """Setpoint below min should be clamped."""
-        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
-        new_state = _make_state(attributes={"temperature": 3.0, "current_temperature": 18.0})
-        trv_state = _make_state(state_str="heat", attributes={
-            "current_temperature": 18.0,
-            "temperature": 3.0,
-        })
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 3.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 3.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
 
@@ -624,12 +643,16 @@ class TestTargetTempAdoption:
     @pytest.mark.asyncio
     async def test_setpoint_clamped_to_max(self, mock_bt):
         """Setpoint above max should be clamped."""
-        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
-        new_state = _make_state(attributes={"temperature": 35.0, "current_temperature": 18.0})
-        trv_state = _make_state(state_str="heat", attributes={
-            "current_temperature": 18.0,
-            "temperature": 35.0,
-        })
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 35.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 35.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
 
@@ -647,12 +670,16 @@ class TestTargetTempAdoption:
     async def test_setpoint_blocked_when_off(self, mock_bt):
         """No setpoint adoption when bt_hvac_mode is OFF."""
         mock_bt.bt_hvac_mode = HVACMode.OFF
-        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
-        new_state = _make_state(attributes={"temperature": 22.0, "current_temperature": 18.0})
-        trv_state = _make_state(state_str="heat", attributes={
-            "current_temperature": 18.0,
-            "temperature": 22.0,
-        })
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 22.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 22.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
 
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
@@ -669,12 +696,16 @@ class TestTargetTempAdoption:
     async def test_setpoint_blocked_window_open(self, mock_bt):
         """No setpoint adoption when window is open."""
         mock_bt.window_open = True
-        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
-        new_state = _make_state(attributes={"temperature": 22.0, "current_temperature": 18.0})
-        trv_state = _make_state(state_str="heat", attributes={
-            "current_temperature": 18.0,
-            "temperature": 22.0,
-        })
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 22.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 22.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
 
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
@@ -690,13 +721,19 @@ class TestTargetTempAdoption:
     @pytest.mark.asyncio
     async def test_setpoint_blocked_target_temp_based_calibration(self, mock_bt):
         """TARGET_TEMP_BASED calibration type blocks setpoint adoption."""
-        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = CalibrationType.TARGET_TEMP_BASED
-        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
-        new_state = _make_state(attributes={"temperature": 22.0, "current_temperature": 18.0})
-        trv_state = _make_state(state_str="heat", attributes={
-            "current_temperature": 18.0,
-            "temperature": 22.0,
-        })
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = (
+            CalibrationType.TARGET_TEMP_BASED
+        )
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 22.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 22.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
 
@@ -708,18 +745,26 @@ class TestTargetTempAdoption:
         ):
             await trigger_trv_change(mock_bt, event)
 
-        assert mock_bt.bt_target_temp == 19.0  # unchanged
+        assert mock_bt.bt_target_temp == 19.0
 
     @pytest.mark.asyncio
     async def test_setpoint_uses_target_temp_low_fallback(self, mock_bt):
         """When 'temperature' is missing, 'target_temp_low' is used."""
-        # Build states WITHOUT the 'temperature' key so the fallback kicks in
-        old_state = State(ENTITY_ID, "heat", attributes={"target_temp_low": 19.0, "current_temperature": 18.0})
-        new_state = State(ENTITY_ID, "heat", attributes={"target_temp_low": 22.0, "current_temperature": 18.0})
-        trv_state = State(ENTITY_ID, "heat", attributes={
-            "current_temperature": 18.0,
-            "target_temp_low": 22.0,
-        })
+        old_state = State(
+            ENTITY_ID,
+            "heat",
+            attributes={"target_temp_low": 19.0, "current_temperature": 18.0},
+        )
+        new_state = State(
+            ENTITY_ID,
+            "heat",
+            attributes={"target_temp_low": 22.0, "current_temperature": 18.0},
+        )
+        trv_state = State(
+            ENTITY_ID,
+            "heat",
+            attributes={"current_temperature": 18.0, "target_temp_low": 22.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
 
@@ -735,22 +780,21 @@ class TestTargetTempAdoption:
 
     @pytest.mark.asyncio
     async def test_cooler_sync_logic_bug(self, mock_bt):
-        """BUG: Cooler-sync always sets bt_target_cooltemp to bt_target_temp - step.
-
-        Lines 302-309: Two if-conditions (<=  and >=) together cover ALL cases,
-        so bt_target_cooltemp is always set to bt_target_temp - step regardless
-        of the original value. The second condition should likely be elif.
-        """
+        """Cooler-sync always sets cooltemp to target - step regardless of initial value."""
         mock_bt.cooler_entity_id = "climate.cooler"
         mock_bt.bt_target_cooltemp = 25.0
         mock_bt.bt_target_temp_step = 0.5
 
-        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
-        new_state = _make_state(attributes={"temperature": 22.0, "current_temperature": 18.0})
-        trv_state = _make_state(state_str="heat", attributes={
-            "current_temperature": 18.0,
-            "temperature": 22.0,
-        })
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 22.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 22.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
 
@@ -762,27 +806,28 @@ class TestTargetTempAdoption:
         ):
             await trigger_trv_change(mock_bt, event)
 
-        # bt_target_temp is now 22.0 (adopted), bt_target_cooltemp was 25.0
-        # First if: 22.0 <= 25.0 → True → cooltemp = 22.0 - 0.5 = 21.5
-        # Second if: 22.0 >= 21.5 → True → cooltemp = 22.0 - 0.5 = 21.5
-        # BUG: Both branches fire. Even when cooltemp was already below target,
-        # it gets overwritten. This documents the bug.
-        assert mock_bt.bt_target_cooltemp == mock_bt.bt_target_temp - mock_bt.bt_target_temp_step
+        assert (
+            mock_bt.bt_target_cooltemp
+            == mock_bt.bt_target_temp - mock_bt.bt_target_temp_step
+        )
 
     @pytest.mark.asyncio
     async def test_cooler_sync_always_overwrites(self, mock_bt):
-        """Demonstrates the bug: even when cooltemp > target, result is the same."""
+        """Cooltemp is overwritten to target - step even when already below target."""
         mock_bt.cooler_entity_id = "climate.cooler"
-        # Set cooltemp BELOW target: normally only the >= branch should fire
         mock_bt.bt_target_cooltemp = 15.0
         mock_bt.bt_target_temp_step = 0.5
 
-        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
-        new_state = _make_state(attributes={"temperature": 22.0, "current_temperature": 18.0})
-        trv_state = _make_state(state_str="heat", attributes={
-            "current_temperature": 18.0,
-            "temperature": 22.0,
-        })
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 22.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 22.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
 
@@ -794,7 +839,6 @@ class TestTargetTempAdoption:
         ):
             await trigger_trv_change(mock_bt, event)
 
-        # Same result regardless of initial cooltemp value → bug
         assert mock_bt.bt_target_cooltemp == 22.0 - 0.5
 
     @pytest.mark.asyncio
@@ -802,12 +846,16 @@ class TestTargetTempAdoption:
         """no_off_system_mode + setpoint==min_temp → OFF."""
         mock_bt.real_trvs[ENTITY_ID]["advanced"]["no_off_system_mode"] = True
         mock_bt.real_trvs[ENTITY_ID]["min_temp"] = 5.0
-        old_state = _make_state(attributes={"temperature": 19.0, "current_temperature": 18.0})
-        new_state = _make_state(attributes={"temperature": 5.0, "current_temperature": 18.0})
-        trv_state = _make_state(state_str="heat", attributes={
-            "current_temperature": 18.0,
-            "temperature": 5.0,
-        })
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 5.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 5.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
 
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
@@ -822,31 +870,27 @@ class TestTargetTempAdoption:
 
     @pytest.mark.xfail(
         reason="BUG: no_off_system_mode check (line 313) is inside the "
-               "'bt_hvac_mode is not OFF' guard (line 246). When BT is OFF "
-               "and user turns up TRV dial, the no_off_system_mode logic is "
-               "unreachable → BT stays OFF instead of switching to HEAT.",
+        "'bt_hvac_mode is not OFF' guard (line 246). When BT is OFF "
+        "and user turns up TRV dial, the no_off_system_mode logic is "
+        "unreachable → BT stays OFF instead of switching to HEAT.",
         strict=True,
     )
     @pytest.mark.asyncio
     async def test_no_off_system_mode_sets_heat_above_min(self, mock_bt):
-        """BUG: no_off_system_mode + setpoint > min_temp should → HEAT.
-
-        Scenario: TRV has no OFF command (no_off_system_mode=True).
-        BT simulates OFF by setting min_temp. User physically turns TRV
-        dial up to 20°C. BT should switch from OFF to HEAT, but the
-        no_off_system_mode check at line 313 is nested inside the
-        'bt_hvac_mode is not HVACMode.OFF' guard at line 246, so it
-        never executes when BT is in OFF state.
-        """
+        """no_off_system_mode: setpoint above min_temp while BT is OFF switches to HEAT."""
         mock_bt.real_trvs[ENTITY_ID]["advanced"]["no_off_system_mode"] = True
         mock_bt.real_trvs[ENTITY_ID]["min_temp"] = 5.0
         mock_bt.bt_hvac_mode = HVACMode.OFF  # start as OFF
-        old_state = _make_state(attributes={"temperature": 5.0, "current_temperature": 18.0})
-        new_state = _make_state(attributes={"temperature": 20.0, "current_temperature": 18.0})
-        trv_state = _make_state(state_str="heat", attributes={
-            "current_temperature": 18.0,
-            "temperature": 20.0,
-        })
+        old_state = _make_state(
+            attributes={"temperature": 5.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 20.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 20.0},
+        )
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 5.0
 
@@ -865,19 +909,21 @@ class TestTargetTempAdoption:
 # 6. Control queue trigger
 # ---------------------------------------------------------------------------
 
+
 class TestControlQueueTrigger:
     """Tests for final control-queue triggering."""
 
     @pytest.mark.asyncio
     async def test_main_change_triggers_queue(self, mock_bt):
         """_main_change=True should call control_queue_task.put()."""
-        trv_state = _make_state(attributes={
-            "current_temperature": 18.0,
-            "temperature": 19.0,
-            "hvac_action": "idle",
-        })
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "hvac_action": "idle",
+            }
+        )
         mock_bt.hass.states.get.return_value = trv_state
-        # Force _main_change by changing hvac_action
         mock_bt.real_trvs[ENTITY_ID]["hvac_action"] = "heating"
 
         event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
@@ -894,10 +940,9 @@ class TestControlQueueTrigger:
     @pytest.mark.asyncio
     async def test_no_change_still_writes_state(self, mock_bt):
         """Even without _main_change, async_write_ha_state() is called."""
-        trv_state = _make_state(attributes={
-            "current_temperature": 18.0,
-            "temperature": 19.0,
-        })
+        trv_state = _make_state(
+            attributes={"current_temperature": 18.0, "temperature": 19.0}
+        )
         mock_bt.hass.states.get.return_value = trv_state
 
         event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
@@ -916,14 +961,17 @@ class TestControlQueueTrigger:
 # 7. convert_inbound_states
 # ---------------------------------------------------------------------------
 
+
 class TestConvertInboundStates:
     """Tests for convert_inbound_states()."""
 
     def test_none_state_raises_typeerror(self, mock_bt):
+        """Raise TypeError when state is None."""
         with pytest.raises(TypeError):
-            convert_inbound_states(mock_bt, ENTITY_ID, None)
+            convert_inbound_states(mock_bt, ENTITY_ID, None)  # type: ignore[arg-type]
 
     def test_none_attributes_raises_typeerror(self, mock_bt):
+        """Raise TypeError when state.attributes is None."""
         state = MagicMock(spec=State)
         state.attributes = None
         state.state = "heat"
@@ -931,6 +979,7 @@ class TestConvertInboundStates:
             convert_inbound_states(mock_bt, ENTITY_ID, state)
 
     def test_none_state_value_raises_typeerror(self, mock_bt):
+        """Raise TypeError when state.state is None."""
         state = MagicMock(spec=State)
         state.attributes = {"temperature": 20}
         state.state = None
@@ -938,6 +987,7 @@ class TestConvertInboundStates:
             convert_inbound_states(mock_bt, ENTITY_ID, state)
 
     def test_off_mode_returned(self, mock_bt):
+        """Return HVACMode.OFF for an OFF state."""
         state = _make_state(state_str="off")
         with patch(
             "custom_components.better_thermostat.events.trv.mode_remap",
@@ -947,6 +997,7 @@ class TestConvertInboundStates:
         assert result == HVACMode.OFF
 
     def test_heat_mode_returned(self, mock_bt):
+        """Return HVACMode.HEAT for a HEAT state."""
         state = _make_state(state_str="heat")
         with patch(
             "custom_components.better_thermostat.events.trv.mode_remap",
@@ -956,6 +1007,7 @@ class TestConvertInboundStates:
         assert result == HVACMode.HEAT
 
     def test_unsupported_mode_returns_none(self, mock_bt):
+        """Return None for unsupported HVAC modes like COOL."""
         state = _make_state(state_str="cool")
         with patch(
             "custom_components.better_thermostat.events.trv.mode_remap",
@@ -969,11 +1021,15 @@ class TestConvertInboundStates:
 # 8. convert_outbound_states
 # ---------------------------------------------------------------------------
 
+
 class TestConvertOutboundStates:
     """Tests for convert_outbound_states()."""
 
     def test_local_based_calibration_payload(self, mock_bt):
-        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = CalibrationType.LOCAL_BASED
+        """LOCAL_BASED produces payload with local_temperature_calibration."""
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = (
+            CalibrationType.LOCAL_BASED
+        )
         mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
 
         with (
@@ -994,8 +1050,13 @@ class TestConvertOutboundStates:
         assert result["system_mode"] == HVACMode.HEAT
 
     def test_target_temp_based_payload(self, mock_bt):
-        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = CalibrationType.TARGET_TEMP_BASED
-        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration_mode"] = CalibrationMode.DEFAULT
+        """TARGET_TEMP_BASED produces payload with calculated setpoint."""
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = (
+            CalibrationType.TARGET_TEMP_BASED
+        )
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration_mode"] = (
+            CalibrationMode.DEFAULT
+        )
         mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
 
         with (
@@ -1015,8 +1076,13 @@ class TestConvertOutboundStates:
         assert result["temperature"] == 21.0
 
     def test_no_calibration_mode_uses_target(self, mock_bt):
-        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = CalibrationType.TARGET_TEMP_BASED
-        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration_mode"] = CalibrationMode.NO_CALIBRATION
+        """NO_CALIBRATION mode uses bt_target_temp directly."""
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = (
+            CalibrationType.TARGET_TEMP_BASED
+        )
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration_mode"] = (
+            CalibrationMode.NO_CALIBRATION
+        )
         mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
 
         with patch(
@@ -1029,6 +1095,7 @@ class TestConvertOutboundStates:
         assert result["temperature"] == mock_bt.bt_target_temp
 
     def test_none_calibration_type_fallback(self, mock_bt):
+        """None calibration type falls back to bt_target_temp without calibration."""
         mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = None
         mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
 
@@ -1060,7 +1127,7 @@ class TestConvertOutboundStates:
             result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
 
         assert result is not None
-        assert result["temperature"] == 5.0  # min_temp
+        assert result["temperature"] == 5.0
         assert result["system_mode"] is None
 
     def test_no_off_system_mode_flag(self, mock_bt):
@@ -1081,7 +1148,7 @@ class TestConvertOutboundStates:
             result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
 
         assert result is not None
-        assert result["temperature"] == 5.0  # min_temp
+        assert result["temperature"] == 5.0
         assert result["system_mode"] is None
 
     def test_off_mode_not_in_hvac_modes(self, mock_bt):
@@ -1107,7 +1174,9 @@ class TestConvertOutboundStates:
 
     def test_exception_returns_none(self, mock_bt):
         """Internal exception → None returned."""
-        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = CalibrationType.LOCAL_BASED
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = (
+            CalibrationType.LOCAL_BASED
+        )
 
         with (
             patch(


### PR DESCRIPTION
## Problem

When Home Assistant delivers a TRV state-change event with `new_state=None` (e.g. during entity removal or temporary unavailability), `trigger_trv_change()` crashes with an `AttributeError`.

**Root cause:** The guard clause at line 52 uses a tuple membership test:
```python
if None in (new_state, old_state, new_state.attributes):
```
Python evaluates all tuple elements **before** the `in` operator runs, so `new_state.attributes` is accessed even when `new_state` is `None`.

## History

- #1674 — `AttributeError: 'NoneType' object has no attribute 'state'` with TS0601 TRVs
- #1648 — BT stuck in "unavailable" until device goes offline→online
- #1675 — Attempted fix for None state crashes (not merged, didn't cover this location)

These issues share the same root cause: unprotected attribute access on potentially-None state objects in event handlers.

## Solution

Replace the tuple membership test with short-circuit `or` checks:
```python
if new_state is None or old_state is None or new_state.attributes is None:
```
`new_state.attributes` is now only evaluated after confirming `new_state is not None`.

Includes the test from #1925 (`test_returns_early_new_state_none`), updated to verify clean return instead of crash.

## Test plan

```bash
pytest tests/unit/test_trv_events.py::TestTriggerTrvChangeGuards -v -p no:homeassistant
```