### PR TITLE
fix: guard against hass.states.get() returning None in TRV event handler

### DIFF
--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -73,6 +73,14 @@ async def trigger_trv_change(self, event):
     # _LOGGER.debug(f"better_thermostat {self.device_name}: TRV {entity_id} update received")
 
     _org_trv_state = self.hass.states.get(entity_id)
+    if _org_trv_state is None:
+        _LOGGER.debug(
+            "better_thermostat %s: TRV %s state not found in registry, skipping",
+            self.device_name,
+            entity_id,
+        )
+        return
+
     child_lock = self.real_trvs[entity_id]["advanced"].get("child_lock")
 
     # Dynamische Modell-Erkennung: nur einmalig (z. B. beim Start) – nicht bei jedem Event

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -194,6 +194,15 @@ class TestTriggerTrvChangeGuards:
         await trigger_trv_change(mock_bt, event)
         mock_bt.control_queue_task.put.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_org_trv_state_none_returns_early(self, mock_bt):
+        """Return early when hass.states.get() returns None (no crash)."""
+        mock_bt.hass.states.get.return_value = None
+        event = _make_event(mock_bt)
+
+        await trigger_trv_change(mock_bt, event)
+        mock_bt.control_queue_task.put.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # 2. Internal temperature change


### PR DESCRIPTION
## Problem

`trigger_trv_change()` crashes with `AttributeError: 'NoneType' object has no attribute 'attributes'` when `hass.states.get(entity_id)` returns `None`.

This happens when a TRV entity is temporarily missing from Home Assistant's state registry — e.g. during entity removal, device unavailability, or Z2M restarts. The crash occurs at line 112 (`_org_trv_state.attributes.get("current_temperature")`), but there are **9 unprotected accesses** to `_org_trv_state.attributes` / `.state` after the assignment, any of which would crash.

> **Note:** #1926 fixed a related but different bug — the `None in (tuple)` guard clause for `new_state`/`old_state`. This PR addresses the *second* unguarded None path in the same function.

## Related issues

- #1033 — `AttributeError: 'NoneType' object has no attribute 'attributes'`
- #1674 — TRV fails to respond, BT entity shows inactive
- #69 — `AttributeError: 'NoneType' object has no attribute 'state'`
- #1675 — Attempted fix for None state crashes (closed, didn't cover this location)

## Solution

Add a None guard immediately after `hass.states.get()`, following the same early-return-with-debug-log pattern used for the `new_state`/`old_state` guard above:

```python
_org_trv_state = self.hass.states.get(entity_id)
if _org_trv_state is None:
    _LOGGER.debug(
        "better_thermostat %s: TRV %s state not found in registry, skipping",
        self.device_name,
        entity_id,
    )
    return
```

Includes a unit test that verifies graceful early return instead of crash.

## Test plan

```bash
pytest tests/unit/test_trv_events.py::TestTriggerTrvChangeGuards::test_org_trv_state_none_returns_early -v -p no:homeassistant
```