### PR TITLE
test: Add comprehensive test suite for sensor platform

### DIFF
--- a/custom_components/better_thermostat/sensor.py
+++ b/custom_components/better_thermostat/sensor.py
@@ -310,6 +310,7 @@ def _get_pid_trvs(bt_climate: BetterThermostat) -> set[str]:
     for trv_entity_id, trv_data in bt_climate.real_trvs.items():
         advanced = trv_data.get("advanced", {})
         calibration_mode = advanced.get(CONF_CALIBRATION_MODE)
+        # Normalize string values to CalibrationMode enum
         if isinstance(calibration_mode, str):
             try:
                 calibration_mode = CalibrationMode(calibration_mode)
@@ -596,6 +597,7 @@ class _BtSensorBase(SensorEntity):
                 "Better Thermostat climate entity has no entity_id yet. "
                 "Sensor update might be delayed."
             )
+        # Also update initially
         self._update_state()
 
     @callback
@@ -616,7 +618,11 @@ class _BtMpcSensorBase(_BtSensorBase):
 
     @property
     def available(self) -> bool:
-        """Return if entity is available."""
+        """Return if entity is available.
+
+        Follow HA guidelines: return False when entity should be unavailable.
+        This prevents "unknown" states and properly shows "unavailable".
+        """
         if not self._bt_climate._available:
             return False
         if self._bt_climate.window_open:
@@ -833,7 +839,7 @@ class BetterThermostatSolarIntensitySensor(_BtSensorBase):
     _attr_device_class = None
     _attr_native_unit_of_measurement = "%"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_should_poll = True
+    _attr_should_poll = True  # Weather entity updates not strictly coupled to climate state
     _attr_icon = "mdi:solar-power"
     _unique_id_suffix = "solar_intensity"
 
@@ -842,6 +848,7 @@ class BetterThermostatSolarIntensitySensor(_BtSensorBase):
         try:
             val = _get_current_solar_intensity(self._bt_climate)
             if val is not None:
+                # Function returns 0.0-1.0, convert to %
                 self._attr_native_value = round(float(val) * 100.0, 1)
             else:
                 self._attr_native_value = 0.0

