### PR TITLE
refactor: Extract valve maintenance into utils/valve_maintenance.py

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1796,9 +1796,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
     async def _run_valve_maintenance(self, trvs: list[str]) -> None:
         """Perform valve exercise: open fully, then close, restore state, and reschedule.
 
-        State mutations (ignore_states, in_maintenance, control_queue,
-        ignore_trv_states) stay here; the pure open/close/restore logic
-        lives in ``utils.valve_maintenance``.
+        Manages state flags (ignore_states, in_maintenance,
+        ignore_trv_states, control_queue) around the pure maintenance
+        logic in ``utils.valve_maintenance``.
         """
         if self.in_maintenance:
             return

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1803,6 +1803,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if self.in_maintenance:
             return
         self.in_maintenance = True
+        # Suppress control loop briefly to prevent interference during maintenance
         self.ignore_states = True
 
         try:
@@ -1870,14 +1871,19 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             )
         finally:
             self._control_needed_after_maintenance = False
+            # Always release ignore_states after maintenance.
+            # If we restore a previous True here, the control_queue loop can get
+            # stuck sleeping forever and never consume queued control actions.
             self.ignore_states = False
             self.in_maintenance = False
 
-            # Trigger one control cycle after maintenance so BT immediately resumes
+            # Trigger one control cycle after maintenance so BT immediately
+            # resumes with the latest window/temp/target states.
             if self.bt_hvac_mode != HVACMode.OFF:
                 try:
                     self.control_queue_task.put_nowait(self)
                 except Exception:
