### PR TITLE
refactor: Extract tolerance-FSM into pure utils/hvac_action.py

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -72,6 +72,12 @@ from .events.trv import trigger_trv_change
 from .events.window import trigger_window_change, window_queue
 from .model_fixes.model_quirks import inital_tweak, load_model_quirks
 from .utils.calibration.mpc import export_mpc_state_map, import_mpc_state_map
+from .utils.hvac_action import (
+    ToleranceHysteresis,
+    TrvSnapshot,
+    compute_hvac_action,
+    should_heat_with_tolerance,
+)
 from .utils.calibration.pid import (
     export_pid_states as pid_export_states,
     import_pid_states as pid_import_states,
@@ -418,8 +424,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.context = None
         self.attr_hvac_action = None
         self.old_attr_hvac_action = None
-        self._tolerance_last_action = HVACAction.IDLE
-        self._tolerance_hold_active = False
+        self._hysteresis = ToleranceHysteresis()
         self.heating_start_temp = None
         self.heating_start_timestamp = None
         self.heating_end_temp = None
@@ -2161,8 +2166,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # Telemetry container (now initialized in __init__)
         now = dt_util.utcnow()  # UTC aware time
 
-        # Determine current action early (pure computation) for transition handling
-        current_action = self._compute_hvac_action()
+        # Determine current action for transition handling
+        result = self._compute_hvac_action_pure()
+        self._commit_hvac_action(result)
+        current_action = result.action
 
         action_changed = current_action != self.old_attr_hvac_action
 
@@ -2400,7 +2407,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             return
 
         now = dt_util.utcnow()
-        current_action = self._compute_hvac_action()
+        result = self._compute_hvac_action_pure()
+        self._commit_hvac_action(result)
+        current_action = result.action
 
         # Do not learn when window is open
         if self.window_open:
@@ -2793,8 +2802,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
     @property
     def hvac_action(self):
-        """Return the current HVAC action (delegates to helper)."""
-        return self._compute_hvac_action()
+        """Return the current HVAC action."""
+        if self.attr_hvac_action is not None:
+            return self.attr_hvac_action
+        return self._compute_hvac_action_pure().action
 
     def _should_heat_with_tolerance(
         self, previous_action: HVACAction | None, tol: float
@@ -2802,180 +2813,75 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         """Apply hysteresis so heating restarts only below target - tolerance."""
         if self.bt_target_temp is None or self.cur_temp is None:
             return False
-        tol = max(0.0, tol)
-        heat_off_threshold = self.bt_target_temp
-        heat_on_threshold = self.bt_target_temp - tol
-        if previous_action == HVACAction.HEATING:
-            return self.cur_temp < heat_off_threshold
-        return self.cur_temp < heat_on_threshold
-
-    def _compute_hvac_action(self):  # helper kept internal for clarity
-        """Pure HVAC action computation with tolerance based hysteresis.
-
-        Rules:
-        - OFF mode returns OFF regardless of temperatures
-        - Open window suppresses active heating/cooling (returns IDLE)
-        - Heating uses a hysteresis band [target - tolerance, target]
-        - Cooling if mode heat_cool and cur_temp > cool_target + tolerance
-        - Otherwise IDLE, unless TRVs explicitly report heating and tolerance does not block it
-        """
-        prev_action = self._tolerance_last_action
-        tol = self.tolerance if self.tolerance is not None else 0.0
-
-        if self.bt_target_temp is None or self.cur_temp is None:
-            self._tolerance_hold_active = False
-            self._tolerance_last_action = HVACAction.IDLE
-            return HVACAction.IDLE
-        if HVACMode.OFF in (self.hvac_mode, self.bt_hvac_mode):
-            self._tolerance_hold_active = False
-            self._tolerance_last_action = HVACAction.IDLE
-            return HVACAction.OFF
-        if self.window_open:
-            self._tolerance_hold_active = False
-            self._tolerance_last_action = HVACAction.IDLE
-            return HVACAction.IDLE
-
-        heating_allowed = self.hvac_mode in (HVACMode.HEAT, HVACMode.HEAT_COOL)
-        action = HVACAction.IDLE
-        tolerance_hold = False
-
-        if heating_allowed:
-            should_heat = self._should_heat_with_tolerance(prev_action, tol)
-            if should_heat:
-                action = HVACAction.HEATING
-            else:
-                tolerance_hold = True
-
-        # Remember the tolerance-based decision *before* TRV overrides so the
-        # hysteresis state machine is not corrupted by a TRV that is still
-        # physically heating after the control logic decided to stop.
-        tolerance_decision = action
-
-        # Cooling decision (if heat_cool mode and cooling setpoint exists)
-        if (
-            self.hvac_mode in (HVACMode.HEAT_COOL,)
-            and self.bt_target_cooltemp is not None
-            and self.cur_temp > (self.bt_target_cooltemp + tol)
-        ):
-            action = HVACAction.COOLING
-            tolerance_hold = False
-
-        # Base decision would be IDLE. If any real TRV indicates active heating, override to HEATING.
-        if action == HVACAction.IDLE:
-            try:
-                # Skip overrides while we intentionally ignore TRV states or when window is open
-                if self.ignore_states or self.window_open:
-                    self._tolerance_last_action = HVACAction.IDLE
-                    self._tolerance_hold_active = tolerance_hold
-                    return HVACAction.IDLE
-
-                def _to_pct(val):
-                    try:
-                        v = float(val)
-                        return v * 100.0 if 0.0 <= v < 1.0 else v
-                    except Exception:
-                        return None
-
-                THRESH = 0.0
-                for trv_id, info in (self.real_trvs or {}).items():
-                    if not isinstance(info, dict):
-                        _LOGGER.debug(
-                            "better_thermostat %s: _compute_hvac_action TRV %s ignored (config invalid)",
-                            self.device_name,
-                            trv_id,
-                        )
-                        continue
-                    if info.get("ignore_trv_states"):
-                        _LOGGER.debug(
-                            "better_thermostat %s: _compute_hvac_action TRV %s ignored (ignore_trv_states=True)",
-                            self.device_name,
-                            trv_id,
-                        )
-                        continue
-
-                    # 0) Use cached hvac_action first; fallback to hass state if missing
-                    try:
-                        action_val = info.get("hvac_action")
-                        action_str = (
-                            str(action_val).lower() if action_val is not None else ""
-                        )
-                        if not action_str:
-                            trv_state = self.hass.states.get(trv_id)
-                            action_raw = None
-                            if trv_state is not None:
-                                action_raw = trv_state.attributes.get("hvac_action")
-                                if action_raw is None:
-                                    action_raw = trv_state.attributes.get("action")
-                            action_str = (
-                                str(action_raw).lower()
-                                if action_raw is not None
-                                else ""
-                            )
-                            if action_str:
-                                try:
-                                    info["hvac_action"] = action_str
-                                except Exception:
-                                    pass
-                        if action_str == "heating" or action_val == HVACAction.HEATING:
-                            _LOGGER.debug(
-                                "better_thermostat %s: overriding hvac_action to HEATING (TRV %s reports heating)",
-                                self.device_name,
-                                trv_id,
-                            )
-                            action = HVACAction.HEATING
-                            break
-                    except Exception:
-                        pass
-
-                    # 2) TRV shows an actual/open valve position > 0
-                    vp = info.get("valve_position")
-                    try:
-                        vp_pct = _to_pct(vp)
-                        if vp_pct is not None and vp_pct > THRESH:
-                            _LOGGER.debug(
-                                "better_thermostat %s: overriding hvac_action to HEATING (valve_position %.1f%%, TRV %s)",
-                                self.device_name,
-                                vp_pct,
-                                trv_id,
-                            )
-                            action = HVACAction.HEATING
-                            break
-                    except Exception:
-                        pass
-
-                    # 3) We last commanded a valve percent > 0 (adapter/override)
-                    last_pct = info.get("last_valve_percent")
-                    try:
-                        last_pct_n = _to_pct(last_pct)
-                        if last_pct_n is not None and last_pct_n > THRESH:
-                            _LOGGER.debug(
-                                "better_thermostat %s: overriding hvac_action to HEATING (last_valve_percent %.1f%%, TRV %s)",
-                                self.device_name,
-                                last_pct_n,
-                                trv_id,
-                            )
-                            action = HVACAction.HEATING
-                            break
-                    except Exception:
-                        pass
-
-            except Exception:
-                # Defensive: if anything goes wrong in overrides, fall back to IDLE
-                pass
-
-        # Persist tolerance state machine for next decision.
-        # Use the tolerance-based decision (before TRV overrides) so that a
-        # TRV still physically heating does not keep the hysteresis in the
-        # lenient "was-heating" mode and cause heating up to target + tolerance.
-        self._tolerance_last_action = (
-            HVACAction.HEATING
-            if tolerance_decision == HVACAction.HEATING
-            else HVACAction.IDLE
+        return should_heat_with_tolerance(
+            self.cur_temp, self.bt_target_temp, tol, previous_action
         )
-        self._tolerance_hold_active = bool(
-            tolerance_hold and action != HVACAction.COOLING
+
+    def _build_trv_snapshots(self) -> list[TrvSnapshot]:
+        """Build TrvSnapshot list from real_trvs with hass state fallback."""
+        snapshots: list[TrvSnapshot] = []
+        for trv_id, info in (self.real_trvs or {}).items():
+            if not isinstance(info, dict):
+                continue
+
+            # Resolve hvac_action: cached first, hass state fallback
+            action_val = info.get("hvac_action")
+            action_str = str(action_val).lower() if action_val is not None else ""
+            if not action_str:
+                try:
+                    trv_state = self.hass.states.get(trv_id)
+                    action_raw = None
+                    if trv_state is not None:
+                        action_raw = trv_state.attributes.get("hvac_action")
+                        if action_raw is None:
+                            action_raw = trv_state.attributes.get("action")
+                    action_str = (
+                        str(action_raw).lower() if action_raw is not None else ""
+                    )
+                    if action_str:
+                        try:
+                            info["hvac_action"] = action_str
+                        except Exception:
+                            pass
+                except Exception:
+                    action_str = ""
+
+            # HVACAction enum also counts as "heating"
+            if action_val == HVACAction.HEATING and action_str != "heating":
+                action_str = "heating"
+
+            snapshots.append(
+                TrvSnapshot(
+                    trv_id=trv_id,
+                    ignore_trv_states=bool(info.get("ignore_trv_states")),
+                    hvac_action=action_str or None,
+                    valve_position=info.get("valve_position"),
+                    last_valve_percent=info.get("last_valve_percent"),
+                )
+            )
+        return snapshots
+
+    def _compute_hvac_action_pure(self):
+        """Compute current HVAC action."""
+        return compute_hvac_action(
+            hysteresis=self._hysteresis,
+            cur_temp=self.cur_temp,
+            target_temp=self.bt_target_temp,
+            cool_target=self.bt_target_cooltemp,
+            hvac_mode=self.hvac_mode,
+            bt_hvac_mode=self.bt_hvac_mode,
+            window_open=self.window_open,
+            tolerance=self.tolerance or 0.0,
+            ignore_states=self.ignore_states,
+            trv_snapshots=self._build_trv_snapshots(),
+            device_name=self.device_name,
         )
-        return action
+
+    def _commit_hvac_action(self, result) -> None:
+        """Apply computed hysteresis state."""
+        self._hysteresis.last_action = result.new_last_action
+        self._hysteresis.hold_active = result.new_hold_active
+
 
     @property
     def target_temperature(self) -> float | None:

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -429,8 +429,10 @@ async def control_trv(self, heater_entity_id=None):
             if hasattr(self, "attr_hvac_action"):
                 self.old_attr_hvac_action = getattr(self, "attr_hvac_action", None)
             # Recompute current hvac action (uses internal climate logic)
-            if hasattr(self, "_compute_hvac_action"):
-                self.attr_hvac_action = self._compute_hvac_action()
+            if hasattr(self, "_compute_hvac_action_pure"):
+                result = self._compute_hvac_action_pure()
+                self._commit_hvac_action(result)
+                self.attr_hvac_action = result.action
         except Exception:
             _LOGGER.debug(
                 "better_thermostat %s: hvac action recompute failed (non critical)",

--- a/custom_components/better_thermostat/utils/hvac_action.py
+++ b/custom_components/better_thermostat/utils/hvac_action.py
@@ -92,7 +92,16 @@ def compute_hvac_action(
     trv_snapshots: list[TrvSnapshot],
     device_name: str = "",
 ) -> HvacActionResult:
-    """Compute the current HVAC action without mutating *hysteresis*."""
+    """Compute the current HVAC action without mutating *hysteresis*.
+
+    Rules
+    -----
+    - OFF mode → OFF regardless of temperatures.
+    - Open window → IDLE (suppresses active heating/cooling).
+    - Heating uses a hysteresis band ``[target - tolerance, target]``.
+    - Cooling when ``heat_cool`` and ``cur_temp > cool_target + tolerance``.
+    - Otherwise IDLE, unless a TRV explicitly reports heating.
+    """
     prev_action = hysteresis.last_action
 
     if target_temp is None or cur_temp is None:
@@ -191,7 +200,9 @@ def compute_hvac_action(
                 action = HVACAction.HEATING
                 break
 
-    # Hysteresis state follows tolerance_decision, not the TRV-overridden action
+    # Hysteresis state follows tolerance_decision, not the TRV-overridden action.
+    # A TRV still physically heating must not keep the state machine in the
+    # lenient "was-heating" mode, which would cause heating past target + tolerance.
     new_last_action = (
         HVACAction.HEATING
         if tolerance_decision == HVACAction.HEATING

--- a/custom_components/better_thermostat/utils/hvac_action.py
+++ b/custom_components/better_thermostat/utils/hvac_action.py
@@ -1,0 +1,205 @@
+"""HVAC action computation with tolerance-based hysteresis."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from homeassistant.components.climate.const import HVACAction, HVACMode
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ToleranceHysteresis:
+    """Mutable hysteresis state for the tolerance state-machine."""
+
+    last_action: HVACAction = field(default=HVACAction.IDLE)
+    hold_active: bool = False
+
+
+@dataclass(frozen=True)
+class HvacActionResult:
+    """Immutable result of a single HVAC-action computation."""
+
+    action: HVACAction
+    tolerance_decision: HVACAction
+    new_last_action: HVACAction
+    new_hold_active: bool
+
+
+@dataclass(frozen=True)
+class TrvSnapshot:
+    """Pre-resolved, immutable view of a single TRV's relevant state."""
+
+    trv_id: str
+    ignore_trv_states: bool = False
+    hvac_action: str | None = None
+    valve_position: float | None = None
+    last_valve_percent: float | None = None
+
+
+def to_pct(val: object) -> float | None:
+    """Normalise a valve value to percent (0-100).
+
+    Values in [0, 1) are treated as fractions and multiplied by 100.
+    Values >= 1 are returned as-is (already percent).
+    Returns *None* for non-numeric / unparseable input.
+    """
+    try:
+        v = float(val)  # type: ignore[arg-type]
+        return v * 100.0 if 0.0 <= v < 1.0 else v
+    except (TypeError, ValueError):
+        return None
+
+
+def should_heat_with_tolerance(
+    cur_temp: float,
+    target_temp: float,
+    tolerance: float,
+    previous_action: HVACAction | None,
+) -> bool:
+    """Hysteresis decision: should we heat right now?
+
+    Band: ``[target - tolerance, target)``
+    * Start heating when ``cur_temp < target - tolerance``.
+    * Continue heating (if already heating) until ``cur_temp >= target``.
+    * Stop at ``target`` – never heat *above* target.
+    """
+    tolerance = max(0.0, tolerance)
+    heat_off_threshold = target_temp
+    heat_on_threshold = target_temp - tolerance
+    if previous_action == HVACAction.HEATING:
+        return cur_temp < heat_off_threshold
+    return cur_temp < heat_on_threshold
+
+
+_VALVE_THRESH = 0.0
+
+
+def compute_hvac_action(
+    hysteresis: ToleranceHysteresis,
+    cur_temp: float | None,
+    target_temp: float | None,
+    cool_target: float | None,
+    hvac_mode: HVACMode,
+    bt_hvac_mode: HVACMode,
+    window_open: bool,
+    tolerance: float,
+    ignore_states: bool,
+    trv_snapshots: list[TrvSnapshot],
+    device_name: str = "",
+) -> HvacActionResult:
+    """Compute the current HVAC action without mutating *hysteresis*."""
+    prev_action = hysteresis.last_action
+
+    if target_temp is None or cur_temp is None:
+        return HvacActionResult(
+            action=HVACAction.IDLE,
+            tolerance_decision=HVACAction.IDLE,
+            new_last_action=HVACAction.IDLE,
+            new_hold_active=False,
+        )
+
+    if HVACMode.OFF in (hvac_mode, bt_hvac_mode):
+        return HvacActionResult(
+            action=HVACAction.OFF,
+            tolerance_decision=HVACAction.OFF,
+            new_last_action=HVACAction.IDLE,
+            new_hold_active=False,
+        )
+
+    if window_open:
+        return HvacActionResult(
+            action=HVACAction.IDLE,
+            tolerance_decision=HVACAction.IDLE,
+            new_last_action=HVACAction.IDLE,
+            new_hold_active=False,
+        )
+
+    # Tolerance-based heating decision
+    heating_allowed = hvac_mode in (HVACMode.HEAT, HVACMode.HEAT_COOL)
+    action = HVACAction.IDLE
+    tolerance_hold = False
+
+    if heating_allowed:
+        if should_heat_with_tolerance(cur_temp, target_temp, tolerance, prev_action):
+            action = HVACAction.HEATING
+        else:
+            tolerance_hold = True
+
+    tolerance_decision = action
+
+    # Cooling decision
+    if (
+        hvac_mode == HVACMode.HEAT_COOL
+        and cool_target is not None
+        and cur_temp > (cool_target + tolerance)
+    ):
+        action = HVACAction.COOLING
+        tolerance_hold = False
+
+    # TRV override: if base decision is IDLE but any TRV is active, show HEATING
+    if action == HVACAction.IDLE:
+        if ignore_states or window_open:
+            return HvacActionResult(
+                action=HVACAction.IDLE,
+                tolerance_decision=tolerance_decision,
+                new_last_action=HVACAction.IDLE,
+                new_hold_active=tolerance_hold,
+            )
+
+        for snap in trv_snapshots:
+            if snap.ignore_trv_states:
+                continue
+
+            if snap.hvac_action is not None:
+                action_str = str(snap.hvac_action).lower()
+                if action_str == "heating":
+                    _LOGGER.debug(
+                        "better_thermostat %s: overriding hvac_action to HEATING "
+                        "(TRV %s reports heating)",
+                        device_name,
+                        snap.trv_id,
+                    )
+                    action = HVACAction.HEATING
+                    break
+
+            vp_pct = to_pct(snap.valve_position)
+            if vp_pct is not None and vp_pct > _VALVE_THRESH:
+                _LOGGER.debug(
+                    "better_thermostat %s: overriding hvac_action to HEATING "
+                    "(valve_position %.1f%%, TRV %s)",
+                    device_name,
+                    vp_pct,
+                    snap.trv_id,
+                )
+                action = HVACAction.HEATING
+                break
+
+            last_pct = to_pct(snap.last_valve_percent)
+            if last_pct is not None and last_pct > _VALVE_THRESH:
+                _LOGGER.debug(
+                    "better_thermostat %s: overriding hvac_action to HEATING "
+                    "(last_valve_percent %.1f%%, TRV %s)",
+                    device_name,
+                    last_pct,
+                    snap.trv_id,
+                )
+                action = HVACAction.HEATING
+                break
+
+    # Hysteresis state follows tolerance_decision, not the TRV-overridden action
+    new_last_action = (
+        HVACAction.HEATING
+        if tolerance_decision == HVACAction.HEATING
+        else HVACAction.IDLE
+    )
+    new_hold_active = bool(tolerance_hold and action != HVACAction.COOLING)
+
+    return HvacActionResult(
+        action=action,
+        tolerance_decision=tolerance_decision,
+        new_last_action=new_last_action,
+        new_hold_active=new_hold_active,
+    )

--- a/custom_components/better_thermostat/utils/hvac_action.py
+++ b/custom_components/better_thermostat/utils/hvac_action.py
@@ -39,18 +39,20 @@ class TrvSnapshot:
     last_valve_percent: float | None = None
 
 
-def to_pct(val: object) -> float | None:
+def to_pct(val: float | str | None) -> float | None:
     """Normalise a valve value to percent (0-100).
 
     Values in [0, 1) are treated as fractions and multiplied by 100.
     Values >= 1 are returned as-is (already percent).
     Returns *None* for non-numeric / unparseable input.
     """
+    if val is None:
+        return None
     try:
-        v = float(val)  # type: ignore[arg-type]
-        return v * 100.0 if 0.0 <= v < 1.0 else v
+        v = float(val)
     except (TypeError, ValueError):
         return None
+    return v * 100.0 if 0.0 <= v < 1.0 else v
 
 
 def should_heat_with_tolerance(

--- a/tests/test_heating_tolerance.py
+++ b/tests/test_heating_tolerance.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock
 from homeassistant.components.climate.const import HVACAction, HVACMode
 import pytest
 
+from custom_components.better_thermostat.utils.hvac_action import ToleranceHysteresis
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -33,8 +35,7 @@ def mock_bt():
     bt.window_open = False
     bt.ignore_states = False
     bt.real_trvs = {}
-    bt._tolerance_last_action = HVACAction.IDLE
-    bt._tolerance_hold_active = False
+    bt._hysteresis = ToleranceHysteresis()
     bt.device_name = "Test"
     bt._hvac_list = [HVACMode.HEAT, HVACMode.OFF]
     bt.cooler_entity_id = None
@@ -47,10 +48,23 @@ def mock_bt():
     bt._should_heat_with_tolerance = types.MethodType(
         BetterThermostat._should_heat_with_tolerance, bt
     )
-    bt._compute_hvac_action = types.MethodType(
-        BetterThermostat._compute_hvac_action, bt
+    bt._build_trv_snapshots = types.MethodType(
+        BetterThermostat._build_trv_snapshots, bt
+    )
+    bt._compute_hvac_action_pure = types.MethodType(
+        BetterThermostat._compute_hvac_action_pure, bt
+    )
+    bt._commit_hvac_action = types.MethodType(
+        BetterThermostat._commit_hvac_action, bt
     )
     return bt
+
+
+def _compute_and_commit(bt) -> HVACAction:
+    """Helper: compute + commit, return the action."""
+    result = bt._compute_hvac_action_pure()
+    bt._commit_hvac_action(result)
+    return result.action
 
 
 # ---------------------------------------------------------------------------
@@ -93,7 +107,7 @@ class TestShouldHeatWithTolerance:
 
 
 # ---------------------------------------------------------------------------
-# _compute_hvac_action – full integration of tolerance + TRV override
+# _compute_hvac_action_pure – full integration of tolerance + TRV override
 # ---------------------------------------------------------------------------
 
 
@@ -103,22 +117,22 @@ class TestComputeHvacActionTolerance:
     def test_heating_starts_below_target_minus_tolerance(self, mock_bt):
         """Test that heating starts when temperature is below target minus tolerance."""
         mock_bt.cur_temp = 20.4
-        mock_bt._tolerance_last_action = HVACAction.IDLE
-        action = mock_bt._compute_hvac_action()
+        mock_bt._hysteresis.last_action = HVACAction.IDLE
+        action = _compute_and_commit(mock_bt)
         assert action == HVACAction.HEATING
 
     def test_heating_continues_until_target(self, mock_bt):
         """Test that heating continues when temperature is below target."""
         mock_bt.cur_temp = 20.8
-        mock_bt._tolerance_last_action = HVACAction.HEATING
-        action = mock_bt._compute_hvac_action()
+        mock_bt._hysteresis.last_action = HVACAction.HEATING
+        action = _compute_and_commit(mock_bt)
         assert action == HVACAction.HEATING
 
     def test_heating_stops_at_target(self, mock_bt):
         """Test that heating stops when temperature reaches target."""
         mock_bt.cur_temp = 21.0
-        mock_bt._tolerance_last_action = HVACAction.HEATING
-        action = mock_bt._compute_hvac_action()
+        mock_bt._hysteresis.last_action = HVACAction.HEATING
+        action = _compute_and_commit(mock_bt)
         assert action == HVACAction.IDLE
 
     def test_no_heating_above_target_even_if_below_target_plus_tol(self, mock_bt):
@@ -128,8 +142,8 @@ class TestComputeHvacActionTolerance:
         should NOT keep heating.
         """
         mock_bt.cur_temp = 21.3
-        mock_bt._tolerance_last_action = HVACAction.HEATING
-        action = mock_bt._compute_hvac_action()
+        mock_bt._hysteresis.last_action = HVACAction.HEATING
+        action = _compute_and_commit(mock_bt)
         assert action == HVACAction.IDLE
 
     def test_heating_does_not_restart_above_target_minus_tol(self, mock_bt):
@@ -139,15 +153,15 @@ class TestComputeHvacActionTolerance:
         NOT restart heating (hysteresis).
         """
         mock_bt.cur_temp = 20.7
-        mock_bt._tolerance_last_action = HVACAction.IDLE
-        action = mock_bt._compute_hvac_action()
+        mock_bt._hysteresis.last_action = HVACAction.IDLE
+        action = _compute_and_commit(mock_bt)
         assert action == HVACAction.IDLE
 
     def test_heating_restarts_at_target_minus_tolerance(self, mock_bt):
         """Heating restarts once temp drops back to target - tolerance."""
         mock_bt.cur_temp = 20.49  # just below 20.5
-        mock_bt._tolerance_last_action = HVACAction.IDLE
-        action = mock_bt._compute_hvac_action()
+        mock_bt._hysteresis.last_action = HVACAction.IDLE
+        action = _compute_and_commit(mock_bt)
         assert action == HVACAction.HEATING
 
 
@@ -155,7 +169,7 @@ class TestTrvOverrideDoesNotCorruptHysteresis:
     """Verify that TRV reporting 'heating' does NOT break the hysteresis state.
 
     Even when the TRV is still physically heating (e.g. thermal inertia),
-    the internal hysteresis state (_tolerance_last_action) must remain
+    the internal hysteresis state (_hysteresis.last_action) must remain
     based on the tolerance decision, not the TRV override.
     """
 
@@ -163,11 +177,11 @@ class TestTrvOverrideDoesNotCorruptHysteresis:
         """Test that hysteresis state survives TRV override.
 
         After tolerance says stop, a heating TRV must not corrupt
-        _tolerance_last_action so that the next cycle uses the strict threshold.
+        _hysteresis.last_action so that the next cycle uses the strict threshold.
         """
         # Step 1: temp reaches target → tolerance says IDLE
         mock_bt.cur_temp = 21.0
-        mock_bt._tolerance_last_action = HVACAction.HEATING
+        mock_bt._hysteresis.last_action = HVACAction.HEATING
 
         # Simulate TRV still reporting heating
         mock_bt.real_trvs = {
@@ -175,11 +189,11 @@ class TestTrvOverrideDoesNotCorruptHysteresis:
         }
         mock_bt.hass = MagicMock()
 
-        mock_bt._compute_hvac_action()
+        _compute_and_commit(mock_bt)
         # The reported action may be HEATING (TRV override), that's OK for display
         # But the hysteresis state must NOT be HEATING:
-        assert mock_bt._tolerance_last_action == HVACAction.IDLE, (
-            "TRV override corrupted _tolerance_last_action; "
+        assert mock_bt._hysteresis.last_action == HVACAction.IDLE, (
+            "TRV override corrupted _hysteresis.last_action; "
             "next cycle would use lenient threshold, heating up to target + tol"
         )
 
@@ -196,13 +210,13 @@ class TestTrvOverrideDoesNotCorruptHysteresis:
 
         # Cycle 1: At target, tolerance says stop
         mock_bt.cur_temp = 21.0
-        mock_bt._tolerance_last_action = HVACAction.HEATING
-        mock_bt._compute_hvac_action()
+        mock_bt._hysteresis.last_action = HVACAction.HEATING
+        _compute_and_commit(mock_bt)
 
         # Cycle 2: TRV stops heating, temp drops slightly but still above target - tol
         mock_bt.real_trvs["climate.trv_1"]["hvac_action"] = "idle"
         mock_bt.cur_temp = 20.8  # between target - tol (20.5) and target (21.0)
-        action = mock_bt._compute_hvac_action()
+        action = _compute_and_commit(mock_bt)
 
         assert action == HVACAction.IDLE, (
             f"Expected IDLE at {mock_bt.cur_temp}°C (between target-tol and target "

--- a/tests/unit/test_hvac_action.py
+++ b/tests/unit/test_hvac_action.py
@@ -1,0 +1,333 @@
+"""Tests for the pure HVAC action computation module.
+
+Covers:
+  - should_heat_with_tolerance  (hysteresis helper)
+  - to_pct                      (valve normalisation)
+  - compute_hvac_action         (main FSM, TRV overrides, idempotency)
+  - Hysteresis state transitions
+"""
+
+from homeassistant.components.climate.const import HVACAction, HVACMode
+import pytest
+
+from custom_components.better_thermostat.utils.hvac_action import (
+    HvacActionResult,
+    ToleranceHysteresis,
+    TrvSnapshot,
+    compute_hvac_action,
+    should_heat_with_tolerance,
+    to_pct,
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _default_kwargs(**overrides):
+    """Return compute_hvac_action kwargs with sensible defaults."""
+    base = dict(
+        hysteresis=ToleranceHysteresis(),
+        cur_temp=20.0,
+        target_temp=21.0,
+        cool_target=None,
+        hvac_mode=HVACMode.HEAT,
+        bt_hvac_mode=HVACMode.HEAT,
+        window_open=False,
+        tolerance=0.5,
+        ignore_states=False,
+        trv_snapshots=[],
+        device_name="Test",
+    )
+    base.update(overrides)
+    return base
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Group 1: should_heat_with_tolerance
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestShouldHeatWithTolerance:
+    def test_starts_below_threshold(self):
+        """Heating starts when temp < target - tolerance."""
+        assert should_heat_with_tolerance(20.4, 21.0, 0.5, HVACAction.IDLE) is True
+
+    def test_no_start_in_band_when_idle(self):
+        """No start in [target-tol, target) when previously IDLE."""
+        assert should_heat_with_tolerance(20.7, 21.0, 0.5, HVACAction.IDLE) is False
+
+    def test_continues_in_band_when_heating(self):
+        """Continue heating in band when already HEATING."""
+        assert should_heat_with_tolerance(20.7, 21.0, 0.5, HVACAction.HEATING) is True
+
+    def test_stops_at_target(self):
+        assert should_heat_with_tolerance(21.0, 21.0, 0.5, HVACAction.HEATING) is False
+
+    def test_stops_above_target(self):
+        assert should_heat_with_tolerance(21.3, 21.0, 0.5, HVACAction.HEATING) is False
+
+    def test_negative_tolerance_clamped(self):
+        """Negative tolerance is clamped to 0 → same as zero tolerance."""
+        # With tol=0, heat_on_threshold = target = 21.0; cur=20.9 < 21.0 → True
+        assert should_heat_with_tolerance(20.9, 21.0, -1.0, HVACAction.IDLE) is True
+
+    def test_zero_tolerance(self):
+        """Zero tolerance: heat_on == heat_off == target."""
+        assert should_heat_with_tolerance(20.99, 21.0, 0.0, HVACAction.IDLE) is True
+        assert should_heat_with_tolerance(21.0, 21.0, 0.0, HVACAction.IDLE) is False
+
+    def test_none_previous_action(self):
+        """None previous_action treated as non-HEATING → strict threshold."""
+        assert should_heat_with_tolerance(20.4, 21.0, 0.5, None) is True
+        assert should_heat_with_tolerance(20.7, 21.0, 0.5, None) is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Group 2: to_pct
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestToPct:
+    def test_fraction_to_percent(self):
+        assert to_pct(0.5) == 50.0
+
+    def test_already_percent(self):
+        assert to_pct(50) == 50.0
+
+    def test_zero(self):
+        assert to_pct(0.0) == 0.0
+
+    def test_one_stays(self):
+        """1.0 is NOT in [0, 1) → returned as-is (already percent)."""
+        assert to_pct(1.0) == 1.0
+
+    def test_invalid_returns_none(self):
+        assert to_pct("abc") is None
+        assert to_pct(None) is None
+
+    def test_string_number(self):
+        assert to_pct("0.5") == 50.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Group 3: compute_hvac_action
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestComputeHvacAction:
+    # --- early exits -------------------------------------------------------
+
+    def test_none_temps_idle(self):
+        r = compute_hvac_action(**_default_kwargs(cur_temp=None))
+        assert r.action == HVACAction.IDLE
+
+    def test_none_target_idle(self):
+        r = compute_hvac_action(**_default_kwargs(target_temp=None))
+        assert r.action == HVACAction.IDLE
+
+    def test_off_mode_returns_off(self):
+        r = compute_hvac_action(**_default_kwargs(hvac_mode=HVACMode.OFF))
+        assert r.action == HVACAction.OFF
+
+    def test_bt_off_mode_returns_off(self):
+        r = compute_hvac_action(**_default_kwargs(bt_hvac_mode=HVACMode.OFF))
+        assert r.action == HVACAction.OFF
+
+    def test_window_open_returns_idle(self):
+        r = compute_hvac_action(**_default_kwargs(window_open=True))
+        assert r.action == HVACAction.IDLE
+
+    # --- heating decision --------------------------------------------------
+
+    def test_heating_below_threshold(self):
+        r = compute_hvac_action(**_default_kwargs(cur_temp=20.4))
+        assert r.action == HVACAction.HEATING
+
+    def test_idle_in_band(self):
+        r = compute_hvac_action(**_default_kwargs(cur_temp=20.7))
+        assert r.action == HVACAction.IDLE
+
+    def test_continues_heating_in_band(self):
+        hyst = ToleranceHysteresis(last_action=HVACAction.HEATING)
+        r = compute_hvac_action(**_default_kwargs(hysteresis=hyst, cur_temp=20.7))
+        assert r.action == HVACAction.HEATING
+
+    def test_stops_at_target(self):
+        hyst = ToleranceHysteresis(last_action=HVACAction.HEATING)
+        r = compute_hvac_action(**_default_kwargs(hysteresis=hyst, cur_temp=21.0))
+        assert r.action == HVACAction.IDLE
+
+    # --- cooling -----------------------------------------------------------
+
+    def test_cooling_in_heat_cool(self):
+        r = compute_hvac_action(
+            **_default_kwargs(
+                hvac_mode=HVACMode.HEAT_COOL,
+                bt_hvac_mode=HVACMode.HEAT_COOL,
+                cur_temp=27.0,
+                cool_target=25.0,
+                tolerance=0.5,
+            )
+        )
+        assert r.action == HVACAction.COOLING
+
+    def test_no_cooling_within_tolerance(self):
+        r = compute_hvac_action(
+            **_default_kwargs(
+                hvac_mode=HVACMode.HEAT_COOL,
+                bt_hvac_mode=HVACMode.HEAT_COOL,
+                cur_temp=25.3,
+                cool_target=25.0,
+                tolerance=0.5,
+            )
+        )
+        assert r.action != HVACAction.COOLING
+
+    # --- TRV override ------------------------------------------------------
+
+    def test_trv_hvac_action_override(self):
+        snap = TrvSnapshot(trv_id="trv1", hvac_action="heating")
+        r = compute_hvac_action(
+            **_default_kwargs(cur_temp=20.7, trv_snapshots=[snap])
+        )
+        assert r.action == HVACAction.HEATING
+
+    def test_trv_valve_position_override(self):
+        snap = TrvSnapshot(trv_id="trv1", valve_position=0.5)
+        r = compute_hvac_action(
+            **_default_kwargs(cur_temp=20.7, trv_snapshots=[snap])
+        )
+        assert r.action == HVACAction.HEATING
+
+    def test_trv_last_valve_percent_override(self):
+        snap = TrvSnapshot(trv_id="trv1", last_valve_percent=30.0)
+        r = compute_hvac_action(
+            **_default_kwargs(cur_temp=20.7, trv_snapshots=[snap])
+        )
+        assert r.action == HVACAction.HEATING
+
+    def test_ignore_states_skips_trv_override(self):
+        snap = TrvSnapshot(trv_id="trv1", hvac_action="heating")
+        r = compute_hvac_action(
+            **_default_kwargs(cur_temp=20.7, ignore_states=True, trv_snapshots=[snap])
+        )
+        assert r.action == HVACAction.IDLE
+
+    def test_ignore_trv_states_per_trv(self):
+        snap = TrvSnapshot(
+            trv_id="trv1", ignore_trv_states=True, hvac_action="heating"
+        )
+        r = compute_hvac_action(
+            **_default_kwargs(cur_temp=20.7, trv_snapshots=[snap])
+        )
+        assert r.action == HVACAction.IDLE
+
+    def test_trv_zero_valve_no_override(self):
+        snap = TrvSnapshot(trv_id="trv1", valve_position=0.0)
+        r = compute_hvac_action(
+            **_default_kwargs(cur_temp=20.7, trv_snapshots=[snap])
+        )
+        assert r.action == HVACAction.IDLE
+
+    # --- idempotency -------------------------------------------------------
+
+    def test_hysteresis_not_mutated(self):
+        """Calling compute_hvac_action must NOT mutate the hysteresis input."""
+        hyst = ToleranceHysteresis(last_action=HVACAction.HEATING, hold_active=True)
+        compute_hvac_action(**_default_kwargs(hysteresis=hyst, cur_temp=21.0))
+        assert hyst.last_action == HVACAction.HEATING
+        assert hyst.hold_active is True
+
+    def test_result_is_frozen(self):
+        r = compute_hvac_action(**_default_kwargs())
+        with pytest.raises(AttributeError):
+            r.action = HVACAction.OFF  # type: ignore[misc]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Group 4: Hysteresis state transitions
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestHysteresisTransitions:
+    def test_tolerance_decision_not_corrupted_by_trv(self):
+        """TRV override must not change tolerance_decision."""
+        hyst = ToleranceHysteresis(last_action=HVACAction.HEATING)
+        snap = TrvSnapshot(trv_id="trv1", hvac_action="heating")
+        r = compute_hvac_action(
+            **_default_kwargs(hysteresis=hyst, cur_temp=21.0, trv_snapshots=[snap])
+        )
+        # Tolerance says IDLE (at target), TRV overrides to HEATING
+        assert r.tolerance_decision == HVACAction.IDLE
+        assert r.action == HVACAction.HEATING
+        # Hysteresis state follows tolerance, not TRV
+        assert r.new_last_action == HVACAction.IDLE
+
+    def test_hold_active_set_in_band(self):
+        r = compute_hvac_action(**_default_kwargs(cur_temp=20.7))
+        assert r.new_hold_active is True
+
+    def test_hold_active_false_when_heating(self):
+        r = compute_hvac_action(**_default_kwargs(cur_temp=20.4))
+        assert r.new_hold_active is False
+
+    def test_hold_active_false_when_cooling(self):
+        r = compute_hvac_action(
+            **_default_kwargs(
+                hvac_mode=HVACMode.HEAT_COOL,
+                bt_hvac_mode=HVACMode.HEAT_COOL,
+                cur_temp=27.0,
+                cool_target=25.0,
+            )
+        )
+        assert r.new_hold_active is False
+
+    def test_100_dashboard_reads_no_drift(self):
+        """Repeated reads with same hysteresis must produce identical results."""
+        hyst = ToleranceHysteresis(last_action=HVACAction.IDLE)
+        kwargs = _default_kwargs(hysteresis=hyst, cur_temp=20.7)
+        first = compute_hvac_action(**kwargs)
+        for _ in range(100):
+            r = compute_hvac_action(**kwargs)
+            assert r == first
+        # Hysteresis unchanged
+        assert hyst.last_action == HVACAction.IDLE
+        assert hyst.hold_active is False
+
+    def test_full_cycle_heat_stop_band_restart(self):
+        """Full cycle: cold → heat → reach target → band → cold → restart."""
+        hyst = ToleranceHysteresis()
+
+        # 1) Cold start → HEATING
+        r = compute_hvac_action(**_default_kwargs(hysteresis=hyst, cur_temp=20.0))
+        assert r.action == HVACAction.HEATING
+        hyst.last_action = r.new_last_action
+        hyst.hold_active = r.new_hold_active
+
+        # 2) In band, still heating (hysteresis)
+        r = compute_hvac_action(**_default_kwargs(hysteresis=hyst, cur_temp=20.7))
+        assert r.action == HVACAction.HEATING
+        hyst.last_action = r.new_last_action
+        hyst.hold_active = r.new_hold_active
+
+        # 3) Reach target → IDLE
+        r = compute_hvac_action(**_default_kwargs(hysteresis=hyst, cur_temp=21.0))
+        assert r.action == HVACAction.IDLE
+        hyst.last_action = r.new_last_action
+        hyst.hold_active = r.new_hold_active
+
+        # 4) Drop into band → still IDLE (hysteresis prevents restart)
+        r = compute_hvac_action(**_default_kwargs(hysteresis=hyst, cur_temp=20.7))
+        assert r.action == HVACAction.IDLE
+        hyst.last_action = r.new_last_action
+        hyst.hold_active = r.new_hold_active
+
+        # 5) Drop below band → HEATING again
+        r = compute_hvac_action(**_default_kwargs(hysteresis=hyst, cur_temp=20.4))
+        assert r.action == HVACAction.HEATING
+
+    def test_off_resets_hysteresis(self):
+        """OFF mode should reset hysteresis to IDLE."""
+        hyst = ToleranceHysteresis(last_action=HVACAction.HEATING, hold_active=True)
+        r = compute_hvac_action(**_default_kwargs(hysteresis=hyst, hvac_mode=HVACMode.OFF))
+        assert r.new_last_action == HVACAction.IDLE
+        assert r.new_hold_active is False


### PR DESCRIPTION
## Summary

- **Extract** the 167-line `_compute_hvac_action()` body from `climate.py` into a pure, side-effect-free `utils/hvac_action.py` module
- **Make `hvac_action` property idempotent** — dashboard reads no longer mutate hysteresis state (fixes double-mutation per cycle)
- **Mutation only at intentional call-sites** (`calculate_heating_power`, `calculate_heat_loss`, `controlling.py`) via explicit `_commit_hvac_action()`

### New module: `utils/hvac_action.py` (~250 lines)

| Symbol | Purpose |
|--------|---------|
| `ToleranceHysteresis` | Mutable dataclass holding hysteresis state (replaces loose `_tolerance_last_action` + `_tolerance_hold_active`) |
| `HvacActionResult` | Frozen result with action, tolerance_decision, and new hysteresis state |
| `TrvSnapshot` | Frozen, pre-resolved TRV data (decouples from hass state access) |
| `compute_hvac_action()` | Pure function — same inputs → same outputs, no side-effects |
| `should_heat_with_tolerance()` | Pure hysteresis helper |
| `to_pct()` | Valve normalization (was inline closure) |

### Changes in `climate.py` (net -77 lines)

- `__init__`: Two loose attributes → `_hysteresis = ToleranceHysteresis()`
- `hvac_action` property: Returns cached `attr_hvac_action` or pure speculative read — **no mutation**
- `_build_trv_snapshots()`: Resolves TRV state (hass fallback + cache side-effect stays in climate.py)
- `_compute_hvac_action_pure()` / `_commit_hvac_action()`: Pure compute + explicit commit
- `_should_heat_with_tolerance()`: Delegates to module-level function

### Other changes

- `controlling.py`: Uses `_compute_hvac_action_pure()` + `_commit_hvac_action()` directly (no wrapper needed)
- `test_heating_tolerance.py`: Fixtures updated to use `_hysteresis` dataclass

## Test plan

- [x] 40 new unit tests in `tests/unit/test_hvac_action.py` (hysteresis, TRV overrides, idempotency, full cycle)
- [x] All 19 existing `test_heating_tolerance.py` tests pass with updated fixtures
- [x] Full suite: 914 tests pass
- [x] `mypy --strict` clean on new module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added eight automation blueprints for thermostat notifications, alerts, and scheduling (heating status, errors, humidity, battery, window control, night mode, presence-based presets, weekly schedules).
  * Introduced new device triggers for automations (heating state, window open/close, temperature reached, device errors, humidity/battery alerts).
  * Expanded documentation with setup guides, FAQs, recommended devices, and configuration walkthroughs.

* **Improvements**
  * Enhanced multi-TRV valve control and distribution.
  * Improved sensor tracking and state management.
  * Better support for additional device models and local calibration types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->