### PR TITLE
refactor: Extract startup() into 8 named submethods

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -41,7 +41,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import Context, CoreState, ServiceCall, callback
+from homeassistant.core import Context, CoreState, ServiceCall, State, callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import (
@@ -145,9 +145,6 @@ DEFAULT_FALLBACK_TEMPERATURE = 20.0
 # Signal für dynamische Entity-Updates
 SIGNAL_BT_CONFIG_CHANGED = "bt_config_changed_{}"
 
-
-class ContinueLoop(Exception):
-    """Continue loop exception."""
 
 
 @callback
@@ -352,15 +349,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             hours=randint(1, 24 * 5)
         )
         self.cur_temp = None
-        self._current_humidity = 0
+        self._current_humidity: float = 0.0
         self.window_open = None
         self.bt_target_temp_step = (
             float(target_temp_step)
             if target_temp_step and target_temp_step != "0.0"
             else None
         )
-        self.bt_min_temp = 0
-        self.bt_max_temp = 30
+        self.bt_min_temp: float = 0.0
+        self.bt_max_temp: float = 30.0
         self.bt_target_temp = 5.0
         self.bt_target_cooltemp = None
         self._support_flags = SUPPORT_FLAGS | ClimateEntityFeature.PRESET_MODE
@@ -846,8 +843,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if self.real_trvs[trv].get("local_calibration_step") is None:
             self.real_trvs[trv]["local_calibration_step"] = 0.5
 
-    async def startup(self):
-        """Run when entity about to be added."""
+    async def startup(self) -> None:
+        """Orchestrate entity startup."""
         while self.startup_running:
             _LOGGER.info(
                 "better_thermostat %s: Starting version %s. Waiting for entity to be ready...",
@@ -856,911 +853,932 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             )
 
             sensor_state = self.hass.states.get(self.sensor_entity_id)
-            if sensor_state is None or sensor_state.state in (
+            if not self._check_entities_ready(sensor_state):
+                await asyncio.sleep(20)
+                continue
+
+            states = self._collect_trv_states()
+            self._resolve_temperature_range(states)
+            self._initialize_sensors(sensor_state)
+            await self._restore_state(states)
+            self._validate_hvac_mode(states)
+            await self._initialize_trvs()
+            await self._finalize_startup()
+            break
+
+    def _check_entities_ready(self, sensor_state: State | None) -> bool:
+        """Check whether sensor and all TRVs are available.
+
+        Returns True when every entity is ready, False otherwise.
+        """
+        if sensor_state is None or sensor_state.state in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+            None,
+        ):
+            _LOGGER.info(
+                "better_thermostat %s: waiting for sensor entity with id '%s' to become fully available...",
+                self.device_name,
+                self.sensor_entity_id,
+            )
+            return False
+
+        for trv in self.real_trvs:
+            trv_state = self.hass.states.get(trv)
+            if trv_state is None or trv_state.state in (
                 STATE_UNAVAILABLE,
                 STATE_UNKNOWN,
                 None,
             ):
                 _LOGGER.info(
-                    "better_thermostat %s: waiting for sensor entity with id '%s' to become fully available...",
+                    "better_thermostat %s: waiting for TRV/climate entity with id '%s' to become fully available...",
                     self.device_name,
-                    self.sensor_entity_id,
+                    trv,
                 )
-                await asyncio.sleep(20)
-                continue
+                return False
+        return True
 
-            try:
-                for trv in self.real_trvs:
-                    trv_state = self.hass.states.get(trv)
-                    if trv_state is None:
-                        _LOGGER.info(
-                            "better_thermostat %s: waiting for TRV/climate entity with id '%s' to become fully available...",
-                            self.device_name,
-                            trv,
-                        )
-                        await asyncio.sleep(20)
-                        raise ContinueLoop
-                    if trv_state is not None:
-                        if trv_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
-                            _LOGGER.info(
-                                "better_thermostat %s: waiting for TRV/climate entity with id '%s' to become fully available...",
-                                self.device_name,
-                                trv,
-                            )
-                            await asyncio.sleep(20)
-                            raise ContinueLoop
-            except ContinueLoop:
-                continue
+    def _collect_trv_states(self) -> list[State]:
+        """Collect current State objects for all TRVs and optional cooler."""
+        states = [
+            state
+            for entity_id in self.real_trvs
+            if (state := self.hass.states.get(entity_id)) is not None
+        ]
 