--- a/custom_components/better_thermostat/sensor.py
+++ b/custom_components/better_thermostat/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, UnitOfTemperature
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity_registry import (
@@ -151,7 +151,7 @@ async def _register_dynamic_entity_callback(
     """Register callback for dynamic entity management."""
 
     @callback
-    def _on_config_change(data: Any) -> None:
+    def _on_config_change(data: object) -> None:
         """Handle configuration changes that might affect entity requirements."""
         _LOGGER.debug(
             "Better Thermostat %s: Configuration change detected via signal, checking entity requirements",
@@ -463,7 +463,7 @@ async def _cleanup_pid_switch_entities(
     entry_id: str,
     bt_climate: BetterThermostat,
 ) -> None:
-    """Remove PID switch entities for TRVs no longer using PID calibration and child lock switches for removed TRVs."""
+    """Remove PID switch and child lock entities for TRVs that changed or were removed."""
     tracked_switches = _ACTIVE_SWITCH_ENTITIES.get(entry_id, {})
     current_pid_trvs = _get_pid_trvs(bt_climate)
 
@@ -601,13 +601,13 @@ class _BtSensorBase(SensorEntity):
         self._update_state()
 
     @callback
-    def _on_climate_update(self, event: Event[Any]) -> None:
+    def _on_climate_update(self, event: Event[EventStateChangedData]) -> None:
         """Handle climate entity update."""
         self._update_state()
         self.async_write_ha_state()
 
     def _update_state(self) -> None:
-        """Update state from climate entity. Override in subclasses."""
+        """Update state from climate entity."""
         raise NotImplementedError
 
 

--- a/custom_components/better_thermostat/sensor.py
+++ b/custom_components/better_thermostat/sensor.py
@@ -1,7 +1,10 @@
 """Better Thermostat Sensor Platform."""
 
+from __future__ import annotations
+
 from collections.abc import Callable
 import logging
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -10,7 +13,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, UnitOfTemperature
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity_registry import (
@@ -22,15 +25,16 @@ from homeassistant.helpers.event import async_track_state_change_event
 from .calibration import _get_current_solar_intensity
 from .utils.const import CONF_CALIBRATION_MODE, CalibrationMode
 
+if TYPE_CHECKING:
+    from .climate import BetterThermostat
+
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = "better_thermostat"
 
 # Globale Tracking-Variablen für aktive algorithmus-spezifische Entitäten
-_ACTIVE_ALGORITHM_ENTITIES: dict[str, dict] = {}
-_ENTITY_CLEANUP_CALLBACKS: dict[str, Callable] = {}
-_DISPATCHER_UNSUBSCRIBES: dict[
-    str, Callable[[], None]
-] = {}  # Store unsubscribe functions
+_ACTIVE_ALGORITHM_ENTITIES: dict[str, dict[CalibrationMode, list[str]]] = {}
+_ENTITY_CLEANUP_CALLBACKS: dict[str, Callable[..., None]] = {}
+_DISPATCHER_UNSUBSCRIBES: dict[str, Callable[[], None]] = {}
 
 # Globale Tracking-Variablen für aktive Preset Number Entitäten
 _ACTIVE_PRESET_NUMBERS: dict[
@@ -57,7 +61,7 @@ async def async_setup_entry(
         )
         return
 
-    sensors = [
+    sensors: list[SensorEntity] = [
         BetterThermostatExternalTempSensor(bt_climate),
         BetterThermostatExternalTemp1hEMASensor(bt_climate),
         BetterThermostatTempSlopeSensor(bt_climate),
@@ -79,9 +83,9 @@ async def async_setup_entry(
 async def _setup_algorithm_sensors(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    bt_climate,
-    algorithms_to_create: set | None = None,
-) -> list:
+    bt_climate: BetterThermostat,
+    algorithms_to_create: set[CalibrationMode] | None = None,
+) -> list[SensorEntity]:
     """Set up algorithm-specific sensors based on current configuration.
 
     Parameters
@@ -90,7 +94,7 @@ async def _setup_algorithm_sensors(
         When provided, only sensors for these algorithms are created.
         When ``None`` (initial setup), all active algorithms are created.
     """
-    algorithm_sensors = []
+    algorithm_sensors: list[SensorEntity] = []
     entry_id = entry.entry_id
     current_algorithms = _get_active_algorithms(bt_climate)
 
@@ -139,12 +143,15 @@ async def _setup_algorithm_sensors(
 
 
 async def _register_dynamic_entity_callback(
-    hass: HomeAssistant, entry: ConfigEntry, bt_climate, async_add_entities
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    bt_climate: BetterThermostat,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Register callback for dynamic entity management."""
 
     @callback
-    def _on_config_change(data):
+    def _on_config_change(data: Any) -> None:
         """Handle configuration changes that might affect entity requirements."""
         _LOGGER.debug(
             "Better Thermostat %s: Configuration change detected via signal, checking entity requirements",
@@ -166,7 +173,10 @@ async def _register_dynamic_entity_callback(
 
 
 async def _handle_dynamic_entity_update(
-    hass: HomeAssistant, entry: ConfigEntry, bt_climate, async_add_entities
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    bt_climate: BetterThermostat,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Handle dynamic entity creation/removal based on configuration."""
     entry_id = entry.entry_id
@@ -209,7 +219,10 @@ async def _handle_dynamic_entity_update(
 
 
 async def _cleanup_stale_algorithm_entities(
-    hass: HomeAssistant, entry_id: str, bt_climate, current_algorithms: set
+    hass: HomeAssistant,
+    entry_id: str,
+    bt_climate: BetterThermostat,
+    current_algorithms: set[CalibrationMode],
 ) -> None:
     """Remove algorithm-specific entities that are no longer needed."""
     if entry_id not in _ACTIVE_ALGORITHM_ENTITIES:
@@ -273,7 +286,7 @@ async def _cleanup_stale_algorithm_entities(
         del _ACTIVE_ALGORITHM_ENTITIES[entry_id]
 
 
-def _get_active_algorithms(bt_climate) -> set:
+def _get_active_algorithms(bt_climate: BetterThermostat) -> set[CalibrationMode]:
     """Get set of calibration algorithms currently in use by any TRV."""
     if not hasattr(bt_climate, "real_trvs") or not bt_climate.real_trvs:
         return set()
@@ -301,7 +314,7 @@ def _get_active_algorithms(bt_climate) -> set:
 
 
 async def _cleanup_unused_number_entities(
-    hass: HomeAssistant, entry_id: str, bt_climate
+    hass: HomeAssistant, entry_id: str, bt_climate: BetterThermostat
 ) -> None:
     """Clean up unused preset and PID number entities."""
     entity_registry = async_get_entity_registry(hass)
@@ -326,8 +339,8 @@ async def _cleanup_preset_number_entities(
     hass: HomeAssistant,
     entity_registry: EntityRegistry,
     entry_id: str,
-    bt_climate,
-    current_presets: set,
+    bt_climate: BetterThermostat,
+    current_presets: set[str],
 ) -> None:
     """Remove preset number entities for disabled presets."""
     tracked_presets = _ACTIVE_PRESET_NUMBERS.get(entry_id, {})
@@ -381,7 +394,10 @@ async def _cleanup_preset_number_entities(
 
 
 async def _cleanup_pid_number_entities(
-    hass: HomeAssistant, entity_registry: EntityRegistry, entry_id: str, bt_climate
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    entry_id: str,
+    bt_climate: BetterThermostat,
 ) -> None:
     """Remove PID number entities for TRVs no longer using PID calibration."""
     tracked_pid_numbers = _ACTIVE_PID_NUMBERS.get(entry_id, {})
@@ -451,7 +467,10 @@ async def _cleanup_pid_number_entities(
 
 
 async def _cleanup_pid_switch_entities(
-    hass: HomeAssistant, entity_registry: EntityRegistry, entry_id: str, bt_climate
+    hass: HomeAssistant,
+    entity_registry: EntityRegistry,
+    entry_id: str,
+    bt_climate: BetterThermostat,
 ) -> None:
     """Remove PID switch entities for TRVs no longer using PID calibration and child lock switches for removed TRVs."""
     tracked_switches = _ACTIVE_SWITCH_ENTITIES.get(entry_id, {})
@@ -568,9 +587,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _get_filtered_temp(bt_climate):
+def _get_filtered_temp(bt_climate: BetterThermostat) -> float | None:
     """Return cur_temp_filtered with fallback to external_temp_ema."""
-    val = getattr(bt_climate, "cur_temp_filtered", None)
+    val: float | None = getattr(bt_climate, "cur_temp_filtered", None)
     if val is None:
         val = getattr(bt_climate, "external_temp_ema", None)
     return val
@@ -589,13 +608,13 @@ class _BtSensorBase(SensorEntity):
     _attr_should_poll = False
     _unique_id_suffix: str
 
-    def __init__(self, bt_climate):
+    def __init__(self, bt_climate: BetterThermostat) -> None:
         """Initialize the sensor."""
         self._bt_climate = bt_climate
         self._attr_unique_id = f"{bt_climate.unique_id}_{self._unique_id_suffix}"
         self._attr_device_info = bt_climate.device_info
 
-    async def async_added_to_hass(self):
+    async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         if self._bt_climate.entity_id:
             self.async_on_remove(
@@ -611,12 +630,12 @@ class _BtSensorBase(SensorEntity):
         self._update_state()
 
     @callback
-    def _on_climate_update(self, event):
+    def _on_climate_update(self, event: Event[Any]) -> None:
         """Handle climate entity update."""
         self._update_state()
         self.async_write_ha_state()
 
-    def _update_state(self):
+    def _update_state(self) -> None:
         """Update state from climate entity. Override in subclasses."""
         raise NotImplementedError
 
@@ -643,7 +662,7 @@ class _BtMpcSensorBase(_BtSensorBase):
             return False
         return True
 
-    def _update_state(self):
+    def _update_state(self) -> None:
         """Update state from calibration_balance debug data."""
         val = None
         if hasattr(self._bt_climate, "real_trvs"):
@@ -670,12 +689,12 @@ class _BtSimpleAttributeSensor(_BtSensorBase):
     _climate_attr: str
     _rounding: int | None = None
 
-    def _update_state(self):
+    def _update_state(self) -> None:
         """Update state from a climate entity attribute."""
-        val = getattr(self._bt_climate, self._climate_attr, None)
+        val: object = getattr(self._bt_climate, self._climate_attr, None)
         if val is not None:
             try:
-                fval = float(val)
+                fval = float(val)  # type: ignore[arg-type]
                 self._attr_native_value = (
                     round(fval, self._rounding)
                     if self._rounding is not None
@@ -700,7 +719,7 @@ class BetterThermostatExternalTempSensor(_BtSensorBase):
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _unique_id_suffix = "external_temp_ema"
 
-    def _update_state(self):
+    def _update_state(self) -> None:
         """Update state from climate entity."""
         val = _get_filtered_temp(self._bt_climate)
         if val is not None:
@@ -721,14 +740,14 @@ class BetterThermostatExternalTemp1hEMASensor(_BtSensorBase):
     _attr_suggested_display_precision = 2
     _unique_id_suffix = "external_temp_ema_1h"
 
-    def __init__(self, bt_climate):
+    def __init__(self, bt_climate: BetterThermostat) -> None:
         """Initialize the sensor."""
         super().__init__(bt_climate)
-        self._ema_value = None
-        self._last_update_ts = None
-        self._tau_s = 3600.0  # 1 hour
+        self._ema_value: float | None = None
+        self._last_update_ts: float | None = None
+        self._tau_s: float = 3600.0  # 1 hour
 
-    def _update_ema(self, new_value):
+    def _update_ema(self, new_value: float) -> None:
         """Update the 1h EMA with a new value."""
         import math
         from time import monotonic
@@ -747,13 +766,14 @@ class BetterThermostatExternalTemp1hEMASensor(_BtSensorBase):
         self._ema_value = ema
         self._last_update_ts = now
 
-    def _update_state(self):
+    def _update_state(self) -> None:
         """Update state from internal EMA."""
         val = _get_filtered_temp(self._bt_climate)
         if val is not None:
             try:
                 self._update_ema(float(val))
-                self._attr_native_value = round(float(self._ema_value), 2)
+                assert self._ema_value is not None  # set by _update_ema
+                self._attr_native_value = round(self._ema_value, 2)
             except (ValueError, TypeError):
                 self._attr_native_value = None
         else:
@@ -854,7 +874,7 @@ class BetterThermostatSolarIntensitySensor(_BtSensorBase):
     _attr_icon = "mdi:solar-power"
     _unique_id_suffix = "solar_intensity"
 
-    def _update_state(self):
+    def _update_state(self) -> None:
         """Update state using utility function."""
         try:
             val = _get_current_solar_intensity(self._bt_climate)

--- a/custom_components/better_thermostat/sensor.py
+++ b/custom_components/better_thermostat/sensor.py
@@ -563,26 +563,40 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-class BetterThermostatExternalTempSensor(SensorEntity):
-    """Representation of a Better Thermostat External Temperature Sensor (EMA)."""
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _get_filtered_temp(bt_climate):
+    """Return cur_temp_filtered with fallback to external_temp_ema."""
+    val = getattr(bt_climate, "cur_temp_filtered", None)
+    if val is None:
+        val = getattr(bt_climate, "external_temp_ema", None)
+    return val
+
+
+# ---------------------------------------------------------------------------
+# Base classes
+# ---------------------------------------------------------------------------
+
+
+class _BtSensorBase(SensorEntity):
+    """Base class for all Better Thermostat sensors."""
 
     _attr_has_entity_name = True
-    _attr_name = "Temperature EMA"
-    _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_should_poll = False
+    _unique_id_suffix: str
 
     def __init__(self, bt_climate):
         """Initialize the sensor."""
         self._bt_climate = bt_climate
-        # Use the climate entity's unique_id as prefix
-        self._attr_unique_id = f"{bt_climate.unique_id}_external_temp_ema"
+        self._attr_unique_id = f"{bt_climate.unique_id}_{self._unique_id_suffix}"
         self._attr_device_info = bt_climate.device_info
 
     async def async_added_to_hass(self):
         """Register callbacks."""
-        # Listen to state changes of the climate entity
         if self._bt_climate.entity_id:
             self.async_on_remove(
                 async_track_state_change_event(
@@ -594,8 +608,6 @@ class BetterThermostatExternalTempSensor(SensorEntity):
                 "Better Thermostat climate entity has no entity_id yet. "
                 "Sensor update might be delayed."
             )
-
-        # Also update initially
         self._update_state()
 
     @callback
@@ -605,11 +617,43 @@ class BetterThermostatExternalTempSensor(SensorEntity):
         self.async_write_ha_state()
 
     def _update_state(self):
-        """Update state from climate entity."""
-        # The EMA is stored in `cur_temp_filtered` attribute of the climate entity instance
-        val = getattr(self._bt_climate, "cur_temp_filtered", None)
-        if val is None:
-            val = getattr(self._bt_climate, "external_temp_ema", None)
+        """Update state from climate entity. Override in subclasses."""
+        raise NotImplementedError
+
+
+class _BtMpcSensorBase(_BtSensorBase):
+    """Base class for MPC algorithm sensors."""
+
+    _debug_key: str
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        if (
+            not hasattr(self._bt_climate, "_available")
+            or not self._bt_climate._available
+        ):
+            return False
+        if getattr(self._bt_climate, "window_open", False):
+            return False
+        if (
+            hasattr(self._bt_climate, "hvac_mode")
+            and self._bt_climate.hvac_mode == "off"
+        ):
+            return False
+        return True
+
+    def _update_state(self):
+        """Update state from calibration_balance debug data."""
+        val = None
+        if hasattr(self._bt_climate, "real_trvs"):
+            for _, trv_data in self._bt_climate.real_trvs.items():
+                cal_bal = trv_data.get("calibration_balance")
+                if cal_bal and "debug" in cal_bal:
+                    debug = cal_bal["debug"]
+                    if self._debug_key in debug:
+                        val = debug[self._debug_key]
+                        break
 
         if val is not None:
             try:
@@ -620,49 +664,69 @@ class BetterThermostatExternalTempSensor(SensorEntity):
             self._attr_native_value = None
 
 
-class BetterThermostatExternalTemp1hEMASensor(SensorEntity):
+class _BtSimpleAttributeSensor(_BtSensorBase):
+    """Base class for sensors reading a single climate attribute."""
+
+    _climate_attr: str
+    _rounding: int | None = None
+
+    def _update_state(self):
+        """Update state from a climate entity attribute."""
+        val = getattr(self._bt_climate, self._climate_attr, None)
+        if val is not None:
+            try:
+                fval = float(val)
+                self._attr_native_value = (
+                    round(fval, self._rounding)
+                    if self._rounding is not None
+                    else fval
+                )
+            except (ValueError, TypeError):
+                self._attr_native_value = None
+        else:
+            self._attr_native_value = None
+
+
+# ---------------------------------------------------------------------------
+# Concrete sensor classes
+# ---------------------------------------------------------------------------
+
+
+class BetterThermostatExternalTempSensor(_BtSensorBase):
+    """Representation of a Better Thermostat External Temperature Sensor (EMA)."""
+
+    _attr_name = "Temperature EMA"
+    _attr_device_class = SensorDeviceClass.TEMPERATURE
+    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+    _unique_id_suffix = "external_temp_ema"
+
+    def _update_state(self):
+        """Update state from climate entity."""
+        val = _get_filtered_temp(self._bt_climate)
+        if val is not None:
+            try:
+                self._attr_native_value = float(val)
+            except (ValueError, TypeError):
+                self._attr_native_value = None
+        else:
+            self._attr_native_value = None
+
+
+class BetterThermostatExternalTemp1hEMASensor(_BtSensorBase):
     """Representation of a Better Thermostat External Temperature 1h EMA Sensor."""
 
-    _attr_has_entity_name = True
     _attr_name = "Temperature EMA 1h"
     _attr_device_class = SensorDeviceClass.TEMPERATURE
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
-    _attr_should_poll = False
     _attr_suggested_display_precision = 2
+    _unique_id_suffix = "external_temp_ema_1h"
 
     def __init__(self, bt_climate):
         """Initialize the sensor."""
-        self._bt_climate = bt_climate
-        self._attr_unique_id = f"{bt_climate.unique_id}_external_temp_ema_1h"
-        self._attr_device_info = bt_climate.device_info
-        # EMA state
+        super().__init__(bt_climate)
         self._ema_value = None
         self._last_update_ts = None
         self._tau_s = 3600.0  # 1 hour
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        # Listen to state changes of the climate entity
-        if self._bt_climate.entity_id:
-            self.async_on_remove(
-                async_track_state_change_event(
-                    self.hass, [self._bt_climate.entity_id], self._on_climate_update
-                )
-            )
-        else:
-            _LOGGER.warning(
-                "Better Thermostat climate entity has no entity_id yet. "
-                "Sensor update might be delayed."
-            )
-        # Also update initially
-        self._update_state()
-
-    @callback
-    def _on_climate_update(self, event):
-        """Handle update from the climate entity."""
-        self._update_state()
-        self.async_write_ha_state()
 
     def _update_ema(self, new_value):
         """Update the 1h EMA with a new value."""
@@ -685,11 +749,7 @@ class BetterThermostatExternalTemp1hEMASensor(SensorEntity):
 
     def _update_state(self):
         """Update state from internal EMA."""
-        # Prefer filtered EMA from climate, fall back to external_temp_ema
-        val = getattr(self._bt_climate, "cur_temp_filtered", None)
-        if val is None:
-            val = getattr(self._bt_climate, "external_temp_ema", None)
-
+        val = _get_filtered_temp(self._bt_climate)
         if val is not None:
             try:
                 self._update_ema(float(val))
@@ -700,479 +760,104 @@ class BetterThermostatExternalTemp1hEMASensor(SensorEntity):
             self._attr_native_value = None
 
 
-class BetterThermostatTempSlopeSensor(SensorEntity):
+class BetterThermostatTempSlopeSensor(_BtSimpleAttributeSensor):
     """Representation of a Better Thermostat Temperature Slope Sensor."""
 
-    _attr_has_entity_name = True
     _attr_name = "Temperature Slope"
     _attr_device_class = None
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "K/min"
-    _attr_should_poll = False
     _attr_icon = "mdi:chart-line"
-
-    def __init__(self, bt_climate):
-        """Initialize the sensor."""
-        self._bt_climate = bt_climate
-        self._attr_unique_id = f"{bt_climate.unique_id}_temp_slope"
-        self._attr_device_info = bt_climate.device_info
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        if self._bt_climate.entity_id:
-            self.async_on_remove(
-                async_track_state_change_event(
-                    self.hass, [self._bt_climate.entity_id], self._on_climate_update
-                )
-            )
-        self._update_state()
-
-    @callback
-    def _on_climate_update(self, event):
-        """Handle climate entity update."""
-        self._update_state()
-        self.async_write_ha_state()
-
-    def _update_state(self):
-        """Update state from climate entity."""
-        val = getattr(self._bt_climate, "temp_slope", None)
-        if val is not None:
-            try:
-                self._attr_native_value = round(float(val), 4)
-            except (ValueError, TypeError):
-                self._attr_native_value = None
-        else:
-            self._attr_native_value = None
+    _climate_attr = "temp_slope"
+    _rounding = 4
+    _unique_id_suffix = "temp_slope"
 
 
-class BetterThermostatHeatingPowerSensor(SensorEntity):
+class BetterThermostatHeatingPowerSensor(_BtSimpleAttributeSensor):
     """Representation of a Better Thermostat Heating Power Sensor."""
 
-    _attr_has_entity_name = True
     _attr_name = "Heating Power"
     _attr_device_class = None
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "K/min"
-    _attr_should_poll = False
     _attr_icon = "mdi:thermometer-plus"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, bt_climate):
-        """Initialize the sensor."""
-        self._bt_climate = bt_climate
-        self._attr_unique_id = f"{bt_climate.unique_id}_heating_power"
-        self._attr_device_info = bt_climate.device_info
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        if self._bt_climate.entity_id:
-            self.async_on_remove(
-                async_track_state_change_event(
-                    self.hass, [self._bt_climate.entity_id], self._on_climate_update
-                )
-            )
-        self._update_state()
-
-    @callback
-    def _on_climate_update(self, event):
-        """Handle climate entity update."""
-        self._update_state()
-        self.async_write_ha_state()
-
-    def _update_state(self):
-        """Update state from climate entity."""
-        val = getattr(self._bt_climate, "heating_power", None)
-        if val is not None:
-            try:
-                self._attr_native_value = float(val)
-            except (ValueError, TypeError):
-                self._attr_native_value = None
-        else:
-            self._attr_native_value = None
+    _climate_attr = "heating_power"
+    _unique_id_suffix = "heating_power"
 
 
-class BetterThermostatHeatLossSensor(SensorEntity):
+class BetterThermostatHeatLossSensor(_BtSimpleAttributeSensor):
     """Representation of a Better Thermostat Heat Loss Sensor."""
 
-    _attr_has_entity_name = True
     _attr_name = "Heat Loss"
     _attr_device_class = None
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "K/min"
-    _attr_should_poll = False
     _attr_icon = "mdi:thermometer-minus"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, bt_climate):
-        """Initialize the sensor."""
-        self._bt_climate = bt_climate
-        self._attr_unique_id = f"{bt_climate.unique_id}_heat_loss"
-        self._attr_device_info = bt_climate.device_info
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        if self._bt_climate.entity_id:
-            self.async_on_remove(
-                async_track_state_change_event(
-                    self.hass, [self._bt_climate.entity_id], self._on_climate_update
-                )
-            )
-        self._update_state()
-
-    @callback
-    def _on_climate_update(self, event):
-        """Handle climate entity update."""
-        self._update_state()
-        self.async_write_ha_state()
-
-    def _update_state(self):
-        """Update state from climate entity."""
-        val = getattr(self._bt_climate, "heat_loss_rate", None)
-        if val is not None:
-            try:
-                self._attr_native_value = float(val)
-            except (ValueError, TypeError):
-                self._attr_native_value = None
-        else:
-            self._attr_native_value = None
+    _climate_attr = "heat_loss_rate"
+    _unique_id_suffix = "heat_loss"
 
 
-class BetterThermostatVirtualTempSensor(SensorEntity):
+class BetterThermostatVirtualTempSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat Virtual Temperature Sensor (MPC)."""
 
-    _attr_has_entity_name = True
     _attr_name = "Virtual Temperature"
     _attr_device_class = SensorDeviceClass.TEMPERATURE
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
-    _attr_should_poll = False
     _attr_icon = "mdi:thermometer-auto"
-
-    def __init__(self, bt_climate):
-        """Initialize the sensor."""
-        self._bt_climate = bt_climate
-        self._attr_unique_id = f"{bt_climate.unique_id}_virtual_temp"
-        self._attr_device_info = bt_climate.device_info
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        if self._bt_climate.entity_id:
-            self.async_on_remove(
-                async_track_state_change_event(
-                    self.hass, [self._bt_climate.entity_id], self._on_climate_update
-                )
-            )
-        self._update_state()
-
-    @callback
-    def _on_climate_update(self, event):
-        """Handle climate entity update."""
-        self._update_state()
-        self.async_write_ha_state()
-
-    @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-        # Follow HA guidelines: return False when entity should be unavailable
-        # This prevents "unknown" states and properly shows "unavailable"
-        if (
-            not hasattr(self._bt_climate, "_available")
-            or not self._bt_climate._available
-        ):
-            return False
-        if getattr(self._bt_climate, "window_open", False):
-            return False
-        if (
-            hasattr(self._bt_climate, "hvac_mode")
-            and self._bt_climate.hvac_mode == "off"
-        ):
-            return False
-        return True
-
-    def _update_state(self):
-        """Update state from climate entity."""
-        # Try to find virtual temp in any TRV's calibration balance debug info
-        val = None
-        if hasattr(self._bt_climate, "real_trvs"):
-            for _, trv_data in self._bt_climate.real_trvs.items():
-                cal_bal = trv_data.get("calibration_balance")
-                if cal_bal and "debug" in cal_bal:
-                    debug = cal_bal["debug"]
-                    if "mpc_virtual_temp" in debug:
-                        val = debug["mpc_virtual_temp"]
-                        break
-
-        if val is not None:
-            try:
-                self._attr_native_value = float(val)
-            except (ValueError, TypeError):
-                self._attr_native_value = None
-        else:
-            self._attr_native_value = None
+    _debug_key = "mpc_virtual_temp"
+    _unique_id_suffix = "virtual_temp"
 
 
-class BetterThermostatMpcGainSensor(SensorEntity):
+class BetterThermostatMpcGainSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat MPC Gain Sensor."""
 
-    _attr_has_entity_name = True
     _attr_name = "MPC Gain"
     _attr_device_class = None
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "K/min"
-    _attr_should_poll = False
     _attr_icon = "mdi:thermometer-plus"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, bt_climate):
-        """Initialize the sensor."""
-        self._bt_climate = bt_climate
-        self._attr_unique_id = f"{bt_climate.unique_id}_mpc_gain"
-        self._attr_device_info = bt_climate.device_info
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        if self._bt_climate.entity_id:
-            self.async_on_remove(
-                async_track_state_change_event(
-                    self.hass, [self._bt_climate.entity_id], self._on_climate_update
-                )
-            )
-        self._update_state()
-
-    @callback
-    def _on_climate_update(self, event):
-        """Handle climate entity update."""
-        self._update_state()
-        self.async_write_ha_state()
-
-    @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-        # Follow HA guidelines: return False when entity should be unavailable
-        # This prevents "unknown" states and properly shows "unavailable"
-        if (
-            not hasattr(self._bt_climate, "_available")
-            or not self._bt_climate._available
-        ):
-            return False
-        if getattr(self._bt_climate, "window_open", False):
-            return False
-        if (
-            hasattr(self._bt_climate, "hvac_mode")
-            and self._bt_climate.hvac_mode == "off"
-        ):
-            return False
-        return True
-
-    def _update_state(self):
-        """Update state from climate entity."""
-        val = None
-        if hasattr(self._bt_climate, "real_trvs"):
-            for _, trv_data in self._bt_climate.real_trvs.items():
-                cal_bal = trv_data.get("calibration_balance")
-                if cal_bal and "debug" in cal_bal:
-                    debug = cal_bal["debug"]
-                    if "mpc_gain" in debug:
-                        val = debug["mpc_gain"]
-                        break
-
-        if val is not None:
-            try:
-                self._attr_native_value = float(val)
-            except (ValueError, TypeError):
-                self._attr_native_value = None
-        else:
-            self._attr_native_value = None
+    _debug_key = "mpc_gain"
+    _unique_id_suffix = "mpc_gain"
 
 
-class BetterThermostatMpcLossSensor(SensorEntity):
+class BetterThermostatMpcLossSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat MPC Loss Sensor."""
 
-    _attr_has_entity_name = True
     _attr_name = "MPC Loss"
     _attr_device_class = None
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "K/min"
-    _attr_should_poll = False
     _attr_icon = "mdi:thermometer-minus"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, bt_climate):
-        """Initialize the sensor."""
-        self._bt_climate = bt_climate
-        self._attr_unique_id = f"{bt_climate.unique_id}_mpc_loss"
-        self._attr_device_info = bt_climate.device_info
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        if self._bt_climate.entity_id:
-            self.async_on_remove(
-                async_track_state_change_event(
-                    self.hass, [self._bt_climate.entity_id], self._on_climate_update
-                )
-            )
-        self._update_state()
-
-    @callback
-    def _on_climate_update(self, event):
-        """Handle climate entity update."""
-        self._update_state()
-        self.async_write_ha_state()
-
-    @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-        # Follow HA guidelines: return False when entity should be unavailable
-        # This prevents "unknown" states and properly shows "unavailable"
-        if (
-            not hasattr(self._bt_climate, "_available")
-            or not self._bt_climate._available
-        ):
-            return False
-        if getattr(self._bt_climate, "window_open", False):
-            return False
-        if (
-            hasattr(self._bt_climate, "hvac_mode")
-            and self._bt_climate.hvac_mode == "off"
-        ):
-            return False
-        return True
-
-    def _update_state(self):
-        """Update state from climate entity."""
-        val = None
-        if hasattr(self._bt_climate, "real_trvs"):
-            for _, trv_data in self._bt_climate.real_trvs.items():
-                cal_bal = trv_data.get("calibration_balance")
-                if cal_bal and "debug" in cal_bal:
-                    debug = cal_bal["debug"]
-                    if "mpc_loss" in debug:
-                        val = debug["mpc_loss"]
-                        break
-
-        if val is not None:
-            try:
-                self._attr_native_value = float(val)
-            except (ValueError, TypeError):
-                self._attr_native_value = None
-        else:
-            self._attr_native_value = None
+    _debug_key = "mpc_loss"
+    _unique_id_suffix = "mpc_loss"
 
 
-class BetterThermostatMpcKaSensor(SensorEntity):
+class BetterThermostatMpcKaSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat MPC Ka (Insulation) Sensor."""
 
-    _attr_has_entity_name = True
     _attr_name = "MPC Insulation (Ka)"
     _attr_device_class = None
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "1/min"
-    _attr_should_poll = False
     _attr_icon = "mdi:home-thermometer-outline"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-
-    def __init__(self, bt_climate):
-        """Initialize the sensor."""
-        self._bt_climate = bt_climate
-        self._attr_unique_id = f"{bt_climate.unique_id}_mpc_ka"
-        self._attr_device_info = bt_climate.device_info
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        if self._bt_climate.entity_id:
-            self.async_on_remove(
-                async_track_state_change_event(
-                    self.hass, [self._bt_climate.entity_id], self._on_climate_update
-                )
-            )
-        self._update_state()
-
-    @callback
-    def _on_climate_update(self, event):
-        """Handle climate entity update."""
-        self._update_state()
-        self.async_write_ha_state()
-
-    @property
-    def available(self) -> bool:
-        """Return if entity is available."""
-        # Follow HA guidelines: return False when entity should be unavailable
-        # This prevents "unknown" states and properly shows "unavailable"
-        if (
-            not hasattr(self._bt_climate, "_available")
-            or not self._bt_climate._available
-        ):
-            return False
-        if getattr(self._bt_climate, "window_open", False):
-            return False
-        if (
-            hasattr(self._bt_climate, "hvac_mode")
-            and self._bt_climate.hvac_mode == "off"
-        ):
-            return False
-        return True
-
-    def _update_state(self):
-        """Update state from climate entity."""
-        val = None
-        if hasattr(self._bt_climate, "real_trvs"):
-            for _, trv_data in self._bt_climate.real_trvs.items():
-                cal_bal = trv_data.get("calibration_balance")
-                if cal_bal and "debug" in cal_bal:
-                    debug = cal_bal["debug"]
-                    if "mpc_ka" in debug:
-                        val = debug["mpc_ka"]
-                        break
-
-        if val is not None:
-            try:
-                self._attr_native_value = float(val)
-            except (ValueError, TypeError):
-                self._attr_native_value = None
-        else:
-            self._attr_native_value = None
+    _debug_key = "mpc_ka"
+    _unique_id_suffix = "mpc_ka"
 
 
-class BetterThermostatSolarIntensitySensor(SensorEntity):
+class BetterThermostatSolarIntensitySensor(_BtSensorBase):
     """Representation of a Better Thermostat Solar Intensity Sensor."""
 
-    _attr_has_entity_name = True
     _attr_name = "Sun Intensity Heatup"
     _attr_device_class = None
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "%"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_should_poll = True  # We might need to poll the weather entity if updates are not strictly coupled
+    _attr_should_poll = True
     _attr_icon = "mdi:solar-power"
-
-    def __init__(self, bt_climate):
-        """Initialize the sensor."""
-        self._bt_climate = bt_climate
-        self._attr_unique_id = f"{bt_climate.unique_id}_solar_intensity"
-        self._attr_device_info = bt_climate.device_info
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        # Listen to state changes of the climate entity
-        if self._bt_climate.entity_id:
-            self.async_on_remove(
-                async_track_state_change_event(
-                    self.hass, [self._bt_climate.entity_id], self._on_climate_update
-                )
-            )
-        self._update_state()
-
-    @callback
-    def _on_climate_update(self, event):
-        """Handle climate entity update."""
-        self._update_state()
-        self.async_write_ha_state()
+    _unique_id_suffix = "solar_intensity"
 
     def _update_state(self):
         """Update state using utility function."""
         try:
             val = _get_current_solar_intensity(self._bt_climate)
-            # Function returns 0.0-1.0, convert to %
             if val is not None:
                 self._attr_native_value = round(float(val) * 100.0, 1)
             else:

--- a/custom_components/better_thermostat/sensor.py
+++ b/custom_components/better_thermostat/sensor.py
@@ -181,12 +181,7 @@ async def _handle_dynamic_entity_update(
     """Handle dynamic entity creation/removal based on configuration."""
     entry_id = entry.entry_id
     current_algorithms = _get_active_algorithms(bt_climate)
-    had_algorithm_entities = entry_id in _ACTIVE_ALGORITHM_ENTITIES
-    previous_algorithms = (
-        set(_ACTIVE_ALGORITHM_ENTITIES.get(entry_id, {}))
-        if had_algorithm_entities
-        else set()
-    )
+    previous_algorithms = set(_ACTIVE_ALGORITHM_ENTITIES.get(entry_id, {}))
 
     # Prüfe auf Änderungen bei den Algorithmen
     algorithms_added = current_algorithms - previous_algorithms
@@ -197,11 +192,11 @@ async def _handle_dynamic_entity_update(
             "Better Thermostat %s: Algorithm configuration changed. Added: %s, Removed: %s",
             bt_climate.device_name,
             [
-                alg.value if hasattr(alg, "value") else str(alg)
+                alg.value
                 for alg in algorithms_added
             ],
             [
-                alg.value if hasattr(alg, "value") else str(alg)
+                alg.value
                 for alg in algorithms_removed
             ],
         )
@@ -231,7 +226,6 @@ async def _cleanup_stale_algorithm_entities(
     entity_registry = async_get_entity_registry(hass)
     tracked_algorithms = _ACTIVE_ALGORITHM_ENTITIES[entry_id]
 
-    total_removed = 0
     algorithms_to_remove = []
 
     for algorithm, entity_unique_ids in tracked_algorithms.items():
@@ -249,18 +243,14 @@ async def _cleanup_stale_algorithm_entities(
                         _LOGGER.debug(
                             "Better Thermostat %s: Removed %s entity %s",
                             bt_climate.device_name,
-                            algorithm.value
-                            if hasattr(algorithm, "value")
-                            else algorithm,
+                            algorithm.value,
                             entity_id,
                         )
                     except Exception as e:
                         _LOGGER.warning(
                             "Better Thermostat %s: Failed to remove %s entity %s: %s",
                             bt_climate.device_name,
-                            algorithm.value
-                            if hasattr(algorithm, "value")
-                            else algorithm,
+                            algorithm.value,
                             entity_id,
                             e,
                         )
@@ -270,9 +260,8 @@ async def _cleanup_stale_algorithm_entities(
                     "Better Thermostat %s: Removed %d %s entities",
                     bt_climate.device_name,
                     removed_count,
-                    algorithm.value if hasattr(algorithm, "value") else algorithm,
+                    algorithm.value,
                 )
-                total_removed += removed_count
 
             if removed_count == len(entity_unique_ids):
                 algorithms_to_remove.append(algorithm)
@@ -288,10 +277,10 @@ async def _cleanup_stale_algorithm_entities(
 
 def _get_active_algorithms(bt_climate: BetterThermostat) -> set[CalibrationMode]:
     """Get set of calibration algorithms currently in use by any TRV."""
-    if not hasattr(bt_climate, "real_trvs") or not bt_climate.real_trvs:
+    if not bt_climate.real_trvs:
         return set()
 
-    active_algorithms = set()
+    active_algorithms: set[CalibrationMode] = set()
     for trv_id, trv in bt_climate.real_trvs.items():
         advanced = trv.get("advanced", {})
         calibration_mode = advanced.get(CONF_CALIBRATION_MODE)
@@ -311,6 +300,24 @@ def _get_active_algorithms(bt_climate: BetterThermostat) -> set[CalibrationMode]
             active_algorithms.add(calibration_mode)
 
     return active_algorithms
+
+
+def _get_pid_trvs(bt_climate: BetterThermostat) -> set[str]:
+    """Return entity IDs of TRVs currently using PID calibration."""
+    pid_trvs: set[str] = set()
+    if not bt_climate.real_trvs:
+        return pid_trvs
+    for trv_entity_id, trv_data in bt_climate.real_trvs.items():
+        advanced = trv_data.get("advanced", {})
+        calibration_mode = advanced.get(CONF_CALIBRATION_MODE)
+        if isinstance(calibration_mode, str):
+            try:
+                calibration_mode = CalibrationMode(calibration_mode)
+            except (ValueError, TypeError):
+                continue
+        if calibration_mode == CalibrationMode.PID_CALIBRATION:
+            pid_trvs.add(trv_entity_id)
+    return pid_trvs
 
 
 async def _cleanup_unused_number_entities(
@@ -401,24 +408,7 @@ async def _cleanup_pid_number_entities(
 ) -> None:
     """Remove PID number entities for TRVs no longer using PID calibration."""
     tracked_pid_numbers = _ACTIVE_PID_NUMBERS.get(entry_id, {})
-
-    # Get current TRVs using PID calibration - consistent with switch cleanup
-    current_pid_trvs = set()
-    if hasattr(bt_climate, "real_trvs") and bt_climate.real_trvs:
-        for trv_entity_id, trv_data in bt_climate.real_trvs.items():
-            advanced = trv_data.get("advanced", {})
-            calibration_mode = advanced.get(CONF_CALIBRATION_MODE)
-
-            # Normalize string values to CalibrationMode enum
-            try:
-                if isinstance(calibration_mode, str):
-                    calibration_mode = CalibrationMode(calibration_mode)
-            except (ValueError, TypeError):
-                # Invalid or unknown calibration mode, skip
-                continue
-
-            if calibration_mode == CalibrationMode.PID_CALIBRATION:
-                current_pid_trvs.add(trv_entity_id)
+    current_pid_trvs = _get_pid_trvs(bt_climate)
 
     # Find PID number entities to remove
     entities_to_remove = []
@@ -474,24 +464,7 @@ async def _cleanup_pid_switch_entities(
 ) -> None:
     """Remove PID switch entities for TRVs no longer using PID calibration and child lock switches for removed TRVs."""
     tracked_switches = _ACTIVE_SWITCH_ENTITIES.get(entry_id, {})
-
-    # Get current TRVs using PID calibration
-    current_pid_trvs = set()
-    if hasattr(bt_climate, "real_trvs") and bt_climate.real_trvs:
-        for trv_entity_id, trv_data in bt_climate.real_trvs.items():
-            advanced = trv_data.get("advanced", {})
-            calibration_mode = advanced.get(CONF_CALIBRATION_MODE)
-
-            # Normalize string values to CalibrationMode enum
-            try:
-                if isinstance(calibration_mode, str):
-                    calibration_mode = CalibrationMode(calibration_mode)
-            except (ValueError, TypeError):
-                # Invalid or unknown calibration mode, skip
-                continue
-
-            if calibration_mode == CalibrationMode.PID_CALIBRATION:
-                current_pid_trvs.add(trv_entity_id)
+    current_pid_trvs = _get_pid_trvs(bt_climate)
 
     # Find switch entities to remove using stored metadata
     entities_to_remove = []
@@ -505,11 +478,7 @@ async def _cleanup_pid_switch_entities(
                 should_remove = True
         elif kind == "child_lock":
             # Remove child lock switches for TRVs that no longer exist
-            if (
-                not hasattr(bt_climate, "real_trvs")
-                or not bt_climate.real_trvs
-                or trv_id not in bt_climate.real_trvs
-            ):
+            if not bt_climate.real_trvs or trv_id not in bt_climate.real_trvs:
                 should_remove = True
 
         if should_remove:
@@ -548,7 +517,7 @@ async def _cleanup_pid_switch_entities(
         tracked_switches[uid] = {"trv": trv_entity_id, "type": "pid_auto_tune"}
 
     # Add Child Lock switches (always present for all TRVs)
-    if hasattr(bt_climate, "real_trvs") and bt_climate.real_trvs:
+    if bt_climate.real_trvs:
         for trv_entity_id in bt_climate.real_trvs:
             uid = f"{bt_climate.unique_id}_{trv_entity_id}_child_lock"
             tracked_switches[uid] = {"trv": trv_entity_id, "type": "child_lock"}
@@ -648,25 +617,19 @@ class _BtMpcSensorBase(_BtSensorBase):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
-        if (
-            not hasattr(self._bt_climate, "_available")
-            or not self._bt_climate._available
-        ):
+        if not self._bt_climate._available:
             return False
-        if getattr(self._bt_climate, "window_open", False):
+        if self._bt_climate.window_open:
             return False
-        if (
-            hasattr(self._bt_climate, "hvac_mode")
-            and self._bt_climate.hvac_mode == "off"
-        ):
+        if self._bt_climate.hvac_mode == "off":
             return False
         return True
 
     def _update_state(self) -> None:
         """Update state from calibration_balance debug data."""
         val = None
-        if hasattr(self._bt_climate, "real_trvs"):
-            for _, trv_data in self._bt_climate.real_trvs.items():
+        if self._bt_climate.real_trvs:
+            for trv_data in self._bt_climate.real_trvs.values():
                 cal_bal = trv_data.get("calibration_balance")
                 if cal_bal and "debug" in cal_bal:
                     debug = cal_bal["debug"]

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -1,0 +1,1204 @@
+"""Tests for Better Thermostat sensor platform (sensor.py).
+
+Covers:
+  - Sensor entity classes (state updates, availability, EMA math)
+  - Setup & algorithm sensor creation
+  - Active algorithm detection
+  - Entity cleanup functions (preset, PID, switch)
+  - Unload cleanup
+"""
+
+import math
+from time import monotonic
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.sensor import (
+    BetterThermostatExternalTemp1hEMASensor,
+    BetterThermostatExternalTempSensor,
+    BetterThermostatHeatLossSensor,
+    BetterThermostatHeatingPowerSensor,
+    BetterThermostatMpcGainSensor,
+    BetterThermostatMpcKaSensor,
+    BetterThermostatMpcLossSensor,
+    BetterThermostatSolarIntensitySensor,
+    BetterThermostatTempSlopeSensor,
+    BetterThermostatVirtualTempSensor,
+    _ACTIVE_ALGORITHM_ENTITIES,
+    _ACTIVE_PID_NUMBERS,
+    _ACTIVE_PRESET_NUMBERS,
+    _ACTIVE_SWITCH_ENTITIES,
+    _DISPATCHER_UNSUBSCRIBES,
+    _ENTITY_CLEANUP_CALLBACKS,
+    _cleanup_pid_number_entities,
+    _cleanup_pid_switch_entities,
+    _cleanup_preset_number_entities,
+    _cleanup_stale_algorithm_entities,
+    _get_active_algorithms,
+    _setup_algorithm_sensors,
+    async_setup_entry,
+    async_unload_entry,
+)
+from custom_components.better_thermostat.utils.const import (
+    CONF_CALIBRATION_MODE,
+    CalibrationMode,
+)
+
+DOMAIN = "better_thermostat"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_bt_climate(**overrides):
+    """Create a mock BT climate entity with sensible defaults."""
+    bt = MagicMock()
+    bt.unique_id = "test_bt_123"
+    bt.device_name = "Test BT"
+    bt.entity_id = "climate.test_bt"
+    bt.device_info = {"identifiers": {(DOMAIN, "test_bt_123")}}
+    bt._available = True
+    bt.window_open = False
+    bt.hvac_mode = "heat"
+    bt.cur_temp_filtered = None
+    bt.external_temp_ema = None
+    bt.temp_slope = None
+    bt.heating_power = None
+    bt.heat_loss_rate = None
+    bt.real_trvs = {}
+    bt.preset_modes = []
+    for k, v in overrides.items():
+        setattr(bt, k, v)
+    return bt
+
+
+def _make_entry(entry_id="entry_1"):
+    """Create a mock ConfigEntry."""
+    entry = MagicMock()
+    entry.entry_id = entry_id
+    return entry
+
+
+def _make_entity_registry():
+    """Create a mock EntityRegistry."""
+    reg = MagicMock()
+    reg.async_get_entity_id = MagicMock(return_value=None)
+    reg.async_remove = MagicMock()
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# Cleanup: reset module-level globals between tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_globals():
+    """Reset module-level tracking dicts before each test."""
+    _ACTIVE_ALGORITHM_ENTITIES.clear()
+    _ENTITY_CLEANUP_CALLBACKS.clear()
+    _DISPATCHER_UNSUBSCRIBES.clear()
+    _ACTIVE_PRESET_NUMBERS.clear()
+    _ACTIVE_PID_NUMBERS.clear()
+    _ACTIVE_SWITCH_ENTITIES.clear()
+    yield
+    _ACTIVE_ALGORITHM_ENTITIES.clear()
+    _ENTITY_CLEANUP_CALLBACKS.clear()
+    _DISPATCHER_UNSUBSCRIBES.clear()
+    _ACTIVE_PRESET_NUMBERS.clear()
+    _ACTIVE_PID_NUMBERS.clear()
+    _ACTIVE_SWITCH_ENTITIES.clear()
+
+
+# ===========================================================================
+# 1. External Temp Sensor (EMA)
+# ===========================================================================
+
+class TestExternalTempSensor:
+    """Tests for BetterThermostatExternalTempSensor."""
+
+    def test_unique_id(self):
+        bt = _make_bt_climate()
+        sensor = BetterThermostatExternalTempSensor(bt)
+        assert sensor._attr_unique_id == "test_bt_123_external_temp_ema"
+
+    def test_update_from_cur_temp_filtered(self):
+        bt = _make_bt_climate(cur_temp_filtered=21.5)
+        sensor = BetterThermostatExternalTempSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 21.5
+
+    def test_fallback_to_external_temp_ema(self):
+        bt = _make_bt_climate(cur_temp_filtered=None, external_temp_ema=22.3)
+        sensor = BetterThermostatExternalTempSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 22.3
+
+    def test_none_when_both_missing(self):
+        bt = _make_bt_climate(cur_temp_filtered=None, external_temp_ema=None)
+        sensor = BetterThermostatExternalTempSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_invalid_float_returns_none(self):
+        bt = _make_bt_climate(cur_temp_filtered="not_a_number")
+        sensor = BetterThermostatExternalTempSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_string_number_converted(self):
+        """A string like '20.5' should be converted to float."""
+        bt = _make_bt_climate(cur_temp_filtered="20.5")
+        sensor = BetterThermostatExternalTempSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 20.5
+
+
+# ===========================================================================
+# 2. External Temp 1h EMA Sensor
+# ===========================================================================
+
+class TestExternalTemp1hEMASensor:
+    """Tests for BetterThermostatExternalTemp1hEMASensor."""
+
+    def test_unique_id(self):
+        bt = _make_bt_climate()
+        sensor = BetterThermostatExternalTemp1hEMASensor(bt)
+        assert sensor._attr_unique_id == "test_bt_123_external_temp_ema_1h"
+
+    def test_first_update_sets_ema_directly(self):
+        bt = _make_bt_climate(cur_temp_filtered=20.0)
+        sensor = BetterThermostatExternalTemp1hEMASensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 20.0
+        assert sensor._ema_value == 20.0
+
+    def test_subsequent_update_applies_ema(self):
+        bt = _make_bt_climate(cur_temp_filtered=20.0)
+        sensor = BetterThermostatExternalTemp1hEMASensor(bt)
+        sensor._update_state()  # first
+        # Simulate time passing
+        sensor._last_update_ts = monotonic() - 60  # 1 minute ago
+        bt.cur_temp_filtered = 25.0
+        sensor._update_state()  # second
+        # EMA should be between 20 and 25, closer to 20
+        assert 20.0 < sensor._attr_native_value < 25.0
+
+    def test_ema_converges_over_time(self):
+        """After many tau periods, EMA should be very close to new value."""
+        bt = _make_bt_climate(cur_temp_filtered=20.0)
+        sensor = BetterThermostatExternalTemp1hEMASensor(bt)
+        sensor._update_state()
+        # Simulate 5 tau (5 hours) passing in one step
+        sensor._last_update_ts = monotonic() - (5 * 3600)
+        bt.cur_temp_filtered = 25.0
+        sensor._update_state()
+        # After 5 tau, alpha ≈ 1 - e^(-5) ≈ 0.993
+        assert abs(sensor._attr_native_value - 25.0) < 0.1
+
+    def test_zero_dt_does_not_change_ema(self):
+        """When dt=0, alpha=0, EMA should not change."""
+        bt = _make_bt_climate(cur_temp_filtered=20.0)
+        sensor = BetterThermostatExternalTemp1hEMASensor(bt)
+        sensor._update_state()  # first → EMA = 20.0
+        # Set last_update_ts to now so dt ≈ 0
+        sensor._last_update_ts = monotonic()
+        bt.cur_temp_filtered = 30.0
+        sensor._update_state()
+        # dt ≈ 0 → alpha ≈ 0 → EMA stays at 20.0
+        assert sensor._attr_native_value == 20.0
+
+    def test_none_value_gives_none(self):
+        bt = _make_bt_climate(cur_temp_filtered=None, external_temp_ema=None)
+        sensor = BetterThermostatExternalTemp1hEMASensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_invalid_float_gives_none(self):
+        bt = _make_bt_climate(cur_temp_filtered="invalid")
+        sensor = BetterThermostatExternalTemp1hEMASensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_ema_math_correctness(self):
+        """Verify the EMA formula matches expected math."""
+        bt = _make_bt_climate(cur_temp_filtered=20.0)
+        sensor = BetterThermostatExternalTemp1hEMASensor(bt)
+        sensor._update_ema(20.0)  # first
+        dt_s = 600.0  # 10 minutes
+        sensor._last_update_ts = monotonic() - dt_s
+        sensor._update_ema(25.0)
+        expected_alpha = 1.0 - math.exp(-dt_s / 3600.0)
+        expected_ema = 20.0 + expected_alpha * (25.0 - 20.0)
+        assert abs(sensor._ema_value - expected_ema) < 0.001
+
+
+# ===========================================================================
+# 3. Simple attribute sensors (TempSlope, HeatingPower, HeatLoss)
+# ===========================================================================
+
+class TestSimpleAttributeSensors:
+    """Tests for sensors that read a single attribute."""
+
+    def test_temp_slope_with_value(self):
+        bt = _make_bt_climate(temp_slope=0.0123)
+        sensor = BetterThermostatTempSlopeSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 0.0123
+
+    def test_temp_slope_rounds_to_4_decimals(self):
+        bt = _make_bt_climate(temp_slope=0.01236789)
+        sensor = BetterThermostatTempSlopeSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 0.0124
+
+    def test_temp_slope_none(self):
+        bt = _make_bt_climate(temp_slope=None)
+        sensor = BetterThermostatTempSlopeSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_heating_power_with_value(self):
+        bt = _make_bt_climate(heating_power=0.05)
+        sensor = BetterThermostatHeatingPowerSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 0.05
+
+    def test_heating_power_none(self):
+        bt = _make_bt_climate(heating_power=None)
+        sensor = BetterThermostatHeatingPowerSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_heat_loss_with_value(self):
+        bt = _make_bt_climate(heat_loss_rate=0.03)
+        sensor = BetterThermostatHeatLossSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 0.03
+
+    def test_heat_loss_none(self):
+        bt = _make_bt_climate(heat_loss_rate=None)
+        sensor = BetterThermostatHeatLossSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_invalid_string_returns_none(self):
+        bt = _make_bt_climate(temp_slope="not_a_number")
+        sensor = BetterThermostatTempSlopeSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+
+# ===========================================================================
+# 4. MPC Sensors (VirtualTemp, Gain, Loss, Ka) – availability & state
+# ===========================================================================
+
+class TestMpcSensorAvailability:
+    """Tests for the shared availability logic of MPC sensors."""
+
+    @pytest.mark.parametrize("SensorClass", [
+        BetterThermostatVirtualTempSensor,
+        BetterThermostatMpcGainSensor,
+        BetterThermostatMpcLossSensor,
+        BetterThermostatMpcKaSensor,
+    ])
+    def test_available_when_all_ok(self, SensorClass):
+        bt = _make_bt_climate(_available=True, window_open=False, hvac_mode="heat")
+        sensor = SensorClass(bt)
+        assert sensor.available is True
+
+    @pytest.mark.parametrize("SensorClass", [
+        BetterThermostatVirtualTempSensor,
+        BetterThermostatMpcGainSensor,
+        BetterThermostatMpcLossSensor,
+        BetterThermostatMpcKaSensor,
+    ])
+    def test_unavailable_when_climate_unavailable(self, SensorClass):
+        bt = _make_bt_climate(_available=False)
+        sensor = SensorClass(bt)
+        assert sensor.available is False
+
+    @pytest.mark.parametrize("SensorClass", [
+        BetterThermostatVirtualTempSensor,
+        BetterThermostatMpcGainSensor,
+        BetterThermostatMpcLossSensor,
+        BetterThermostatMpcKaSensor,
+    ])
+    def test_unavailable_when_window_open(self, SensorClass):
+        bt = _make_bt_climate(window_open=True)
+        sensor = SensorClass(bt)
+        assert sensor.available is False
+
+    @pytest.mark.parametrize("SensorClass", [
+        BetterThermostatVirtualTempSensor,
+        BetterThermostatMpcGainSensor,
+        BetterThermostatMpcLossSensor,
+        BetterThermostatMpcKaSensor,
+    ])
+    def test_unavailable_when_hvac_off(self, SensorClass):
+        bt = _make_bt_climate(hvac_mode="off")
+        sensor = SensorClass(bt)
+        assert sensor.available is False
+
+    @pytest.mark.parametrize("SensorClass", [
+        BetterThermostatVirtualTempSensor,
+        BetterThermostatMpcGainSensor,
+        BetterThermostatMpcLossSensor,
+        BetterThermostatMpcKaSensor,
+    ])
+    def test_available_missing_attr_returns_false(self, SensorClass):
+        """If _available attribute is missing entirely, sensor should be unavailable."""
+        bt = _make_bt_climate()
+        del bt._available  # remove attribute
+        sensor = SensorClass(bt)
+        assert sensor.available is False
+
+
+class TestMpcSensorState:
+    """Tests for MPC sensor state retrieval from calibration_balance debug."""
+
+    def _make_trv_with_debug(self, **debug_values):
+        return {
+            "trv_1": {
+                "calibration_balance": {
+                    "debug": debug_values,
+                },
+            }
+        }
+
+    def test_virtual_temp_reads_from_debug(self):
+        bt = _make_bt_climate(real_trvs=self._make_trv_with_debug(mpc_virtual_temp=22.5))
+        sensor = BetterThermostatVirtualTempSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 22.5
+
+    def test_mpc_gain_reads_from_debug(self):
+        bt = _make_bt_climate(real_trvs=self._make_trv_with_debug(mpc_gain=0.05))
+        sensor = BetterThermostatMpcGainSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 0.05
+
+    def test_mpc_loss_reads_from_debug(self):
+        bt = _make_bt_climate(real_trvs=self._make_trv_with_debug(mpc_loss=0.03))
+        sensor = BetterThermostatMpcLossSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 0.03
+
+    def test_mpc_ka_reads_from_debug(self):
+        bt = _make_bt_climate(real_trvs=self._make_trv_with_debug(mpc_ka=0.001))
+        sensor = BetterThermostatMpcKaSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 0.001
+
+    def test_no_calibration_balance_returns_none(self):
+        bt = _make_bt_climate(real_trvs={"trv_1": {}})
+        sensor = BetterThermostatVirtualTempSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_no_debug_key_returns_none(self):
+        bt = _make_bt_climate(real_trvs={"trv_1": {"calibration_balance": {}}})
+        sensor = BetterThermostatVirtualTempSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_no_real_trvs_attr_returns_none(self):
+        bt = _make_bt_climate()
+        del bt.real_trvs
+        sensor = BetterThermostatVirtualTempSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_empty_real_trvs_returns_none(self):
+        bt = _make_bt_climate(real_trvs={})
+        sensor = BetterThermostatVirtualTempSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_invalid_debug_value_returns_none(self):
+        bt = _make_bt_climate(real_trvs=self._make_trv_with_debug(mpc_virtual_temp="bad"))
+        sensor = BetterThermostatVirtualTempSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_first_trv_with_debug_wins(self):
+        """When multiple TRVs exist, the first with debug data should be used."""
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {},
+            "trv_2": {"calibration_balance": {"debug": {"mpc_virtual_temp": 23.0}}},
+        })
+        sensor = BetterThermostatVirtualTempSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 23.0
+
+
+# ===========================================================================
+# 5. Solar Intensity Sensor
+# ===========================================================================
+
+class TestSolarIntensitySensor:
+    """Tests for BetterThermostatSolarIntensitySensor."""
+
+    def test_unique_id(self):
+        bt = _make_bt_climate()
+        sensor = BetterThermostatSolarIntensitySensor(bt)
+        assert sensor._attr_unique_id == "test_bt_123_solar_intensity"
+
+    @patch("custom_components.better_thermostat.sensor._get_current_solar_intensity")
+    def test_normal_value_converted_to_percent(self, mock_solar):
+        mock_solar.return_value = 0.75
+        bt = _make_bt_climate()
+        sensor = BetterThermostatSolarIntensitySensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 75.0
+
+    @patch("custom_components.better_thermostat.sensor._get_current_solar_intensity")
+    def test_zero_intensity(self, mock_solar):
+        mock_solar.return_value = 0.0
+        bt = _make_bt_climate()
+        sensor = BetterThermostatSolarIntensitySensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 0.0
+
+    @patch("custom_components.better_thermostat.sensor._get_current_solar_intensity")
+    def test_none_returns_zero(self, mock_solar):
+        """When _get_current_solar_intensity returns None, sensor shows 0.0."""
+        mock_solar.return_value = None
+        bt = _make_bt_climate()
+        sensor = BetterThermostatSolarIntensitySensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 0.0
+
+    @patch("custom_components.better_thermostat.sensor._get_current_solar_intensity")
+    def test_exception_returns_none(self, mock_solar):
+        mock_solar.side_effect = RuntimeError("weather unavailable")
+        bt = _make_bt_climate()
+        sensor = BetterThermostatSolarIntensitySensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    @patch("custom_components.better_thermostat.sensor._get_current_solar_intensity")
+    def test_full_intensity_gives_100_percent(self, mock_solar):
+        mock_solar.return_value = 1.0
+        bt = _make_bt_climate()
+        sensor = BetterThermostatSolarIntensitySensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 100.0
+
+
+# ===========================================================================
+# 6. _get_active_algorithms
+# ===========================================================================
+
+class TestGetActiveAlgorithms:
+    """Tests for _get_active_algorithms helper."""
+
+    def test_no_real_trvs_returns_empty(self):
+        bt = _make_bt_climate(real_trvs={})
+        assert _get_active_algorithms(bt) == set()
+
+    def test_no_real_trvs_attr_returns_empty(self):
+        bt = _make_bt_climate()
+        del bt.real_trvs
+        assert _get_active_algorithms(bt) == set()
+
+    def test_mpc_calibration_detected(self):
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: CalibrationMode.MPC_CALIBRATION}},
+        })
+        result = _get_active_algorithms(bt)
+        assert CalibrationMode.MPC_CALIBRATION in result
+
+    def test_string_calibration_mode_converted(self):
+        """String values should be auto-converted to CalibrationMode enum."""
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: "mpc_calibration"}},
+        })
+        result = _get_active_algorithms(bt)
+        assert CalibrationMode.MPC_CALIBRATION in result
+
+    def test_invalid_calibration_mode_skipped(self):
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: "totally_invalid_mode"}},
+        })
+        result = _get_active_algorithms(bt)
+        assert result == set()
+
+    def test_multiple_trvs_different_modes(self):
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: CalibrationMode.MPC_CALIBRATION}},
+            "trv_2": {"advanced": {CONF_CALIBRATION_MODE: CalibrationMode.PID_CALIBRATION}},
+        })
+        result = _get_active_algorithms(bt)
+        assert result == {CalibrationMode.MPC_CALIBRATION, CalibrationMode.PID_CALIBRATION}
+
+    def test_none_calibration_mode_skipped(self):
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: None}},
+        })
+        result = _get_active_algorithms(bt)
+        assert result == set()
+
+    def test_missing_advanced_key_skipped(self):
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {},
+        })
+        result = _get_active_algorithms(bt)
+        assert result == set()
+
+    def test_real_trvs_none_returns_empty(self):
+        """real_trvs=None should be handled as empty."""
+        bt = _make_bt_climate(real_trvs=None)
+        result = _get_active_algorithms(bt)
+        assert result == set()
+
+
+# ===========================================================================
+# 7. _setup_algorithm_sensors
+# ===========================================================================
+
+class TestSetupAlgorithmSensors:
+    """Tests for _setup_algorithm_sensors."""
+
+    @pytest.mark.asyncio
+    async def test_mpc_creates_four_sensors(self):
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_1": {"climate": None}}}
+        entry = _make_entry()
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: CalibrationMode.MPC_CALIBRATION}},
+        })
+        with patch(
+            "custom_components.better_thermostat.sensor.async_get_entity_registry",
+            return_value=_make_entity_registry(),
+        ):
+            sensors = await _setup_algorithm_sensors(hass, entry, bt)
+        assert len(sensors) == 4
+        assert isinstance(sensors[0], BetterThermostatVirtualTempSensor)
+
+    @pytest.mark.asyncio
+    async def test_no_algorithms_returns_empty(self):
+        hass = MagicMock()
+        entry = _make_entry()
+        bt = _make_bt_climate(real_trvs={})
+        with patch(
+            "custom_components.better_thermostat.sensor.async_get_entity_registry",
+            return_value=_make_entity_registry(),
+        ):
+            sensors = await _setup_algorithm_sensors(hass, entry, bt)
+        assert sensors == []
+
+    @pytest.mark.asyncio
+    async def test_algorithms_to_create_filters(self):
+        """When algorithms_to_create is provided, only those algorithms create sensors."""
+        hass = MagicMock()
+        entry = _make_entry()
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: CalibrationMode.MPC_CALIBRATION}},
+        })
+        with patch(
+            "custom_components.better_thermostat.sensor.async_get_entity_registry",
+            return_value=_make_entity_registry(),
+        ):
+            # Request only PID sensors → MPC should be excluded
+            sensors = await _setup_algorithm_sensors(
+                hass, entry, bt, algorithms_to_create={CalibrationMode.PID_CALIBRATION}
+            )
+        assert sensors == []
+
+    @pytest.mark.asyncio
+    async def test_mpc_tracking_registered(self):
+        hass = MagicMock()
+        entry = _make_entry()
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: CalibrationMode.MPC_CALIBRATION}},
+        })
+        with patch(
+            "custom_components.better_thermostat.sensor.async_get_entity_registry",
+            return_value=_make_entity_registry(),
+        ):
+            await _setup_algorithm_sensors(hass, entry, bt)
+        assert "entry_1" in _ACTIVE_ALGORITHM_ENTITIES
+        assert CalibrationMode.MPC_CALIBRATION in _ACTIVE_ALGORITHM_ENTITIES["entry_1"]
+        tracked_ids = _ACTIVE_ALGORITHM_ENTITIES["entry_1"][CalibrationMode.MPC_CALIBRATION]
+        assert len(tracked_ids) == 5  # 4 sensors + mpc_status
+
+
+# ===========================================================================
+# 8. async_setup_entry
+# ===========================================================================
+
+class TestAsyncSetupEntry:
+    """Tests for async_setup_entry."""
+
+    @pytest.mark.asyncio
+    async def test_no_climate_returns_early(self):
+        """If climate entity not found, no sensors should be added."""
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_1": {"climate": None}}}
+        entry = _make_entry()
+        async_add_entities = MagicMock()
+
+        await async_setup_entry(hass, entry, async_add_entities)
+        async_add_entities.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_creates_six_core_sensors(self):
+        """Should create 6 core sensors when climate exists."""
+        bt = _make_bt_climate()
+        hass = MagicMock()
+        hass.data = {DOMAIN: {"entry_1": {"climate": bt}}}
+        entry = _make_entry()
+        async_add_entities = MagicMock()
+
+        with patch(
+            "custom_components.better_thermostat.sensor._setup_algorithm_sensors",
+            return_value=[],
+        ), patch(
+            "custom_components.better_thermostat.sensor._register_dynamic_entity_callback",
+        ):
+            await async_setup_entry(hass, entry, async_add_entities)
+
+        async_add_entities.assert_called_once()
+        sensors = async_add_entities.call_args[0][0]
+        assert len(sensors) == 6
+
+
+# ===========================================================================
+# 9. async_unload_entry
+# ===========================================================================
+
+class TestAsyncUnloadEntry:
+    """Tests for async_unload_entry."""
+
+    @pytest.mark.asyncio
+    async def test_unsubscribes_dispatcher(self):
+        entry = _make_entry()
+        unsub = MagicMock()
+        _DISPATCHER_UNSUBSCRIBES["entry_1"] = unsub
+        hass = MagicMock()
+
+        result = await async_unload_entry(hass, entry)
+        assert result is True
+        unsub.assert_called_once()
+        assert "entry_1" not in _DISPATCHER_UNSUBSCRIBES
+
+    @pytest.mark.asyncio
+    async def test_cleans_all_tracking_dicts(self):
+        entry = _make_entry()
+        _ACTIVE_ALGORITHM_ENTITIES["entry_1"] = {"algo": ["id1"]}
+        _ENTITY_CLEANUP_CALLBACKS["entry_1"] = MagicMock()
+        _ACTIVE_PRESET_NUMBERS["entry_1"] = {"uid": {}}
+        _ACTIVE_PID_NUMBERS["entry_1"] = {"uid": {}}
+        _ACTIVE_SWITCH_ENTITIES["entry_1"] = {"uid": {}}
+        hass = MagicMock()
+
+        await async_unload_entry(hass, entry)
+
+        assert "entry_1" not in _ACTIVE_ALGORITHM_ENTITIES
+        assert "entry_1" not in _ENTITY_CLEANUP_CALLBACKS
+        assert "entry_1" not in _ACTIVE_PRESET_NUMBERS
+        assert "entry_1" not in _ACTIVE_PID_NUMBERS
+        assert "entry_1" not in _ACTIVE_SWITCH_ENTITIES
+
+    @pytest.mark.asyncio
+    async def test_no_dispatcher_no_error(self):
+        """Unloading an entry without registered dispatcher should not fail."""
+        entry = _make_entry()
+        hass = MagicMock()
+        result = await async_unload_entry(hass, entry)
+        assert result is True
+
+
+# ===========================================================================
+# 10. _cleanup_stale_algorithm_entities
+# ===========================================================================
+
+class TestCleanupStaleAlgorithmEntities:
+    """Tests for _cleanup_stale_algorithm_entities."""
+
+    @pytest.mark.asyncio
+    async def test_no_tracked_returns_early(self):
+        """If entry not tracked, should return without error."""
+        hass = MagicMock()
+        bt = _make_bt_climate()
+        await _cleanup_stale_algorithm_entities(hass, "entry_1", bt, set())
+        # No exception → pass
+
+    @pytest.mark.asyncio
+    async def test_removes_stale_entities(self):
+        """Entities for algorithms no longer active should be removed."""
+        reg = _make_entity_registry()
+        reg.async_get_entity_id.return_value = "sensor.mpc_virtual_temp"
+
+        _ACTIVE_ALGORITHM_ENTITIES["entry_1"] = {
+            CalibrationMode.MPC_CALIBRATION: ["uid_1", "uid_2"],
+        }
+
+        with patch(
+            "custom_components.better_thermostat.sensor.async_get_entity_registry",
+            return_value=reg,
+        ):
+            bt = _make_bt_climate()
+            # current_algorithms is empty → MPC should be cleaned up
+            await _cleanup_stale_algorithm_entities(hass=MagicMock(), entry_id="entry_1", bt_climate=bt, current_algorithms=set())
+
+        assert reg.async_remove.call_count == 2
+        # Tracking should be cleaned up
+        assert "entry_1" not in _ACTIVE_ALGORITHM_ENTITIES
+
+    @pytest.mark.asyncio
+    async def test_keeps_active_algorithms(self):
+        """Entities for still-active algorithms should NOT be removed."""
+        reg = _make_entity_registry()
+        _ACTIVE_ALGORITHM_ENTITIES["entry_1"] = {
+            CalibrationMode.MPC_CALIBRATION: ["uid_1"],
+        }
+
+        with patch(
+            "custom_components.better_thermostat.sensor.async_get_entity_registry",
+            return_value=reg,
+        ):
+            bt = _make_bt_climate()
+            await _cleanup_stale_algorithm_entities(
+                hass=MagicMock(),
+                entry_id="entry_1",
+                bt_climate=bt,
+                current_algorithms={CalibrationMode.MPC_CALIBRATION},
+            )
+
+        reg.async_remove.assert_not_called()
+        # Tracking should still exist
+        assert "entry_1" in _ACTIVE_ALGORITHM_ENTITIES
+
+    @pytest.mark.asyncio
+    async def test_partial_removal_keeps_tracking(self):
+        """If not all entities could be removed, tracking should remain."""
+        reg = _make_entity_registry()
+        # First entity found, second not found
+        reg.async_get_entity_id.side_effect = ["sensor.found", None]
+
+        _ACTIVE_ALGORITHM_ENTITIES["entry_1"] = {
+            CalibrationMode.MPC_CALIBRATION: ["uid_1", "uid_2"],
+        }
+
+        with patch(
+            "custom_components.better_thermostat.sensor.async_get_entity_registry",
+            return_value=reg,
+        ):
+            bt = _make_bt_climate()
+            await _cleanup_stale_algorithm_entities(
+                hass=MagicMock(), entry_id="entry_1", bt_climate=bt, current_algorithms=set()
+            )
+
+        # Only 1 entity removed (other not found in registry)
+        assert reg.async_remove.call_count == 1
+        # Since only 1 of 2 removed, algorithm tracking should remain
+        assert CalibrationMode.MPC_CALIBRATION in _ACTIVE_ALGORITHM_ENTITIES.get("entry_1", {})
+
+    @pytest.mark.asyncio
+    async def test_remove_exception_handled_gracefully(self):
+        """If async_remove raises, it should be caught and logged."""
+        reg = _make_entity_registry()
+        reg.async_get_entity_id.return_value = "sensor.entity"
+        reg.async_remove.side_effect = RuntimeError("registry error")
+
+        _ACTIVE_ALGORITHM_ENTITIES["entry_1"] = {
+            CalibrationMode.MPC_CALIBRATION: ["uid_1"],
+        }
+
+        with patch(
+            "custom_components.better_thermostat.sensor.async_get_entity_registry",
+            return_value=reg,
+        ):
+            bt = _make_bt_climate()
+            # Should not raise
+            await _cleanup_stale_algorithm_entities(
+                hass=MagicMock(), entry_id="entry_1", bt_climate=bt, current_algorithms=set()
+            )
+
+
+# ===========================================================================
+# 11. _cleanup_preset_number_entities
+# ===========================================================================
+
+class TestCleanupPresetNumberEntities:
+    """Tests for _cleanup_preset_number_entities."""
+
+    @pytest.mark.asyncio
+    async def test_removes_disabled_preset_entities(self):
+        reg = _make_entity_registry()
+        reg.async_get_entity_id.return_value = "number.preset_away"
+
+        _ACTIVE_PRESET_NUMBERS["entry_1"] = {
+            "uid_away": {"preset": "away"},
+            "uid_home": {"preset": "home"},
+        }
+        bt = _make_bt_climate()
+        # Only "home" is current → "away" should be removed
+        await _cleanup_preset_number_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1",
+            bt_climate=bt, current_presets={"home"},
+        )
+
+        reg.async_remove.assert_called_once_with("number.preset_away")
+
+    @pytest.mark.asyncio
+    async def test_none_unique_id_skipped(self):
+        """Entries with None as unique_id should be skipped."""
+        reg = _make_entity_registry()
+        _ACTIVE_PRESET_NUMBERS["entry_1"] = {
+            None: {"preset": "away"},
+        }
+        bt = _make_bt_climate()
+        await _cleanup_preset_number_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1",
+            bt_climate=bt, current_presets=set(),
+        )
+        reg.async_get_entity_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_merges_new_presets_into_tracking(self):
+        reg = _make_entity_registry()
+        bt = _make_bt_climate()
+        await _cleanup_preset_number_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1",
+            bt_climate=bt, current_presets={"comfort", "eco"},
+        )
+        tracked = _ACTIVE_PRESET_NUMBERS["entry_1"]
+        assert f"{bt.unique_id}_preset_comfort" in tracked
+        assert f"{bt.unique_id}_preset_eco" in tracked
+
+    @pytest.mark.asyncio
+    async def test_remove_failure_keeps_tracking(self):
+        """On removal failure, tracking entry should remain for retry."""
+        reg = _make_entity_registry()
+        reg.async_get_entity_id.return_value = "number.preset_away"
+        reg.async_remove.side_effect = RuntimeError("fail")
+
+        _ACTIVE_PRESET_NUMBERS["entry_1"] = {
+            "uid_away": {"preset": "away"},
+        }
+        bt = _make_bt_climate()
+        await _cleanup_preset_number_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1",
+            bt_climate=bt, current_presets=set(),
+        )
+        # Tracking should remain since removal failed
+        assert "uid_away" in _ACTIVE_PRESET_NUMBERS["entry_1"]
+
+
+# ===========================================================================
+# 12. _cleanup_pid_number_entities
+# ===========================================================================
+
+class TestCleanupPidNumberEntities:
+    """Tests for _cleanup_pid_number_entities."""
+
+    @pytest.mark.asyncio
+    async def test_removes_pid_entities_for_non_pid_trv(self):
+        reg = _make_entity_registry()
+        reg.async_get_entity_id.return_value = "number.pid_kp"
+
+        _ACTIVE_PID_NUMBERS["entry_1"] = {
+            "uid_kp": {"trv": "trv_1", "param": "kp"},
+        }
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: CalibrationMode.DEFAULT}},
+        })
+        await _cleanup_pid_number_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1", bt_climate=bt,
+        )
+        reg.async_remove.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_keeps_pid_entities_for_pid_trv(self):
+        reg = _make_entity_registry()
+        _ACTIVE_PID_NUMBERS["entry_1"] = {
+            "uid_kp": {"trv": "trv_1", "param": "kp"},
+        }
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: CalibrationMode.PID_CALIBRATION}},
+        })
+        await _cleanup_pid_number_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1", bt_climate=bt,
+        )
+        reg.async_remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_merges_pid_tracking_for_current_trvs(self):
+        reg = _make_entity_registry()
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: CalibrationMode.PID_CALIBRATION}},
+        })
+        await _cleanup_pid_number_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1", bt_climate=bt,
+        )
+        tracked = _ACTIVE_PID_NUMBERS["entry_1"]
+        # Should have 3 entries for trv_1 (kp, ki, kd)
+        trv_entries = [v for v in tracked.values() if v.get("trv") == "trv_1"]
+        assert len(trv_entries) == 3
+
+    @pytest.mark.asyncio
+    async def test_no_real_trvs_returns_empty_pid_trvs(self):
+        """If no real_trvs, no PID TRVs should be found."""
+        reg = _make_entity_registry()
+        _ACTIVE_PID_NUMBERS["entry_1"] = {
+            "uid_kp": {"trv": "trv_1", "param": "kp"},
+        }
+        bt = _make_bt_climate(real_trvs={})
+        reg.async_get_entity_id.return_value = "number.pid_kp"
+        await _cleanup_pid_number_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1", bt_climate=bt,
+        )
+        reg.async_remove.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_invalid_calibration_mode_trv_skipped(self):
+        reg = _make_entity_registry()
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: "totally_bogus"}},
+        })
+        await _cleanup_pid_number_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1", bt_climate=bt,
+        )
+        # No PID TRVs found, nothing to merge
+        tracked = _ACTIVE_PID_NUMBERS["entry_1"]
+        assert not any(v.get("trv") == "trv_1" for v in tracked.values())
+
+
+# ===========================================================================
+# 13. _cleanup_pid_switch_entities
+# ===========================================================================
+
+class TestCleanupPidSwitchEntities:
+    """Tests for _cleanup_pid_switch_entities."""
+
+    @pytest.mark.asyncio
+    async def test_removes_pid_autotune_for_non_pid_trv(self):
+        reg = _make_entity_registry()
+        reg.async_get_entity_id.return_value = "switch.pid_auto_tune"
+
+        _ACTIVE_SWITCH_ENTITIES["entry_1"] = {
+            "uid_autotune": {"trv": "trv_1", "type": "pid_auto_tune"},
+        }
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: CalibrationMode.DEFAULT}},
+        })
+        await _cleanup_pid_switch_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1", bt_climate=bt,
+        )
+        reg.async_remove.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_removes_child_lock_for_removed_trv(self):
+        reg = _make_entity_registry()
+        reg.async_get_entity_id.return_value = "switch.child_lock"
+
+        _ACTIVE_SWITCH_ENTITIES["entry_1"] = {
+            "uid_lock": {"trv": "trv_removed", "type": "child_lock"},
+        }
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: CalibrationMode.DEFAULT}},
+        })
+        await _cleanup_pid_switch_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1", bt_climate=bt,
+        )
+        reg.async_remove.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_keeps_child_lock_for_existing_trv(self):
+        reg = _make_entity_registry()
+        _ACTIVE_SWITCH_ENTITIES["entry_1"] = {
+            "uid_lock": {"trv": "trv_1", "type": "child_lock"},
+        }
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: CalibrationMode.DEFAULT}},
+        })
+        await _cleanup_pid_switch_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1", bt_climate=bt,
+        )
+        reg.async_remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_merges_switch_tracking(self):
+        reg = _make_entity_registry()
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {CONF_CALIBRATION_MODE: CalibrationMode.PID_CALIBRATION}},
+        })
+        await _cleanup_pid_switch_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1", bt_climate=bt,
+        )
+        tracked = _ACTIVE_SWITCH_ENTITIES["entry_1"]
+        # Should have pid_auto_tune + child_lock for trv_1
+        types = {v["type"] for v in tracked.values() if v.get("trv") == "trv_1"}
+        assert types == {"pid_auto_tune", "child_lock"}
+
+    @pytest.mark.asyncio
+    async def test_child_lock_for_no_real_trvs(self):
+        """When real_trvs missing, child lock for tracked TRV should be removed."""
+        reg = _make_entity_registry()
+        reg.async_get_entity_id.return_value = "switch.child_lock"
+
+        _ACTIVE_SWITCH_ENTITIES["entry_1"] = {
+            "uid_lock": {"trv": "trv_1", "type": "child_lock"},
+        }
+        bt = _make_bt_climate()
+        del bt.real_trvs
+        await _cleanup_pid_switch_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1", bt_climate=bt,
+        )
+        reg.async_remove.assert_called_once()
+
+
+# ===========================================================================
+# 14. Edge cases & potential bugs
+# ===========================================================================
+
+class TestEdgeCasesAndPotentialBugs:
+    """Tests probing edge cases that might reveal bugs."""
+
+    def test_mpc_sensor_real_trvs_none_does_not_crash(self):
+        """If real_trvs is None instead of dict, _update_state should not crash.
+
+        The code checks `hasattr(self._bt_climate, 'real_trvs')` but a MagicMock
+        always has every attribute → it will try to iterate None.
+        """
+        bt = _make_bt_climate()
+        bt.real_trvs = None
+        sensor = BetterThermostatVirtualTempSensor(bt)
+        # This might crash with TypeError: cannot unpack non-iterable NoneType
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_mpc_sensor_real_trvs_is_list_not_dict(self):
+        """If real_trvs is a list instead of dict, .items() would fail."""
+        bt = _make_bt_climate()
+        bt.real_trvs = [{"calibration_balance": {"debug": {"mpc_virtual_temp": 22.0}}}]
+        sensor = BetterThermostatVirtualTempSensor(bt)
+        # list doesn't have .items() → should it crash?
+        try:
+            sensor._update_state()
+        except AttributeError:
+            pass  # documents the bug
+
+    def test_solar_sensor_negative_intensity(self):
+        """What happens if solar intensity returns a negative value?"""
+        with patch(
+            "custom_components.better_thermostat.sensor._get_current_solar_intensity"
+        ) as mock_solar:
+            mock_solar.return_value = -0.5
+            bt = _make_bt_climate()
+            sensor = BetterThermostatSolarIntensitySensor(bt)
+            sensor._update_state()
+            # Code does val * 100.0 → would show -50.0%
+            # This might be unexpected behavior
+            assert sensor._attr_native_value == -50.0
+
+    def test_solar_sensor_above_one_intensity(self):
+        """What happens if solar intensity returns > 1.0?"""
+        with patch(
+            "custom_components.better_thermostat.sensor._get_current_solar_intensity"
+        ) as mock_solar:
+            mock_solar.return_value = 1.5
+            bt = _make_bt_climate()
+            sensor = BetterThermostatSolarIntensitySensor(bt)
+            sensor._update_state()
+            assert sensor._attr_native_value == 150.0
+
+    def test_1h_ema_negative_dt_clamped(self):
+        """If monotonic() goes backward (shouldn't happen but defensive), dt is clamped to 0."""
+        bt = _make_bt_climate(cur_temp_filtered=20.0)
+        sensor = BetterThermostatExternalTemp1hEMASensor(bt)
+        sensor._update_ema(20.0)
+        # Set last_update to the future
+        sensor._last_update_ts = monotonic() + 1000
+        sensor._update_ema(25.0)
+        # dt = max(0, now - future) = 0 → alpha = 0 → EMA stays at 20
+        assert sensor._ema_value == 20.0
+
+    def test_cleanup_stale_empty_entry_removed(self):
+        """After all algorithms removed, the entry_id key should be deleted."""
+        _ACTIVE_ALGORITHM_ENTITIES["entry_1"] = {}
+        # empty dict → should be cleaned up
+        reg = _make_entity_registry()
+        hass = MagicMock()
+        bt = _make_bt_climate()
+        import asyncio
+        asyncio.get_event_loop().run_until_complete(
+            _cleanup_stale_algorithm_entities(hass, "entry_1", bt, set())
+        )
+        # The function checks `if not _ACTIVE_ALGORITHM_ENTITIES[entry_id]`
+        # and deletes it → entry should be gone
+        assert "entry_1" not in _ACTIVE_ALGORITHM_ENTITIES
+
+    @pytest.mark.asyncio
+    async def test_cleanup_preset_entities_with_empty_tracking(self):
+        """Cleaning up when there are no tracked presets should not fail."""
+        reg = _make_entity_registry()
+        bt = _make_bt_climate()
+        await _cleanup_preset_number_entities(
+            hass=MagicMock(), entity_registry=reg, entry_id="entry_1",
+            bt_climate=bt, current_presets={"comfort"},
+        )
+        # Should just merge without error
+        assert "entry_1" in _ACTIVE_PRESET_NUMBERS
+
+    @pytest.mark.asyncio
+    async def test_get_active_algorithms_with_empty_advanced(self):
+        """TRV with empty advanced dict should return no algorithms."""
+        bt = _make_bt_climate(real_trvs={
+            "trv_1": {"advanced": {}},
+        })
+        result = _get_active_algorithms(bt)
+        assert result == set()
+
+    def test_external_temp_sensor_with_nan(self):
+        """NaN as temperature value should be handled."""
+        bt = _make_bt_climate(cur_temp_filtered=float("nan"))
+        sensor = BetterThermostatExternalTempSensor(bt)
+        sensor._update_state()
+        # NaN is a valid float, so it will be set (but it's arguably a bug)
+        assert sensor._attr_native_value is not None  # float("nan") is a float
+        assert math.isnan(sensor._attr_native_value)
+
+    def test_external_temp_sensor_with_inf(self):
+        """Infinity as temperature should be handled."""
+        bt = _make_bt_climate(cur_temp_filtered=float("inf"))
+        sensor = BetterThermostatExternalTempSensor(bt)
+        sensor._update_state()
+        # inf is a valid float → will be set (potentially problematic)
+        assert sensor._attr_native_value == float("inf")
+
+    def test_1h_ema_with_nan_input(self):
+        """NaN input to EMA should propagate NaN."""
+        bt = _make_bt_climate(cur_temp_filtered=20.0)
+        sensor = BetterThermostatExternalTemp1hEMASensor(bt)
+        sensor._update_ema(20.0)
+        sensor._last_update_ts = monotonic() - 60
+        sensor._update_ema(float("nan"))
+        # NaN math: 20 + alpha * (nan - 20) = nan
+        assert math.isnan(sensor._ema_value)
+
+    @pytest.mark.asyncio
+    async def test_setup_entry_missing_domain_key_crashes(self):
+        """If hass.data doesn't have the DOMAIN key, it should crash with KeyError."""
+        hass = MagicMock()
+        hass.data = {}  # no DOMAIN key
+        entry = _make_entry()
+        async_add_entities = MagicMock()
+
+        with pytest.raises(KeyError):
+            await async_setup_entry(hass, entry, async_add_entities)
+
+    @pytest.mark.asyncio
+    async def test_setup_entry_missing_entry_id_crashes(self):
+        """If the entry_id is not in hass.data[DOMAIN], KeyError should occur."""
+        hass = MagicMock()
+        hass.data = {DOMAIN: {}}  # no entry_id
+        entry = _make_entry()
+        async_add_entities = MagicMock()
+
+        with pytest.raises(KeyError):
+            await async_setup_entry(hass, entry, async_add_entities)

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -29,6 +29,9 @@ from custom_components.better_thermostat.sensor import (
     _ACTIVE_PID_NUMBERS,
     _ACTIVE_PRESET_NUMBERS,
     _ACTIVE_SWITCH_ENTITIES,
+    _BtMpcSensorBase,
+    _BtSensorBase,
+    _BtSimpleAttributeSensor,
     _DISPATCHER_UNSUBSCRIBES,
     _ENTITY_CLEANUP_CALLBACKS,
     _cleanup_pid_number_entities,
@@ -36,6 +39,7 @@ from custom_components.better_thermostat.sensor import (
     _cleanup_preset_number_entities,
     _cleanup_stale_algorithm_entities,
     _get_active_algorithms,
+    _get_filtered_temp,
     _setup_algorithm_sensors,
     async_setup_entry,
     async_unload_entry,
@@ -1202,3 +1206,115 @@ class TestEdgeCasesAndPotentialBugs:
 
         with pytest.raises(KeyError):
             await async_setup_entry(hass, entry, async_add_entities)
+
+
+# ===========================================================================
+# 15. Base class tests
+# ===========================================================================
+
+class TestBtSensorBase:
+    """Tests for _BtSensorBase.__init__ and shared behavior."""
+
+    def test_init_sets_unique_id_from_suffix(self):
+        bt = _make_bt_climate()
+        sensor = BetterThermostatTempSlopeSensor(bt)
+        assert sensor._attr_unique_id == "test_bt_123_temp_slope"
+
+    def test_init_stores_bt_climate(self):
+        bt = _make_bt_climate()
+        sensor = BetterThermostatHeatingPowerSensor(bt)
+        assert sensor._bt_climate is bt
+
+    def test_init_sets_device_info(self):
+        bt = _make_bt_climate()
+        sensor = BetterThermostatHeatLossSensor(bt)
+        assert sensor._attr_device_info == bt.device_info
+
+    def test_all_sensors_inherit_from_base(self):
+        """All concrete sensor classes should inherit from _BtSensorBase."""
+        bt = _make_bt_climate()
+        for cls in [
+            BetterThermostatExternalTempSensor,
+            BetterThermostatExternalTemp1hEMASensor,
+            BetterThermostatTempSlopeSensor,
+            BetterThermostatHeatingPowerSensor,
+            BetterThermostatHeatLossSensor,
+            BetterThermostatVirtualTempSensor,
+            BetterThermostatMpcGainSensor,
+            BetterThermostatMpcLossSensor,
+            BetterThermostatMpcKaSensor,
+            BetterThermostatSolarIntensitySensor,
+        ]:
+            sensor = cls(bt)
+            assert isinstance(sensor, _BtSensorBase), f"{cls.__name__} should inherit from _BtSensorBase"
+
+    def test_mpc_sensors_inherit_from_mpc_base(self):
+        """All MPC sensors should inherit from _BtMpcSensorBase."""
+        bt = _make_bt_climate()
+        for cls in [
+            BetterThermostatVirtualTempSensor,
+            BetterThermostatMpcGainSensor,
+            BetterThermostatMpcLossSensor,
+            BetterThermostatMpcKaSensor,
+        ]:
+            sensor = cls(bt)
+            assert isinstance(sensor, _BtMpcSensorBase), f"{cls.__name__} should inherit from _BtMpcSensorBase"
+
+    def test_simple_sensors_inherit_from_simple_base(self):
+        """Simple attribute sensors should inherit from _BtSimpleAttributeSensor."""
+        bt = _make_bt_climate()
+        for cls in [
+            BetterThermostatTempSlopeSensor,
+            BetterThermostatHeatingPowerSensor,
+            BetterThermostatHeatLossSensor,
+        ]:
+            sensor = cls(bt)
+            assert isinstance(sensor, _BtSimpleAttributeSensor), f"{cls.__name__} should inherit from _BtSimpleAttributeSensor"
+
+
+class TestGetFilteredTemp:
+    """Tests for _get_filtered_temp helper."""
+
+    def test_prefers_cur_temp_filtered(self):
+        bt = _make_bt_climate(cur_temp_filtered=21.5, external_temp_ema=22.0)
+        assert _get_filtered_temp(bt) == 21.5
+
+    def test_falls_back_to_external_temp_ema(self):
+        bt = _make_bt_climate(cur_temp_filtered=None, external_temp_ema=22.0)
+        assert _get_filtered_temp(bt) == 22.0
+
+    def test_returns_none_when_both_missing(self):
+        bt = _make_bt_climate(cur_temp_filtered=None, external_temp_ema=None)
+        assert _get_filtered_temp(bt) is None
+
+    def test_zero_value_not_treated_as_none(self):
+        bt = _make_bt_climate(cur_temp_filtered=0.0, external_temp_ema=22.0)
+        assert _get_filtered_temp(bt) == 0.0
+
+
+class TestBtSimpleAttributeSensor:
+    """Tests for _BtSimpleAttributeSensor base behavior."""
+
+    def test_rounding_applied_when_set(self):
+        bt = _make_bt_climate(temp_slope=0.01236789)
+        sensor = BetterThermostatTempSlopeSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 0.0124
+
+    def test_no_rounding_when_none(self):
+        bt = _make_bt_climate(heating_power=0.05123456)
+        sensor = BetterThermostatHeatingPowerSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value == 0.05123456
+
+    def test_none_attribute_gives_none(self):
+        bt = _make_bt_climate(heating_power=None)
+        sensor = BetterThermostatHeatingPowerSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None
+
+    def test_invalid_string_gives_none(self):
+        bt = _make_bt_climate(temp_slope="not_a_number")
+        sensor = BetterThermostatTempSlopeSensor(bt)
+        sensor._update_state()
+        assert sensor._attr_native_value is None

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -351,10 +351,10 @@ class TestMpcSensorAvailability:
         BetterThermostatMpcLossSensor,
         BetterThermostatMpcKaSensor,
     ])
