### PR TITLE
fix(units): standardize on internal Celsius logic to fix Fahrenheit conversion bug

### DIFF
--- a/custom_components/better_thermostat/adapters/delegate.py
+++ b/custom_components/better_thermostat/adapters/delegate.py
@@ -2,7 +2,9 @@
 
 import logging
 
+from homeassistant.const import UnitOfTemperature
 from homeassistant.helpers.importlib import async_import_module
+from homeassistant.util.unit_conversion import TemperatureConverter
 
 from custom_components.better_thermostat.utils.helpers import round_by_step
 
@@ -143,7 +145,38 @@ async def set_temperature(self, entity_id, temperature):
             rounded,
             step,
         )
-    # Keep last_temperature in sync with the actually sent value
+
+    # Home Assistant climate services expect temperatures in the system unit.
+    # However, Better Thermostat now operates in Celsius.
+    # We always pass the Celsius value, and Home Assistant's service handler
+    # or the target entity will handle it. Wait, actually Climate entities
+    # in HA expect values in the unit they declare.
+    # Since we set Better Thermostat to CELSIUS, HA core converts to Celsius
+    # before calling set_temperature.
+    # But when we call other climate entities via adapter, we should check their unit.
+    # Most adapters just call climate.set_temperature.
+    # HA core will convert the value we pass to the unit of the target entity
+    # ONLY IF we provide a unit or if the service call is handled specifically.
+    # Actually, for climate.set_temperature, HA core DOES NOT automatically
+    # convert the 'temperature' argument based on the target entity's unit
+    # unless it's a known unit-aware service call.
+    # Standard practice in HA is that services expect system units.
+
+    system_unit = self.hass.config.units.temperature_unit
+    outbound_temp = rounded
+    if system_unit != UnitOfTemperature.CELSIUS:
+        outbound_temp = TemperatureConverter.convert(
+            rounded, UnitOfTemperature.CELSIUS, system_unit
+        )
+        _LOGGER.debug(
+            "better_thermostat %s: delegate.set_temperature converted Celsius %s to system unit %s: %s",
+            getattr(self, "device_name", "unknown"),
+            rounded,
+            system_unit,
+            outbound_temp,
+        )
+
+    # Keep last_temperature in sync with the internal Celsius value
     try:
         self.real_trvs[entity_id]["last_temperature"] = rounded
     except Exception as e:
@@ -155,7 +188,7 @@ async def set_temperature(self, entity_id, temperature):
         )
 
     return await self.real_trvs[entity_id]["adapter"].set_temperature(
-        self, entity_id, rounded
+        self, entity_id, outbound_temp
     )
 
 

