### PR TITLE
fix: allow no_off_system_mode TRVs to recover from OFF state

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -409,7 +409,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.cur_temp = None
         self._current_humidity = 0
         self.window_open = None
-        self.bt_target_temp_step = float(target_temp_step) if target_temp_step and target_temp_step != "0.0" else None
+        self.bt_target_temp_step = (
+            float(target_temp_step)
+            if target_temp_step and target_temp_step != "0.0"
+            else None
+        )
         self.bt_min_temp = 0
         self.bt_max_temp = 30
         self.bt_target_temp = 5.0

--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -59,8 +59,10 @@ _LOGGER = logging.getLogger(__name__)
 TEMP_STEP_SELECTOR = selector.SelectSelector(
     selector.SelectSelectorConfig(
         options=[
-            selector.SelectOptionDict(value="0.0", label="Auto"),  # Keep for backwards compatibility
-            selector.SelectOptionDict(value="", label="Auto (New)"), 
+            selector.SelectOptionDict(
+                value="0.0", label="Auto"
+            ),  # Keep for backwards compatibility
+            selector.SelectOptionDict(value="", label="Auto (New)"),
             selector.SelectOptionDict(value="0.1", label="0.1 °C"),
             selector.SelectOptionDict(value="0.2", label="0.2 °C"),
             selector.SelectOptionDict(value="0.25", label="0.25 °C"),

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -240,10 +240,13 @@ async def trigger_trv_change(self, event):
         self.device_name,
         "trigger_trv_change()",
     )
+    _is_no_off_device = self.real_trvs[entity_id]["advanced"].get(
+        "no_off_system_mode", False
+    )
     if (
         _new_heating_setpoint is not None
         and _old_heating_setpoint is not None
-        and self.bt_hvac_mode is not HVACMode.OFF
+        and (self.bt_hvac_mode is not HVACMode.OFF or _is_no_off_device)
     ):
         _LOGGER.debug(
             "better_thermostat %s: trigger_trv_change / _old_heating_setpoint: %s - _new_heating_setpoint: %s - _last_temperature: %s",

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -236,7 +236,9 @@ def _deserialize(raw: dict[str, Any]) -> RuntimeState:
         except (TypeError, ValueError):
             heating_power = None
         try:
-            heat_loss_rate = float(heat_loss_rate) if heat_loss_rate is not None else None
+            heat_loss_rate = (
+                float(heat_loss_rate) if heat_loss_rate is not None else None
+            )
         except (TypeError, ValueError):
             heat_loss_rate = None
         state.thermal = ThermalStats(

--- a/tests/unit/test_mpc_comprehensive.py
+++ b/tests/unit/test_mpc_comprehensive.py
@@ -105,10 +105,16 @@ def _default_params(
     overrides = {
         k: local[k]
         for k in base_field_names
-        if k in local and local[k] is not _UNSET and k not in {
-            "min_update_interval_s", "min_percent_hold_time_s",
-            "percent_hysteresis_pts", "mpc_du_max_pct",
-            "use_virtual_temp", "enable_min_effective_percent",
+        if k in local
+        and local[k] is not _UNSET
+        and k
+        not in {
+            "min_update_interval_s",
+            "min_percent_hold_time_s",
+            "percent_hysteresis_pts",
+            "mpc_du_max_pct",
+            "use_virtual_temp",
+            "enable_min_effective_percent",
         }
     }
     return replace(base, **overrides) if overrides else base

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -868,13 +868,6 @@ class TestTargetTempAdoption:
 
         assert mock_bt.bt_hvac_mode == HVACMode.OFF
 
-    @pytest.mark.xfail(
-        reason="BUG: no_off_system_mode check (line 313) is inside the "
-        "'bt_hvac_mode is not OFF' guard (line 246). When BT is OFF "
-        "and user turns up TRV dial, the no_off_system_mode logic is "
-        "unreachable → BT stays OFF instead of switching to HEAT.",
-        strict=True,
-    )
     @pytest.mark.asyncio
     async def test_no_off_system_mode_sets_heat_above_min(self, mock_bt):
         """no_off_system_mode: setpoint above min_temp while BT is OFF switches to HEAT."""


### PR DESCRIPTION
## Problem

TRVs without an OFF HVAC mode (e.g. Shelly BLU TRV, Danfoss Ally, certain Tuya models) use the `no_off_system_mode` flag. BT simulates OFF by setting the TRV to `min_temp`. When the user physically turns the TRV dial up from `min_temp` to resume heating, **BT stays permanently in OFF state** and never recovers.

**Root cause:** The `no_off_system_mode` detection logic at line 313 is nested inside the `bt_hvac_mode is not HVACMode.OFF` guard at line 246. When BT is already OFF, the entire setpoint processing block is skipped — including the mode recovery that should switch BT back to HEAT:

```python
if (
    _new_heating_setpoint is not None
    and _old_heating_setpoint is not None
    and self.bt_hvac_mode is not HVACMode.OFF   # ← blocks everything when OFF
):
    # ... setpoint adoption ...
    if no_off_system_mode:           # ← never reached!
        if setpoint > min_temp:
            self.bt_hvac_mode = HVACMode.HEAT    # ← dead code when OFF
```

## History

- #1195 — TRV stays forever at 5°C after window closed (with `no_off_system_mode`) — **9 upvotes, 15 comments**
- #1760 — Opening window and turning off heating doesn't work (Shelly BLU TRV)
- #1885 — BT entities remain "unavailable" with Tuya Local TRVs (no "off" HVAC mode) — **still open**
- #1781 — Diagnostic logging PR for `no_off_system_mode` (Copilot, only adds logging, no fix)

All share the same root cause: the `no_off_system_mode` recovery path is dead code when BT is in OFF state.

## Solution

Add a one-line bypass to the guard condition for `no_off_system_mode` devices:

```python
_is_no_off_device = self.real_trvs[entity_id]["advanced"].get(
    "no_off_system_mode", False
)
if (
    _new_heating_setpoint is not None
    and _old_heating_setpoint is not None
    and (self.bt_hvac_mode is not HVACMode.OFF or _is_no_off_device)
):
```

For `no_off_system_mode` devices, the setpoint processing block now executes even when BT is OFF. This allows:
1. Setpoint clamping (range validation)
2. Setpoint adoption (user's new temperature is picked up)
3. Mode recovery (`min_temp` → OFF, `> min_temp` → HEAT)

Non-`no_off_system_mode` devices are completely unaffected.

## Test plan

```bash
pytest tests/unit/test_trv_events.py -k no_off -v -p no:homeassistant
```

- `test_no_off_system_mode_sets_off_at_min` — setpoint==min_temp → OFF (existing behavior, unchanged)
- `test_no_off_system_mode_sets_heat_above_min` — setpoint > min_temp while OFF → HEAT (**previously xfail, now passes**)