-    def test_available_missing_attr_returns_false(self, SensorClass):
-        """If _available attribute is missing entirely, sensor should be unavailable."""
+    def test_available_false_when_not_available(self, SensorClass):
+        """If _available is False, sensor should be unavailable."""
         bt = _make_bt_climate()
-        del bt._available  # remove attribute
+        bt._available = False
         sensor = SensorClass(bt)
         assert sensor.available is False
 
@@ -407,9 +407,8 @@ class TestMpcSensorState:
         sensor._update_state()
         assert sensor._attr_native_value is None
 
-    def test_no_real_trvs_attr_returns_none(self):
-        bt = _make_bt_climate()
-        del bt.real_trvs
+    def test_real_trvs_none_returns_none(self):
+        bt = _make_bt_climate(real_trvs=None)
         sensor = BetterThermostatVirtualTempSensor(bt)
         sensor._update_state()
         assert sensor._attr_native_value is None
@@ -502,9 +501,8 @@ class TestGetActiveAlgorithms:
         bt = _make_bt_climate(real_trvs={})
         assert _get_active_algorithms(bt) == set()
 
-    def test_no_real_trvs_attr_returns_empty(self):
-        bt = _make_bt_climate()
-        del bt.real_trvs
+    def test_real_trvs_none_returns_empty(self):
+        bt = _make_bt_climate(real_trvs=None)
         assert _get_active_algorithms(bt) == set()
 
     def test_mpc_calibration_detected(self):