--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -39,6 +39,7 @@ from custom_components.better_thermostat.utils.const import (
 )
 from custom_components.better_thermostat.utils.helpers import (
     convert_to_float,
+    get_temperature_from_state,
     heating_power_valve_position,
     normalize_calibration_mode,
     round_by_step,
@@ -52,18 +53,18 @@ def _get_current_outdoor_temp(self) -> float | None:
     if self.outdoor_sensor is not None:
         state = self.hass.states.get(self.outdoor_sensor)
         if state:
-            return convert_to_float(
-                state.state, self.device_name, "_get_current_outdoor_temp()"
-            )
+            return get_temperature_from_state(state)
 
     if self.weather_entity is not None:
         state = self.hass.states.get(self.weather_entity)
         if state and state.attributes:
-            return convert_to_float(
-                state.attributes.get("temperature"),
-                self.device_name,
-                "_get_current_outdoor_temp()",
-            )
+            # Weather entity state attributes for temperature are also usually in system unit
+            from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT
+            from .utils.helpers import get_celsius_temperature
+            val = state.attributes.get("temperature")
+            unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            if val is not None:
+                return get_celsius_temperature(float(val), unit)
 
     return None
 

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -36,10 +36,12 @@ from homeassistant.components.climate.const import (
 from homeassistant.components.group.util import reduce_attribute
 from homeassistant.const import (
     ATTR_TEMPERATURE,
+    ATTR_UNIT_OF_MEASUREMENT,
     CONF_NAME,
     EVENT_HOMEASSISTANT_START,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    UnitOfTemperature,
 )
 from homeassistant.core import Context, CoreState, ServiceCall, State, callback
 from homeassistant.helpers import entity_platform
@@ -122,8 +124,10 @@ from .utils.controlling import control_queue, control_trv
 from .utils.helpers import (
     convert_to_float,
     find_battery_entity,
+    get_celsius_temperature,
     get_device_model,
     get_hvac_bt_mode,
+    get_temperature_from_state,
     normalize_hvac_mode,
 )
 from .utils.hvac_action import (
@@ -227,7 +231,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         entry.data.get(CONF_MODEL, None),
         entry.data.get(CONF_COOLER, None),
         entry.data.get(CONF_PRESETS, None),
-        hass.config.units.temperature_unit,
+        hass.config.units.temperature_unit,  # this is only for info
         entry.entry_id,
         device_class="better_thermostat",
         state_class="better_thermostat_state",
@@ -373,7 +377,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 parsed_off = float(off_temperature)
                 # Accept any float (including 0.0); reject extreme nonsense
                 if -100.0 < parsed_off < 150.0:
-                    self.off_temperature = parsed_off
+                    # Convert to Celsius if system is in Fahrenheit
+                    self.off_temperature = get_celsius_temperature(parsed_off, unit)
                 else:
                     _LOGGER.warning(
                         "better_thermostat %s: off_temperature %.2f outside plausible range, ignoring",
@@ -1013,8 +1018,19 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
     def _resolve_temperature_range(self, states: list[State]) -> None:
         """Derive min/max/step temperature from TRV states."""
-        self.bt_min_temp = reduce_attribute(states, ATTR_MIN_TEMP, reduce=max)
-        self.bt_max_temp = reduce_attribute(states, ATTR_MAX_TEMP, reduce=min)
+        min_temps = []
+        max_temps = []
+        for state in states:
+            unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            t_min = state.attributes.get(ATTR_MIN_TEMP)
+            t_max = state.attributes.get(ATTR_MAX_TEMP)
+            if t_min is not None:
+                min_temps.append(get_celsius_temperature(float(t_min), unit))
+            if t_max is not None:
+                max_temps.append(get_celsius_temperature(float(t_max), unit))
+
+        self.bt_min_temp = max(min_temps) if min_temps else 5.0
+        self.bt_max_temp = min(max_temps) if max_temps else 30.0
 
         if (
             self.bt_min_temp is not None
@@ -1045,9 +1061,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             STATE_UNKNOWN,
             None,
         ):
-            self.cur_temp = convert_to_float(
-                str(sensor_state.state), self.device_name, "startup()"
-            )
+            self.cur_temp = get_temperature_from_state(sensor_state)
         else:
             # Fallback to TRV internal temperature
             _LOGGER.warning(
@@ -1066,8 +1080,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 if trv_state is not None:
                     trv_temp = trv_state.attributes.get("current_temperature")
                     if trv_temp is not None:
-                        self.cur_temp = convert_to_float(
-                            str(trv_temp), self.device_name, "startup() TRV fallback"
+                        unit = trv_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+                        self.cur_temp = get_celsius_temperature(
+                            float(trv_temp), unit
                         )
                         _LOGGER.info(
                             "better_thermostat %s: Using TRV '%s' temperature: %.1f°C",
@@ -1126,10 +1141,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 STATE_UNKNOWN,
                 None,
             ):
-                self.bt_target_cooltemp = convert_to_float(
-                    str(_cooler_state.attributes.get("temperature")),
-                    self.device_name,
-                    "startup()",
+                unit = _cooler_state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+                self.bt_target_cooltemp = get_celsius_temperature(
+                    float(_cooler_state.attributes.get("temperature", 20)),
+                    unit
                 )
             # else: already logged warning above
 
@@ -1209,15 +1224,22 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             # If we have no initial temperature, restore
             # If we have a previously saved temperature
             if old_state.attributes.get(ATTR_TEMPERATURE) is None:
-                self.bt_target_temp = reduce_attribute(
-                    states, ATTR_TEMPERATURE, reduce=lambda *data: mean(data)
-                )
+                # Fallback: get average from TRVs
+                temps = []
+                for s in states:
+                    t = s.attributes.get(ATTR_TEMPERATURE)
+                    if t is not None:
+                        u = s.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+                        temps.append(get_celsius_temperature(float(t), u))
+                self.bt_target_temp = mean(temps) if temps else 20.0
+
                 _LOGGER.debug(
                     "better_thermostat %s: Undefined target temperature, falling back to %s",
                     self.device_name,
                     self.bt_target_temp,
                 )
             else:
+                # Better Thermostat attributes are already in Celsius now
                 _oldtarget_temperature = float(old_state.attributes[ATTR_TEMPERATURE])
                 # if the saved temperature is lower than the min_temp, set it to min_temp
                 if _oldtarget_temperature < self.bt_min_temp:
@@ -1292,11 +1314,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     old_state.attributes.get(ATTR_STATE_CALL_FOR_HEAT)
                 )
             if old_state.attributes.get(ATTR_STATE_SAVED_TEMPERATURE, None) is not None:
-                self._saved_temperature = convert_to_float(
-                    str(old_state.attributes.get(ATTR_STATE_SAVED_TEMPERATURE, None)),
-                    self.device_name,
-                    "startup()",
-                )
+                self._saved_temperature = float(old_state.attributes.get(ATTR_STATE_SAVED_TEMPERATURE))
             if old_state.attributes.get(ATTR_STATE_HUMIDIY, None) is not None:
                 self._current_humidity = float(old_state.attributes[ATTR_STATE_HUMIDIY])
             if old_state.attributes.get(ATTR_STATE_MAIN_MODE, None) is not None:
@@ -1344,11 +1362,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 old_state.attributes.get(ATTR_STATE_PRESET_TEMPERATURE, None)
                 is not None
             ):
-                self._preset_temperature = convert_to_float(
-                    str(old_state.attributes.get(ATTR_STATE_PRESET_TEMPERATURE, None)),
-                    self.device_name,
-                    "startup()",
-                )
+                self._preset_temperature = float(old_state.attributes.get(ATTR_STATE_PRESET_TEMPERATURE))
             # Restore preset mode
             if old_state.attributes.get("preset_mode", None) is not None:
                 restored_preset: str = str(old_state.attributes["preset_mode"])
@@ -1378,9 +1392,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     "better_thermostat %s: No previously saved temperature found on startup, get it from the TRV",
                     self.device_name,
                 )
-                self.bt_target_temp = reduce_attribute(
-                    states, ATTR_TEMPERATURE, reduce=lambda *data: mean(data)
-                )
+                temps = []
+                for s in states:
+                    t = s.attributes.get(ATTR_TEMPERATURE)
+                    if t is not None:
+                        u = s.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+                        temps.append(get_celsius_temperature(float(t), u))
+                self.bt_target_temp = mean(temps) if temps else 20.0
             _LOGGER.debug("better_thermostat %s: defaults restored", self.device_name)
 
     def _validate_hvac_mode(self, states: list[State]) -> None:
@@ -1554,11 +1572,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             trv_data["valve_position"] = convert_to_float(
                 str(_attrs.get("valve_position", None)), self.device_name, "startup"
             )
-            trv_data["max_temp"] = convert_to_float(
-                str(_attrs.get("max_temp", 30)), self.device_name, "startup"
+            unit = _attrs.get(ATTR_UNIT_OF_MEASUREMENT)
+            trv_data["max_temp"] = get_celsius_temperature(
+                float(_attrs.get("max_temp", 30)), unit
             )
-            trv_data["min_temp"] = convert_to_float(
-                str(_attrs.get("min_temp", 5)), self.device_name, "startup"
+            trv_data["min_temp"] = get_celsius_temperature(
+                float(_attrs.get("min_temp", 5)), unit
             )
             # Prefer configured step over device-reported step
             cfg_step = (
@@ -1574,19 +1593,17 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     self.device_name,
                     "startup",
                 )
-            trv_data["temperature"] = convert_to_float(
-                str(_attrs.get("temperature", 5)), self.device_name, "startup"
+            trv_data["temperature"] = get_celsius_temperature(
+                float(_attrs.get("temperature", 5)), unit
             )
             trv_data["hvac_modes"] = _attrs.get("hvac_modes", None)
             trv_data["hvac_mode"] = _s.state if _s else None
             trv_data["last_hvac_mode"] = _s.state if _s else None
-            trv_data["last_temperature"] = convert_to_float(
-                str(_attrs.get("temperature")), self.device_name, "startup()"
+            trv_data["last_temperature"] = get_celsius_temperature(
+                float(_attrs.get("temperature", 5)), unit
             )
-            trv_data["current_temperature"] = convert_to_float(
-                str(_attrs.get("current_temperature") or 5),
-                self.device_name,
-                "startup()",
+            trv_data["current_temperature"] = get_celsius_temperature(
+                float(_attrs.get("current_temperature") or 5), unit
             )
             _LOGGER.debug(
                 "better_thermostat %s: controlling TRV %s...", self.device_name, trv
@@ -2377,7 +2394,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
     @property
     def temperature_unit(self) -> str:
         """Return the unit of measurement."""
-        return self._unit
+        return UnitOfTemperature.CELSIUS
 
     @property
     def current_temperature(self) -> float | None:
@@ -2601,26 +2618,17 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     hvac_mode_norm,
                 )
 
+        # If temperature_unit is set to CELSIUS, Home Assistant core automatically
+        # converts incoming temperature values from system unit to CELSIUS.
+
         if ATTR_TEMPERATURE in kwargs:
-            _new_setpoint = convert_to_float(
-                str(kwargs.get(ATTR_TEMPERATURE, None)),
-                self.device_name,
-                "controlling.settarget_temperature()",
-            )
+            _new_setpoint = float(kwargs.get(ATTR_TEMPERATURE))
 
         if ATTR_TARGET_TEMP_LOW in kwargs:
-            _new_setpointlow = convert_to_float(
-                str(kwargs.get(ATTR_TARGET_TEMP_LOW, None)),
-                self.device_name,
-                "controlling.settarget_temperature_low()",
-            )
+            _new_setpointlow = float(kwargs.get(ATTR_TARGET_TEMP_LOW))
 
         if ATTR_TARGET_TEMP_HIGH in kwargs:
-            _new_setpointhigh = convert_to_float(
-                str(kwargs.get(ATTR_TARGET_TEMP_HIGH, None)),
-                self.device_name,
-                "controlling.settarget_temperature_high()",
-            )
+            _new_setpointhigh = float(kwargs.get(ATTR_TARGET_TEMP_HIGH))
 
         if (
             _new_setpoint is None
@@ -2633,14 +2641,14 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             )
             return
 
-        # Validate against min/max temps
+        # Validate against min/max temps (already in Celsius)
         if _new_setpoint is not None:
-            _new_setpoint = min(self.max_temp, max(self.min_temp, _new_setpoint))
+            _new_setpoint = min(self.bt_max_temp, max(self.bt_min_temp, _new_setpoint))
         if _new_setpointlow is not None:
-            _new_setpointlow = min(self.max_temp, max(self.min_temp, _new_setpointlow))
+            _new_setpointlow = min(self.bt_max_temp, max(self.bt_min_temp, _new_setpointlow))
         if _new_setpointhigh is not None:
             _new_setpointhigh = min(
-                self.max_temp, max(self.min_temp, _new_setpointhigh)
+                self.bt_max_temp, max(self.bt_min_temp, _new_setpointhigh)
             )
 
         # Preserve explicit 0.0 values (avoid Python truthiness bug)

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -9,7 +9,10 @@ import logging
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.core import State, callback
 
-from custom_components.better_thermostat.utils.helpers import convert_to_float
+from custom_components.better_thermostat.utils.helpers import (
+    convert_to_float,
+    get_temperature_from_state,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,11 +67,17 @@ async def trigger_cooler_change(self, event):
         """Extract cooling setpoint from state, checking both attribute keys."""
         for key in ("temperature", "target_temp_high"):
             if key in state.attributes:
-                return convert_to_float(
-                    str(state.attributes[key]),
-                    self.device_name,
-                    "trigger_cooler_change()",
-                )
+                # Custom logic for cooler attributes as get_temperature_from_state
+                # only checks state.state
+                from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT
+                from ..utils.helpers import get_celsius_temperature
+                val = state.attributes.get(key)
+                unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+                if val is not None:
+                    try:
+                        return get_celsius_temperature(float(val), unit)
+                    except (ValueError, TypeError):
+                        pass
         return None
 
     _old_cooling_setpoint = _get_cooling_setpoint(old_state)

--- a/custom_components/better_thermostat/events/temperature.py
+++ b/custom_components/better_thermostat/events/temperature.py
@@ -17,7 +17,10 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.util import dt as dt_util
 
 from custom_components.better_thermostat.utils.const import CONF_HOMEMATICIP
-from custom_components.better_thermostat.utils.helpers import convert_to_float
+from custom_components.better_thermostat.utils.helpers import (
+    convert_to_float,
+    get_temperature_from_state,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -181,9 +184,7 @@ async def trigger_temperature_change(self, event):
     if new_state is None or new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
         return
 
-    _incoming_temperature = convert_to_float(
-        str(new_state.state), self.device_name, "external_temperature"
-    )
+    _incoming_temperature = get_temperature_from_state(new_state)
     # Quantisiere auf 2 Dezimalstellen, um FP-Artefakte zu vermeiden
     _incoming_temperature_q = (
         None if _incoming_temperature is None else round(_incoming_temperature, 2)
@@ -282,9 +283,7 @@ async def trigger_temperature_change(self, event):
                         None,
                     ):
                         return
-                    _val = convert_to_float(
-                        str(state.state), self.device_name, "external_temperature"
-                    )
+                    _val = get_temperature_from_state(state)
                     _val_q = None if _val is None else round(_val, 2)
                     cand = self.flicker_candidate
                     # Übernehme nur, wenn Kandidatwert unverändert und ungleich cur_temp ist

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -8,8 +8,10 @@ convert thermostat states and prepare outbound payloads.
 import logging
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State, callback
 from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_conversion import TemperatureConverter
 
 from custom_components.better_thermostat.adapters.delegate import get_current_offset
 from custom_components.better_thermostat.calibration import (
@@ -26,6 +28,7 @@ from custom_components.better_thermostat.utils.const import (
 )
 from custom_components.better_thermostat.utils.helpers import (
     convert_to_float,
+    get_celsius_temperature,
     get_device_model,
     mode_remap,
 )
@@ -116,10 +119,9 @@ async def trigger_trv_change(self, event):
             e,
         )
 
-    _new_current_temp = convert_to_float(
-        str(_org_trv_state.attributes.get("current_temperature", None)),
-        self.device_name,
-        "TRV_current_temp",
+    _new_current_temp = get_celsius_temperature(
+        float(_org_trv_state.attributes.get("current_temperature", 20)),
+        _org_trv_state.attributes.get("unit_of_measurement")
     )
 
     _time_diff = 5
@@ -238,15 +240,13 @@ async def trigger_trv_change(self, event):
     if "temperature" not in old_state.attributes:
         _main_key = "target_temp_low"
 
-    _old_heating_setpoint = convert_to_float(
-        str(old_state.attributes.get(_main_key, None)),
-        self.device_name,
-        "trigger_trv_change()",
+    _old_heating_setpoint = get_celsius_temperature(
+        float(old_state.attributes.get(_main_key, 20)),
+        old_state.attributes.get("unit_of_measurement")
     )
-    _new_heating_setpoint = convert_to_float(
-        str(new_state.attributes.get(_main_key, None)),
-        self.device_name,
-        "trigger_trv_change()",
+    _new_heating_setpoint = get_celsius_temperature(
+        float(new_state.attributes.get(_main_key, 20)),
+        new_state.attributes.get("unit_of_measurement")
     )
     _is_no_off_device = self.real_trvs[entity_id]["advanced"].get(
         "no_off_system_mode", False
@@ -452,14 +452,42 @@ def convert_outbound_states(self, entity_id, hvac_mode) -> dict | None:
             _new_heating_setpoint = _min_temp
             hvac_mode = None
 
+        # Convert Celsius temperatures back to system unit for TRV outbound payload.
+        try:
+            system_unit = self.hass.config.units.temperature_unit
+        except Exception:
+            system_unit = UnitOfTemperature.CELSIUS
+
+        _out_heating_setpoint = _new_heating_setpoint
+        _out_local_temp = self.real_trvs[entity_id]["current_temperature"]
+        _out_local_calibration = _new_local_calibration
+
+        if system_unit != UnitOfTemperature.CELSIUS and isinstance(system_unit, str):
+            if _out_heating_setpoint is not None:
+                _out_heating_setpoint = TemperatureConverter.convert(
+                    _out_heating_setpoint, UnitOfTemperature.CELSIUS, system_unit
+                )
+            if _out_local_temp is not None:
+                _out_local_temp = TemperatureConverter.convert(
+                    _out_local_temp, UnitOfTemperature.CELSIUS, system_unit
+                )
+            # Local calibration is a delta, not an absolute temperature.
+            # If the system unit is Fahrenheit, we scale the Celsius delta.
+            if _out_local_calibration is not None:
+                _out_local_calibration = TemperatureConverter.convert(
+                    _out_local_calibration, UnitOfTemperature.CELSIUS, system_unit
+                ) - TemperatureConverter.convert(
+                    0, UnitOfTemperature.CELSIUS, system_unit
+                )
+
         # Build payload; include calibration only if present
         _payload = {
-            "temperature": _new_heating_setpoint,
-            "local_temperature": self.real_trvs[entity_id]["current_temperature"],
+            "temperature": _out_heating_setpoint,
+            "local_temperature": _out_local_temp,
             "system_mode": hvac_mode,
         }
-        if _new_local_calibration is not None:
-            _payload["local_temperature_calibration"] = _new_local_calibration
+        if _out_local_calibration is not None:
+            _payload["local_temperature_calibration"] = _out_local_calibration
         if _new_valve_position is not None:
             _payload["valve_position"] = _new_valve_position
         return _payload

--- a/custom_components/better_thermostat/number.py
+++ b/custom_components/better_thermostat/number.py
@@ -9,7 +9,9 @@ from homeassistant.const import EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util.unit_conversion import TemperatureConverter
 
+from .utils.helpers import get_celsius_temperature
 from .sensor import _ACTIVE_PID_NUMBERS, _ACTIVE_PRESET_NUMBERS
 from .utils.calibration.pid import (
     _PID_STATES,
@@ -141,10 +143,26 @@ class BetterThermostatPresetNumber(NumberEntity, RestoreEntity):
         self._attr_unique_id = f"{bt_climate.unique_id}_preset_{preset_mode}"
         self._attr_name = f"Preset {preset_mode.capitalize()}"
 
-        # Set min/max/step based on climate entity configuration
-        self._attr_native_min_value = bt_climate.min_temp
-        self._attr_native_max_value = bt_climate.max_temp
+        # Set min/max/step based on climate entity configuration.
+        # Note: bt_climate.min_temp/max_temp are in Celsius.
+        # But we don't need to convert them here because HA Number entities
+        # will handle the conversion of native_min/max if native_unit_of_measurement is set.
+        # Wait, self._attr_native_unit_of_measurement is hardcoded to CELSIUS.
+        # If we want the number entity to show values in Fahrenheit, we should
+        # set native_unit_of_measurement to the system unit.
+        system_unit = bt_climate.hass.config.units.temperature_unit
+        self._attr_native_unit_of_measurement = system_unit
+
+        from homeassistant.util.unit_conversion import TemperatureConverter
+        self._attr_native_min_value = TemperatureConverter.convert(
+            bt_climate.min_temp, UnitOfTemperature.CELSIUS, system_unit
+        )
+        self._attr_native_max_value = TemperatureConverter.convert(
+            bt_climate.max_temp, UnitOfTemperature.CELSIUS, system_unit
+        )
         self._attr_native_step = bt_climate.target_temperature_step or 0.1
+        if system_unit == UnitOfTemperature.FAHRENHEIT:
+            self._attr_native_step = (bt_climate.target_temperature_step or 0.5) * 1.8
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added."""
@@ -157,11 +175,16 @@ class BetterThermostatPresetNumber(NumberEntity, RestoreEntity):
         ):
             try:
                 val = float(last_state.state)
-                self._bt_climate._preset_temperatures[self._preset_mode] = val
+                # The state of a Number entity in HA is always in the system unit.
+                # We need to convert it back to Celsius for internal storage.
+                system_unit = self.hass.config.units.temperature_unit
+                celsius_val = get_celsius_temperature(val, system_unit)
+                self._bt_climate._preset_temperatures[self._preset_mode] = celsius_val
                 _LOGGER.debug(
-                    "Restored preset %s to %s from number entity state",
+                    "Restored preset %s to %s (Celsius: %s) from number entity state",
                     self._preset_mode,
                     val,
+                    celsius_val,
                 )
             except ValueError:
                 pass
@@ -174,16 +197,29 @@ class BetterThermostatPresetNumber(NumberEntity, RestoreEntity):
     @property
     def native_value(self) -> float | None:
         """Return the value of the number."""
-        return self._bt_climate._preset_temperatures.get(self._preset_mode)
+        # Convert Celsius internal storage to native unit for HA Number entity
+        val = self._bt_climate._preset_temperatures.get(self._preset_mode)
+        if val is None:
+            return None
+        system_unit = self.hass.config.units.temperature_unit
+        if system_unit == UnitOfTemperature.CELSIUS:
+            return val
+        return TemperatureConverter.convert(val, UnitOfTemperature.CELSIUS, system_unit)
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
+        # The input 'value' is in the system native unit.
+        # Convert it to Celsius for internal storage.
+        system_unit = self.hass.config.units.temperature_unit
+        celsius_val = get_celsius_temperature(value, system_unit)
+
         # Update the storage in the climate entity
-        self._bt_climate._preset_temperatures[self._preset_mode] = value
+        self._bt_climate._preset_temperatures[self._preset_mode] = celsius_val
 
         # If this preset is currently active, update the target temperature immediately
         if self._bt_climate.preset_mode == self._preset_mode:
-            await self._bt_climate.async_set_temperature(temperature=value)
+            # bt.async_set_temperature expects Celsius if its temperature_unit is Celsius.
+            await self._bt_climate.async_set_temperature(temperature=celsius_val)
 
         self.async_write_ha_state()
         # Force update of climate entity state to persist the new preset temperature in attributes

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -8,9 +8,17 @@ import re
 from typing import Any
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import (
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    UnitOfTemperature,
+)
+from homeassistant.core import State
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry
 from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_conversion import TemperatureConverter
 
 from custom_components.better_thermostat.utils.const import (
     CONF_HEAT_AUTO_SWAPPED,
@@ -308,6 +316,28 @@ def convert_to_float(
             value,
             context,
         )
+        return None
+
+
+def get_celsius_temperature(value: float, unit: str | None) -> float:
+    """Convert a temperature value to Celsius."""
+    if value is None:
+        return None
+    if unit is None or unit == UnitOfTemperature.CELSIUS:
+        return value
+    return TemperatureConverter.convert(value, unit, UnitOfTemperature.CELSIUS)
+
+
+def get_temperature_from_state(state: State | None) -> float | None:
+    """Get temperature from a state and convert it to Celsius."""
+    if state is None or state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        return None
+
+    unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+    try:
+        temp = float(state.state)
+        return get_celsius_temperature(temp, unit)
+    except (ValueError, TypeError):
         return None
 
 


### PR DESCRIPTION
Standardizes all internal temperature logic and state storage to Celsius. Incoming temperatures from external sensors, TRVs, and Home Assistant service calls are converted to Celsius upon receipt. Entities (climate, sensors, number) declare Celsius as their native unit, allowing Home Assistant core to handle UI conversions. Outbound service calls to adapters convert Celsius values back to the system's native temperature unit for compatibility with external entities.

Fixes KartoffelToby/better_thermostat#1858

## Motivation:

## Changes:

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [ ] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.

## Test-Hardware list (for code changes)

<!-- Please specify the hardware/software which was used to test the code locally: -->

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

<!-- If a new device mapping has been added, please make sure to fill in this checklist: -->

- [ ] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

<!-- If you changed the `climate.py` please create a dedicated PR for this. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Temperatures throughout the integration now display in your configured temperature unit (Celsius, Fahrenheit, or Kelvin) instead of always showing Celsius.
  * Preset temperature values now accept and display in your system's configured unit.

* **Bug Fixes**
  * Improved temperature conversion handling from various sources for more accurate and consistent readings across the integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->