+                    # Queue full or not ready; periodic tick will eventually catch up.
                     pass
 
     # -- Unified state persistence helpers ------------------------------------

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -104,7 +104,6 @@ from .utils.const import (
     CONF_SENSOR_WINDOW,
     CONF_TARGET_TEMP_STEP,
     CONF_TOLERANCE,
-    CONF_VALVE_MAINTENANCE,
     CONF_WEATHER,
     CONF_WINDOW_TIMEOUT,
     CONF_WINDOW_TIMEOUT_AFTER,
@@ -128,6 +127,13 @@ from .utils.helpers import (
     normalize_hvac_mode,
 )
 from .utils.state_manager import StateManager
+from .utils.valve_maintenance import (
+    build_trv_snapshots,
+    collect_maintenance_trvs,
+    compute_initial_maintenance,
+    compute_next_maintenance,
+    run_valve_maintenance,
+)
 from .utils.watcher import (
     await_optional_sensors,
     check_and_update_degraded_mode,
@@ -1655,41 +1661,14 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
             # Ventilwartung: separaten Tick nur aktivieren, wenn mindestens ein TRV sie eingeschaltet hat
             try:
-                any_maintenance = any(
-                    bool(
-                        (trv_info.get("advanced", {}) or {}).get(
-                            CONF_VALVE_MAINTENANCE, False
-                        )
-                    )
-                    for trv_info in self.real_trvs.values()
-                )
+                maint_trvs = collect_maintenance_trvs(self.real_trvs)
             except Exception:
-                any_maintenance = False
+                maint_trvs = []
 
-            if any_maintenance:
-                # Re-calculate next maintenance based on loaded TRV quirks
-                # (overrides the random 1h-5d startup default)
-                min_interval_hours = 168  # Default 7 days
-                for trv_id, trv_data in self.real_trvs.items():
-                    if bool(
-                        (trv_data.get("advanced", {}) or {}).get(
-                            CONF_VALVE_MAINTENANCE, False
-                        )
-                    ):
-                        quirks = trv_data.get("model_quirks")
-                        interval = int(
-                            getattr(quirks, "VALVE_MAINTENANCE_INTERVAL_HOURS", 168)
-                        )
-                        min_interval_hours = min(min_interval_hours, interval)
-
-                now = datetime.now()
-                # Schedule initial run: randomize within [1h, min(5d, interval)]
-                # If interval is very short (e.g. 12h), respect it.
-                max_delay_hours = min(24 * 5, min_interval_hours)
-                delay_hours = randint(1, max(2, max_delay_hours))
-
-                self.next_valve_maintenance = now + timedelta(hours=delay_hours)
-
+            if maint_trvs:
+                self.next_valve_maintenance = compute_initial_maintenance(
+                    self.real_trvs, maint_trvs
+                )
                 self.async_on_remove(
                     async_track_time_interval(
                         self.hass, self._maintenance_tick, timedelta(minutes=5)
@@ -1801,12 +1780,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             return
 
         # Check if any TRV actually has maintenance enabled
-        trvs_to_service: list[str] = []
         try:
-            for trv_id, info in self.real_trvs.items():
-                adv = info.get("advanced", {}) or {}
-                if bool(adv.get(CONF_VALVE_MAINTENANCE, False)):
-                    trvs_to_service.append(trv_id)
+            trvs_to_service = collect_maintenance_trvs(self.real_trvs)
         except Exception:
             trvs_to_service = []
 
@@ -1819,190 +1794,90 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.hass.async_create_task(self._run_valve_maintenance(trvs_to_service))
 
     async def _run_valve_maintenance(self, trvs: list[str]) -> None:
-        """Perform valve exercise: open fully, then close, restore state, and reschedule."""
+        """Perform valve exercise: open fully, then close, restore state, and reschedule.
+
+        State mutations (ignore_states, in_maintenance, control_queue,
+        ignore_trv_states) stay here; the pure open/close/restore logic
+        lives in ``utils.valve_maintenance``.
+        """
         if self.in_maintenance:
             return
         self.in_maintenance = True
-        # Suppress control loop briefly
         self.ignore_states = True
-        now = datetime.now()
 
         try:
-            _LOGGER.info(
-                "better_thermostat %s: starting valve maintenance for %d TRV(s)",
-                self.device_name,
-                len(trvs),
-            )
-
-            # Snapshot TRV states & determine method per TRV
-            trv_infos: dict[str, dict] = {}
-
-            # Helper to set valve percent; delegate records last percent/method.
-            async def _set_valve_pct(trv_id: str, pct: int) -> bool:
-                try:
-                    from .adapters.delegate import set_valve as _delegate_set_valve
-
-                    ok = await _delegate_set_valve(self, trv_id, int(pct))
-                    return bool(ok)
-                except Exception:
-                    return False
-
+            # Set per-TRV guard
             for trv_id in trvs:
-                # Per-TRV guard
                 try:
                     self.real_trvs[trv_id]["ignore_trv_states"] = True
                 except Exception:
                     pass
 
-                trv_state = self.hass.states.get(trv_id)
-                if trv_state is None:
-                    _LOGGER.debug(
-                        "better_thermostat %s: maintenance skip %s (state None)",
-                        self.device_name,
-                        trv_id,
-                    )
-                    # Release guard for this TRV (we won't touch it)
+            # Build snapshots (skips TRVs with state=None)
+            infos = build_trv_snapshots(
+                self.real_trvs, trvs, self.hass.states.get, self.device_name
+            )
+            serviced_ids = {info.entity_id for info in infos}
+
+            # Release guard for TRVs that were skipped (state=None)
+            for trv_id in trvs:
+                if trv_id not in serviced_ids:
                     try:
                         self.real_trvs[trv_id]["ignore_trv_states"] = False
                     except Exception:
                         pass
-                    continue
 
-                cur_mode = trv_state.state
-                cur_temp = trv_state.attributes.get("temperature")
+            # Bind adapter callbacks to self
+            from .adapters.delegate import set_valve as _delegate_set_valve
 
-                valve_entity = (self.real_trvs.get(trv_id, {}) or {}).get(
-                    "valve_position_entity"
-                )
-                quirks = (self.real_trvs.get(trv_id, {}) or {}).get("model_quirks")
-                support_valve = bool(valve_entity) or bool(
-                    getattr(quirks, "override_set_valve", None)
-                )
-                _calibration_type = (
-                    (self.real_trvs.get(trv_id, {}) or {})
-                    .get("advanced", {})
-                    .get("calibration")
-                )
-
-                use_direct_valve = bool(
-                    support_valve
-                    and _calibration_type == CalibrationType.DIRECT_VALVE_BASED
-                )
-
-                trv_infos[trv_id] = {
-                    "cur_mode": cur_mode,
-                    "cur_temp": cur_temp,
-                    "use_direct_valve": use_direct_valve,
-                    "max_t": (self.real_trvs.get(trv_id, {}) or {}).get("max_temp", 30),
-                    "min_t": (self.real_trvs.get(trv_id, {}) or {}).get("min_temp", 5),
-                }
-
-            async def _open_step(trv_id: str):
-                info = trv_infos.get(trv_id)
-                if not info:
-                    return
-                if info["use_direct_valve"]:
-                    await _set_valve_pct(trv_id, 100)
-                    return
-                # temp-extremes fallback: only when TRV is not OFF
-                if info["cur_mode"] != HVACMode.OFF:
-                    await adapter_set_temperature(self, trv_id, info["max_t"])
-
-            async def _close_step(trv_id: str):
-                info = trv_infos.get(trv_id)
-                if not info:
-                    return
-                if info["use_direct_valve"]:
-                    await _set_valve_pct(trv_id, 0)
-                    return
-                if info["cur_mode"] != HVACMode.OFF:
-                    await adapter_set_temperature(self, trv_id, info["min_t"])
-
-            # Execute in synchronized steps across all TRVs (much faster than sequential).
-            # Open all -> wait -> close all -> wait (repeat twice)
-            for i in range(2):
-                _LOGGER.debug(
-                    "better_thermostat %s: valve maintenance cycle %d/2 starting for %d TRV(s)",
-                    self.device_name,
-                    i + 1,
-                    len(trv_infos),
-                )
-                await asyncio.gather(
-                    *(_open_step(trv_id) for trv_id in trv_infos),
-                    return_exceptions=True,
-                )
-                await asyncio.sleep(30)
-                await asyncio.gather(
-                    *(_close_step(trv_id) for trv_id in trv_infos),
-                    return_exceptions=True,
-                )
-                await asyncio.sleep(30)
-
-            # Restore previous setpoint and mode for all TRVs
-            async def _restore_one(trv_id: str):
-                info = trv_infos.get(trv_id)
-                if not info:
-                    return
+            async def _set_valve(entity_id: str, pct: int) -> bool:
                 try:
-                    if info.get("cur_temp") is not None:
-                        await adapter_set_temperature(self, trv_id, info["cur_temp"])
+                    ok = await _delegate_set_valve(self, entity_id, int(pct))
+                    return bool(ok)
                 except Exception:
-                    pass
-                try:
-                    await adapter_set_hvac_mode(self, trv_id, info["cur_mode"])
-                except Exception:
-                    pass
-                try:
-                    self.real_trvs[trv_id]["ignore_trv_states"] = False
-                except Exception:
-                    pass
+                    return False
 
-            await asyncio.gather(
-                *(_restore_one(trv_id) for trv_id in trv_infos), return_exceptions=True
+            async def _set_temp(entity_id: str, temp: float) -> None:
+                await adapter_set_temperature(self, entity_id, temp)
+
+            async def _set_mode(entity_id: str, mode: str) -> None:
+                await adapter_set_hvac_mode(self, entity_id, mode)
+
+            # Run 2× open/close + restore
+            await run_valve_maintenance(
+                infos,
+                set_valve_fn=_set_valve,
+                set_temperature_fn=_set_temp,
+                set_hvac_mode_fn=_set_mode,
+                device_name=self.device_name,
             )
 
-            # Ensure we always release the guard for TRVs that were skipped above.
-            for trv_id in trvs:
-                if trv_id in trv_infos:
-                    continue
+            # Release per-TRV guard for serviced TRVs
+            for trv_id in serviced_ids:
                 try:
                     self.real_trvs[trv_id]["ignore_trv_states"] = False
                 except Exception:
                     pass
 
-            # Determine next maintenance interval based on the quirks of enabled TRVs
-            min_interval_hours = 168  # Default 7 days
-            for trv_id in trvs:
-                quirks = (self.real_trvs.get(trv_id, {}) or {}).get("model_quirks")
-                # Default to 168 hours if quirk doesn't specify
-                interval = int(getattr(quirks, "VALVE_MAINTENANCE_INTERVAL_HOURS", 168))
-                min_interval_hours = min(min_interval_hours, interval)
-
-            # Add ~7% randomization
-            variance = max(1, int(min_interval_hours * 0.07))
-            self.next_valve_maintenance = now + timedelta(
-                hours=min_interval_hours + randint(0, variance)
+            # Schedule next run
+            self.next_valve_maintenance = compute_next_maintenance(
+                self.real_trvs, trvs
             )
             _LOGGER.info(
-                "better_thermostat %s: valve maintenance finished; next at %s",
+                "better_thermostat %s: next valve maintenance at %s",
                 self.device_name,
                 self.next_valve_maintenance,
             )
         finally:
             self._control_needed_after_maintenance = False
-            # Always release ignore_states after maintenance.
-            # If we restore a previous True here, the control_queue loop can get stuck
-            # sleeping forever and never consume queued control actions.
             self.ignore_states = False
             self.in_maintenance = False
 
             # Trigger one control cycle after maintenance so BT immediately resumes
-            # with the latest window/temp/target states.
             if self.bt_hvac_mode != HVACMode.OFF:
                 try:
                     self.control_queue_task.put_nowait(self)
                 except Exception:
-                    # Queue full or not ready; periodic tick will eventually catch up.
                     pass
 
     # -- Unified state persistence helpers ------------------------------------
@@ -3305,14 +3180,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     self.device_name,
                 )
                 return
-            # gather enabled TRVs
-            trvs_to_service = [
-                trv_id
-                for trv_id, info in self.real_trvs.items()
-                if bool(
-                    (info.get("advanced", {}) or {}).get(CONF_VALVE_MAINTENANCE, False)
-                )
-            ]
+            trvs_to_service = collect_maintenance_trvs(self.real_trvs)
             if not trvs_to_service:
                 _LOGGER.debug(
                     "better_thermostat %s: valve maintenance requested, but no TRV has it enabled",

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -11,13 +11,17 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from random import randint
-from typing import Any, Awaitable, Callable
+from typing import Awaitable, Callable
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.core import State
 
 from .const import CONF_VALVE_MAINTENANCE, CalibrationType
 
 _LOGGER = logging.getLogger(__name__)
+
+# Type alias for the nested TRV config dicts used throughout the codebase.
+TrvMap = dict[str, dict[str, object]]
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -41,18 +45,24 @@ class MaintenanceTrvInfo:
 # ---------------------------------------------------------------------------
 
 
-def collect_maintenance_trvs(real_trvs: dict[str, dict[str, Any]]) -> list[str]:
+def _get_advanced(info: dict[str, object]) -> dict[str, object]:
+    """Safely extract the ``advanced`` sub-dict from a TRV config entry."""
+    adv = info.get("advanced")
+    return adv if isinstance(adv, dict) else {}
+
+
+def collect_maintenance_trvs(real_trvs: TrvMap) -> list[str]:
     """Return entity-ids of TRVs that have valve maintenance enabled."""
     result: list[str] = []
     for trv_id, info in real_trvs.items():
-        adv = info.get("advanced", {}) or {}
+        adv = _get_advanced(info)
         if bool(adv.get(CONF_VALVE_MAINTENANCE, False)):
             result.append(trv_id)
     return result
 
 
 def compute_next_maintenance(
-    real_trvs: dict[str, dict[str, Any]],
+    real_trvs: TrvMap,
     trv_ids: list[str],
     *,
     now: datetime | None = None,
@@ -76,7 +86,7 @@ def compute_next_maintenance(
 
 
 def compute_initial_maintenance(
-    real_trvs: dict[str, dict[str, Any]],
+    real_trvs: TrvMap,
     trv_ids: list[str],
     *,
     now: datetime | None = None,
@@ -106,9 +116,9 @@ def compute_initial_maintenance(
 
 
 def build_trv_snapshots(
-    real_trvs: dict[str, dict[str, Any]],
+    real_trvs: TrvMap,
     trv_ids: list[str],
-    get_state: Callable[[str], Any],
+    get_state: Callable[[str], State | None],
     device_name: str,
 ) -> list[MaintenanceTrvInfo]:
     """Build per-TRV snapshots needed for the maintenance cycle.
@@ -133,19 +143,22 @@ def build_trv_snapshots(
         support_valve = bool(valve_entity) or bool(
             getattr(quirks, "override_set_valve", None)
         )
-        cal_type = (trv_data.get("advanced", {}) or {}).get("calibration")
+        adv = _get_advanced(trv_data)
+        cal_type = adv.get("calibration")
         use_direct = bool(
             support_valve and cal_type == CalibrationType.DIRECT_VALVE_BASED
         )
 
+        raw_max = trv_data.get("max_temp", 30)
+        raw_min = trv_data.get("min_temp", 5)
         infos.append(
             MaintenanceTrvInfo(
                 entity_id=trv_id,
                 cur_mode=trv_state.state,
                 cur_temp=trv_state.attributes.get("temperature"),
                 use_direct_valve=use_direct,
-                max_temp=trv_data.get("max_temp", 30),
-                min_temp=trv_data.get("min_temp", 5),
+                max_temp=float(raw_max) if isinstance(raw_max, (int, float)) else 30.0,
+                min_temp=float(raw_min) if isinstance(raw_min, (int, float)) else 5.0,
             )
         )
     return infos

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -1,8 +1,7 @@
 """Pure-logic helpers for periodic TRV valve maintenance.
 
-Extracted from climate.py to keep the main entity slim.  All functions
-are side-effect-free (aside from the async callbacks they receive) and
-can be tested without Home Assistant.
+All functions are side-effect-free (aside from the async callbacks they
+receive) and can be tested without Home Assistant.
 """
 
 from __future__ import annotations

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -1,0 +1,294 @@
+"""Pure-logic helpers for periodic TRV valve maintenance.
+
+Extracted from climate.py to keep the main entity slim.  All functions
+are side-effect-free (aside from the async callbacks they receive) and
+can be tested without Home Assistant.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from random import randint
+from typing import Any, Awaitable, Callable
+
+from homeassistant.components.climate.const import HVACMode
+
+from .const import CONF_VALVE_MAINTENANCE, CalibrationType
+
+_LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MaintenanceTrvInfo:
+    """Snapshot of a single TRV needed during valve maintenance."""
+
+    entity_id: str
+    cur_mode: str
+    cur_temp: float | None
+    use_direct_valve: bool
+    max_temp: float
+    min_temp: float
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def collect_maintenance_trvs(real_trvs: dict[str, dict[str, Any]]) -> list[str]:
+    """Return entity-ids of TRVs that have valve maintenance enabled."""
+    result: list[str] = []
+    for trv_id, info in real_trvs.items():
+        adv = info.get("advanced", {}) or {}
+        if bool(adv.get(CONF_VALVE_MAINTENANCE, False)):
+            result.append(trv_id)
+    return result
+
+
+def compute_next_maintenance(
+    real_trvs: dict[str, dict[str, Any]],
+    trv_ids: list[str],
+    *,
+    now: datetime | None = None,
+) -> datetime:
+    """Compute the next maintenance datetime based on TRV quirks.
+
+    Uses the *minimum* interval across all enabled TRVs and adds ~7 %
+    random jitter.
+    """
+    if now is None:
+        now = datetime.now()
+
+    min_interval_hours = 168  # default 7 days
+    for trv_id in trv_ids:
+        quirks = (real_trvs.get(trv_id, {}) or {}).get("model_quirks")
+        interval = int(getattr(quirks, "VALVE_MAINTENANCE_INTERVAL_HOURS", 168))
+        min_interval_hours = min(min_interval_hours, interval)
+
+    variance = max(1, int(min_interval_hours * 0.07))
+    return now + timedelta(hours=min_interval_hours + randint(0, variance))
+
+
+def compute_initial_maintenance(
+    real_trvs: dict[str, dict[str, Any]],
+    trv_ids: list[str],
+    *,
+    now: datetime | None = None,
+) -> datetime:
+    """Compute the *first* maintenance datetime after startup.
+
+    Randomises within ``[1 h, min(5 d, interval)]`` so that multiple
+    BT instances don't all fire at once.
+    """
+    if now is None:
+        now = datetime.now()
+
+    min_interval_hours = 168
+    for trv_id in trv_ids:
+        quirks = (real_trvs.get(trv_id, {}) or {}).get("model_quirks")
+        interval = int(getattr(quirks, "VALVE_MAINTENANCE_INTERVAL_HOURS", 168))
+        min_interval_hours = min(min_interval_hours, interval)
+
+    max_delay_hours = min(24 * 5, min_interval_hours)
+    delay_hours = randint(1, max(2, max_delay_hours))
+    return now + timedelta(hours=delay_hours)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot builder
+# ---------------------------------------------------------------------------
+
+
+def build_trv_snapshots(
+    real_trvs: dict[str, dict[str, Any]],
+    trv_ids: list[str],
+    get_state: Callable[[str], Any],
+    device_name: str,
+) -> list[MaintenanceTrvInfo]:
+    """Build per-TRV snapshots needed for the maintenance cycle.
+
+    *get_state* should be ``hass.states.get``.  TRVs whose HA state is
+    ``None`` are silently skipped (logged at debug level).
+    """
+    infos: list[MaintenanceTrvInfo] = []
+    for trv_id in trv_ids:
+        trv_state = get_state(trv_id)
+        if trv_state is None:
+            _LOGGER.debug(
+                "better_thermostat %s: maintenance skip %s (state None)",
+                device_name,
+                trv_id,
+            )
+            continue
+
+        trv_data = real_trvs.get(trv_id, {}) or {}
+        valve_entity = trv_data.get("valve_position_entity")
+        quirks = trv_data.get("model_quirks")
+        support_valve = bool(valve_entity) or bool(
+            getattr(quirks, "override_set_valve", None)
+        )
+        cal_type = (trv_data.get("advanced", {}) or {}).get("calibration")
+        use_direct = bool(
+            support_valve and cal_type == CalibrationType.DIRECT_VALVE_BASED
+        )
+
+        infos.append(
+            MaintenanceTrvInfo(
+                entity_id=trv_id,
+                cur_mode=trv_state.state,
+                cur_temp=trv_state.attributes.get("temperature"),
+                use_direct_valve=use_direct,
+                max_temp=trv_data.get("max_temp", 30),
+                min_temp=trv_data.get("min_temp", 5),
+            )
+        )
+    return infos
+
+
+# ---------------------------------------------------------------------------
+# Async step helpers
+# ---------------------------------------------------------------------------
+
+SetValveFn = Callable[[str, int], Awaitable[bool]]
+SetTemperatureFn = Callable[[str, float], Awaitable[None]]
+SetHvacModeFn = Callable[[str, str], Awaitable[None]]
+
+
+async def _set_valve_pct(
+    trv_id: str, pct: int, set_valve_fn: SetValveFn
+) -> bool:
+    """Set valve percentage via callback."""
+    try:
+        return bool(await set_valve_fn(trv_id, int(pct)))
+    except Exception:
+        return False
+
+
+async def open_step(
+    info: MaintenanceTrvInfo,
+    *,
+    set_valve_fn: SetValveFn,
+    set_temperature_fn: SetTemperatureFn,
+) -> None:
+    """Open a TRV valve fully."""
+    if info.use_direct_valve:
+        await _set_valve_pct(info.entity_id, 100, set_valve_fn)
+        return
+    if info.cur_mode != HVACMode.OFF:
+        await set_temperature_fn(info.entity_id, info.max_temp)
+
+
+async def close_step(
+    info: MaintenanceTrvInfo,
+    *,
+    set_valve_fn: SetValveFn,
+    set_temperature_fn: SetTemperatureFn,
+) -> None:
+    """Close a TRV valve fully."""
+    if info.use_direct_valve:
+        await _set_valve_pct(info.entity_id, 0, set_valve_fn)
+        return
+    if info.cur_mode != HVACMode.OFF:
+        await set_temperature_fn(info.entity_id, info.min_temp)
+
+
+async def restore_one(
+    info: MaintenanceTrvInfo,
+    *,
+    set_temperature_fn: SetTemperatureFn,
+    set_hvac_mode_fn: SetHvacModeFn,
+) -> None:
+    """Restore a TRV to its pre-maintenance state."""
+    if info.cur_temp is not None:
+        try:
+            await set_temperature_fn(info.entity_id, info.cur_temp)
+        except Exception:
+            pass
+    try:
+        await set_hvac_mode_fn(info.entity_id, info.cur_mode)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Main orchestrator
+# ---------------------------------------------------------------------------
+
+
+async def run_valve_maintenance(
+    infos: list[MaintenanceTrvInfo],
+    *,
+    set_valve_fn: SetValveFn,
+    set_temperature_fn: SetTemperatureFn,
+    set_hvac_mode_fn: SetHvacModeFn,
+    device_name: str,
+    cycle_sleep: float = 30,
+) -> None:
+    """Execute 2 x open/close cycles on all TRVs, then restore state.
+
+    This is the pure async orchestrator.  State mutations on
+    ``self`` (ignore_states, in_maintenance, control_queue) stay in
+    ``climate.py``'s wrapper.
+    """
+    _LOGGER.info(
+        "better_thermostat %s: starting valve maintenance for %d TRV(s)",
+        device_name,
+        len(infos),
+    )
+
+    for i in range(2):
+        _LOGGER.debug(
+            "better_thermostat %s: valve maintenance cycle %d/2 starting for %d TRV(s)",
+            device_name,
+            i + 1,
+            len(infos),
+        )
+        await asyncio.gather(
+            *(
+                open_step(
+                    info,
+                    set_valve_fn=set_valve_fn,
+                    set_temperature_fn=set_temperature_fn,
+                )
+                for info in infos
+            ),
+            return_exceptions=True,
+        )
+        await asyncio.sleep(cycle_sleep)
+        await asyncio.gather(
+            *(
+                close_step(
+                    info,
+                    set_valve_fn=set_valve_fn,
+                    set_temperature_fn=set_temperature_fn,
+                )
+                for info in infos
+            ),
+            return_exceptions=True,
+        )
+        await asyncio.sleep(cycle_sleep)
+
+    # Restore
+    await asyncio.gather(
+        *(
+            restore_one(
+                info,
+                set_temperature_fn=set_temperature_fn,
+                set_hvac_mode_fn=set_hvac_mode_fn,
+            )
+            for info in infos
+        ),
+        return_exceptions=True,
+    )
+
+    _LOGGER.info(
+        "better_thermostat %s: valve maintenance finished",
+        device_name,
+    )

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -193,6 +193,7 @@ async def open_step(
     if info.use_direct_valve:
         await _set_valve_pct(info.entity_id, 100, set_valve_fn)
         return
+    # Temp-extremes fallback: only when TRV is not OFF (OFF TRVs ignore temp changes)
     if info.cur_mode != HVACMode.OFF:
         await set_temperature_fn(info.entity_id, info.max_temp)
 
@@ -207,6 +208,7 @@ async def close_step(
     if info.use_direct_valve:
         await _set_valve_pct(info.entity_id, 0, set_valve_fn)
         return
+    # Temp-extremes fallback: only when TRV is not OFF (OFF TRVs ignore temp changes)
     if info.cur_mode != HVACMode.OFF:
         await set_temperature_fn(info.entity_id, info.min_temp)
 
@@ -255,6 +257,8 @@ async def run_valve_maintenance(
         len(infos),
     )
 
+    # Execute in synchronized steps across all TRVs (much faster than sequential).
+    # Open all → wait → close all → wait (repeat twice).
     for i in range(2):
         _LOGGER.debug(
             "better_thermostat %s: valve maintenance cycle %d/2 starting for %d TRV(s)",

--- a/tests/unit/test_valve_maintenance.py
+++ b/tests/unit/test_valve_maintenance.py
@@ -1,0 +1,473 @@
+"""Tests for utils/valve_maintenance.py – pure valve-maintenance helpers.
+
+Covers:
+  - collect_maintenance_trvs  (filter enabled TRVs)
+  - compute_next_maintenance  (interval + jitter)
+  - compute_initial_maintenance (startup delay)
+  - build_trv_snapshots       (snapshot builder)
+  - open_step / close_step    (direct valve vs temp-based)
+  - restore_one               (temperature + mode restore)
+  - run_valve_maintenance      (full 2-cycle orchestrator)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.better_thermostat.utils.valve_maintenance import (
+    MaintenanceTrvInfo,
+    build_trv_snapshots,
+    close_step,
+    collect_maintenance_trvs,
+    compute_initial_maintenance,
+    compute_next_maintenance,
+    open_step,
+    restore_one,
+    run_valve_maintenance,
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _trv(
+    *,
+    maintenance: bool = False,
+    max_temp: float = 30,
+    min_temp: float = 5,
+    quirks: object | None = None,
+    valve_entity: str | None = None,
+    calibration: str | None = None,
+) -> dict:
+    """Build a ``real_trvs[entity_id]`` dict for testing."""
+    return {
+        "advanced": {"valve_maintenance": maintenance, "calibration": calibration},
+        "max_temp": max_temp,
+        "min_temp": min_temp,
+        "model_quirks": quirks,
+        "valve_position_entity": valve_entity,
+    }
+
+
+def _info(
+    entity_id: str = "climate.trv1",
+    cur_mode: str = "heat",
+    cur_temp: float | None = 21.0,
+    use_direct_valve: bool = False,
+    max_temp: float = 30,
+    min_temp: float = 5,
+) -> MaintenanceTrvInfo:
+    """Convenience factory for MaintenanceTrvInfo."""
+    return MaintenanceTrvInfo(
+        entity_id=entity_id,
+        cur_mode=cur_mode,
+        cur_temp=cur_temp,
+        use_direct_valve=use_direct_valve,
+        max_temp=max_temp,
+        min_temp=min_temp,
+    )
+
+
+def _ha_state(state: str = "heat", temperature: float = 21.0):
+    """Mimic a HA State object."""
+    return SimpleNamespace(state=state, attributes={"temperature": temperature})
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# collect_maintenance_trvs
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestCollectMaintenanceTrvs:
+    def test_empty_dict(self):
+        assert collect_maintenance_trvs({}) == []
+
+    def test_no_maintenance_enabled(self):
+        trvs = {"trv1": _trv(maintenance=False), "trv2": _trv(maintenance=False)}
+        assert collect_maintenance_trvs(trvs) == []
+
+    def test_single_enabled(self):
+        trvs = {"trv1": _trv(maintenance=True)}
+        assert collect_maintenance_trvs(trvs) == ["trv1"]
+
+    def test_mixed(self):
+        trvs = {
+            "trv1": _trv(maintenance=False),
+            "trv2": _trv(maintenance=True),
+            "trv3": _trv(maintenance=True),
+        }
+        result = collect_maintenance_trvs(trvs)
+        assert set(result) == {"trv2", "trv3"}
+
+    def test_missing_advanced_key(self):
+        """TRV dict without 'advanced' should not crash."""
+        trvs = {"trv1": {"max_temp": 30}}
+        assert collect_maintenance_trvs(trvs) == []
+
+    def test_advanced_is_none(self):
+        """advanced=None should not crash."""
+        trvs = {"trv1": {"advanced": None}}
+        assert collect_maintenance_trvs(trvs) == []
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# compute_next_maintenance
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestComputeNextMaintenance:
+    def test_default_168h(self):
+        """Without quirks the interval should be ~168 h (± 7 % jitter)."""
+        trvs = {"trv1": _trv(maintenance=True)}
+        now = datetime(2026, 1, 1)
+        result = compute_next_maintenance(trvs, ["trv1"], now=now)
+        delta_h = (result - now).total_seconds() / 3600
+        assert 168 <= delta_h <= 168 + 168 * 0.07 + 1
+
+    def test_quirks_shorter_interval(self):
+        quirks = SimpleNamespace(VALVE_MAINTENANCE_INTERVAL_HOURS=24)
+        trvs = {"trv1": _trv(maintenance=True, quirks=quirks)}
+        now = datetime(2026, 1, 1)
+        result = compute_next_maintenance(trvs, ["trv1"], now=now)
+        delta_h = (result - now).total_seconds() / 3600
+        # 24h + up to ~7% jitter
+        assert 24 <= delta_h <= 24 + 24 * 0.07 + 1
+
+    def test_minimum_across_trvs(self):
+        q12 = SimpleNamespace(VALVE_MAINTENANCE_INTERVAL_HOURS=12)
+        q48 = SimpleNamespace(VALVE_MAINTENANCE_INTERVAL_HOURS=48)
+        trvs = {
+            "trv1": _trv(maintenance=True, quirks=q12),
+            "trv2": _trv(maintenance=True, quirks=q48),
+        }
+        now = datetime(2026, 1, 1)
+        result = compute_next_maintenance(trvs, ["trv1", "trv2"], now=now)
+        delta_h = (result - now).total_seconds() / 3600
+        # Should use 12h (minimum)
+        assert 12 <= delta_h <= 12 + 12 * 0.07 + 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# compute_initial_maintenance
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestComputeInitialMaintenance:
+    def test_default_range(self):
+        trvs = {"trv1": _trv(maintenance=True)}
+        now = datetime(2026, 1, 1)
+        result = compute_initial_maintenance(trvs, ["trv1"], now=now)
+        delta_h = (result - now).total_seconds() / 3600
+        assert 1 <= delta_h <= 24 * 5
+
+    def test_short_quirk_constrains_delay(self):
+        quirks = SimpleNamespace(VALVE_MAINTENANCE_INTERVAL_HOURS=6)
+        trvs = {"trv1": _trv(maintenance=True, quirks=quirks)}
+        now = datetime(2026, 1, 1)
+        result = compute_initial_maintenance(trvs, ["trv1"], now=now)
+        delta_h = (result - now).total_seconds() / 3600
+        # max_delay_hours = min(120, 6) = 6 → randint(1, max(2, 6))
+        assert 1 <= delta_h <= 6
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# build_trv_snapshots
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestBuildTrvSnapshots:
+    def test_state_none_skipped(self):
+        trvs = {"trv1": _trv(maintenance=True)}
+        result = build_trv_snapshots(trvs, ["trv1"], lambda _: None, "Test")
+        assert result == []
+
+    def test_basic_snapshot(self):
+        trvs = {"trv1": _trv(maintenance=True, max_temp=28, min_temp=6)}
+
+        def get_state(eid):
+            return _ha_state("heat", 22.0)
+
+        result = build_trv_snapshots(trvs, ["trv1"], get_state, "Test")
+        assert len(result) == 1
+        assert result[0].entity_id == "trv1"
+        assert result[0].cur_mode == "heat"
+        assert result[0].cur_temp == 22.0
+        assert result[0].max_temp == 28
+        assert result[0].min_temp == 6
+        assert result[0].use_direct_valve is False
+
+    def test_direct_valve_detection(self):
+        quirks = SimpleNamespace(override_set_valve=lambda: None)
+        trvs = {
+            "trv1": _trv(
+                maintenance=True,
+                quirks=quirks,
+                calibration="direct_valve_based",
+            )
+        }
+        result = build_trv_snapshots(
+            trvs, ["trv1"], lambda _: _ha_state(), "Test"
+        )
+        assert result[0].use_direct_valve is True
+
+    def test_valve_entity_direct(self):
+        trvs = {
+            "trv1": _trv(
+                maintenance=True,
+                valve_entity="number.valve",
+                calibration="direct_valve_based",
+            )
+        }
+        result = build_trv_snapshots(
+            trvs, ["trv1"], lambda _: _ha_state(), "Test"
+        )
+        assert result[0].use_direct_valve is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# open_step / close_step
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestOpenStep:
+    @pytest.mark.asyncio
+    async def test_direct_valve_sets_100(self):
+        valve_fn = AsyncMock(return_value=True)
+        temp_fn = AsyncMock()
+        info = _info(use_direct_valve=True)
+        await open_step(info, set_valve_fn=valve_fn, set_temperature_fn=temp_fn)
+        valve_fn.assert_awaited_once_with("climate.trv1", 100)
+        temp_fn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_temp_based_sets_max(self):
+        valve_fn = AsyncMock()
+        temp_fn = AsyncMock()
+        info = _info(use_direct_valve=False, max_temp=28)
+        await open_step(info, set_valve_fn=valve_fn, set_temperature_fn=temp_fn)
+        temp_fn.assert_awaited_once_with("climate.trv1", 28)
+        valve_fn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_off_mode_no_call(self):
+        valve_fn = AsyncMock()
+        temp_fn = AsyncMock()
+        info = _info(cur_mode="off", use_direct_valve=False)
+        await open_step(info, set_valve_fn=valve_fn, set_temperature_fn=temp_fn)
+        valve_fn.assert_not_awaited()
+        temp_fn.assert_not_awaited()
+
+
+class TestCloseStep:
+    @pytest.mark.asyncio
+    async def test_direct_valve_sets_0(self):
+        valve_fn = AsyncMock(return_value=True)
+        temp_fn = AsyncMock()
+        info = _info(use_direct_valve=True)
+        await close_step(info, set_valve_fn=valve_fn, set_temperature_fn=temp_fn)
+        valve_fn.assert_awaited_once_with("climate.trv1", 0)
+        temp_fn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_temp_based_sets_min(self):
+        valve_fn = AsyncMock()
+        temp_fn = AsyncMock()
+        info = _info(use_direct_valve=False, min_temp=4)
+        await close_step(info, set_valve_fn=valve_fn, set_temperature_fn=temp_fn)
+        temp_fn.assert_awaited_once_with("climate.trv1", 4)
+        valve_fn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_off_mode_no_call(self):
+        valve_fn = AsyncMock()
+        temp_fn = AsyncMock()
+        info = _info(cur_mode="off", use_direct_valve=False)
+        await close_step(info, set_valve_fn=valve_fn, set_temperature_fn=temp_fn)
+        valve_fn.assert_not_awaited()
+        temp_fn.assert_not_awaited()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# restore_one
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRestoreOne:
+    @pytest.mark.asyncio
+    async def test_restores_temp_and_mode(self):
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+        info = _info(cur_temp=22.5, cur_mode="heat")
+        await restore_one(info, set_temperature_fn=temp_fn, set_hvac_mode_fn=mode_fn)
+        temp_fn.assert_awaited_once_with("climate.trv1", 22.5)
+        mode_fn.assert_awaited_once_with("climate.trv1", "heat")
+
+    @pytest.mark.asyncio
+    async def test_cur_temp_none_skips_temperature(self):
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+        info = _info(cur_temp=None)
+        await restore_one(info, set_temperature_fn=temp_fn, set_hvac_mode_fn=mode_fn)
+        temp_fn.assert_not_awaited()
+        mode_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_temp_exception_still_sets_mode(self):
+        temp_fn = AsyncMock(side_effect=RuntimeError("fail"))
+        mode_fn = AsyncMock()
+        info = _info(cur_temp=20.0, cur_mode="heat")
+        await restore_one(info, set_temperature_fn=temp_fn, set_hvac_mode_fn=mode_fn)
+        mode_fn.assert_awaited_once_with("climate.trv1", "heat")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# run_valve_maintenance (full orchestrator)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestRunValveMaintenance:
+    @pytest.mark.asyncio
+    async def test_two_cycles_open_close(self):
+        """Each TRV should get 2 open + 2 close calls."""
+        valve_fn = AsyncMock(return_value=True)
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+        infos = [_info(entity_id="trv1", use_direct_valve=True)]
+
+        await run_valve_maintenance(
+            infos,
+            set_valve_fn=valve_fn,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            device_name="Test",
+            cycle_sleep=0,
+        )
+
+        # 2 opens (100) + 2 closes (0) = 4 valve calls
+        assert valve_fn.await_count == 4
+        calls = [c.args for c in valve_fn.await_args_list]
+        assert calls == [("trv1", 100), ("trv1", 0), ("trv1", 100), ("trv1", 0)]
+
+    @pytest.mark.asyncio
+    async def test_multiple_trvs(self):
+        valve_fn = AsyncMock(return_value=True)
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+        infos = [
+            _info(entity_id="trv1", use_direct_valve=True),
+            _info(entity_id="trv2", use_direct_valve=True),
+        ]
+
+        await run_valve_maintenance(
+            infos,
+            set_valve_fn=valve_fn,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            device_name="Test",
+            cycle_sleep=0,
+        )
+
+        # 2 TRVs × (2 open + 2 close) = 8 valve calls
+        assert valve_fn.await_count == 8
+
+    @pytest.mark.asyncio
+    async def test_temp_based_cycles(self):
+        valve_fn = AsyncMock()
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+        infos = [_info(entity_id="trv1", use_direct_valve=False, max_temp=30, min_temp=5)]
+
+        await run_valve_maintenance(
+            infos,
+            set_valve_fn=valve_fn,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            device_name="Test",
+            cycle_sleep=0,
+        )
+
+        # 2 opens (max) + 2 closes (min) = 4 temp calls, plus 1 restore = 5
+        assert temp_fn.await_count == 5
+        valve_fn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_restores_after_cycles(self):
+        valve_fn = AsyncMock(return_value=True)
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+        infos = [_info(entity_id="trv1", cur_temp=22.0, cur_mode="heat", use_direct_valve=True)]
+
+        await run_valve_maintenance(
+            infos,
+            set_valve_fn=valve_fn,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            device_name="Test",
+            cycle_sleep=0,
+        )
+
+        # restore calls temp + mode
+        temp_fn.assert_awaited_once_with("trv1", 22.0)
+        mode_fn.assert_awaited_once_with("trv1", "heat")
+
+    @pytest.mark.asyncio
+    async def test_empty_infos_noop(self):
+        """No TRVs → no calls, no crash."""
+        valve_fn = AsyncMock()
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+
+        await run_valve_maintenance(
+            [],
+            set_valve_fn=valve_fn,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            device_name="Test",
+            cycle_sleep=0,
+        )
+
+        valve_fn.assert_not_awaited()
+        temp_fn.assert_not_awaited()
+        mode_fn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_off_trvs_skipped_in_temp_mode(self):
+        """TRVs in OFF mode with temp-based control should not get open/close calls."""
+        valve_fn = AsyncMock()
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+        infos = [_info(entity_id="trv1", cur_mode="off", use_direct_valve=False, cur_temp=20.0)]
+
+        await run_valve_maintenance(
+            infos,
+            set_valve_fn=valve_fn,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            device_name="Test",
+            cycle_sleep=0,
+        )
+
+        # open/close skipped for OFF, but restore still sets temp + mode
+        assert temp_fn.await_count == 1  # only restore
+        mode_fn.assert_awaited_once_with("trv1", "off")
+
+    @pytest.mark.asyncio
+    async def test_exception_in_valve_fn_doesnt_crash(self):
+        """Exceptions in callbacks should be caught (return_exceptions=True)."""
+        valve_fn = AsyncMock(side_effect=RuntimeError("hardware fault"))
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+        infos = [_info(entity_id="trv1", use_direct_valve=True)]
+
+        # Should not raise
+        await run_valve_maintenance(
+            infos,
+            set_valve_fn=valve_fn,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            device_name="Test",
+            cycle_sleep=0,
+        )


### PR DESCRIPTION
## Summary
- Extract ~270 lines of valve maintenance logic from `climate.py` into a pure, mypy-strict-clean module `utils/valve_maintenance.py`
- Callback-based adapter access (`set_valve_fn`, `set_temperature_fn`, `set_hvac_mode_fn`) — no dependency on `self`
- Thin wrapper in `climate.py` retained for state mutations (`in_maintenance`, `ignore_states`, `ignore_trv_states`, `control_queue`)
- Net reduction: **-132 lines** in `climate.py`

### New module exports
| Function | Purpose |
|----------|---------|
| `MaintenanceTrvInfo` | Frozen dataclass — per-TRV snapshot |
| `collect_maintenance_trvs()` | Filter TRVs with maintenance enabled |
| `compute_next_maintenance()` | Next schedule (interval + 7% jitter) |
| `compute_initial_maintenance()` | Startup delay (randomised) |
| `build_trv_snapshots()` | Build snapshots via `hass.states.get` callback |
| `open_step()` / `close_step()` | Direct valve or temp-based open/close |
| `restore_one()` | Restore temperature + HVAC mode |
| `run_valve_maintenance()` | Async orchestrator: 2× open/close + restore |

## Test plan
- [x] 31 new unit tests in `tests/unit/test_valve_maintenance.py`
- [x] Full suite green (905 passed)
- [x] `mypy --strict` clean on `valve_maintenance.py` (0 errors in our file)