-            states = [
-                state
-                for entity_id in self.real_trvs
-                if (state := self.hass.states.get(entity_id)) is not None
-            ]
-
-            # Include cooler entity in min/max calculation to ensure BT's
-            # temperature range is compatible with all controlled devices
-            if self.cooler_entity_id is not None:
-                cooler_state = self.hass.states.get(self.cooler_entity_id)
-                if cooler_state is not None and cooler_state.state not in (
-                    STATE_UNAVAILABLE,
-                    STATE_UNKNOWN,
-                    None,
-                ):
-                    states.append(cooler_state)
-
-            self.bt_min_temp = reduce_attribute(states, ATTR_MIN_TEMP, reduce=max)
-            self.bt_max_temp = reduce_attribute(states, ATTR_MAX_TEMP, reduce=min)
-
-            if (
-                self.bt_min_temp is not None
-                and self.bt_max_temp is not None
-                and self.bt_min_temp > self.bt_max_temp
-            ):
-                _LOGGER.warning(
-                    "better_thermostat %s: min temp (%.1f°) > max temp (%.1f°). "
-                    "This indicates non-overlapping temperature ranges between "
-                    "heater and cooler entities. Please check your configuration.",
-                    self.device_name,
-                    self.bt_min_temp,
-                    self.bt_max_temp,
-                )
-
-            if self.bt_target_temp_step is None:
-                self.bt_target_temp_step = reduce_attribute(
-                    states, ATTR_TARGET_TEMP_STEP, reduce=max
-                )
-
-            self.all_entities.append(self.sensor_entity_id)
-
-            # Handle room temperature sensor with TRV fallback
-            if sensor_state is not None and sensor_state.state not in (
+        # Include cooler entity in min/max calculation to ensure BT's
+        # temperature range is compatible with all controlled devices
+        if self.cooler_entity_id is not None:
+            cooler_state = self.hass.states.get(self.cooler_entity_id)
+            if cooler_state is not None and cooler_state.state not in (
                 STATE_UNAVAILABLE,
                 STATE_UNKNOWN,
                 None,
             ):
-                self.cur_temp = convert_to_float(
-                    str(sensor_state.state), self.device_name, "startup()"
-                )
-            else:
-                # Fallback to TRV internal temperature
-                _LOGGER.warning(
-                    "better_thermostat %s: Room temperature sensor '%s' unavailable. "
-                    "Falling back to TRV internal temperature.",
-                    self.device_name,
-                    self.sensor_entity_id,
-                )
-                if self.sensor_entity_id not in self.unavailable_sensors:
-                    self.unavailable_sensors.append(self.sensor_entity_id)
-                    self.degraded_mode = True
-                # Get temperature from first available TRV
-                self.cur_temp = None
-                for trv_id in self.real_trvs:
-                    trv_state = self.hass.states.get(trv_id)
-                    if trv_state is not None:
-                        trv_temp = trv_state.attributes.get("current_temperature")
-                        if trv_temp is not None:
-                            self.cur_temp = convert_to_float(
-                                str(trv_temp),
-                                self.device_name,
-                                "startup() TRV fallback",
-                            )
-                            _LOGGER.info(
-                                "better_thermostat %s: Using TRV '%s' temperature: %.1f°C",
-                                self.device_name,
-                                trv_id,
-                                self.cur_temp if self.cur_temp else 0,
-                            )
-                            break
-                if self.cur_temp is None:
-                    self.cur_temp = DEFAULT_FALLBACK_TEMPERATURE
-                    _LOGGER.warning(
-                        "better_thermostat %s: No temperature available, using default %.1f°C",
-                        self.device_name,
-                        DEFAULT_FALLBACK_TEMPERATURE,
-                    )
+                states.append(cooler_state)
 
-            # Initialize EMA with current temperature at startup
-            if self.cur_temp is not None:
-                self.last_known_external_temp = self.cur_temp
-                try:
-                    from .events.temperature import _update_external_temp_ema
+        return states
 
-                    _update_external_temp_ema(self, float(self.cur_temp))
-                    _LOGGER.debug(
-                        "better_thermostat %s: initialized external_temp_ema at startup with %.2f",
-                        self.device_name,
-                        self.cur_temp,
-                    )
-                except (ValueError, TypeError, ImportError) as e:
-                    _LOGGER.warning(
-                        "better_thermostat %s: failed to initialize external_temp_ema at startup: %s",
-                        self.device_name,
-                        e,
-                    )
+    def _resolve_temperature_range(self, states: list[State]) -> None:
+        """Derive min/max/step temperature from TRV states."""
+        self.bt_min_temp = reduce_attribute(states, ATTR_MIN_TEMP, reduce=max)
+        self.bt_max_temp = reduce_attribute(states, ATTR_MAX_TEMP, reduce=min)
 
-            if self.humidity_sensor_entity_id is not None:
-                self.all_entities.append(self.humidity_sensor_entity_id)
-                _hum_state = self.hass.states.get(self.humidity_sensor_entity_id)
-                if _hum_state is not None and _hum_state.state not in (
-                    STATE_UNAVAILABLE,
-                    STATE_UNKNOWN,
-                    None,
-                ):
-                    self._current_humidity = convert_to_float(
-                        str(_hum_state.state), self.device_name, "startup()"
-                    )
-                # else: already logged warning above, _current_humidity stays None
-
-            if self.cooler_entity_id is not None:
-                _cooler_state = self.hass.states.get(self.cooler_entity_id)
-                if _cooler_state is not None and _cooler_state.state not in (
-                    STATE_UNAVAILABLE,
-                    STATE_UNKNOWN,
-                    None,
-                ):
-                    self.bt_target_cooltemp = convert_to_float(
-                        str(_cooler_state.attributes.get("temperature")),
-                        self.device_name,
-                        "startup()",
-                    )
-                # else: already logged warning above
-
-            if self.window_id is not None:
-                self.all_entities.append(self.window_id)
-                window = self.hass.states.get(self.window_id)
-
-                if window is not None and window.state not in (
-                    STATE_UNAVAILABLE,
-                    STATE_UNKNOWN,
-                    None,
-                ):
-                    check = window.state
-                    if check in ("on", "open", "true"):
-                        self.window_open = True
-                    else:
-                        self.window_open = False
-                    _LOGGER.debug(
-                        "better_thermostat %s: detected window state at startup: %s",
-                        self.device_name,
-                        "Open" if self.window_open else "Closed",
-                    )
-                else:
-                    # Window sensor unavailable - assume closed (safer default)
-                    self.window_open = False
-                    _LOGGER.debug(
-                        "better_thermostat %s: window sensor unavailable, assuming closed",
-                        self.device_name,
-                    )
-            else:
-                self.window_open = False
-
-            # Check If we have an old state
-            _LOGGER.debug(
-                "better_thermostat %s: calling async_get_last_state", self.device_name
-            )
-            old_state = await self.async_get_last_state()
-            _LOGGER.debug(
-                "better_thermostat %s: async_get_last_state returned", self.device_name
-            )
-            if old_state is not None:
-                _LOGGER.debug(
-                    "better_thermostat %s: restoring state...", self.device_name
-                )
-                # Restore external_temp_ema if available (overwrites startup init)
-                if "external_temp_ema" in old_state.attributes:
-                    try:
-                        _restored_ema = float(old_state.attributes["external_temp_ema"])
-                        self.external_temp_ema = _restored_ema
-                        self.cur_temp_filtered = round(_restored_ema, 2)
-                        # Reset timestamp to now so the next delta is calculated from restart time
-                        self._external_temp_ema_ts = monotonic()
-                        _LOGGER.debug(
-                            "better_thermostat %s: restored external_temp_ema from state: %.2f",
-                            self.device_name,
-                            _restored_ema,
-                        )
-                    except (ValueError, TypeError):
-                        pass
-
-                # Restore temp_slope if available
-                if "temp_slope_K_min" in old_state.attributes:
-                    try:
-                        _restored_slope = float(
-                            old_state.attributes["temp_slope_K_min"]
-                        )
-                        self.temp_slope = _restored_slope
-                        _LOGGER.debug(
-                            "better_thermostat %s: restored temp_slope from state: %.4f",
-                            self.device_name,
-                            _restored_slope,
-                        )
-                    except (ValueError, TypeError):
-                        pass
-
-                _LOGGER.debug(
-                    "better_thermostat %s: restoring target temperature...",
-                    self.device_name,
-                )
-                # If we have no initial temperature, restore
-                # If we have a previously saved temperature
-                if old_state.attributes.get(ATTR_TEMPERATURE) is None:
-                    self.bt_target_temp = reduce_attribute(
-                        states, ATTR_TEMPERATURE, reduce=lambda *data: mean(data)
-                    )
-                    _LOGGER.debug(
-                        "better_thermostat %s: Undefined target temperature, falling back to %s",
-                        self.device_name,
-                        self.bt_target_temp,
-                    )
-                else:
-                    _oldtarget_temperature = float(
-                        old_state.attributes.get(ATTR_TEMPERATURE)
-                    )
-                    # if the saved temperature is lower than the min_temp, set it to min_temp
-                    if _oldtarget_temperature < self.bt_min_temp:
-                        _LOGGER.warning(
-                            "better_thermostat %s: Saved target temperature %s is lower than min_temp %s, setting to min_temp",
-                            self.device_name,
-                            _oldtarget_temperature,
-                            self.bt_min_temp,
-                        )
-                        _oldtarget_temperature = self.bt_min_temp
-                    # if the saved temperature is higher than the max_temp, set it to max_temp
-                    elif _oldtarget_temperature > self.bt_max_temp:
-                        _LOGGER.warning(
-                            "better_thermostat %s: Saved target temperature %s is higher than max_temp %s, setting to max_temp",
-                            self.device_name,
-                            _oldtarget_temperature,
-                            self.bt_min_temp,
-                        )
-                        _oldtarget_temperature = self.bt_max_temp
-                    self.bt_target_temp = convert_to_float(
-                        str(_oldtarget_temperature), self.device_name, "startup()"
-                    )
-                _LOGGER.debug(
-                    "better_thermostat %s: target temperature restored",
-                    self.device_name,
-                )
-
-                _LOGGER.debug(
-                    "better_thermostat %s: restoring preset mode...", self.device_name
-                )
-                # Restore preset mode if present
-                _old_preset = old_state.attributes.get("preset_mode")
-                if _old_preset in ([PRESET_NONE] + list(self._preset_temperatures)):
-                    self._preset_mode = _old_preset
-                else:
-                    self._preset_mode = PRESET_NONE
-
-                _LOGGER.debug(
-                    "better_thermostat %s: applying restored preset temperature...",
-                    self.device_name,
-                )
-                # If we restored a preset (not NONE) and we have a stored temperature for it,
-                # ensure target temp matches (unless the restored target was already equal).
-                if (
-                    self._preset_mode is not None
-                    and self._preset_mode != PRESET_NONE
-                    and self._preset_mode in self._preset_temperatures
-                ):
-                    preset_temp = self._preset_temperatures[self._preset_mode]
-                    # Only override if different to avoid masking manual restore logic
-                    if (
-                        isinstance(preset_temp, (int, float))
-                        and preset_temp is not None
-                        and self.bt_target_temp != preset_temp
-                    ):
-                        _LOGGER.debug(
-                            "better_thermostat %s: Applying restored preset %s temperature %s after startup",
-                            self.device_name,
-                            self._preset_mode,
-                            preset_temp,
-                        )
-                        self.bt_target_temp = preset_temp
-                _LOGGER.debug(
-                    "better_thermostat %s: restored preset temperature applied",
-                    self.device_name,
-                )
-
-                _LOGGER.debug(
-                    "better_thermostat %s: restoring other attributes...",
-                    self.device_name,
-                )
-                if old_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
-                    self.bt_hvac_mode = old_state.state
-                if old_state.attributes.get(ATTR_STATE_CALL_FOR_HEAT, None) is not None:
-                    self.call_for_heat = old_state.attributes.get(
-                        ATTR_STATE_CALL_FOR_HEAT
-                    )
-                if (
-                    old_state.attributes.get(ATTR_STATE_SAVED_TEMPERATURE, None)
-                    is not None
-                ):
-                    self._saved_temperature = convert_to_float(
-                        str(
-                            old_state.attributes.get(ATTR_STATE_SAVED_TEMPERATURE, None)
-                        ),
-                        self.device_name,
-                        "startup()",
-                    )
-                if old_state.attributes.get(ATTR_STATE_HUMIDIY, None) is not None:
-                    self._current_humidity = old_state.attributes.get(
-                        ATTR_STATE_HUMIDIY
-                    )
-                if old_state.attributes.get(ATTR_STATE_MAIN_MODE, None) is not None:
-                    self.last_main_hvac_mode = old_state.attributes.get(
-                        ATTR_STATE_MAIN_MODE
-                    )
-                if old_state.attributes.get(ATTR_STATE_HEATING_POWER, None) is not None:
-                    try:
-                        _power_value = old_state.attributes.get(
-                            ATTR_STATE_HEATING_POWER
-                        )
-                        if _power_value is not None:
-                            loaded_power = float(_power_value)
-                        else:
-                            loaded_power = 0.01
-                    except (TypeError, ValueError):
-                        loaded_power = 0.01
-                    # Bound to realistic values to prevent issues from incorrectly learned values
-                    bounded_power = max(
-                        MIN_HEATING_POWER, min(MAX_HEATING_POWER, loaded_power)
-                    )
-                    if bounded_power != loaded_power:
-                        _LOGGER.info(
-                            "better_thermostat %s: Restored heating_power %.3f "
-                            "is outside allowed range [%s, %s]; clamped to %.3f",
-                            self.device_name,
-                            loaded_power,
-                            MIN_HEATING_POWER,
-                            MAX_HEATING_POWER,
-                            bounded_power,
-                        )
-                    self.heating_power = bounded_power
-
-                # Restore heat loss if available
-                if old_state.attributes.get(ATTR_STATE_HEAT_LOSS, None) is not None:
-                    try:
-                        _loss_value = old_state.attributes.get(ATTR_STATE_HEAT_LOSS)
-                        if _loss_value is not None:
-                            loaded_loss = float(_loss_value)
-                        else:
-                            loaded_loss = 0.01
-                        bounded_loss = max(
-                            MIN_HEAT_LOSS, min(MAX_HEAT_LOSS, loaded_loss)
-                        )
-                        self.heat_loss_rate = bounded_loss
-                    except (TypeError, ValueError):
-                        pass
-                if (
-                    old_state.attributes.get(ATTR_STATE_PRESET_TEMPERATURE, None)
-                    is not None
-                ):
-                    self._preset_temperature = convert_to_float(
-                        str(
-                            old_state.attributes.get(
-                                ATTR_STATE_PRESET_TEMPERATURE, None
-                            )
-                        ),
-                        self.device_name,
-                        "startup()",
-                    )
-                # Restore preset mode
-                if old_state.attributes.get("preset_mode", None) is not None:
-                    restored_preset = old_state.attributes.get("preset_mode")
-                    if restored_preset in self.preset_modes:
-                        self._preset_mode = restored_preset
-                        _LOGGER.debug(
-                            "better_thermostat %s: Restored preset mode: %s",
-                            self.device_name,
-                            restored_preset,
-                        )
-                _LOGGER.debug(
-                    "better_thermostat %s: state restoration completed",
-                    self.device_name,
-                )
-
-                # ECO mode state / saved ECO temperature not restored; Eco preset is supported via PRESET_ECO.
-
-            else:
-                # No previous state, try and restore defaults
-                _LOGGER.debug(
-                    "better_thermostat %s: no previous state, restoring defaults...",
-                    self.device_name,
-                )
-                if self.bt_target_temp is None or not isinstance(
-                    self.bt_target_temp, float
-                ):
-                    _LOGGER.info(
-                        "better_thermostat %s: No previously saved temperature found on startup, get it from the TRV",
-                        self.device_name,
-                    )
-                    self.bt_target_temp = reduce_attribute(
-                        states, ATTR_TEMPERATURE, reduce=lambda *data: mean(data)
-                    )
-                _LOGGER.debug(
-                    "better_thermostat %s: defaults restored", self.device_name
-                )
-
-            # if hvac mode could not be restored, turn heat off
-            _LOGGER.debug(
-                "better_thermostat %s: checking hvac mode...", self.device_name
-            )
-            if self.bt_hvac_mode in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
-                current_hvac_modes = [
-                    x.state for x in states if x.state != HVACMode.OFF
-                ]
-                # return the most common hvac mode (what the thermostat is set to do) except OFF
-                if current_hvac_modes:
-                    _temp_bt_hvac_mode = max(
-                        set(current_hvac_modes), key=current_hvac_modes.count
-                    )
-                    if _temp_bt_hvac_mode is not HVACMode.OFF:
-                        self.bt_hvac_mode = HVACMode.HEAT
-                    else:
-                        self.bt_hvac_mode = HVACMode.OFF
-                    _LOGGER.debug(
-                        "better_thermostat %s: No previously hvac mode found on startup, turn bt to trv mode %s",
-                        self.device_name,
-                        self.bt_hvac_mode,
-                    )
-                # return off if all are off
-                elif all(x.state == HVACMode.OFF for x in states):
-                    self.bt_hvac_mode = HVACMode.OFF
-                    _LOGGER.debug(
-                        "better_thermostat %s: No previously hvac mode found on startup, turn bt to trv mode %s",
-                        self.device_name,
-                        self.bt_hvac_mode,
-                    )
-                else:
-                    _LOGGER.warning(
-                        "better_thermostat %s: No previously hvac mode found on startup, turn heat off",
-                        self.device_name,
-                    )
-                    self.bt_hvac_mode = HVACMode.OFF
-
-            _LOGGER.debug(
-                "better_thermostat %s: Startup config, BT hvac mode is %s, Target temp %s",
+        if (
+            self.bt_min_temp is not None
+            and self.bt_max_temp is not None
+            and self.bt_min_temp > self.bt_max_temp
+        ):
+            _LOGGER.warning(
+                "better_thermostat %s: min temp (%.1f°) > max temp (%.1f°). "
+                "This indicates non-overlapping temperature ranges between "
+                "heater and cooler entities. Please check your configuration.",
                 self.device_name,
-                self.bt_hvac_mode,
-                self.bt_target_temp,
+                self.bt_min_temp,
+                self.bt_max_temp,
             )
 
-            if self.last_main_hvac_mode is None:
-                self.last_main_hvac_mode = self.bt_hvac_mode
-
-            _LOGGER.debug(
-                "better_thermostat %s: checking humidity sensor...", self.device_name
+        if self.bt_target_temp_step is None:
+            self.bt_target_temp_step = reduce_attribute(
+                states, ATTR_TARGET_TEMP_STEP, reduce=max
             )
-            if self.humidity_sensor_entity_id is not None:
-                _hum_state = self.hass.states.get(self.humidity_sensor_entity_id)
-                if _hum_state is None:
-                    _LOGGER.warning(
-                        "better_thermostat %s: Humidity sensor %s not found or not ready",
-                        self.device_name,
-                        self.humidity_sensor_entity_id,
-                    )
-                    self._current_humidity = 0
-                else:
-                    self._current_humidity = convert_to_float(
-                        str(_hum_state.state), self.device_name, "startup()"
-                    )
-            else:
-                self._current_humidity = 0
 
-            self.last_window_state = self.window_open
-            if self.bt_hvac_mode not in (
-                HVACMode.OFF,
-                HVACMode.HEAT_COOL,
-                HVACMode.HEAT,
-            ):
-                self.bt_hvac_mode = HVACMode.HEAT
+    def _initialize_sensors(self, sensor_state: State | None) -> None:
+        """Set up room temperature, humidity, cooler and window sensors."""
+        self.all_entities.append(self.sensor_entity_id)
 
-            _LOGGER.debug(
-                "better_thermostat %s: writing initial state...", self.device_name
+        # Handle room temperature sensor with TRV fallback
+        if sensor_state is not None and sensor_state.state not in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+            None,
+        ):
+            self.cur_temp = convert_to_float(
+                str(sensor_state.state), self.device_name, "startup()"
             )
-            self.async_write_ha_state()
-
-            for trv, trv_data in self.real_trvs.items():
-                self.all_entities.append(trv)
-                _LOGGER.debug(
-                    "better_thermostat %s: initializing TRV %s", self.device_name, trv
-                )
-                try:
-                    await asyncio.wait_for(init(self, trv), timeout=30)
-                    _LOGGER.debug(
-                        "better_thermostat %s: TRV %s initialized",
-                        self.device_name,
-                        trv,
-                    )
-                except TimeoutError:
-                    _LOGGER.error(
-                        "better_thermostat %s: Timeout initializing TRV %s",
-                        self.device_name,
-                        trv,
-                    )
-                except Exception as exc:
-                    _LOGGER.error(
-                        "better_thermostat %s: Error initializing TRV %s: %s",
-                        self.device_name,
-                        trv,
-                        exc,
-                    )
-
-                try:
-                    await inital_tweak(self, trv)
-                except Exception as exc:
-                    _LOGGER.error(
-                        "better_thermostat %s: Error running initial tweak for TRV %s: %s",
-                        self.device_name,
-                        trv,
-                        exc,
-                    )
-
-                if trv_data["calibration"] != 1:
-                    _LOGGER.debug(
-                        "better_thermostat %s: getting offsets for TRV %s",
-                        self.device_name,
-                        trv,
-                    )
-
-                    try:
-                        async with asyncio.timeout(10):
-                            trv_data["last_calibration"] = await get_current_offset(
-                                self, trv
-                            )
-                            trv_data["local_calibration_min"] = await get_min_offset(
-                                self, trv
-                            )
-                            trv_data["local_calibration_max"] = await get_max_offset(
-                                self, trv
-                            )
-                            trv_data["local_calibration_step"] = await get_offset_step(
-                                self, trv
-                            )
-                        # Ensure None values are replaced with sensible defaults
-                        self._set_trv_calibration_defaults(trv)
-                        _LOGGER.debug(
-                            "better_thermostat %s: offsets for TRV %s retrieved",
+        else:
+            # Fallback to TRV internal temperature
+            _LOGGER.warning(
+                "better_thermostat %s: Room temperature sensor '%s' unavailable. "
+                "Falling back to TRV internal temperature.",
+                self.device_name,
+                self.sensor_entity_id,
+            )
+            if self.sensor_entity_id not in self.unavailable_sensors:
+                self.unavailable_sensors.append(self.sensor_entity_id)
+                self.degraded_mode = True
+            # Get temperature from first available TRV
+            self.cur_temp = None
+            for trv_id in self.real_trvs:
+                trv_state = self.hass.states.get(trv_id)
+                if trv_state is not None:
+                    trv_temp = trv_state.attributes.get("current_temperature")
+                    if trv_temp is not None:
+                        self.cur_temp = convert_to_float(
+                            str(trv_temp),
                             self.device_name,
-                            trv,
+                            "startup() TRV fallback",
                         )
-                    except TimeoutError:
-                        _LOGGER.error(
-                            "better_thermostat %s: Timeout getting offsets for TRV %s",
+                        _LOGGER.info(
+                            "better_thermostat %s: Using TRV '%s' temperature: %.1f°C",
                             self.device_name,
-                            trv,
+                            trv_id,
+                            self.cur_temp if self.cur_temp else 0,
                         )
-                        self._set_trv_calibration_defaults(trv)
-                    except Exception as exc:
-                        _LOGGER.error(
-                            "better_thermostat %s: Error getting offsets for TRV %s: %s",
-                            self.device_name,
-                            trv,
-                            exc,
-                        )
-                        self._set_trv_calibration_defaults(trv)
-                else:
-                    trv_data["last_calibration"] = 0
-                    trv_data["local_calibration_min"] = -7
-                    trv_data["local_calibration_max"] = 7
-                    trv_data["local_calibration_step"] = 0.5
-
-                _s = self.hass.states.get(trv)
-                _attrs = _s.attributes if _s else {}
-                _LOGGER.debug(
-                    "better_thermostat %s: reading TRV %s attributes...",
+                        break
+            if self.cur_temp is None:
+                self.cur_temp = DEFAULT_FALLBACK_TEMPERATURE
+                _LOGGER.warning(
+                    "better_thermostat %s: No temperature available, using default %.1f°C",
                     self.device_name,
-                    trv,
+                    DEFAULT_FALLBACK_TEMPERATURE,
                 )
-                trv_data["valve_position"] = convert_to_float(
-                    str(_attrs.get("valve_position", None)), self.device_name, "startup"
+
+        # Initialize EMA with current temperature at startup
+        if self.cur_temp is not None:
+            self.last_known_external_temp = self.cur_temp
+            try:
+                from .events.temperature import _update_external_temp_ema
+
+                _update_external_temp_ema(self, float(self.cur_temp))
+                _LOGGER.debug(
+                    "better_thermostat %s: initialized external_temp_ema at startup with %.2f",
+                    self.device_name,
+                    self.cur_temp,
                 )
-                trv_data["max_temp"] = convert_to_float(
-                    str(_attrs.get("max_temp", 30)), self.device_name, "startup"
+            except (ValueError, TypeError, ImportError) as e:
+                _LOGGER.warning(
+                    "better_thermostat %s: failed to initialize external_temp_ema at startup: %s",
+                    self.device_name,
+                    e,
                 )
-                trv_data["min_temp"] = convert_to_float(
-                    str(_attrs.get("min_temp", 5)), self.device_name, "startup"
-                )
-                # Prefer configured step over device-reported step
-                cfg_step = (
-                    self.bt_target_temp_step
-                    if self.bt_target_temp_step and self.bt_target_temp_step > 0.0
-                    else None
-                )
-                if cfg_step is not None:
-                    trv_data["target_temp_step"] = cfg_step
-                else:
-                    trv_data["target_temp_step"] = convert_to_float(
-                        str(_attrs.get("target_temp_step", 0.5)),
-                        self.device_name,
-                        "startup",
-                    )
-                trv_data["temperature"] = convert_to_float(
-                    str(_attrs.get("temperature", 5)), self.device_name, "startup"
-                )
-                trv_data["hvac_modes"] = _attrs.get("hvac_modes", None)
-                trv_data["hvac_mode"] = _s.state if _s else None
-                trv_data["last_hvac_mode"] = _s.state if _s else None
-                trv_data["last_temperature"] = convert_to_float(
-                    str(_attrs.get("temperature")), self.device_name, "startup()"
-                )
-                trv_data["current_temperature"] = convert_to_float(
-                    str(_attrs.get("current_temperature") or 5),
+
+        if self.humidity_sensor_entity_id is not None:
+            self.all_entities.append(self.humidity_sensor_entity_id)
+            _hum_state = self.hass.states.get(self.humidity_sensor_entity_id)
+            if _hum_state is not None and _hum_state.state not in (
+                STATE_UNAVAILABLE,
+                STATE_UNKNOWN,
+                None,
+            ):
+                self._current_humidity = convert_to_float(
+                    str(_hum_state.state), self.device_name, "startup()"
+                ) or 0.0
+            # else: already logged warning above, _current_humidity stays None
+
+        if self.cooler_entity_id is not None:
+            _cooler_state = self.hass.states.get(self.cooler_entity_id)
+            if _cooler_state is not None and _cooler_state.state not in (
+                STATE_UNAVAILABLE,
+                STATE_UNKNOWN,
+                None,
+            ):
+                self.bt_target_cooltemp = convert_to_float(
+                    str(_cooler_state.attributes.get("temperature")),
                     self.device_name,
                     "startup()",
                 )
+            # else: already logged warning above
+
+        if self.window_id is not None:
+            self.all_entities.append(self.window_id)
+            window = self.hass.states.get(self.window_id)
+
+            if window is not None and window.state not in (
+                STATE_UNAVAILABLE,
+                STATE_UNKNOWN,
+                None,
+            ):
+                check = window.state
+                if check in ("on", "open", "true"):
+                    self.window_open = True
+                else:
+                    self.window_open = False
                 _LOGGER.debug(
-                    "better_thermostat %s: controlling TRV %s...", self.device_name, trv
+                    "better_thermostat %s: detected window state at startup: %s",
+                    self.device_name,
+                    "Open" if self.window_open else "Closed",
                 )
+            else:
+                # Window sensor unavailable - assume closed (safer default)
+                self.window_open = False
+                _LOGGER.debug(
+                    "better_thermostat %s: window sensor unavailable, assuming closed",
+                    self.device_name,
+                )
+        else:
+            self.window_open = False
+
+    async def _restore_state(self, states: list[State]) -> None:
+        """Restore previous state from HA state machine or fall back to defaults."""
+        _LOGGER.debug(
+            "better_thermostat %s: calling async_get_last_state", self.device_name
+        )
+        old_state = await self.async_get_last_state()
+        _LOGGER.debug(
+            "better_thermostat %s: async_get_last_state returned", self.device_name
+        )
+        if old_state is not None:
+            _LOGGER.debug(
+                "better_thermostat %s: restoring state...", self.device_name
+            )
+            # Restore external_temp_ema if available (overwrites startup init)
+            if "external_temp_ema" in old_state.attributes:
                 try:
-                    await asyncio.wait_for(control_trv(self, trv), timeout=10)
+                    _restored_ema = float(old_state.attributes["external_temp_ema"])
+                    self.external_temp_ema = _restored_ema
+                    self.cur_temp_filtered = round(_restored_ema, 2)
+                    # Reset timestamp to now so the next delta is calculated from restart time
+                    self._external_temp_ema_ts = monotonic()
                     _LOGGER.debug(
-                        "better_thermostat %s: TRV %s controlled", self.device_name, trv
+                        "better_thermostat %s: restored external_temp_ema from state: %.2f",
+                        self.device_name,
+                        _restored_ema,
                     )
-                except TimeoutError:
-                    _LOGGER.error(
-                        "better_thermostat %s: Timeout controlling TRV %s",
+                except (ValueError, TypeError):
+                    pass
+
+            # Restore temp_slope if available
+            if "temp_slope_K_min" in old_state.attributes:
+                try:
+                    _restored_slope = float(
+                        old_state.attributes["temp_slope_K_min"]
+                    )
+                    self.temp_slope = _restored_slope
+                    _LOGGER.debug(
+                        "better_thermostat %s: restored temp_slope from state: %.4f",
+                        self.device_name,
+                        _restored_slope,
+                    )
+                except (ValueError, TypeError):
+                    pass
+
+            _LOGGER.debug(
+                "better_thermostat %s: restoring target temperature...",
+                self.device_name,
+            )
+            # If we have no initial temperature, restore
+            # If we have a previously saved temperature
+            if old_state.attributes.get(ATTR_TEMPERATURE) is None:
+                self.bt_target_temp = reduce_attribute(
+                    states, ATTR_TEMPERATURE, reduce=lambda *data: mean(data)
+                )
+                _LOGGER.debug(
+                    "better_thermostat %s: Undefined target temperature, falling back to %s",
+                    self.device_name,
+                    self.bt_target_temp,
+                )
+            else:
+                _oldtarget_temperature = float(
+                    old_state.attributes[ATTR_TEMPERATURE]
+                )
+                # if the saved temperature is lower than the min_temp, set it to min_temp
+                if _oldtarget_temperature < self.bt_min_temp:
+                    _LOGGER.warning(
+                        "better_thermostat %s: Saved target temperature %s is lower than min_temp %s, setting to min_temp",
+                        self.device_name,
+                        _oldtarget_temperature,
+                        self.bt_min_temp,
+                    )
+                    _oldtarget_temperature = self.bt_min_temp
+                # if the saved temperature is higher than the max_temp, set it to max_temp
+                elif _oldtarget_temperature > self.bt_max_temp:
+                    _LOGGER.warning(
+                        "better_thermostat %s: Saved target temperature %s is higher than max_temp %s, setting to max_temp",
+                        self.device_name,
+                        _oldtarget_temperature,
+                        self.bt_min_temp,
+                    )
+                    _oldtarget_temperature = self.bt_max_temp
+                self.bt_target_temp = _oldtarget_temperature
+            _LOGGER.debug(
+                "better_thermostat %s: target temperature restored",
+                self.device_name,
+            )
+
+            _LOGGER.debug(
+                "better_thermostat %s: restoring preset mode...", self.device_name
+            )
+            # Restore preset mode if present
+            _old_preset = old_state.attributes.get("preset_mode")
+            if _old_preset in ([PRESET_NONE] + list(self._preset_temperatures)):
+                self._preset_mode = _old_preset
+            else:
+                self._preset_mode = PRESET_NONE
+
+            _LOGGER.debug(
+                "better_thermostat %s: applying restored preset temperature...",
+                self.device_name,
+            )
+            # If we restored a preset (not NONE) and we have a stored temperature for it,
+            # ensure target temp matches (unless the restored target was already equal).
+            if (
+                self._preset_mode is not None
+                and self._preset_mode != PRESET_NONE
+                and self._preset_mode in self._preset_temperatures
+            ):
+                preset_temp = self._preset_temperatures[self._preset_mode]
+                # Only override if different to avoid masking manual restore logic
+                if (
+                    isinstance(preset_temp, (int, float))
+                    and preset_temp is not None
+                    and self.bt_target_temp != preset_temp
+                ):
+                    _LOGGER.debug(
+                        "better_thermostat %s: Applying restored preset %s temperature %s after startup",
+                        self.device_name,
+                        self._preset_mode,
+                        preset_temp,
+                    )
+                    self.bt_target_temp = preset_temp
+            _LOGGER.debug(
+                "better_thermostat %s: restored preset temperature applied",
+                self.device_name,
+            )
+
+            _LOGGER.debug(
+                "better_thermostat %s: restoring other attributes...",
+                self.device_name,
+            )
+            if old_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
+                self.bt_hvac_mode = old_state.state
+            if old_state.attributes.get(ATTR_STATE_CALL_FOR_HEAT, None) is not None:
+                self.call_for_heat = bool(
+                    old_state.attributes.get(ATTR_STATE_CALL_FOR_HEAT)
+                )
+            if (
+                old_state.attributes.get(ATTR_STATE_SAVED_TEMPERATURE, None)
+                is not None
+            ):
+                self._saved_temperature = convert_to_float(
+                    str(
+                        old_state.attributes.get(ATTR_STATE_SAVED_TEMPERATURE, None)
+                    ),
+                    self.device_name,
+                    "startup()",
+                )
+            if old_state.attributes.get(ATTR_STATE_HUMIDIY, None) is not None:
+                self._current_humidity = float(
+                    old_state.attributes[ATTR_STATE_HUMIDIY]
+                )
+            if old_state.attributes.get(ATTR_STATE_MAIN_MODE, None) is not None:
+                self.last_main_hvac_mode = str(
+                    old_state.attributes[ATTR_STATE_MAIN_MODE]
+                )
+            if old_state.attributes.get(ATTR_STATE_HEATING_POWER, None) is not None:
+                try:
+                    _power_value = old_state.attributes.get(
+                        ATTR_STATE_HEATING_POWER
+                    )
+                    if _power_value is not None:
+                        loaded_power = float(_power_value)
+                    else:
+                        loaded_power = 0.01
+                except (TypeError, ValueError):
+                    loaded_power = 0.01
+                # Bound to realistic values to prevent issues from incorrectly learned values
+                bounded_power = max(
+                    MIN_HEATING_POWER, min(MAX_HEATING_POWER, loaded_power)
+                )
+                if bounded_power != loaded_power:
+                    _LOGGER.info(
+                        "better_thermostat %s: Restored heating_power %.3f "
+                        "is outside allowed range [%s, %s]; clamped to %.3f",
+                        self.device_name,
+                        loaded_power,
+                        MIN_HEATING_POWER,
+                        MAX_HEATING_POWER,
+                        bounded_power,
+                    )
+                self.heating_power = bounded_power
+
+            # Restore heat loss if available
+            if old_state.attributes.get(ATTR_STATE_HEAT_LOSS, None) is not None:
+                try:
+                    _loss_value = old_state.attributes.get(ATTR_STATE_HEAT_LOSS)
+                    if _loss_value is not None:
+                        loaded_loss = float(_loss_value)
+                    else:
+                        loaded_loss = 0.01
+                    bounded_loss = max(
+                        MIN_HEAT_LOSS, min(MAX_HEAT_LOSS, loaded_loss)
+                    )
+                    self.heat_loss_rate = bounded_loss
+                except (TypeError, ValueError):
+                    pass
+            if (
+                old_state.attributes.get(ATTR_STATE_PRESET_TEMPERATURE, None)
+                is not None
+            ):
+                self._preset_temperature = convert_to_float(
+                    str(
+                        old_state.attributes.get(
+                            ATTR_STATE_PRESET_TEMPERATURE, None
+                        )
+                    ),
+                    self.device_name,
+                    "startup()",
+                )
+            # Restore preset mode
+            if old_state.attributes.get("preset_mode", None) is not None:
+                restored_preset: str = str(old_state.attributes["preset_mode"])
+                if restored_preset in self.preset_modes:
+                    self._preset_mode = restored_preset
+                    _LOGGER.debug(
+                        "better_thermostat %s: Restored preset mode: %s",
+                        self.device_name,
+                        restored_preset,
+                    )
+            _LOGGER.debug(
+                "better_thermostat %s: state restoration completed",
+                self.device_name,
+            )
+
+            # ECO mode state / saved ECO temperature not restored; Eco preset is supported via PRESET_ECO.
+
+        else:
+            # No previous state, try and restore defaults
+            _LOGGER.debug(
+                "better_thermostat %s: no previous state, restoring defaults...",
+                self.device_name,
+            )
+            if self.bt_target_temp is None or not isinstance(
+                self.bt_target_temp, float
+            ):
+                _LOGGER.info(
+                    "better_thermostat %s: No previously saved temperature found on startup, get it from the TRV",
+                    self.device_name,
+                )
+                self.bt_target_temp = reduce_attribute(
+                    states, ATTR_TEMPERATURE, reduce=lambda *data: mean(data)
+                )
+            _LOGGER.debug(
+                "better_thermostat %s: defaults restored", self.device_name
+            )
+
+    def _validate_hvac_mode(self, states: list[State]) -> None:
+        """Validate and fix HVAC mode after state restoration."""
+        # if hvac mode could not be restored, turn heat off
+        _LOGGER.debug(
+            "better_thermostat %s: checking hvac mode...", self.device_name
+        )
+        if self.bt_hvac_mode in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
+            current_hvac_modes = [
+                x.state for x in states if x.state != HVACMode.OFF
+            ]
+            # return the most common hvac mode (what the thermostat is set to do) except OFF
+            if current_hvac_modes:
+                _temp_bt_hvac_mode = max(
+                    set(current_hvac_modes), key=current_hvac_modes.count
+                )
+                if _temp_bt_hvac_mode is not HVACMode.OFF:
+                    self.bt_hvac_mode = HVACMode.HEAT
+                else:
+                    self.bt_hvac_mode = HVACMode.OFF
+                _LOGGER.debug(
+                    "better_thermostat %s: No previously hvac mode found on startup, turn bt to trv mode %s",
+                    self.device_name,
+                    self.bt_hvac_mode,
+                )
+            # return off if all are off
+            elif all(x.state == HVACMode.OFF for x in states):
+                self.bt_hvac_mode = HVACMode.OFF
+                _LOGGER.debug(
+                    "better_thermostat %s: No previously hvac mode found on startup, turn bt to trv mode %s",
+                    self.device_name,
+                    self.bt_hvac_mode,
+                )
+            else:
+                _LOGGER.warning(
+                    "better_thermostat %s: No previously hvac mode found on startup, turn heat off",
+                    self.device_name,
+                )
+                self.bt_hvac_mode = HVACMode.OFF
+
+        _LOGGER.debug(
+            "better_thermostat %s: Startup config, BT hvac mode is %s, Target temp %s",
+            self.device_name,
+            self.bt_hvac_mode,
+            self.bt_target_temp,
+        )
+
+        if self.last_main_hvac_mode is None:
+            self.last_main_hvac_mode = self.bt_hvac_mode
+
+        _LOGGER.debug(
+            "better_thermostat %s: checking humidity sensor...", self.device_name
+        )
+        if self.humidity_sensor_entity_id is not None:
+            _hum_state = self.hass.states.get(self.humidity_sensor_entity_id)
+            if _hum_state is None:
+                _LOGGER.warning(
+                    "better_thermostat %s: Humidity sensor %s not found or not ready",
+                    self.device_name,
+                    self.humidity_sensor_entity_id,
+                )
+                self._current_humidity = 0
+            else:
+                self._current_humidity = convert_to_float(
+                    str(_hum_state.state), self.device_name, "startup()"
+                ) or 0.0
+        else:
+            self._current_humidity = 0.0
+
+        self.last_window_state = self.window_open
+        if self.bt_hvac_mode not in (
+            HVACMode.OFF,
+            HVACMode.HEAT_COOL,
+            HVACMode.HEAT,
+        ):
+            self.bt_hvac_mode = HVACMode.HEAT
+
+        _LOGGER.debug(
+            "better_thermostat %s: writing initial state...", self.device_name
+        )
+        self.async_write_ha_state()
+
+    async def _initialize_trvs(self) -> None:
+        """Initialize each TRV: init, tweak, calibration offsets, attributes, control."""
+        for trv, trv_data in self.real_trvs.items():
+            self.all_entities.append(trv)
+            _LOGGER.debug(
+                "better_thermostat %s: initializing TRV %s", self.device_name, trv
+            )
+            try:
+                await asyncio.wait_for(init(self, trv), timeout=30)
+                _LOGGER.debug(
+                    "better_thermostat %s: TRV %s initialized",
+                    self.device_name,
+                    trv,
+                )
+            except TimeoutError:
+                _LOGGER.error(
+                    "better_thermostat %s: Timeout initializing TRV %s",
+                    self.device_name,
+                    trv,
+                )
+            except Exception as exc:
+                _LOGGER.error(
+                    "better_thermostat %s: Error initializing TRV %s: %s",
+                    self.device_name,
+                    trv,
+                    exc,
+                )
+
+            try:
+                await inital_tweak(self, trv)
+            except Exception as exc:
+                _LOGGER.error(
+                    "better_thermostat %s: Error running initial tweak for TRV %s: %s",
+                    self.device_name,
+                    trv,
+                    exc,
+                )
+
+            if trv_data["calibration"] != 1:
+                _LOGGER.debug(
+                    "better_thermostat %s: getting offsets for TRV %s",
+                    self.device_name,
+                    trv,
+                )
+
+                try:
+                    async with asyncio.timeout(10):
+                        trv_data["last_calibration"] = await get_current_offset(
+                            self, trv
+                        )
+                        trv_data["local_calibration_min"] = await get_min_offset(
+                            self, trv
+                        )
+                        trv_data["local_calibration_max"] = await get_max_offset(
+                            self, trv
+                        )
+                        trv_data["local_calibration_step"] = await get_offset_step(
+                            self, trv
+                        )
+                    # Ensure None values are replaced with sensible defaults
+                    self._set_trv_calibration_defaults(trv)
+                    _LOGGER.debug(
+                        "better_thermostat %s: offsets for TRV %s retrieved",
                         self.device_name,
                         trv,
                     )
+                except TimeoutError:
+                    _LOGGER.error(
+                        "better_thermostat %s: Timeout getting offsets for TRV %s",
+                        self.device_name,
+                        trv,
+                    )
+                    self._set_trv_calibration_defaults(trv)
                 except Exception as exc:
                     _LOGGER.error(
-                        "better_thermostat %s: Error controlling TRV %s: %s",
+                        "better_thermostat %s: Error getting offsets for TRV %s: %s",
                         self.device_name,
                         trv,
                         exc,
                     )
-
-            _LOGGER.debug("better_thermostat %s: triggering time...", self.device_name)
-            await self._trigger_time(None)
-            _LOGGER.debug(
-                "better_thermostat %s: triggering check weather...", self.device_name
-            )
-            await self._trigger_check_weather(None)
-            _LOGGER.debug(
-                "better_thermostat %s: startup finishing...", self.device_name
-            )
-            self.startup_running = False
-            self._available = True
-            self.async_write_ha_state()
-
-            _LOGGER.debug("better_thermostat %s: sleeping 15s...", self.device_name)
-            await asyncio.sleep(15)
-            _LOGGER.debug(
-                "better_thermostat %s: finding battery entities...", self.device_name
-            )
-
-            # try to find battery entities for all related entities
-            for entity in self.all_entities:
-                if entity is not None:
-                    battery_id = await find_battery_entity(self, entity)
-                    if battery_id is not None:
-                        self.devices_states[entity] = {
-                            "battery_id": battery_id,
-                            "battery": None,
-                        }
-
-            if self.is_removed:
-                return
-
-            # Add listener
-            if self.outdoor_sensor is not None:
-                self.all_entities.append(self.outdoor_sensor)
-                self.async_on_remove(
-                    async_track_time_change(self.hass, self._trigger_time, 5, 0, 0)
-                )
-
-            _LOGGER.debug(
-                "better_thermostat %s: checking critical entities...", self.device_name
-            )
-            await check_critical_entities(self)
-
-            # Wait for optional sensors with increasing retry delays before
-            # entering degraded mode (see await_optional_sensors for details).
-            await await_optional_sensors(self)
-            await check_and_update_degraded_mode(self)
-
-            if self.is_removed:
-                return
-
-            _LOGGER.debug(
-                "better_thermostat %s: registering periodic tasks...", self.device_name
-            )
-            self.async_on_remove(
-                async_track_time_interval(
-                    self.hass, self._trigger_check_weather, timedelta(hours=1)
-                )
-            )
-
-            # Periodischer 5-Minuten-Tick: nur aktivieren, wenn Balance konfiguriert ist
-            balance_modes = {"heuristic", "pid"}
-            active_balance_modes = set()
-            active_calibration_modes = set()
-            try:
-                for trv_info in self.real_trvs.values():
-                    advanced = trv_info.get("advanced", {}) or {}
-
-                    raw_balance = advanced.get("balance_mode", "")
-                    balance_value = getattr(raw_balance, "value", raw_balance)
-                    if isinstance(balance_value, str):
-                        balance_mode = balance_value.lower()
-                        if balance_mode in balance_modes:
-                            active_balance_modes.add(balance_mode)
-
-                    raw_calibration = advanced.get("calibration_mode", "")
-                    calibration_value = getattr(
-                        raw_calibration, "value", raw_calibration
-                    )
-                    if isinstance(calibration_value, str):
-                        calibration_mode = calibration_value.lower()
-                        if calibration_mode in (
-                            CalibrationMode.DEFAULT.value,
-                            CalibrationMode.MPC_CALIBRATION.value,
-                            CalibrationMode.TPI_CALIBRATION.value,
-                            CalibrationMode.PID_CALIBRATION.value,
-                        ):
-                            active_calibration_modes.add(calibration_mode)
-            except Exception:
-                active_balance_modes = set()
-                active_calibration_modes = set()
-
-            if active_balance_modes or active_calibration_modes:
-                self.async_on_remove(
-                    async_track_time_interval(
-                        self.hass, self._trigger_time, timedelta(minutes=5)
-                    )
-                )
-                _LOGGER.debug(
-                    "better_thermostat %s: 5min periodic tick enabled (balance_modes=%s calibration_modes=%s)",
-                    self.device_name,
-                    sorted(active_balance_modes),
-                    sorted(active_calibration_modes),
-                )
+                    self._set_trv_calibration_defaults(trv)
             else:
-                _LOGGER.debug(
-                    "better_thermostat %s: 5min periodic tick skipped (no supported balance/calibration mode)",
-                    self.device_name,
-                )
+                trv_data["last_calibration"] = 0
+                trv_data["local_calibration_min"] = -7
+                trv_data["local_calibration_max"] = 7
+                trv_data["local_calibration_step"] = 0.5
 
-            # Periodischer Keepalive: externe Temperatur mindestens alle 30 Minuten an TRVs senden
-            self.async_on_remove(
-                async_track_time_interval(
-                    self.hass,
-                    self._external_temperature_keepalive,
-                    timedelta(minutes=30),
-                )
+            _s = self.hass.states.get(trv)
+            _attrs = _s.attributes if _s else {}
+            _LOGGER.debug(
+                "better_thermostat %s: reading TRV %s attributes...",
+                self.device_name,
+                trv,
             )
-
-            # Ventilwartung: separaten Tick nur aktivieren, wenn mindestens ein TRV sie eingeschaltet hat
-            try:
-                any_maintenance = any(
-                    bool(
-                        (trv_info.get("advanced", {}) or {}).get(
-                            CONF_VALVE_MAINTENANCE, False
-                        )
-                    )
-                    for trv_info in self.real_trvs.values()
-                )
-            except Exception:
-                any_maintenance = False
-
-            if any_maintenance:
-                # Re-calculate next maintenance based on loaded TRV quirks
-                # (overrides the random 1h-5d startup default)
-                min_interval_hours = 168  # Default 7 days
-                for trv_id, trv_data in self.real_trvs.items():
-                    if bool(
-                        (trv_data.get("advanced", {}) or {}).get(
-                            CONF_VALVE_MAINTENANCE, False
-                        )
-                    ):
-                        quirks = trv_data.get("model_quirks")
-                        interval = int(
-                            getattr(quirks, "VALVE_MAINTENANCE_INTERVAL_HOURS", 168)
-                        )
-                        min_interval_hours = min(min_interval_hours, interval)
-
-                now = datetime.now()
-                # Schedule initial run: randomize within [1h, min(5d, interval)]
-                # If interval is very short (e.g. 12h), respect it.
-                max_delay_hours = min(24 * 5, min_interval_hours)
-                delay_hours = randint(1, max(2, max_delay_hours))
-
-                self.next_valve_maintenance = now + timedelta(hours=delay_hours)
-
-                self.async_on_remove(
-                    async_track_time_interval(
-                        self.hass, self._maintenance_tick, timedelta(minutes=5)
-                    )
-                )
-                _LOGGER.debug(
-                    "better_thermostat %s: valve maintenance tick enabled (5min), first run at %s",
-                    self.device_name,
-                    self.next_valve_maintenance,
-                )
+            trv_data["valve_position"] = convert_to_float(
+                str(_attrs.get("valve_position", None)), self.device_name, "startup"
+            )
+            trv_data["max_temp"] = convert_to_float(
+                str(_attrs.get("max_temp", 30)), self.device_name, "startup"
+            )
+            trv_data["min_temp"] = convert_to_float(
+                str(_attrs.get("min_temp", 5)), self.device_name, "startup"
+            )
+            # Prefer configured step over device-reported step
+            cfg_step = (
+                self.bt_target_temp_step
+                if self.bt_target_temp_step and self.bt_target_temp_step > 0.0
+                else None
+            )
+            if cfg_step is not None:
+                trv_data["target_temp_step"] = cfg_step
             else:
-                _LOGGER.debug(
-                    "better_thermostat %s: valve maintenance tick skipped (no TRV enabled)",
+                trv_data["target_temp_step"] = convert_to_float(
+                    str(_attrs.get("target_temp_step", 0.5)),
                     self.device_name,
+                    "startup",
                 )
-
-            self.async_on_remove(
-                async_track_state_change_event(
-                    self.hass, [self.sensor_entity_id], self._trigger_temperature_change
-                )
+            trv_data["temperature"] = convert_to_float(
+                str(_attrs.get("temperature", 5)), self.device_name, "startup"
             )
-            if self.humidity_sensor_entity_id is not None:
-                self.async_on_remove(
-                    async_track_state_change_event(
-                        self.hass,
-                        [self.humidity_sensor_entity_id],
-                        self._trigger_humidity_change,
-                    )
-                )
-            if self._async_unsub_state_changed is None:
-                self._async_unsub_state_changed = async_track_state_change_event(
-                    self.hass, self.entity_ids, self._trigger_trv_change
-                )
-                self.async_on_remove(self._async_unsub_state_changed)
-            if self.window_id is not None:
-                self.async_on_remove(
-                    async_track_state_change_event(
-                        self.hass, [self.window_id], self._trigger_window_change
-                    )
-                )
-            if self.cooler_entity_id is not None:
-                self.async_on_remove(
-                    async_track_state_change_event(
-                        self.hass, [self.cooler_entity_id], self._tigger_cooler_change
-                    )
-                )
-            # Sende initial sofort einen Keepalive, damit TRVs nicht bis zum ersten 30min-Tick warten müssen
+            trv_data["hvac_modes"] = _attrs.get("hvac_modes", None)
+            trv_data["hvac_mode"] = _s.state if _s else None
+            trv_data["last_hvac_mode"] = _s.state if _s else None
+            trv_data["last_temperature"] = convert_to_float(
+                str(_attrs.get("temperature")), self.device_name, "startup()"
+            )
+            trv_data["current_temperature"] = convert_to_float(
+                str(_attrs.get("current_temperature") or 5),
+                self.device_name,
+                "startup()",
+            )
+            _LOGGER.debug(
+                "better_thermostat %s: controlling TRV %s...", self.device_name, trv
+            )
             try:
+                await asyncio.wait_for(control_trv(self, trv), timeout=10)
                 _LOGGER.debug(
-                    "better_thermostat %s: creating keepalive task...", self.device_name
+                    "better_thermostat %s: TRV %s controlled", self.device_name, trv
                 )
-                self.hass.async_create_task(self._external_temperature_keepalive())
+            except TimeoutError:
+                _LOGGER.error(
+                    "better_thermostat %s: Timeout controlling TRV %s",
+                    self.device_name,
+                    trv,
+                )
             except Exception as exc:
                 _LOGGER.error(
-                    "better_thermostat %s: Failed to create external temperature keepalive task: %s",
+                    "better_thermostat %s: Error controlling TRV %s: %s",
                     self.device_name,
+                    trv,
                     exc,
                 )
-            # Start periodic EMA update (every minute)
-            _LOGGER.debug(
-                "better_thermostat %s: starting EMA timer...", self.device_name
+
+    async def _finalize_startup(self) -> None:
+        """Run post-init tasks: triggers, listeners, periodic jobs."""
+        _LOGGER.debug("better_thermostat %s: triggering time...", self.device_name)
+        await self._trigger_time(None)
+        _LOGGER.debug(
+            "better_thermostat %s: triggering check weather...", self.device_name
+        )
+        await self._trigger_check_weather(None)
+        _LOGGER.debug(
+            "better_thermostat %s: startup finishing...", self.device_name
+        )
+        self.startup_running = False
+        self._available = True
+        self.async_write_ha_state()
+
+        _LOGGER.debug("better_thermostat %s: sleeping 15s...", self.device_name)
+        await asyncio.sleep(15)
+        _LOGGER.debug(
+            "better_thermostat %s: finding battery entities...", self.device_name
+        )
+
+        # try to find battery entities for all related entities
+        for entity in self.all_entities:
+            if entity is not None:
+                battery_id = await find_battery_entity(self, entity)
+                if battery_id is not None:
+                    self.devices_states[entity] = {
+                        "battery_id": battery_id,
+                        "battery": None,
+                    }
+
+        if self.is_removed:
+            return
+
+        # Add listener
+        if self.outdoor_sensor is not None:
+            self.all_entities.append(self.outdoor_sensor)
+            self.async_on_remove(
+                async_track_time_change(self.hass, self._trigger_time, 5, 0, 0)
             )
+
+        _LOGGER.debug(
+            "better_thermostat %s: checking critical entities...", self.device_name
+        )
+        await check_critical_entities(self)
+
+        # Wait for optional sensors with increasing retry delays before
+        # entering degraded mode (see await_optional_sensors for details).
+        await await_optional_sensors(self)
+        await check_and_update_degraded_mode(self)
+
+        if self.is_removed:
+            return
+
+        _LOGGER.debug(
+            "better_thermostat %s: registering periodic tasks...", self.device_name
+        )
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass, self._trigger_check_weather, timedelta(hours=1)
+            )
+        )
+
+        # Periodischer 5-Minuten-Tick: nur aktivieren, wenn Balance konfiguriert ist
+        balance_modes = {"heuristic", "pid"}
+        active_balance_modes = set()
+        active_calibration_modes = set()
+        try:
+            for trv_info in self.real_trvs.values():
+                advanced = trv_info.get("advanced", {}) or {}
+
+                raw_balance = advanced.get("balance_mode", "")
+                balance_value = getattr(raw_balance, "value", raw_balance)
+                if isinstance(balance_value, str):
+                    balance_mode = balance_value.lower()
+                    if balance_mode in balance_modes:
+                        active_balance_modes.add(balance_mode)
+
+                raw_calibration = advanced.get("calibration_mode", "")
+                calibration_value = getattr(
+                    raw_calibration, "value", raw_calibration
+                )
+                if isinstance(calibration_value, str):
+                    calibration_mode = calibration_value.lower()
+                    if calibration_mode in (
+                        CalibrationMode.DEFAULT.value,
+                        CalibrationMode.MPC_CALIBRATION.value,
+                        CalibrationMode.TPI_CALIBRATION.value,
+                        CalibrationMode.PID_CALIBRATION.value,
+                    ):
+                        active_calibration_modes.add(calibration_mode)
+        except Exception:
+            active_balance_modes = set()
+            active_calibration_modes = set()
+
+        if active_balance_modes or active_calibration_modes:
             self.async_on_remove(
                 async_track_time_interval(
-                    self.hass, self._async_update_ema_periodic, timedelta(minutes=1)
+                    self.hass, self._trigger_time, timedelta(minutes=5)
                 )
             )
-            _LOGGER.info("better_thermostat %s: startup completed.", self.device_name)
-            self.async_write_ha_state()
-            await self.async_update_ha_state(force_refresh=True)
-            break
+            _LOGGER.debug(
+                "better_thermostat %s: 5min periodic tick enabled (balance_modes=%s calibration_modes=%s)",
+                self.device_name,
+                sorted(active_balance_modes),
+                sorted(active_calibration_modes),
+            )
+        else:
+            _LOGGER.debug(
+                "better_thermostat %s: 5min periodic tick skipped (no supported balance/calibration mode)",
+                self.device_name,
+            )
+
+        # Periodischer Keepalive: externe Temperatur mindestens alle 30 Minuten an TRVs senden
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass,
+                self._external_temperature_keepalive,
+                timedelta(minutes=30),
+            )
+        )
+
+        # Ventilwartung: separaten Tick nur aktivieren, wenn mindestens ein TRV sie eingeschaltet hat
+        try:
+            any_maintenance = any(
+                bool(
+                    (trv_info.get("advanced", {}) or {}).get(
+                        CONF_VALVE_MAINTENANCE, False
+                    )
+                )
+                for trv_info in self.real_trvs.values()
+            )
+        except Exception:
+            any_maintenance = False
+
+        if any_maintenance:
+            # Re-calculate next maintenance based on loaded TRV quirks
+            # (overrides the random 1h-5d startup default)
+            min_interval_hours = 168  # Default 7 days
+            for trv_id, trv_data in self.real_trvs.items():
+                if bool(
+                    (trv_data.get("advanced", {}) or {}).get(
+                        CONF_VALVE_MAINTENANCE, False
+                    )
+                ):
+                    quirks = trv_data.get("model_quirks")
+                    interval = int(
+                        getattr(quirks, "VALVE_MAINTENANCE_INTERVAL_HOURS", 168)
+                    )
+                    min_interval_hours = min(min_interval_hours, interval)
+
+            now = datetime.now()
+            # Schedule initial run: randomize within [1h, min(5d, interval)]
+            # If interval is very short (e.g. 12h), respect it.
+            max_delay_hours = min(24 * 5, min_interval_hours)
+            delay_hours = randint(1, max(2, max_delay_hours))
+
+            self.next_valve_maintenance = now + timedelta(hours=delay_hours)
+
+            self.async_on_remove(
+                async_track_time_interval(
+                    self.hass, self._maintenance_tick, timedelta(minutes=5)
+                )
+            )
+            _LOGGER.debug(
+                "better_thermostat %s: valve maintenance tick enabled (5min), first run at %s",
+                self.device_name,
+                self.next_valve_maintenance,
+            )
+        else:
+            _LOGGER.debug(
+                "better_thermostat %s: valve maintenance tick skipped (no TRV enabled)",
+                self.device_name,
+            )
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass, [self.sensor_entity_id], self._trigger_temperature_change
+            )
+        )
+        if self.humidity_sensor_entity_id is not None:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass,
+                    [self.humidity_sensor_entity_id],
+                    self._trigger_humidity_change,
+                )
+            )
+        if self._async_unsub_state_changed is None:
+            self._async_unsub_state_changed = async_track_state_change_event(
+                self.hass, self.entity_ids, self._trigger_trv_change
+            )
+            self.async_on_remove(self._async_unsub_state_changed)
+        if self.window_id is not None:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass, [self.window_id], self._trigger_window_change
+                )
+            )
+        if self.cooler_entity_id is not None:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass, [self.cooler_entity_id], self._tigger_cooler_change
+                )
+            )
+        # Sende initial sofort einen Keepalive, damit TRVs nicht bis zum ersten 30min-Tick warten müssen
+        try:
+            _LOGGER.debug(
+                "better_thermostat %s: creating keepalive task...", self.device_name
+            )
+            self.hass.async_create_task(self._external_temperature_keepalive())
+        except Exception as exc:
+            _LOGGER.error(
+                "better_thermostat %s: Failed to create external temperature keepalive task: %s",
+                self.device_name,
+                exc,
+            )
+        # Start periodic EMA update (every minute)
+        _LOGGER.debug(
+            "better_thermostat %s: starting EMA timer...", self.device_name
+        )
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass, self._async_update_ema_periodic, timedelta(minutes=1)
+            )
+        )
+        _LOGGER.info("better_thermostat %s: startup completed.", self.device_name)
+        self.async_write_ha_state()
+        await self.async_update_ha_state(force_refresh=True)
 
     async def _maintenance_tick(self, event=None):
         """Periodic maintenance tick: runs valve exercise when due and enabled."""

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -1,0 +1,511 @@
+"""Tests for the startup() submethods extracted from BetterThermostat.startup().
+
+Covers: _check_entities_ready, _collect_trv_states, _resolve_temperature_range,
+_initialize_sensors, _restore_state, _validate_hvac_mode.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.climate import (
+    BetterThermostat,
+    DEFAULT_FALLBACK_TEMPERATURE,
+)
+from custom_components.better_thermostat.utils.const import (
+    ATTR_STATE_CALL_FOR_HEAT,
+    ATTR_STATE_HEATING_POWER,
+    MAX_HEATING_POWER,
+)
+
+SENSOR_ID = "sensor.room_temp"
+TRV_ID = "climate.test_trv"
+TRV_ID_2 = "climate.test_trv_2"
+COOLER_ID = "climate.cooler"
+WINDOW_ID = "binary_sensor.window"
+HUMIDITY_ID = "sensor.humidity"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bt():
+    """Create a mock BetterThermostat with sensible defaults."""
+    mock = MagicMock(spec=BetterThermostat)
+    mock.hass = MagicMock()
+    mock.device_name = "Test BT"
+    mock.sensor_entity_id = SENSOR_ID
+    mock.real_trvs = {TRV_ID: {"calibration": 1}}
+    mock.cooler_entity_id = None
+    mock.humidity_sensor_entity_id = None
+    mock.window_id = None
+    mock.all_entities = []
+    mock.unavailable_sensors = []
+    mock.degraded_mode = False
+    mock.bt_min_temp = 5.0
+    mock.bt_max_temp = 30.0
+    mock.bt_target_temp = 21.0
+    mock.bt_target_temp_step = None
+    mock.bt_target_cooltemp = None
+    mock.bt_hvac_mode = None
+    mock.cur_temp = None
+    mock.cur_temp_filtered = None
+    mock.external_temp_ema = None
+    mock._external_temp_ema_ts = None
+    mock.external_temp_ema_tau_s = 300.0
+    mock.temp_slope = None
+    mock.last_known_external_temp = None
+    mock._current_humidity = None
+    mock.window_open = None
+    mock.last_window_state = None
+    mock.last_main_hvac_mode = None
+    mock.call_for_heat = None
+    mock._saved_temperature = None
+    mock.heating_power = 0.01
+    mock.heat_loss_rate = 0.01
+    mock._preset_temperature = None
+    mock._preset_mode = None
+    mock._preset_temperatures = {"comfort": 22.0, "eco": 18.0}
+    mock.preset_modes = ["none", "comfort", "eco"]
+    mock.version = "1.0.0"
+    mock.startup_running = True
+    return mock
+
+
+def _make_trv_state(entity_id=TRV_ID, state="heat", attrs=None):
+    """Build a TRV State with typical attributes."""
+    default_attrs = {
+        "min_temp": 5.0,
+        "max_temp": 30.0,
+        "target_temp_step": 0.5,
+        ATTR_TEMPERATURE: 21.0,
+        "current_temperature": 20.0,
+    }
+    if attrs:
+        default_attrs.update(attrs)
+    return State(entity_id, state, attributes=default_attrs)
+
+
+def _make_sensor_state(temp="21.5", state_val=None):
+    """Build a sensor State."""
+    return State(SENSOR_ID, state_val or temp)
+
+
+# ---------------------------------------------------------------------------
+# 1. _check_entities_ready
+# ---------------------------------------------------------------------------
+
+
+class TestCheckEntitiesReady:
+    """Tests for _check_entities_ready."""
+
+    def test_sensor_none_returns_false(self, bt):
+        result = BetterThermostat._check_entities_ready(bt, None)
+        assert result is False
+
+    def test_sensor_unavailable_returns_false(self, bt):
+        sensor = State(SENSOR_ID, STATE_UNAVAILABLE)
+        result = BetterThermostat._check_entities_ready(bt, sensor)
+        assert result is False
+
+    def test_sensor_unknown_returns_false(self, bt):
+        sensor = State(SENSOR_ID, STATE_UNKNOWN)
+        result = BetterThermostat._check_entities_ready(bt, sensor)
+        assert result is False
+
+    def test_trv_none_returns_false(self, bt):
+        sensor = _make_sensor_state()
+        bt.hass.states.get.return_value = None
+        result = BetterThermostat._check_entities_ready(bt, sensor)
+        assert result is False
+
+    def test_trv_unavailable_returns_false(self, bt):
+        sensor = _make_sensor_state()
+        bt.hass.states.get.return_value = State(TRV_ID, STATE_UNAVAILABLE)
+        result = BetterThermostat._check_entities_ready(bt, sensor)
+        assert result is False
+
+    def test_all_ready_returns_true(self, bt):
+        sensor = _make_sensor_state()
+        bt.hass.states.get.return_value = _make_trv_state()
+        result = BetterThermostat._check_entities_ready(bt, sensor)
+        assert result is True
+
+    def test_multiple_trvs_second_unavailable(self, bt):
+        sensor = _make_sensor_state()
+        bt.real_trvs = {TRV_ID: {}, TRV_ID_2: {}}
+
+        def side_effect(entity_id):
+            if entity_id == TRV_ID:
+                return _make_trv_state()
+            return State(TRV_ID_2, STATE_UNAVAILABLE)
+
+        bt.hass.states.get.side_effect = side_effect
+        result = BetterThermostat._check_entities_ready(bt, sensor)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# 2. _collect_trv_states
+# ---------------------------------------------------------------------------
+
+
+class TestCollectTrvStates:
+    """Tests for _collect_trv_states."""
+
+    def test_collects_single_trv(self, bt):
+        trv_state = _make_trv_state()
+        bt.hass.states.get.return_value = trv_state
+        result = BetterThermostat._collect_trv_states(bt)
+        assert len(result) == 1
+        assert result[0] is trv_state
+
+    def test_includes_cooler_when_available(self, bt):
+        bt.cooler_entity_id = COOLER_ID
+        cooler_state = State(COOLER_ID, "cool", {"min_temp": 18, "max_temp": 28})
+        trv_state = _make_trv_state()
+
+        def side_effect(entity_id):
+            if entity_id == TRV_ID:
+                return trv_state
+            if entity_id == COOLER_ID:
+                return cooler_state
+            return None
+
+        bt.hass.states.get.side_effect = side_effect
+        result = BetterThermostat._collect_trv_states(bt)
+        assert len(result) == 2
+        assert cooler_state in result
+
+    def test_skips_unavailable_cooler(self, bt):
+        bt.cooler_entity_id = COOLER_ID
+        trv_state = _make_trv_state()
+
+        def side_effect(entity_id):
+            if entity_id == TRV_ID:
+                return trv_state
+            if entity_id == COOLER_ID:
+                return State(COOLER_ID, STATE_UNAVAILABLE)
+            return None
+
+        bt.hass.states.get.side_effect = side_effect
+        result = BetterThermostat._collect_trv_states(bt)
+        assert len(result) == 1
+
+    def test_missing_trv_state_skipped(self, bt):
+        bt.real_trvs = {TRV_ID: {}, TRV_ID_2: {}}
+
+        def side_effect(entity_id):
+            if entity_id == TRV_ID:
+                return _make_trv_state()
+            return None
+
+        bt.hass.states.get.side_effect = side_effect
+        result = BetterThermostat._collect_trv_states(bt)
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. _resolve_temperature_range
+# ---------------------------------------------------------------------------
+
+
+class TestResolveTemperatureRange:
+    """Tests for _resolve_temperature_range."""
+
+    def test_normal_range(self, bt):
+        states = [_make_trv_state(attrs={"min_temp": 5.0, "max_temp": 30.0})]
+        BetterThermostat._resolve_temperature_range(bt, states)
+        assert bt.bt_min_temp == 5.0
+        assert bt.bt_max_temp == 30.0
+
+    def test_min_greater_than_max(self, bt):
+        """When heater min > cooler max, range is still set."""
+        states = [
+            _make_trv_state(attrs={"min_temp": 20.0, "max_temp": 15.0}),
+        ]
+        # Set attributes so reduce_attribute returns the right values
+        bt.bt_min_temp = None
+        bt.bt_max_temp = None
+        BetterThermostat._resolve_temperature_range(bt, states)
+        # min_temp=20, max_temp=15 → warning
+        assert bt.bt_min_temp == 20.0
+        assert bt.bt_max_temp == 15.0
+
+    def test_step_already_set_not_overwritten(self, bt):
+        bt.bt_target_temp_step = 1.0
+        states = [_make_trv_state(attrs={"target_temp_step": 0.5})]
+        BetterThermostat._resolve_temperature_range(bt, states)
+        assert bt.bt_target_temp_step == 1.0
+
+    def test_step_none_gets_resolved(self, bt):
+        bt.bt_target_temp_step = None
+        states = [_make_trv_state(attrs={"target_temp_step": 0.5})]
+        BetterThermostat._resolve_temperature_range(bt, states)
+        assert bt.bt_target_temp_step == 0.5
+
+
+# ---------------------------------------------------------------------------
+# 4. _initialize_sensors
+# ---------------------------------------------------------------------------
+
+
+class TestInitializeSensors:
+    """Tests for _initialize_sensors."""
+
+    def test_sensor_ok_sets_cur_temp(self, bt):
+        sensor = _make_sensor_state("21.5")
+        BetterThermostat._initialize_sensors(bt, sensor)
+        assert bt.cur_temp is not None
+        assert SENSOR_ID in bt.all_entities
+
+    def test_sensor_unavailable_falls_back_to_trv(self, bt):
+        sensor = State(SENSOR_ID, STATE_UNAVAILABLE)
+        trv_state = _make_trv_state(attrs={"current_temperature": 19.5})
+        bt.hass.states.get.return_value = trv_state
+        BetterThermostat._initialize_sensors(bt, sensor)
+        assert bt.cur_temp is not None
+        assert bt.degraded_mode is True
+
+    def test_no_sensor_no_trv_uses_default(self, bt):
+        sensor = State(SENSOR_ID, STATE_UNAVAILABLE)
+        # TRV has no current_temperature
+        trv_state = _make_trv_state(attrs={"current_temperature": None})
+        bt.hass.states.get.return_value = trv_state
+        BetterThermostat._initialize_sensors(bt, sensor)
+        assert bt.cur_temp == DEFAULT_FALLBACK_TEMPERATURE
+
+    def test_window_open_detected(self, bt):
+        bt.window_id = WINDOW_ID
+        sensor = _make_sensor_state("20.0")
+
+        def side_effect(entity_id):
+            if entity_id == WINDOW_ID:
+                return State(WINDOW_ID, "on")
+            return None
+
+        bt.hass.states.get.side_effect = side_effect
+        BetterThermostat._initialize_sensors(bt, sensor)
+        assert bt.window_open is True
+        assert WINDOW_ID in bt.all_entities
+
+    def test_window_none_defaults_closed(self, bt):
+        bt.window_id = None
+        sensor = _make_sensor_state("20.0")
+        BetterThermostat._initialize_sensors(bt, sensor)
+        assert bt.window_open is False
+
+    def test_humidity_sensor_initialized(self, bt):
+        bt.humidity_sensor_entity_id = HUMIDITY_ID
+        sensor = _make_sensor_state("20.0")
+        bt.hass.states.get.return_value = State(HUMIDITY_ID, "55.0")
+        BetterThermostat._initialize_sensors(bt, sensor)
+        assert HUMIDITY_ID in bt.all_entities
+
+    def test_ema_initialized_with_cur_temp(self, bt):
+        sensor = _make_sensor_state("21.5")
+        with patch(
+            "custom_components.better_thermostat.events.temperature._update_external_temp_ema"
+        ):
+            BetterThermostat._initialize_sensors(bt, sensor)
+        assert bt.last_known_external_temp is not None
+
+
+# ---------------------------------------------------------------------------
+# 5. _restore_state
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreState:
+    """Tests for _restore_state."""
+
+    @pytest.mark.asyncio
+    async def test_restores_ema_and_slope(self, bt):
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {
+            "external_temp_ema": "20.5",
+            "temp_slope_K_min": "0.0012",
+            ATTR_TEMPERATURE: 21.0,
+        }
+        bt.async_get_last_state = AsyncMock(return_value=old)
+        bt._preset_temperatures = {}
+
+        states = [_make_trv_state()]
+        await BetterThermostat._restore_state(bt, states)
+
+        assert bt.external_temp_ema == 20.5
+        assert bt.cur_temp_filtered == 20.5
+        assert bt.temp_slope == 0.0012
+
+    @pytest.mark.asyncio
+    async def test_target_clamped_to_min(self, bt):
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {ATTR_TEMPERATURE: 2.0}  # below min
+        bt.async_get_last_state = AsyncMock(return_value=old)
+        bt.bt_min_temp = 5.0
+        bt.bt_max_temp = 30.0
+        bt._preset_temperatures = {}
+
+        states = [_make_trv_state()]
+        await BetterThermostat._restore_state(bt, states)
+
+        assert bt.bt_target_temp is not None
+
+    @pytest.mark.asyncio
+    async def test_target_clamped_to_max(self, bt):
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {ATTR_TEMPERATURE: 35.0}  # above max
+        bt.async_get_last_state = AsyncMock(return_value=old)
+        bt.bt_min_temp = 5.0
+        bt.bt_max_temp = 30.0
+        bt._preset_temperatures = {}
+
+        states = [_make_trv_state()]
+        await BetterThermostat._restore_state(bt, states)
+
+        assert bt.bt_target_temp is not None
+
+    @pytest.mark.asyncio
+    async def test_restores_preset_mode(self, bt):
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {
+            ATTR_TEMPERATURE: 22.0,
+            "preset_mode": "comfort",
+        }
+        bt.async_get_last_state = AsyncMock(return_value=old)
+        bt._preset_temperatures = {"comfort": 22.0, "eco": 18.0}
+
+        states = [_make_trv_state()]
+        await BetterThermostat._restore_state(bt, states)
+
+        assert bt._preset_mode == "comfort"
+
+    @pytest.mark.asyncio
+    async def test_restores_heating_power_clamped(self, bt):
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {
+            ATTR_TEMPERATURE: 21.0,
+            ATTR_STATE_HEATING_POWER: "999.0",  # way above max
+        }
+        bt.async_get_last_state = AsyncMock(return_value=old)
+        bt._preset_temperatures = {}
+
+        states = [_make_trv_state()]
+        await BetterThermostat._restore_state(bt, states)
+
+        assert bt.heating_power == MAX_HEATING_POWER
+
+    @pytest.mark.asyncio
+    async def test_no_old_state_uses_trv_defaults(self, bt):
+        bt.async_get_last_state = AsyncMock(return_value=None)
+        bt.bt_target_temp = None
+
+        states = [_make_trv_state(attrs={ATTR_TEMPERATURE: 20.0})]
+        await BetterThermostat._restore_state(bt, states)
+
+        # Should have set bt_target_temp from TRV states
+        assert bt.bt_target_temp is not None
+
+    @pytest.mark.asyncio
+    async def test_restores_call_for_heat(self, bt):
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {
+            ATTR_TEMPERATURE: 21.0,
+            ATTR_STATE_CALL_FOR_HEAT: True,
+        }
+        bt.async_get_last_state = AsyncMock(return_value=old)
+        bt._preset_temperatures = {}
+
+        states = [_make_trv_state()]
+        await BetterThermostat._restore_state(bt, states)
+
+        assert bt.call_for_heat is True
+
+
+# ---------------------------------------------------------------------------
+# 6. _validate_hvac_mode
+# ---------------------------------------------------------------------------
+
+
+class TestValidateHvacMode:
+    """Tests for _validate_hvac_mode."""
+
+    def test_already_set_stays(self, bt):
+        bt.bt_hvac_mode = HVACMode.HEAT
+        bt.humidity_sensor_entity_id = None
+        states = [_make_trv_state(state="heat")]
+        BetterThermostat._validate_hvac_mode(bt, states)
+        assert bt.bt_hvac_mode == HVACMode.HEAT
+
+    def test_none_mode_all_off_sets_off(self, bt):
+        bt.bt_hvac_mode = None
+        bt.humidity_sensor_entity_id = None
+        states = [_make_trv_state(state="off")]
+        BetterThermostat._validate_hvac_mode(bt, states)
+        assert bt.bt_hvac_mode == HVACMode.OFF
+
+    def test_none_mode_most_heat_sets_heat(self, bt):
+        bt.bt_hvac_mode = None
+        bt.humidity_sensor_entity_id = None
+        states = [
+            _make_trv_state(TRV_ID, state="heat"),
+            _make_trv_state(TRV_ID_2, state="heat"),
+        ]
+        BetterThermostat._validate_hvac_mode(bt, states)
+        assert bt.bt_hvac_mode == HVACMode.HEAT
+
+    def test_invalid_mode_forced_to_heat(self, bt):
+        bt.bt_hvac_mode = "auto"  # not in allowed set
+        bt.humidity_sensor_entity_id = None
+        states = [_make_trv_state(state="heat")]
+        BetterThermostat._validate_hvac_mode(bt, states)
+        assert bt.bt_hvac_mode == HVACMode.HEAT
+
+    def test_last_main_hvac_mode_default(self, bt):
+        bt.bt_hvac_mode = HVACMode.HEAT
+        bt.last_main_hvac_mode = None
+        bt.humidity_sensor_entity_id = None
+        states = [_make_trv_state()]
+        BetterThermostat._validate_hvac_mode(bt, states)
+        assert bt.last_main_hvac_mode == HVACMode.HEAT
+
+    def test_last_window_state_set(self, bt):
+        bt.bt_hvac_mode = HVACMode.HEAT
+        bt.window_open = True
+        bt.humidity_sensor_entity_id = None
+        states = [_make_trv_state()]
+        BetterThermostat._validate_hvac_mode(bt, states)
+        assert bt.last_window_state is True
+
+    def test_humidity_sensor_re_read(self, bt):
+        bt.bt_hvac_mode = HVACMode.HEAT
+        bt.humidity_sensor_entity_id = HUMIDITY_ID
+        bt.hass.states.get.return_value = State(HUMIDITY_ID, "60.0")
+        states = [_make_trv_state()]
+        BetterThermostat._validate_hvac_mode(bt, states)
+        # humidity should be re-read
+        assert bt._current_humidity is not None
+
+    def test_humidity_sensor_none_sets_zero(self, bt):
+        bt.bt_hvac_mode = HVACMode.HEAT
+        bt.humidity_sensor_entity_id = HUMIDITY_ID
+        bt.hass.states.get.return_value = None
+        states = [_make_trv_state()]
+        BetterThermostat._validate_hvac_mode(bt, states)
+        assert bt._current_humidity == 0


### PR DESCRIPTION
## Summary

- Break the monolithic `startup()` (~888 lines) into a slim orchestrator (~22 lines) and 8 focused private methods with strict type annotations
- Eliminate the `ContinueLoop` exception anti-pattern
- Fix type inconsistencies found during extraction (`_current_humidity`, `bt_min_temp`/`bt_max_temp`, attribute restore casts)

## Changes

### New orchestrator (`startup()`)
```python
async def startup(self) -> None:
    while self.startup_running:
        sensor_state = self.hass.states.get(self.sensor_entity_id)
        if not self._check_entities_ready(sensor_state):
            await asyncio.sleep(20)
            continue
        states = self._collect_trv_states()
        self._resolve_temperature_range(states)
        self._initialize_sensors(sensor_state)
        await self._restore_state(states)
        self._validate_hvac_mode(states)
        await self._initialize_trvs()
        await self._finalize_startup()
        break
```

### 8 extracted submethods

| # | Method | Sync/Async | Responsibility |
|---|--------|-----------|----------------|
| 1 | `_check_entities_ready(sensor_state: State \| None) -> bool` | sync | Sensor + TRV availability check |
| 2 | `_collect_trv_states() -> list[State]` | sync | Gather TRV + optional cooler states |
| 3 | `_resolve_temperature_range(states: list[State])` | sync | Min/max/step from TRV states |
| 4 | `_initialize_sensors(sensor_state: State \| None)` | sync | Room temp, humidity, cooler, window |
| 5 | `_restore_state(states: list[State])` | async | Restore from `async_get_last_state` |
| 6 | `_validate_hvac_mode(states: list[State])` | sync | HVAC mode validation + initial HA state |
| 7 | `_initialize_trvs()` | async | TRV init, tweak, calibration, control |
| 8 | `_finalize_startup()` | async | Triggers, listeners, periodic tasks |

### Type fixes
- `_current_humidity`: `0` (int) → `0.0: float` — matches `current_humidity` property return type
- `bt_min_temp`/`bt_max_temp`: `0`/`30` (int) → `0.0`/`30.0: float` — matches `reduce_attribute()` output
- Explicit `bool()`, `float()`, `str()` casts on `attributes.get()` restores
- Removed redundant `convert_to_float()` on already-float value

## Test plan
- [x] 37 new tests in `tests/unit/test_climate_startup.py` covering submethods 1–6
- [x] Full suite: 911 passed
- [ ] Manual HA integration test