### PR TITLE
fix: Catch TypeError in HomematicIP detection loop

### DIFF
--- a/custom_components/better_thermostat/events/temperature.py
+++ b/custom_components/better_thermostat/events/temperature.py
@@ -206,7 +206,7 @@ async def trigger_temperature_change(self, event):
         for trv in self.all_trvs:
             if trv["advanced"][CONF_HOMEMATICIP]:
                 _time_diff = 600
-    except KeyError:
+    except (KeyError, TypeError):
         pass
 
     if _incoming_temperature_q is None or _incoming_temperature_q < -50:


### PR DESCRIPTION
## Summary
- Widen `except KeyError` to `except (KeyError, TypeError)` in the HomematicIP TRV detection loop (`temperature.py:209`)
- Prevents crash when `self.all_trvs` is `None` or `trv["advanced"]` is `None`
- Gracefully falls back to the default 5s debounce interval

## Root Cause
The `for trv in self.all_trvs` loop and the `trv["advanced"][CONF_HOMEMATICIP]` lookup
can raise `TypeError` in two scenarios:
1. **`all_trvs` is `None`** — `for trv in None` → `TypeError: 'NoneType' object is not iterable`
2. **`trv["advanced"]` is `None`** — `None[CONF_HOMEMATICIP]` → `TypeError: 'NoneType' object is not subscriptable`

The existing `except KeyError` handler only catches missing dict keys, not `TypeError`.

## Related Issues
This is part of a broader pattern of `NoneType` crashes in the codebase:
- #1772 — `'local_calibration_step' argument of type 'NoneType' is not iterable` (fixed by #1778)
- #1114 — `unsupported operand type(s) for -: 'NoneType' and 'float'`
- #878, #1089, #1122 — various "BT entity unavailable" issues potentially caused by unhandled exceptions

Similar defensive fixes already merged:
- #1869 — `fix: Handle TypeError in check_float for None and invalid types`
- #1778 — `Fix NoneType errors in calibration initialization`

## Test Plan
- [x] `test_all_trvs_none_does_not_crash` — verifies `all_trvs=None` doesn't crash
- [x] `test_all_trvs_advanced_none_does_not_crash` — verifies `advanced=None` doesn't crash
- Tests in Draft PR #1941