### PR TITLE
refactor: Extract preset management into PresetManager

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -23,14 +23,7 @@ from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
     ATTR_TARGET_TEMP_STEP,
-    PRESET_ACTIVITY,
-    PRESET_AWAY,
-    PRESET_BOOST,
-    PRESET_COMFORT,
-    PRESET_ECO,
-    PRESET_HOME,
     PRESET_NONE,
-    PRESET_SLEEP,
     ClimateEntityFeature,
     HVACAction,
     HVACMode,
@@ -142,6 +135,7 @@ from .utils.hvac_action import (
     compute_hvac_action,
     should_heat_with_tolerance,
 )
+from .utils.preset_manager import PresetManager
 from .utils.state_manager import StateManager
 from .utils.thermal_learning import HeatingPowerTracker, HeatLossTracker
 from .utils.valve_maintenance import (
@@ -425,7 +419,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self._device_class = device_class
         self._state_class = state_class
         self._hvac_list = [HVACMode.HEAT, HVACMode.OFF]
-        self._preset_mode = PRESET_NONE
         self.map_on_hvac_mode = HVACMode.HEAT
         self.next_valve_maintenance = dt_util.now() + timedelta(
             hours=randint(1, 24 * 5)
@@ -459,34 +452,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.bt_update_lock = False
         self.startup_running = True
         self._saved_temperature = None
-        # ECO mode removed; preserved eco preset via PRESET_ECO
-        self._preset_temperature = (
-            None  # Temperature saved before entering any preset mode
-        )
-        self._enabled_presets = enabled_presets
-        if not self._enabled_presets:
-            self._enabled_presets = [
-                PRESET_AWAY,
-                PRESET_BOOST,
-                PRESET_SLEEP,
-                PRESET_COMFORT,
-                PRESET_ECO,
-                PRESET_ACTIVITY,
-                PRESET_HOME,
-            ]
-
-        self._preset_temperatures = {
-            PRESET_NONE: 20.0,
-            PRESET_AWAY: 16.0,
-            PRESET_BOOST: 24.0,
-            PRESET_COMFORT: 21.0,
-            PRESET_ECO: 19.0,
-            PRESET_HOME: 20.0,
-            PRESET_SLEEP: 18.0,
-            PRESET_ACTIVITY: 22.0,
-        }
-        # Keep a copy of original configured preset temperatures to detect user customization
-        self._original_preset_temperatures = self._preset_temperatures.copy()
+        if enabled_presets:
+            self.preset_mgr = PresetManager(enabled_presets=enabled_presets)
+        else:
+            self.preset_mgr = PresetManager()
         # Config entry id (same as unique id passed in) used for durable persistence beyond RestoreEntity
         self._config_entry_id = self._unique_id
         self.last_avg_outdoor_temp = None
@@ -1327,12 +1296,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             )
             # Restore preset mode if present
             _old_preset = old_state.attributes.get("preset_mode")
-            if isinstance(_old_preset, str) and _old_preset in (
-                [PRESET_NONE] + list(self._preset_temperatures)
+            if (
+                isinstance(_old_preset, str)
+                and _old_preset in self.preset_mgr.available_modes
             ):
-                self._preset_mode = _old_preset
+                self.preset_mgr.mode = _old_preset
             else:
-                self._preset_mode = PRESET_NONE
+                self.preset_mgr.mode = PRESET_NONE
 
             _LOGGER.debug(
                 "better_thermostat %s: applying restored preset temperature...",
@@ -1341,11 +1311,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             # If we restored a preset (not NONE) and we have a stored temperature for it,
             # ensure target temp matches (unless the restored target was already equal).
             if (
-                self._preset_mode is not None
-                and self._preset_mode != PRESET_NONE
-                and self._preset_mode in self._preset_temperatures
+                self.preset_mgr.mode is not None
+                and self.preset_mgr.mode != PRESET_NONE
             ):
-                preset_temp = self._preset_temperatures[self._preset_mode]
+                preset_temp = self.preset_mgr.get_temperature(self.preset_mgr.mode)
                 # Only override if different to avoid masking manual restore logic
                 if (
                     isinstance(preset_temp, (int, float))
@@ -1355,7 +1324,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     _LOGGER.debug(
                         "better_thermostat %s: Applying restored preset %s temperature %s after startup",
                         self.device_name,
-                        self._preset_mode,
+                        self.preset_mgr.mode,
                         preset_temp,
                     )
                     self.bt_target_temp = preset_temp
@@ -1426,7 +1395,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 old_state.attributes.get(ATTR_STATE_PRESET_TEMPERATURE, None)
                 is not None
             ):
-                self._preset_temperature = convert_to_float(
+                self.preset_mgr.saved_temperature = convert_to_float(
                     str(old_state.attributes.get(ATTR_STATE_PRESET_TEMPERATURE, None)),
                     self.device_name,
                     "startup()",
@@ -1435,7 +1404,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             if old_state.attributes.get("preset_mode", None) is not None:
                 restored_preset: str = str(old_state.attributes["preset_mode"])
                 if restored_preset in self.preset_modes:
-                    self._preset_mode = restored_preset
+                    self.preset_mgr.mode = restored_preset
                     _LOGGER.debug(
                         "better_thermostat %s: Restored preset mode: %s",
                         self.device_name,
@@ -2287,7 +2256,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             ATTR_STATE_CALL_FOR_HEAT: self.call_for_heat,
             ATTR_STATE_LAST_CHANGE: self.last_change.isoformat(),
             ATTR_STATE_SAVED_TEMPERATURE: self._saved_temperature,
-            ATTR_STATE_PRESET_TEMPERATURE: self._preset_temperature,
+            ATTR_STATE_PRESET_TEMPERATURE: self.preset_mgr.saved_temperature,
             ATTR_STATE_HUMIDIY: self._current_humidity,
             ATTR_STATE_MAIN_MODE: self.last_main_hvac_mode,
             ATTR_STATE_OFF_TEMPERATURE: self.off_temperature,
@@ -2700,7 +2669,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             "better_thermostat %s: async_set_temperature kwargs=%s, current preset=%s, hvac_mode=%s",
             self.device_name,
             kwargs,
-            self._preset_mode,
+            self.preset_mgr.mode,
             self.bt_hvac_mode,
         )
 
@@ -2798,19 +2767,19 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # For specific presets (Comfort, Eco, etc.), the value is now managed via
         # separate Number entities and should NOT be overwritten by manual setpoint changes.
         if (
-            self._preset_mode == PRESET_NONE
-            and self._preset_mode in self._preset_temperatures
+            self.preset_mgr.mode == PRESET_NONE
+            and self.preset_mgr.mode in self.preset_mgr.temperatures
             and (_new_setpoint is not None or _new_setpointlow is not None)
         ):
             if self.bt_target_temp is not None:
                 applied = float(self.bt_target_temp)
-                old_value = self._preset_temperatures.get(self._preset_mode)
+                old_value = self.preset_mgr.temperatures.get(self.preset_mgr.mode)
                 if old_value != applied:
-                    self._preset_temperatures[self._preset_mode] = applied
+                    self.preset_mgr.temperatures[self.preset_mgr.mode] = applied
                     _LOGGER.debug(
                         "better_thermostat %s: Updated stored preset temperature for %s from %s to %s due to manual change",
                         self.device_name,
-                        self._preset_mode,
+                        self.preset_mgr.mode,
                         old_value,
                         applied,
                     )
@@ -2818,7 +2787,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     _LOGGER.debug(
                         "better_thermostat %s: Manual change equals current stored preset %s value=%s; no update",
                         self.device_name,
-                        self._preset_mode,
+                        self.preset_mgr.mode,
                         applied,
                     )
 
@@ -2937,91 +2906,34 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
     @property
     def preset_mode(self):
         """Return the current preset mode."""
-        return self._preset_mode
+        return self.preset_mgr.mode
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode (HA async API).
 
         NOTE:
             Home Assistant calls `async_set_preset_mode` directly when present.
-            Previously this integration implemented an async coroutine named
-            `set_preset_mode` (without the `async_` prefix). The core will
-            assume a method named `set_preset_mode` is synchronous and will try
-            to execute it inside an executor thread. Because it was actually
-            declared with `async def`, HA attempted to run a coroutine function
-            via `run_in_executor`, resulting in an error similar to:
-
-                "set_preset_mode cannot be used with run_in_executor".
-
-            Renaming the method to `async_set_preset_mode` fixes this by letting
-            HA await the coroutine directly.
+            A coroutine named `set_preset_mode` (without the `async_` prefix)
+            would be assumed synchronous and executed via `run_in_executor`,
+            raising "set_preset_mode cannot be used with run_in_executor".
         """
-        if preset_mode not in self.preset_modes:
-            _LOGGER.warning(
-                "better_thermostat %s: Unsupported preset mode %s",
-                self.device_name,
-                preset_mode,
-            )
-            return
-
         self.bt_update_lock = True
         try:
-            old_preset = self._preset_mode
-            self._preset_mode = preset_mode
-
-            _LOGGER.debug(
-                "better_thermostat %s: Setting preset mode from %s to %s",
-                self.device_name,
-                old_preset,
-                preset_mode,
+            old_preset = self.preset_mgr.mode
+            new_temp = self.preset_mgr.activate(
+                preset_mode, self.bt_target_temp, self.min_temp, self.max_temp
             )
 
-            # If switching from PRESET_NONE to another preset, save current temperature
-            if old_preset == PRESET_NONE and preset_mode != PRESET_NONE:
-                if self._preset_temperature is None:
-                    self._preset_temperature = self.bt_target_temp
-                    _LOGGER.debug(
-                        "better_thermostat %s: Saved temperature %s before entering preset mode",
-                        self.device_name,
-                        self._preset_temperature,
-                    )
-
-            # If switching back to PRESET_NONE, restore saved temperature
-            if preset_mode == PRESET_NONE and self._preset_temperature is not None:
-                self.bt_target_temp = self._preset_temperature
-                self._preset_temperature = None
-                _LOGGER.debug(
-                    "better_thermostat %s: Restored temperature %s from preset mode",
-                    self.device_name,
-                    self.bt_target_temp,
-                )
-
-            # Apply configured preset temperature
-            elif (
-                preset_mode != PRESET_NONE and preset_mode in self._preset_temperatures
-            ):
-                # Use the configured absolute temperature for this preset
-                configured_temp = self._preset_temperatures[preset_mode]
-
-                _LOGGER.debug(
-                    "better_thermostat %s: Preset %s configured: %.1f, Min: %.1f, Max: %.1f",
+            if new_temp is None and preset_mode not in self.preset_mgr.available_modes:
+                _LOGGER.warning(
+                    "better_thermostat %s: Unsupported preset mode %s",
                     self.device_name,
                     preset_mode,
-                    configured_temp,
-                    self.min_temp,
-                    self.max_temp,
                 )
+                return
 
-                # Ensure the temperature is within min/max bounds
-                new_temp = min(self.max_temp, max(self.min_temp, configured_temp))
-
+            if new_temp is not None:
                 self.bt_target_temp = new_temp
-                _LOGGER.debug(
-                    "better_thermostat %s: Applied preset %s with configured temperature: %s°C",
-                    self.device_name,
-                    preset_mode,
-                    new_temp,
-                )
 
             _LOGGER.debug(
                 "better_thermostat %s: After preset change %s -> %s, bt_target_temp=%s, bt_hvac_mode=%s",
@@ -3062,7 +2974,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
     @property
     def preset_modes(self):
         """Return the available preset modes."""
-        return [PRESET_NONE] + self._enabled_presets
+        return self.preset_mgr.available_modes
 
     async def reset_pid_learnings_service(
         self,

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -452,7 +452,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.bt_update_lock = False
         self.startup_running = True
         self._saved_temperature = None
-        if enabled_presets:
+        if enabled_presets is not None:
             self.preset_mgr = PresetManager(enabled_presets=enabled_presets)
         else:
             self.preset_mgr = PresetManager()

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1310,10 +1310,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             )
             # If we restored a preset (not NONE) and we have a stored temperature for it,
             # ensure target temp matches (unless the restored target was already equal).
-            if (
-                self.preset_mgr.mode is not None
-                and self.preset_mgr.mode != PRESET_NONE
-            ):
+            if self.preset_mgr.mode is not None and self.preset_mgr.mode != PRESET_NONE:
                 preset_temp = self.preset_mgr.get_temperature(self.preset_mgr.mode)
                 # Only override if different to avoid masking manual restore logic
                 if (

--- a/custom_components/better_thermostat/number.py
+++ b/custom_components/better_thermostat/number.py
@@ -157,7 +157,7 @@ class BetterThermostatPresetNumber(NumberEntity, RestoreEntity):
         ):
             try:
                 val = float(last_state.state)
-                self._bt_climate._preset_temperatures[self._preset_mode] = val
+                self._bt_climate.preset_mgr.update_temperature(self._preset_mode, val)
                 _LOGGER.debug(
                     "Restored preset %s to %s from number entity state",
                     self._preset_mode,
@@ -174,12 +174,12 @@ class BetterThermostatPresetNumber(NumberEntity, RestoreEntity):
     @property
     def native_value(self) -> float | None:
         """Return the value of the number."""
-        return self._bt_climate._preset_temperatures.get(self._preset_mode)
+        return self._bt_climate.preset_mgr.get_temperature(self._preset_mode)
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         # Update the storage in the climate entity
-        self._bt_climate._preset_temperatures[self._preset_mode] = value
+        self._bt_climate.preset_mgr.update_temperature(self._preset_mode, value)
 
         # If this preset is currently active, update the target temperature immediately
         if self._bt_climate.preset_mode == self._preset_mode:

--- a/custom_components/better_thermostat/utils/preset_manager.py
+++ b/custom_components/better_thermostat/utils/preset_manager.py
@@ -76,9 +76,15 @@ class PresetManager:
             self.saved_temperature = None
             return temp
 
-        # Apply preset temp
-        if preset != PRESET_NONE and preset in self.temperatures:
-            return min(max_temp, max(min_temp, self.temperatures[preset]))
+        # Apply preset temp — fall back through (preset, PRESET_NONE, midpoint)
+        # so an enabled preset missing from ``temperatures`` still produces a
+        # sensible clamped target.
+        if preset != PRESET_NONE:
+            temp = self.temperatures.get(
+                preset,
+                self.temperatures.get(PRESET_NONE, (min_temp + max_temp) / 2),
+            )
+            return min(max_temp, max(min_temp, temp))
 
         return None
 

--- a/custom_components/better_thermostat/utils/preset_manager.py
+++ b/custom_components/better_thermostat/utils/preset_manager.py
@@ -1,0 +1,100 @@
+"""Preset management for Better Thermostat."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from homeassistant.components.climate.const import (
+    PRESET_ACTIVITY,
+    PRESET_AWAY,
+    PRESET_BOOST,
+    PRESET_COMFORT,
+    PRESET_ECO,
+    PRESET_HOME,
+    PRESET_NONE,
+    PRESET_SLEEP,
+)
+
+_DEFAULT_ENABLED_PRESETS: list[str] = [
+    PRESET_AWAY,
+    PRESET_BOOST,
+    PRESET_SLEEP,
+    PRESET_COMFORT,
+    PRESET_ECO,
+    PRESET_ACTIVITY,
+    PRESET_HOME,
+]
+
+_DEFAULT_TEMPERATURES: dict[str, float] = {
+    PRESET_NONE: 20.0,
+    PRESET_AWAY: 16.0,
+    PRESET_BOOST: 24.0,
+    PRESET_COMFORT: 21.0,
+    PRESET_ECO: 19.0,
+    PRESET_HOME: 20.0,
+    PRESET_SLEEP: 18.0,
+    PRESET_ACTIVITY: 22.0,
+}
+
+
+@dataclass
+class PresetManager:
+    """Manages preset modes and their associated temperatures."""
+
+    mode: str = PRESET_NONE
+    temperatures: dict[str, float] = field(default_factory=lambda: _DEFAULT_TEMPERATURES.copy())
+    enabled_presets: list[str] = field(default_factory=lambda: list(_DEFAULT_ENABLED_PRESETS))
+    saved_temperature: float | None = None
+
+    @property
+    def available_modes(self) -> list[str]:
+        """Return list of available preset modes (NONE + enabled)."""
+        return [PRESET_NONE] + self.enabled_presets
+
+    def activate(
+        self,
+        preset: str,
+        current_temp: float,
+        min_temp: float,
+        max_temp: float,
+    ) -> float | None:
+        """Switch to *preset*. Returns new target temperature, or ``None``."""
+        if preset not in self.available_modes:
+            return None
+
+        old = self.mode
+        self.mode = preset
+
+        # Save temp when leaving NONE
+        if old == PRESET_NONE and preset != PRESET_NONE:
+            if self.saved_temperature is None:
+                self.saved_temperature = current_temp
+
+        # Restore when returning to NONE
+        if preset == PRESET_NONE and self.saved_temperature is not None:
+            temp = self.saved_temperature
+            self.saved_temperature = None
+            return temp
+
+        # Apply preset temp
+        if preset != PRESET_NONE and preset in self.temperatures:
+            return min(max_temp, max(min_temp, self.temperatures[preset]))
+
+        return None
+
+    def deactivate(self) -> float | None:
+        """Return to PRESET_NONE. Returns the previously saved temperature."""
+        if self.mode == PRESET_NONE:
+            return None
+        self.mode = PRESET_NONE
+        temp = self.saved_temperature
+        self.saved_temperature = None
+        return temp
+
+    def update_temperature(self, preset: str, value: float) -> None:
+        """Set the stored temperature for *preset*."""
+        self.temperatures[preset] = value
+
+    def get_temperature(self, preset: str) -> float | None:
+        """Return the stored temperature for *preset*, or ``None``."""
+        return self.temperatures.get(preset)

--- a/custom_components/better_thermostat/utils/preset_manager.py
+++ b/custom_components/better_thermostat/utils/preset_manager.py
@@ -42,8 +42,8 @@ class PresetManager:
     """Manages preset modes and their associated temperatures."""
 
     mode: str = PRESET_NONE
-    temperatures: dict[str, float] = field(default_factory=lambda: _DEFAULT_TEMPERATURES.copy())
-    enabled_presets: list[str] = field(default_factory=lambda: list(_DEFAULT_ENABLED_PRESETS))
+    temperatures: dict[str, float] = field(default_factory=_DEFAULT_TEMPERATURES.copy)
+    enabled_presets: list[str] = field(default_factory=_DEFAULT_ENABLED_PRESETS.copy)
     saved_temperature: float | None = None
 
     @property
@@ -52,11 +52,7 @@ class PresetManager:
         return [PRESET_NONE] + self.enabled_presets
 
     def activate(
-        self,
-        preset: str,
-        current_temp: float,
-        min_temp: float,
-        max_temp: float,
+        self, preset: str, current_temp: float, min_temp: float, max_temp: float
     ) -> float | None:
         """Switch to *preset*. Returns new target temperature, or ``None``."""
         if preset not in self.available_modes:
@@ -81,8 +77,7 @@ class PresetManager:
         # sensible clamped target.
         if preset != PRESET_NONE:
             temp = self.temperatures.get(
-                preset,
-                self.temperatures.get(PRESET_NONE, (min_temp + max_temp) / 2),
+                preset, self.temperatures.get(PRESET_NONE, (min_temp + max_temp) / 2)
             )
             return min(max_temp, max(min_temp, temp))
 

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -82,15 +82,16 @@ def mock_bt():
     type(bt).last_heat_loss_stats = property(lambda self: self._loss_tracker.stats)
     type(bt).loss_cycles = property(lambda self: self._loss_tracker.cycles)
     # Presets
-    bt._preset_mode = PRESET_NONE
-    bt._preset_temperature = None
-    bt._preset_temperatures = {
-        PRESET_NONE: 20.0,
-        PRESET_COMFORT: 21.0,
-        PRESET_ECO: 19.0,
-        PRESET_AWAY: 16.0,
-    }
-    bt._enabled_presets = [PRESET_COMFORT, PRESET_ECO, PRESET_AWAY]
+    from custom_components.better_thermostat.utils.preset_manager import PresetManager
+    bt.preset_mgr = PresetManager(
+        temperatures={
+            PRESET_NONE: 20.0,
+            PRESET_COMFORT: 21.0,
+            PRESET_ECO: 19.0,
+            PRESET_AWAY: 16.0,
+        },
+        enabled_presets=[PRESET_COMFORT, PRESET_ECO, PRESET_AWAY],
+    )
     bt.bt_update_lock = False
     # TRVs
     bt.real_trvs = {}
@@ -852,60 +853,60 @@ class TestAsyncSetPresetMode:
         """Invalid preset → warning, no state change."""
         # preset_modes returns [PRESET_NONE] + _enabled_presets
         mock_bt.preset_modes = [PRESET_NONE, PRESET_COMFORT, PRESET_ECO, PRESET_AWAY]
-        old_preset = mock_bt._preset_mode
+        old_preset = mock_bt.preset_mgr.mode
         old_temp = mock_bt.bt_target_temp
         await self._call(mock_bt, "nonexistent")
-        assert mock_bt._preset_mode == old_preset
+        assert mock_bt.preset_mgr.mode == old_preset
         assert mock_bt.bt_target_temp == old_temp
 
     @pytest.mark.asyncio
     async def test_none_to_comfort(self, mock_bt):
         """NONE → Comfort: saves current temp, applies configured comfort temp."""
         mock_bt.preset_modes = [PRESET_NONE, PRESET_COMFORT, PRESET_ECO, PRESET_AWAY]
-        mock_bt._preset_mode = PRESET_NONE
+        mock_bt.preset_mgr.mode = PRESET_NONE
         mock_bt.bt_target_temp = 20.0
-        mock_bt._preset_temperature = None
+        mock_bt.preset_mgr.saved_temperature = None
         mock_bt.min_temp = mock_bt.bt_min_temp
         mock_bt.max_temp = mock_bt.bt_max_temp
         await self._call(mock_bt, PRESET_COMFORT)
-        assert mock_bt._preset_mode == PRESET_COMFORT
-        assert mock_bt._preset_temperature == 20.0  # saved original
+        assert mock_bt.preset_mgr.mode == PRESET_COMFORT
+        assert mock_bt.preset_mgr.saved_temperature == 20.0  # saved original
         assert mock_bt.bt_target_temp == 21.0  # configured comfort temp
 
     @pytest.mark.asyncio
     async def test_comfort_to_none_restores(self, mock_bt):
         """Comfort → NONE: bt_target_temp restored, _preset_temperature cleared."""
         mock_bt.preset_modes = [PRESET_NONE, PRESET_COMFORT, PRESET_ECO, PRESET_AWAY]
-        mock_bt._preset_mode = PRESET_COMFORT
-        mock_bt._preset_temperature = 20.0
+        mock_bt.preset_mgr.mode = PRESET_COMFORT
+        mock_bt.preset_mgr.saved_temperature = 20.0
         mock_bt.bt_target_temp = 21.0
         mock_bt.min_temp = mock_bt.bt_min_temp
         mock_bt.max_temp = mock_bt.bt_max_temp
         await self._call(mock_bt, PRESET_NONE)
-        assert mock_bt._preset_mode == PRESET_NONE
+        assert mock_bt.preset_mgr.mode == PRESET_NONE
         assert mock_bt.bt_target_temp == 20.0  # restored
-        assert mock_bt._preset_temperature is None
+        assert mock_bt.preset_mgr.saved_temperature is None
 
     @pytest.mark.asyncio
     async def test_comfort_to_eco(self, mock_bt):
         """Comfort → Eco: bt_target_temp = eco config, _preset_temperature unchanged."""
         mock_bt.preset_modes = [PRESET_NONE, PRESET_COMFORT, PRESET_ECO, PRESET_AWAY]
-        mock_bt._preset_mode = PRESET_COMFORT
-        mock_bt._preset_temperature = 20.0  # saved from initial manual temp
+        mock_bt.preset_mgr.mode = PRESET_COMFORT
+        mock_bt.preset_mgr.saved_temperature = 20.0  # saved from initial manual temp
         mock_bt.bt_target_temp = 21.0
         mock_bt.min_temp = mock_bt.bt_min_temp
         mock_bt.max_temp = mock_bt.bt_max_temp
         await self._call(mock_bt, PRESET_ECO)
-        assert mock_bt._preset_mode == PRESET_ECO
+        assert mock_bt.preset_mgr.mode == PRESET_ECO
         assert mock_bt.bt_target_temp == 19.0  # eco configured
-        assert mock_bt._preset_temperature == 20.0  # still saved
+        assert mock_bt.preset_mgr.saved_temperature == 20.0  # still saved
 
     @pytest.mark.asyncio
     async def test_eco_to_none_restores_original(self, mock_bt):
         """Eco → NONE: bt_target_temp = saved original temp."""
         mock_bt.preset_modes = [PRESET_NONE, PRESET_COMFORT, PRESET_ECO, PRESET_AWAY]
-        mock_bt._preset_mode = PRESET_ECO
-        mock_bt._preset_temperature = 20.0
+        mock_bt.preset_mgr.mode = PRESET_ECO
+        mock_bt.preset_mgr.saved_temperature = 20.0
         mock_bt.bt_target_temp = 19.0
         mock_bt.min_temp = mock_bt.bt_min_temp
         mock_bt.max_temp = mock_bt.bt_max_temp
@@ -916,8 +917,8 @@ class TestAsyncSetPresetMode:
     async def test_preset_temp_clamped_to_max(self, mock_bt):
         """Preset temp above max → clamped to max_temp."""
         mock_bt.preset_modes = [PRESET_NONE, PRESET_COMFORT, PRESET_ECO, PRESET_AWAY]
-        mock_bt._preset_mode = PRESET_NONE
-        mock_bt._preset_temperatures[PRESET_COMFORT] = 35.0  # above max
+        mock_bt.preset_mgr.mode = PRESET_NONE
+        mock_bt.preset_mgr.temperatures[PRESET_COMFORT] = 35.0  # above max
         mock_bt.min_temp = mock_bt.bt_min_temp
         mock_bt.max_temp = mock_bt.bt_max_temp  # 30.0
         await self._call(mock_bt, PRESET_COMFORT)
@@ -947,7 +948,7 @@ class TestAsyncSetTemperature:
     @pytest.mark.asyncio
     async def test_simple_setpoint(self, mock_bt):
         """Simple temperature set: {ATTR_TEMPERATURE: 22.0}."""
-        mock_bt._preset_mode = PRESET_NONE
+        mock_bt.preset_mgr.mode = PRESET_NONE
         mock_bt.bt_hvac_mode = HVACMode.HEAT
         await self._call(mock_bt, **{ATTR_TEMPERATURE: 22.0})
         assert mock_bt.bt_target_temp == 22.0
@@ -955,7 +956,7 @@ class TestAsyncSetTemperature:
     @pytest.mark.asyncio
     async def test_hvac_mode_change_in_kwargs(self, mock_bt):
         """HVAC mode change passed in kwargs."""
-        mock_bt._preset_mode = PRESET_NONE
+        mock_bt.preset_mgr.mode = PRESET_NONE
         mock_bt.bt_hvac_mode = HVACMode.HEAT
         await self._call(
             mock_bt, **{ATTR_TEMPERATURE: 22.0, ATTR_HVAC_MODE: HVACMode.OFF}
@@ -967,7 +968,7 @@ class TestAsyncSetTemperature:
         """HEAT_COOL with low/high setpoints."""
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_hvac_mode = HVACMode.HEAT_COOL
-        mock_bt._preset_mode = PRESET_NONE
+        mock_bt.preset_mgr.mode = PRESET_NONE
         mock_bt.min_temp = mock_bt.bt_min_temp
         mock_bt.max_temp = mock_bt.bt_max_temp
         await self._call(
@@ -981,7 +982,7 @@ class TestAsyncSetTemperature:
         """Cool target adjusted to be above heat target in HEAT_COOL mode."""
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_hvac_mode = HVACMode.HEAT_COOL
-        mock_bt._preset_mode = PRESET_NONE
+        mock_bt.preset_mgr.mode = PRESET_NONE
         mock_bt.min_temp = mock_bt.bt_min_temp
         mock_bt.max_temp = mock_bt.bt_max_temp
         mock_bt.bt_target_temp = 22.0
@@ -992,7 +993,7 @@ class TestAsyncSetTemperature:
     @pytest.mark.asyncio
     async def test_min_max_clamping(self, mock_bt):
         """Temperature clamped to min/max bounds."""
-        mock_bt._preset_mode = PRESET_NONE
+        mock_bt.preset_mgr.mode = PRESET_NONE
         mock_bt.min_temp = mock_bt.bt_min_temp  # 5.0
         mock_bt.max_temp = mock_bt.bt_max_temp  # 30.0
         await self._call(mock_bt, **{ATTR_TEMPERATURE: 50.0})
@@ -1001,7 +1002,7 @@ class TestAsyncSetTemperature:
     @pytest.mark.asyncio
     async def test_min_clamping(self, mock_bt):
         """Temperature below min → clamped to min."""
-        mock_bt._preset_mode = PRESET_NONE
+        mock_bt.preset_mgr.mode = PRESET_NONE
         mock_bt.min_temp = mock_bt.bt_min_temp  # 5.0
         mock_bt.max_temp = mock_bt.bt_max_temp  # 30.0
         await self._call(mock_bt, **{ATTR_TEMPERATURE: 1.0})
@@ -1010,17 +1011,17 @@ class TestAsyncSetTemperature:
     @pytest.mark.asyncio
     async def test_preset_none_stored_temp_updated(self, mock_bt):
         """In PRESET_NONE, stored temp is updated on manual change."""
-        mock_bt._preset_mode = PRESET_NONE
+        mock_bt.preset_mgr.mode = PRESET_NONE
         mock_bt.bt_target_temp = 20.0
         mock_bt.min_temp = mock_bt.bt_min_temp
         mock_bt.max_temp = mock_bt.bt_max_temp
         await self._call(mock_bt, **{ATTR_TEMPERATURE: 23.0})
-        assert mock_bt._preset_temperatures[PRESET_NONE] == 23.0
+        assert mock_bt.preset_mgr.temperatures[PRESET_NONE] == 23.0
 
     @pytest.mark.asyncio
     async def test_off_mode_no_queue_put(self, mock_bt):
         """In OFF mode, queue.put is NOT called."""
-        mock_bt._preset_mode = PRESET_NONE
+        mock_bt.preset_mgr.mode = PRESET_NONE
         mock_bt.bt_hvac_mode = HVACMode.OFF
         mock_bt.min_temp = mock_bt.bt_min_temp
         mock_bt.max_temp = mock_bt.bt_max_temp
@@ -1030,7 +1031,7 @@ class TestAsyncSetTemperature:
     @pytest.mark.asyncio
     async def test_maintenance_no_queue_put(self, mock_bt):
         """During maintenance, _control_needed_after_maintenance set, no queue.put."""
-        mock_bt._preset_mode = PRESET_NONE
+        mock_bt.preset_mgr.mode = PRESET_NONE
         mock_bt.bt_hvac_mode = HVACMode.HEAT
         mock_bt.in_maintenance = True
         mock_bt.min_temp = mock_bt.bt_min_temp
@@ -1042,7 +1043,7 @@ class TestAsyncSetTemperature:
     @pytest.mark.asyncio
     async def test_queue_put_called_in_heat_mode(self, mock_bt):
         """In HEAT mode, queue.put IS called."""
-        mock_bt._preset_mode = PRESET_NONE
+        mock_bt.preset_mgr.mode = PRESET_NONE
         mock_bt.bt_hvac_mode = HVACMode.HEAT
         mock_bt.min_temp = mock_bt.bt_min_temp
         mock_bt.max_temp = mock_bt.bt_max_temp

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -83,6 +83,7 @@ def mock_bt():
     type(bt).loss_cycles = property(lambda self: self._loss_tracker.cycles)
     # Presets
     from custom_components.better_thermostat.utils.preset_manager import PresetManager
+
     bt.preset_mgr = PresetManager(
         temperatures={
             PRESET_NONE: 20.0,

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -69,9 +69,12 @@ def bt():
     mock._saved_temperature = None
     mock.heating_power = 0.01
     mock.heat_loss_rate = 0.01
-    mock._preset_temperature = None
-    mock._preset_mode = None
-    mock._preset_temperatures = {"comfort": 22.0, "eco": 18.0}
+    from custom_components.better_thermostat.utils.preset_manager import PresetManager
+    mock.preset_mgr = PresetManager(
+        mode="none",
+        temperatures={"none": 20.0, "comfort": 22.0, "eco": 18.0},
+        enabled_presets=["comfort", "eco"],
+    )
     mock.preset_modes = ["none", "comfort", "eco"]
     mock.version = "1.0.0"
     mock.startup_running = True
@@ -355,7 +358,7 @@ class TestRestoreState:
             ATTR_TEMPERATURE: 21.0,
         }
         bt.async_get_last_state = AsyncMock(return_value=old)
-        bt._preset_temperatures = {}
+        bt.preset_mgr.temperatures = {}
 
         states = [_make_trv_state()]
         await BetterThermostat._restore_state(bt, states)
@@ -373,7 +376,7 @@ class TestRestoreState:
         bt.async_get_last_state = AsyncMock(return_value=old)
         bt.bt_min_temp = 5.0
         bt.bt_max_temp = 30.0
-        bt._preset_temperatures = {}
+        bt.preset_mgr.temperatures = {}
 
         states = [_make_trv_state()]
         await BetterThermostat._restore_state(bt, states)
@@ -389,7 +392,7 @@ class TestRestoreState:
         bt.async_get_last_state = AsyncMock(return_value=old)
         bt.bt_min_temp = 5.0
         bt.bt_max_temp = 30.0
-        bt._preset_temperatures = {}
+        bt.preset_mgr.temperatures = {}
 
         states = [_make_trv_state()]
         await BetterThermostat._restore_state(bt, states)
@@ -403,12 +406,12 @@ class TestRestoreState:
         old.state = "heat"
         old.attributes = {ATTR_TEMPERATURE: 22.0, "preset_mode": "comfort"}
         bt.async_get_last_state = AsyncMock(return_value=old)
-        bt._preset_temperatures = {"comfort": 22.0, "eco": 18.0}
+        bt.preset_mgr.temperatures = {"comfort": 22.0, "eco": 18.0}
 
         states = [_make_trv_state()]
         await BetterThermostat._restore_state(bt, states)
 
-        assert bt._preset_mode == "comfort"
+        assert bt.preset_mgr.mode == "comfort"
 
     @pytest.mark.asyncio
     async def test_restores_heating_power_clamped(self, bt):
@@ -420,7 +423,7 @@ class TestRestoreState:
             ATTR_STATE_HEATING_POWER: "999.0",  # way above max
         }
         bt.async_get_last_state = AsyncMock(return_value=old)
-        bt._preset_temperatures = {}
+        bt.preset_mgr.temperatures = {}
 
         states = [_make_trv_state()]
         await BetterThermostat._restore_state(bt, states)
@@ -446,7 +449,7 @@ class TestRestoreState:
         old.state = "heat"
         old.attributes = {ATTR_TEMPERATURE: 21.0, ATTR_STATE_CALL_FOR_HEAT: True}
         bt.async_get_last_state = AsyncMock(return_value=old)
-        bt._preset_temperatures = {}
+        bt.preset_mgr.temperatures = {}
 
         states = [_make_trv_state()]
         await BetterThermostat._restore_state(bt, states)

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -70,6 +70,7 @@ def bt():
     mock.heating_power = 0.01
     mock.heat_loss_rate = 0.01
     from custom_components.better_thermostat.utils.preset_manager import PresetManager
+
     mock.preset_mgr = PresetManager(
         mode="none",
         temperatures={"none": 20.0, "comfort": 22.0, "eco": 18.0},

--- a/tests/unit/test_preset_manager.py
+++ b/tests/unit/test_preset_manager.py
@@ -52,6 +52,11 @@ class TestAvailableModes:
     def test_custom_presets(self, custom_mgr: PresetManager):
         assert custom_mgr.available_modes == [PRESET_NONE, PRESET_COMFORT, PRESET_ECO]
 
+    def test_empty_enabled_presets_yields_none_only(self):
+        """An explicit empty list disables all presets; only PRESET_NONE remains."""
+        mgr = PresetManager(enabled_presets=[])
+        assert mgr.available_modes == [PRESET_NONE]
+
 
 # ---------------------------------------------------------------------------
 # activate()
@@ -111,6 +116,30 @@ class TestActivate:
         mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
         mgr.activate(PRESET_ECO, current_temp=21.0, min_temp=5.0, max_temp=30.0)
         assert mgr.saved_temperature == 20.0
+
+    def test_enabled_preset_missing_from_temperatures_falls_back(self):
+        """A preset that is enabled but absent from ``temperatures`` still yields
+        a clamped target (falls back via PRESET_NONE, then mid-range)."""
+        mgr = PresetManager(
+            enabled_presets=[PRESET_COMFORT],
+            temperatures={PRESET_NONE: 19.5},  # COMFORT intentionally missing
+        )
+        result = mgr.activate(
+            PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0
+        )
+        assert result == 19.5
+        assert mgr.mode == PRESET_COMFORT
+
+    def test_enabled_preset_missing_and_no_none_default_uses_midpoint(self):
+        """No preset value and no PRESET_NONE default → midpoint of min/max."""
+        mgr = PresetManager(
+            enabled_presets=[PRESET_COMFORT],
+            temperatures={},
+        )
+        result = mgr.activate(
+            PRESET_COMFORT, current_temp=20.0, min_temp=10.0, max_temp=30.0
+        )
+        assert result == 20.0  # (10 + 30) / 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_preset_manager.py
+++ b/tests/unit/test_preset_manager.py
@@ -1,6 +1,5 @@
 """Tests for PresetManager."""
 
-import pytest
 from homeassistant.components.climate.const import (
     PRESET_AWAY,
     PRESET_BOOST,
@@ -8,17 +7,18 @@ from homeassistant.components.climate.const import (
     PRESET_ECO,
     PRESET_NONE,
 )
+import pytest
 
 from custom_components.better_thermostat.utils.preset_manager import (
-    PresetManager,
     _DEFAULT_ENABLED_PRESETS,
     _DEFAULT_TEMPERATURES,
+    PresetManager,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mgr() -> PresetManager:
@@ -31,11 +31,7 @@ def custom_mgr() -> PresetManager:
     """Return a PresetManager with custom presets."""
     return PresetManager(
         enabled_presets=[PRESET_COMFORT, PRESET_ECO],
-        temperatures={
-            PRESET_NONE: 20.0,
-            PRESET_COMFORT: 22.0,
-            PRESET_ECO: 18.0,
-        },
+        temperatures={PRESET_NONE: 20.0, PRESET_COMFORT: 22.0, PRESET_ECO: 18.0},
     )
 
 
@@ -43,13 +39,18 @@ def custom_mgr() -> PresetManager:
 # available_modes
 # ---------------------------------------------------------------------------
 
+
 class TestAvailableModes:
+    """available_modes property returns PRESET_NONE followed by enabled presets."""
+
     def test_default_presets(self, mgr: PresetManager):
+        """Defaults expose PRESET_NONE plus the standard enabled set."""
         modes = mgr.available_modes
         assert modes[0] == PRESET_NONE
         assert set(modes[1:]) == set(_DEFAULT_ENABLED_PRESETS)
 
     def test_custom_presets(self, custom_mgr: PresetManager):
+        """Custom enabled_presets are exposed in the configured order."""
         assert custom_mgr.available_modes == [PRESET_NONE, PRESET_COMFORT, PRESET_ECO]
 
     def test_empty_enabled_presets_yields_none_only(self):
@@ -62,51 +63,78 @@ class TestAvailableModes:
 # activate()
 # ---------------------------------------------------------------------------
 
+
 class TestActivate:
+    """activate() switches presets, saves/restores user temperature, clamps to bounds."""
+
     def test_none_to_comfort_saves_and_returns_preset_temp(self, mgr: PresetManager):
-        result = mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        """Going NONE→COMFORT saves the current temp and returns the preset value."""
+        result = mgr.activate(
+            PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0
+        )
         assert mgr.mode == PRESET_COMFORT
         assert mgr.saved_temperature == 20.0
         assert result == _DEFAULT_TEMPERATURES[PRESET_COMFORT]
 
     def test_comfort_to_none_restores_saved_temp(self, mgr: PresetManager):
+        """Returning to NONE restores the previously saved user temperature."""
         mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
-        result = mgr.activate(PRESET_NONE, current_temp=21.0, min_temp=5.0, max_temp=30.0)
+        result = mgr.activate(
+            PRESET_NONE, current_temp=21.0, min_temp=5.0, max_temp=30.0
+        )
         assert result == 20.0
         assert mgr.saved_temperature is None
         assert mgr.mode == PRESET_NONE
 
     def test_comfort_to_eco_keeps_saved_temp(self, mgr: PresetManager):
+        """Preset→preset transitions preserve the originally saved temperature."""
         mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
-        result = mgr.activate(PRESET_ECO, current_temp=21.0, min_temp=5.0, max_temp=30.0)
+        result = mgr.activate(
+            PRESET_ECO, current_temp=21.0, min_temp=5.0, max_temp=30.0
+        )
         assert result == _DEFAULT_TEMPERATURES[PRESET_ECO]
         # saved_temperature should still hold the original value
         assert mgr.saved_temperature == 20.0
 
     def test_clamping_to_min(self, mgr: PresetManager):
+        """Preset values below min_temp are clamped to min_temp."""
         mgr.temperatures[PRESET_AWAY] = 3.0
-        result = mgr.activate(PRESET_AWAY, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        result = mgr.activate(
+            PRESET_AWAY, current_temp=20.0, min_temp=5.0, max_temp=30.0
+        )
         assert result == 5.0
 
     def test_clamping_to_max(self, mgr: PresetManager):
+        """Preset values above max_temp are clamped to max_temp."""
         mgr.temperatures[PRESET_BOOST] = 50.0
-        result = mgr.activate(PRESET_BOOST, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        result = mgr.activate(
+            PRESET_BOOST, current_temp=20.0, min_temp=5.0, max_temp=30.0
+        )
         assert result == 30.0
 
     def test_invalid_preset_returns_none(self, mgr: PresetManager):
-        result = mgr.activate("nonexistent", current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        """Activating an unknown preset name is a no-op returning None."""
+        result = mgr.activate(
+            "nonexistent", current_temp=20.0, min_temp=5.0, max_temp=30.0
+        )
         assert result is None
         assert mgr.mode == PRESET_NONE
 
     def test_none_to_none_is_noop(self, mgr: PresetManager):
-        result = mgr.activate(PRESET_NONE, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        """Activating NONE while already on NONE is a no-op (nothing to save)."""
+        result = mgr.activate(
+            PRESET_NONE, current_temp=20.0, min_temp=5.0, max_temp=30.0
+        )
         assert result is None
         assert mgr.saved_temperature is None
 
     def test_same_preset_is_idempotent(self, mgr: PresetManager):
+        """Re-activating the current preset is idempotent and does not re-save."""
         mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
         saved_before = mgr.saved_temperature
-        result = mgr.activate(PRESET_COMFORT, current_temp=21.0, min_temp=5.0, max_temp=30.0)
+        result = mgr.activate(
+            PRESET_COMFORT, current_temp=21.0, min_temp=5.0, max_temp=30.0
+        )
         assert result == _DEFAULT_TEMPERATURES[PRESET_COMFORT]
         # saved_temperature must not be overwritten
         assert mgr.saved_temperature == saved_before
@@ -118,8 +146,10 @@ class TestActivate:
         assert mgr.saved_temperature == 20.0
 
     def test_enabled_preset_missing_from_temperatures_falls_back(self):
-        """A preset that is enabled but absent from ``temperatures`` still yields
-        a clamped target (falls back via PRESET_NONE, then mid-range)."""
+        """Enabled preset absent from temperatures falls back via PRESET_NONE.
+
+        Still yields a clamped target.
+        """
         mgr = PresetManager(
             enabled_presets=[PRESET_COMFORT],
             temperatures={PRESET_NONE: 19.5},  # COMFORT intentionally missing
@@ -132,10 +162,7 @@ class TestActivate:
 
     def test_enabled_preset_missing_and_no_none_default_uses_midpoint(self):
         """No preset value and no PRESET_NONE default → midpoint of min/max."""
-        mgr = PresetManager(
-            enabled_presets=[PRESET_COMFORT],
-            temperatures={},
-        )
+        mgr = PresetManager(enabled_presets=[PRESET_COMFORT], temperatures={})
         result = mgr.activate(
             PRESET_COMFORT, current_temp=20.0, min_temp=10.0, max_temp=30.0
         )
@@ -146,8 +173,12 @@ class TestActivate:
 # deactivate()
 # ---------------------------------------------------------------------------
 
+
 class TestDeactivate:
+    """deactivate() returns to PRESET_NONE and restores the saved temperature."""
+
     def test_deactivate_restores_temp(self, mgr: PresetManager):
+        """deactivate() restores the saved temperature and clears state."""
         mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
         result = mgr.deactivate()
         assert result == 20.0
@@ -155,6 +186,7 @@ class TestDeactivate:
         assert mgr.saved_temperature is None
 
     def test_deactivate_from_none_returns_none(self, mgr: PresetManager):
+        """deactivate() with no preset active returns None (nothing to restore)."""
         result = mgr.deactivate()
         assert result is None
         assert mgr.mode == PRESET_NONE
@@ -164,15 +196,21 @@ class TestDeactivate:
 # update_temperature / get_temperature
 # ---------------------------------------------------------------------------
 
+
 class TestTemperatureAccess:
+    """update_temperature() and get_temperature() round-trip preset values."""
+
     def test_update_and_get(self, mgr: PresetManager):
+        """A stored preset value is returned verbatim by get_temperature()."""
         mgr.update_temperature(PRESET_COMFORT, 23.5)
         assert mgr.get_temperature(PRESET_COMFORT) == 23.5
 
     def test_get_unknown_preset_returns_none(self, mgr: PresetManager):
+        """get_temperature() returns None for unknown preset names."""
         assert mgr.get_temperature("nonexistent") is None
 
     def test_update_creates_new_entry(self, mgr: PresetManager):
+        """update_temperature() inserts new preset entries on demand."""
         mgr.update_temperature("custom_preset", 19.0)
         assert mgr.get_temperature("custom_preset") == 19.0
 
@@ -181,8 +219,12 @@ class TestTemperatureAccess:
 # saved_temperature lifecycle
 # ---------------------------------------------------------------------------
 
+
 class TestSavedTemperatureLifecycle:
+    """End-to-end lifecycle of saved_temperature across activate/deactivate cycles."""
+
     def test_save_on_activate_restore_on_deactivate(self, mgr: PresetManager):
+        """Saved temperature is set on activation and cleared on deactivation."""
         mgr.activate(PRESET_AWAY, current_temp=21.5, min_temp=5.0, max_temp=30.0)
         assert mgr.saved_temperature == 21.5
         restored = mgr.deactivate()
@@ -190,11 +232,13 @@ class TestSavedTemperatureLifecycle:
         assert mgr.saved_temperature is None
 
     def test_preset_to_preset_keeps_saved(self, mgr: PresetManager):
+        """Switching between presets preserves the originally saved temperature."""
         mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
         mgr.activate(PRESET_ECO, current_temp=21.0, min_temp=5.0, max_temp=30.0)
         assert mgr.saved_temperature == 20.0
 
     def test_double_activate_from_none_does_not_overwrite(self, mgr: PresetManager):
+        """Re-activating the same preset does not overwrite the saved temperature."""
         mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
         # Simulate scenario: already in comfort, activate again
         mgr.activate(PRESET_COMFORT, current_temp=25.0, min_temp=5.0, max_temp=30.0)
@@ -205,15 +249,23 @@ class TestSavedTemperatureLifecycle:
 # Dataclass defaults / isolation
 # ---------------------------------------------------------------------------
 
+
 class TestDefaults:
+    """Dataclass defaults isolate state between instances and start in the NONE preset."""
+
     def test_instances_do_not_share_state(self):
+        """Each PresetManager gets its own temperatures dict (no shared default)."""
         mgr1 = PresetManager()
         mgr2 = PresetManager()
         mgr1.temperatures[PRESET_COMFORT] = 99.0
-        assert mgr2.temperatures[PRESET_COMFORT] == _DEFAULT_TEMPERATURES[PRESET_COMFORT]
+        assert (
+            mgr2.temperatures[PRESET_COMFORT] == _DEFAULT_TEMPERATURES[PRESET_COMFORT]
+        )
 
     def test_default_mode_is_none(self, mgr: PresetManager):
+        """Fresh PresetManager starts in PRESET_NONE."""
         assert mgr.mode == PRESET_NONE
 
     def test_default_saved_temperature_is_none(self, mgr: PresetManager):
+        """Fresh PresetManager has no saved_temperature."""
         assert mgr.saved_temperature is None

--- a/tests/unit/test_preset_manager.py
+++ b/tests/unit/test_preset_manager.py
@@ -1,0 +1,190 @@
+"""Tests for PresetManager."""
+
+import pytest
+from homeassistant.components.climate.const import (
+    PRESET_AWAY,
+    PRESET_BOOST,
+    PRESET_COMFORT,
+    PRESET_ECO,
+    PRESET_NONE,
+)
+
+from custom_components.better_thermostat.utils.preset_manager import (
+    PresetManager,
+    _DEFAULT_ENABLED_PRESETS,
+    _DEFAULT_TEMPERATURES,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mgr() -> PresetManager:
+    """Return a fresh PresetManager with defaults."""
+    return PresetManager()
+
+
+@pytest.fixture
+def custom_mgr() -> PresetManager:
+    """Return a PresetManager with custom presets."""
+    return PresetManager(
+        enabled_presets=[PRESET_COMFORT, PRESET_ECO],
+        temperatures={
+            PRESET_NONE: 20.0,
+            PRESET_COMFORT: 22.0,
+            PRESET_ECO: 18.0,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# available_modes
+# ---------------------------------------------------------------------------
+
+class TestAvailableModes:
+    def test_default_presets(self, mgr: PresetManager):
+        modes = mgr.available_modes
+        assert modes[0] == PRESET_NONE
+        assert set(modes[1:]) == set(_DEFAULT_ENABLED_PRESETS)
+
+    def test_custom_presets(self, custom_mgr: PresetManager):
+        assert custom_mgr.available_modes == [PRESET_NONE, PRESET_COMFORT, PRESET_ECO]
+
+
+# ---------------------------------------------------------------------------
+# activate()
+# ---------------------------------------------------------------------------
+
+class TestActivate:
+    def test_none_to_comfort_saves_and_returns_preset_temp(self, mgr: PresetManager):
+        result = mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        assert mgr.mode == PRESET_COMFORT
+        assert mgr.saved_temperature == 20.0
+        assert result == _DEFAULT_TEMPERATURES[PRESET_COMFORT]
+
+    def test_comfort_to_none_restores_saved_temp(self, mgr: PresetManager):
+        mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        result = mgr.activate(PRESET_NONE, current_temp=21.0, min_temp=5.0, max_temp=30.0)
+        assert result == 20.0
+        assert mgr.saved_temperature is None
+        assert mgr.mode == PRESET_NONE
+
+    def test_comfort_to_eco_keeps_saved_temp(self, mgr: PresetManager):
+        mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        result = mgr.activate(PRESET_ECO, current_temp=21.0, min_temp=5.0, max_temp=30.0)
+        assert result == _DEFAULT_TEMPERATURES[PRESET_ECO]
+        # saved_temperature should still hold the original value
+        assert mgr.saved_temperature == 20.0
+
+    def test_clamping_to_min(self, mgr: PresetManager):
+        mgr.temperatures[PRESET_AWAY] = 3.0
+        result = mgr.activate(PRESET_AWAY, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        assert result == 5.0
+
+    def test_clamping_to_max(self, mgr: PresetManager):
+        mgr.temperatures[PRESET_BOOST] = 50.0
+        result = mgr.activate(PRESET_BOOST, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        assert result == 30.0
+
+    def test_invalid_preset_returns_none(self, mgr: PresetManager):
+        result = mgr.activate("nonexistent", current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        assert result is None
+        assert mgr.mode == PRESET_NONE
+
+    def test_none_to_none_is_noop(self, mgr: PresetManager):
+        result = mgr.activate(PRESET_NONE, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        assert result is None
+        assert mgr.saved_temperature is None
+
+    def test_same_preset_is_idempotent(self, mgr: PresetManager):
+        mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        saved_before = mgr.saved_temperature
+        result = mgr.activate(PRESET_COMFORT, current_temp=21.0, min_temp=5.0, max_temp=30.0)
+        assert result == _DEFAULT_TEMPERATURES[PRESET_COMFORT]
+        # saved_temperature must not be overwritten
+        assert mgr.saved_temperature == saved_before
+
+    def test_double_activate_does_not_overwrite_saved(self, mgr: PresetManager):
+        """Activating two presets in a row should keep original saved temp."""
+        mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        mgr.activate(PRESET_ECO, current_temp=21.0, min_temp=5.0, max_temp=30.0)
+        assert mgr.saved_temperature == 20.0
+
+
+# ---------------------------------------------------------------------------
+# deactivate()
+# ---------------------------------------------------------------------------
+
+class TestDeactivate:
+    def test_deactivate_restores_temp(self, mgr: PresetManager):
+        mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        result = mgr.deactivate()
+        assert result == 20.0
+        assert mgr.mode == PRESET_NONE
+        assert mgr.saved_temperature is None
+
+    def test_deactivate_from_none_returns_none(self, mgr: PresetManager):
+        result = mgr.deactivate()
+        assert result is None
+        assert mgr.mode == PRESET_NONE
+
+
+# ---------------------------------------------------------------------------
+# update_temperature / get_temperature
+# ---------------------------------------------------------------------------
+
+class TestTemperatureAccess:
+    def test_update_and_get(self, mgr: PresetManager):
+        mgr.update_temperature(PRESET_COMFORT, 23.5)
+        assert mgr.get_temperature(PRESET_COMFORT) == 23.5
+
+    def test_get_unknown_preset_returns_none(self, mgr: PresetManager):
+        assert mgr.get_temperature("nonexistent") is None
+
+    def test_update_creates_new_entry(self, mgr: PresetManager):
+        mgr.update_temperature("custom_preset", 19.0)
+        assert mgr.get_temperature("custom_preset") == 19.0
+
+
+# ---------------------------------------------------------------------------
+# saved_temperature lifecycle
+# ---------------------------------------------------------------------------
+
+class TestSavedTemperatureLifecycle:
+    def test_save_on_activate_restore_on_deactivate(self, mgr: PresetManager):
+        mgr.activate(PRESET_AWAY, current_temp=21.5, min_temp=5.0, max_temp=30.0)
+        assert mgr.saved_temperature == 21.5
+        restored = mgr.deactivate()
+        assert restored == 21.5
+        assert mgr.saved_temperature is None
+
+    def test_preset_to_preset_keeps_saved(self, mgr: PresetManager):
+        mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        mgr.activate(PRESET_ECO, current_temp=21.0, min_temp=5.0, max_temp=30.0)
+        assert mgr.saved_temperature == 20.0
+
+    def test_double_activate_from_none_does_not_overwrite(self, mgr: PresetManager):
+        mgr.activate(PRESET_COMFORT, current_temp=20.0, min_temp=5.0, max_temp=30.0)
+        # Simulate scenario: already in comfort, activate again
+        mgr.activate(PRESET_COMFORT, current_temp=25.0, min_temp=5.0, max_temp=30.0)
+        assert mgr.saved_temperature == 20.0
+
+
+# ---------------------------------------------------------------------------
+# Dataclass defaults / isolation
+# ---------------------------------------------------------------------------
+
+class TestDefaults:
+    def test_instances_do_not_share_state(self):
+        mgr1 = PresetManager()
+        mgr2 = PresetManager()
+        mgr1.temperatures[PRESET_COMFORT] = 99.0
+        assert mgr2.temperatures[PRESET_COMFORT] == _DEFAULT_TEMPERATURES[PRESET_COMFORT]
+
+    def test_default_mode_is_none(self, mgr: PresetManager):
+        assert mgr.mode == PRESET_NONE
+
+    def test_default_saved_temperature_is_none(self, mgr: PresetManager):
+        assert mgr.saved_temperature is None


### PR DESCRIPTION
## Summary
- Extract 5 loose preset attributes from `climate.py` into a new `PresetManager` dataclass in `utils/preset_manager.py`
- Simplify `async_set_preset_mode` from ~100 lines to ~35 lines by delegating save/restore/clamping logic to `PresetManager.activate()`
- Update `number.py` (`BetterThermostatPresetNumber`) to use `preset_mgr.update_temperature()` / `get_temperature()` instead of direct dict access

## Details
**New file: `utils/preset_manager.py` (~100 lines)**
- `PresetManager` dataclass with `mode`, `temperatures`, `enabled_presets`, `saved_temperature`
- `activate(preset, current_temp, min_temp, max_temp)` → handles save/restore/clamping, returns new target temp
- `deactivate()` → returns to PRESET_NONE, returns saved temp
- `update_temperature()` / `get_temperature()` → API for Number entities
- `available_modes` property → `[PRESET_NONE] + enabled_presets`
- mypy `--strict` clean, no `Any`/`cast`/`type: ignore` workarounds

**Removed from `climate.py`:**
- `self._preset_mode` → `self.preset_mgr.mode`
- `self._preset_temperature` → `self.preset_mgr.saved_temperature`
- `self._preset_temperatures` → `self.preset_mgr.temperatures`
- `self._enabled_presets` → `self.preset_mgr.enabled_presets`
- `self._original_preset_temperatures` (dead code, never read)
- 7 unused PRESET_* constant imports

## Test plan
- [x] 22 new unit tests in `tests/unit/test_preset_manager.py` covering activate, deactivate, clamping, saved_temperature lifecycle, instance isolation
- [x] Full test suite passes (896 tests, 0 failures)
- [x] `mypy --strict` clean for `preset_manager.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked preset handling into a dedicated manager for more reliable preset selection, temperature persistence, and state restoration.

* **Bug Fixes**
  * Ensure restored presets validate against available modes and fall back safely; manual temp updates persist only when appropriate.

* **Tests**
  * Added and updated unit tests covering preset activation, deactivation, temperature clamping, persistence, and restore behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KartoffelToby/better_thermostat/pull/1950)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->