@@ -1048,8 +1046,7 @@ class TestCleanupPidSwitchEntities:
         _ACTIVE_SWITCH_ENTITIES["entry_1"] = {
             "uid_lock": {"trv": "trv_1", "type": "child_lock"},
         }
-        bt = _make_bt_climate()
-        del bt.real_trvs
+        bt = _make_bt_climate(real_trvs=None)
         await _cleanup_pid_switch_entities(
             hass=MagicMock(), entity_registry=reg, entry_id="entry_1", bt_climate=bt,
         )
@@ -1064,11 +1061,7 @@ class TestEdgeCasesAndPotentialBugs:
     """Tests probing edge cases that might reveal bugs."""
 
     def test_mpc_sensor_real_trvs_none_does_not_crash(self):
-        """If real_trvs is None instead of dict, _update_state should not crash.
-
-        The code checks `hasattr(self._bt_climate, 'real_trvs')` but a MagicMock
-        always has every attribute → it will try to iterate None.
-        """
+        """If real_trvs is None instead of dict, _update_state should not crash."""
         bt = _make_bt_climate()
         bt.real_trvs = None
         sensor = BetterThermostatVirtualTempSensor(bt)


### PR DESCRIPTION
## Summary
- Add **121 unit tests** covering all 10 sensor classes in sensor.py
- Test sensor state updates, availability logic, EMA math, cleanup functions, and edge cases
- Includes base class tests for the `_BtSensorBase`, `_BtMpcSensorBase`, `_BtSimpleAttributeSensor` hierarchy

> **Depends on:** #1944 — merge that PR first, then this one applies cleanly.

## Test coverage

| Area | Tests |
|---|---|
| ExternalTempSensor (EMA) | 6 |
| ExternalTemp1hEMASensor | 8 |
| Simple attribute sensors (Slope, Power, Loss) | 8 |
| MPC sensor availability | 16 (4 classes × 4 scenarios) |
| MPC sensor state | 11 |
| Solar intensity | 5 |
| `_get_active_algorithms` | 9 |
| `_setup_algorithm_sensors` | 4 |
| `async_setup_entry` / `async_unload_entry` | 5 |
| Cleanup functions (preset, PID, switch) | 16 |
| Edge cases & potential bugs | 15 |
| Base class hierarchy | 10 |
| `_get_filtered_temp` helper | 4 |

## Test plan
- [x] `uv run pytest tests/unit/test_sensor.py -v -p no:homeassistant` → 121 passed