### PR TITLE
fix: boost mode respects valve_max_opening per TRV

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -49,9 +49,17 @@ def _get_valve_control(
     valve_settings_dict contains 'valve_percent' and 'apply_valve' keys.
     Returns (None, None) if no valve control should be applied.
     """
-    # Boost mode takes priority - set valve to 100%
+    # Boost mode opens the valve up to the user-configured
+    # valve_max_opening (default 100%).
     if _is_boost_heating_active(self):
-        return {"valve_percent": 100, "apply_valve": True}, "boost_mode"
+        max_opening = (self.real_trvs.get(heater_entity_id) or {}).get(
+            "valve_max_opening", 100
+        )
+        if isinstance(max_opening, (int, float)):
+            target_pct = max(0, min(100, int(round(float(max_opening)))))
+        else:
+            target_pct = 100
+        return {"valve_percent": target_pct, "apply_valve": True}, "boost_mode"
 
     # Check calibration-based valve control
     if calibration_type != CalibrationType.DIRECT_VALVE_BASED:

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -20,6 +20,7 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.controlling import (
+    _get_valve_control,
     check_system_mode,
     check_target_temperature,
     handle_window_open,
@@ -435,3 +436,93 @@ class TestCheckTargetTemperature:
 
         assert result is True
         # convert_to_float should handle string "21.0" and match float 21.0
+
+
+# ---------------------------------------------------------------------------
+# _get_valve_control — boost mode honors valve_max_opening
+# ---------------------------------------------------------------------------
+
+
+class TestGetValveControlBoostMaxOpening:
+    """Boost mode should clamp valve_percent to the user's valve_max_opening."""
+
+    def _mock_in_boost(self, max_opening):
+        mock_self = MagicMock()
+        # Trigger boost branch via _is_boost_heating_active(...)
+        mock_self.preset_mode = "boost"
+        mock_self.cur_temp = 19.0
+        mock_self.bt_target_temp = 22.0
+        mock_self.real_trvs = {
+            "climate.trv1": {"valve_max_opening": max_opening},
+        }
+        return mock_self
+
+    def test_no_setting_defaults_to_100(self):
+        """Without a configured limit, boost still applies 100%."""
+        mock_self = self._mock_in_boost(max_opening=None)
+        # Simulate "key missing" by removing it entirely
+        mock_self.real_trvs["climate.trv1"] = {}
+        bal, source = _get_valve_control(
+            mock_self,
+            "climate.trv1",
+            CalibrationMode.MPC_CALIBRATION,
+            CalibrationType.TARGET_TEMP_BASED,
+        )
+        assert source == "boost_mode"
+        assert bal == {"valve_percent": 100, "apply_valve": True}
+
+    def test_setting_100_returns_100(self):
+        """An explicit 100% setting yields 100%."""
+        mock_self = self._mock_in_boost(max_opening=100)
+        bal, _ = _get_valve_control(
+            mock_self,
+            "climate.trv1",
+            CalibrationMode.MPC_CALIBRATION,
+            CalibrationType.TARGET_TEMP_BASED,
+        )
+        assert bal == {"valve_percent": 100, "apply_valve": True}
+
+    def test_setting_60_clamps_to_60(self):
+        """Boost respects a configured 60% maximum."""
+        mock_self = self._mock_in_boost(max_opening=60)
+        bal, source = _get_valve_control(
+            mock_self,
+            "climate.trv1",
+            CalibrationMode.MPC_CALIBRATION,
+            CalibrationType.TARGET_TEMP_BASED,
+        )
+        assert source == "boost_mode"
+        assert bal == {"valve_percent": 60, "apply_valve": True}
+
+    def test_float_setting_rounded(self):
+        """Non-integer settings round to nearest int and clamp to [0, 100]."""
+        mock_self = self._mock_in_boost(max_opening=72.6)
+        bal, _ = _get_valve_control(
+            mock_self,
+            "climate.trv1",
+            CalibrationMode.MPC_CALIBRATION,
+            CalibrationType.TARGET_TEMP_BASED,
+        )
+        assert bal == {"valve_percent": 73, "apply_valve": True}
+
+    def test_out_of_range_setting_clamped_to_100(self):
+        """A nonsensical >100 value is clamped to 100."""
+        mock_self = self._mock_in_boost(max_opening=150)
+        bal, _ = _get_valve_control(
+            mock_self,
+            "climate.trv1",
+            CalibrationMode.MPC_CALIBRATION,
+            CalibrationType.TARGET_TEMP_BASED,
+        )
+        assert bal == {"valve_percent": 100, "apply_valve": True}
+
+    def test_non_numeric_setting_defaults_to_100(self):
+        """A garbage non-numeric setting is treated as 'no limit'."""
+        mock_self = self._mock_in_boost(max_opening="not a number")
+        bal, _ = _get_valve_control(
+            mock_self,
+            "climate.trv1",
+            CalibrationMode.MPC_CALIBRATION,
+            CalibrationType.TARGET_TEMP_BASED,
+        )
+        assert bal == {"valve_percent": 100, "apply_valve": True}

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -452,9 +452,7 @@ class TestGetValveControlBoostMaxOpening:
         mock_self.preset_mode = "boost"
         mock_self.cur_temp = 19.0
         mock_self.bt_target_temp = 22.0
-        mock_self.real_trvs = {
-            "climate.trv1": {"valve_max_opening": max_opening},
-        }
+        mock_self.real_trvs = {"climate.trv1": {"valve_max_opening": max_opening}}
         return mock_self
 
     def test_no_setting_defaults_to_100(self):


### PR DESCRIPTION
## Summary

When boost preset is active and the room is below target, \`_get_valve_control\` returned a hard-coded \`valve_percent: 100\` and ignored the per-TRV \`valve_max_opening\` setting. Calibration paths (MPC/PID) already honor this limit via \`_get_trv_max_opening\`; boost now does the same.

The \`valve_max_opening\` setting exists for hydraulic balancing (so a boost-mode TRV does not starve other TRVs on the same circuit) and for hardware/noise protection — bypassing it in boost defeats the purpose of having the setting.

Clamping is applied at the source (in \`_get_valve_control\`), so the value in the returned balance dict — used for logging and downstream consumers — is the actual value sent to the TRV.

## Behavior change

| Setting | Before | After |
|---|---|---|
| valve_max_opening = 100 (default) | 100% | 100% |
| valve_max_opening = 60 | 100% (bypass) | **60%** |
| not configured | 100% | 100% |

## Test plan
- [x] 6 new unit tests in \`tests/unit/controlling/test_helpers.py\` covering: default (no setting), explicit 100, lower limit, float rounding, out-of-range, non-numeric
- [x] \`uv run pytest tests/ -p no:homeassistant\` — 1119 passed (1113 + 6 new)

## Note for reviewer

If boost is intended to bypass \`valve_max_opening\` (e.g. as a deliberate "override everything for quick heat" semantics), close this PR — the current behavior is then by design. The change here assumes that a user-configured limit should always be honored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Boost mode valve control now respects configured maximum valve opening limits instead of always defaulting to 100%.

* **Tests**
  * Added comprehensive unit tests for boost mode valve control validation, including default behavior, explicit limits, rounding of non-integer values, clamping of out-of-range values, and handling of non-numeric input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KartoffelToby/better_thermostat/pull/1987)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->