### PR TITLE
fix: suppress degraded-mode warning during startup grace period

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1789,8 +1789,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         async def _post_grace_degraded_recheck() -> None:
             remaining = (
-                self._degraded_grace_until - dt_util.now()
-            ).total_seconds() if self._degraded_grace_until else 0.0
+                (self._degraded_grace_until - dt_util.now()).total_seconds()
+                if self._degraded_grace_until
+                else 0.0
+            )
             if remaining > 0:
                 await asyncio.sleep(remaining)
             if self.is_removed:

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC
 import asyncio
 from collections import deque
-from datetime import timedelta
+from datetime import datetime, timedelta
 from functools import cached_property
 import json
 import logging
@@ -152,6 +152,7 @@ from .utils.valve_maintenance import (
     run_valve_maintenance,
 )
 from .utils.watcher import (
+    STARTUP_DEGRADED_GRACE_PERIOD,
     await_optional_sensors,
     check_and_update_degraded_mode,
     check_critical_entities,
@@ -522,6 +523,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # Degraded mode: thermostat continues operating with some sensors unavailable
         self.degraded_mode = False
         self.unavailable_sensors = []
+        # Startup grace period suppresses the degraded-mode WARNING and the HA
+        # repair issue while slow integrations finish initializing.
+        self._degraded_grace_until: datetime | None = None
+        self._degraded_warning_emitted: bool = False
         self.control_queue_task: asyncio.Queue[BetterThermostat] = asyncio.Queue(
             maxsize=1
         )
@@ -1775,8 +1780,27 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         # Wait for optional sensors with increasing retry delays before
         # entering degraded mode (see await_optional_sensors for details).
+        # During the startup grace window, a transition into degraded mode is
+        # logged at DEBUG and the HA repair issue is deferred — slow cloud
+        # integrations get time to come online before the user sees a warning.
+        self._degraded_grace_until = dt_util.now() + STARTUP_DEGRADED_GRACE_PERIOD
         await await_optional_sensors(self)
         await check_and_update_degraded_mode(self)
+
+        async def _post_grace_degraded_recheck() -> None:
+            remaining = (
+                self._degraded_grace_until - dt_util.now()
+            ).total_seconds() if self._degraded_grace_until else 0.0
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+            if self.is_removed:
+                return
+            await check_and_update_degraded_mode(self)
+
+        self.hass.async_create_background_task(
+            _post_grace_degraded_recheck(),
+            name=f"bt_post_grace_degraded_{self.device_name}",
+        )
 
         if self.is_removed:
             return

--- a/custom_components/better_thermostat/utils/watcher.py
+++ b/custom_components/better_thermostat/utils/watcher.py
@@ -9,13 +9,21 @@ outdoor, weather) can be unavailable without blocking thermostat operation.
 
 from __future__ import annotations
 
+from datetime import timedelta
 import logging
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.util import dt as dt_util
 
 DOMAIN = "better_thermostat"
 _LOGGER = logging.getLogger(__name__)
+
+# Window after startup during which a transition into degraded mode is logged
+# at DEBUG and does not raise a Home Assistant repair. Slow integrations
+# (cloud weather, Ecowitt, etc.) often need several minutes to publish their
+# first state.
+STARTUP_DEGRADED_GRACE_PERIOD = timedelta(minutes=5)
 
 # States considered unavailable
 UNAVAILABLE_STATES = (
@@ -352,13 +360,16 @@ async def check_and_update_degraded_mode(self) -> bool:
     self.degraded_mode = len(unavailable) > 0
     self.unavailable_sensors = unavailable
 
-    if self.degraded_mode and not old_degraded:
+    grace_until = getattr(self, "_degraded_grace_until", None)
+    in_grace = grace_until is not None and dt_util.now() < grace_until
+    has_warned = getattr(self, "_degraded_warning_emitted", False)
+
+    if self.degraded_mode and not has_warned and not in_grace:
         _LOGGER.warning(
             "better_thermostat %s: Entering degraded mode. Unavailable sensors: %s",
             self.device_name,
             ", ".join(unavailable),
         )
-        # Create a single issue for degraded mode
         ir.async_create_issue(
             hass=self.hass,
             domain=DOMAIN,
@@ -373,12 +384,21 @@ async def check_and_update_degraded_mode(self) -> bool:
                 "sensors": ", ".join(unavailable),
             },
         )
-    elif not self.degraded_mode and old_degraded:
+        self._degraded_warning_emitted = True
+    elif self.degraded_mode and in_grace and not old_degraded:
+        _LOGGER.debug(
+            "better_thermostat %s: degraded mode during startup grace period "
+            "(unavailable: %s); waiting for sensors before warning",
+            self.device_name,
+            ", ".join(unavailable),
+        )
+    elif not self.degraded_mode and has_warned:
         _LOGGER.info(
             "better_thermostat %s: Exiting degraded mode. All sensors available.",
             self.device_name,
         )
         ir.async_delete_issue(self.hass, DOMAIN, f"degraded_mode_{self.device_name}")
+        self._degraded_warning_emitted = False
 
     self.async_write_ha_state()
     return self.degraded_mode

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -47,6 +47,8 @@ def mock_bt_instance(mock_hass):
     bt.devices_errors = []
     bt.degraded_mode = False
     bt.unavailable_sensors = []
+    bt._degraded_grace_until = None
+    bt._degraded_warning_emitted = False
     return bt
 
 
@@ -332,6 +334,167 @@ class TestCheckAndUpdateDegradedMode:
                 assert (
                     mock_bt_instance.hass.async_create_background_task.call_count == 5
                 )
+
+
+class TestDegradedModeGracePeriod:
+    """Tests for the startup grace period that suppresses degraded-mode noise."""
+
+    @staticmethod
+    def _mock_get_with_unavailable(unavailable_id):
+        def mock_get(entity_id):
+            state = MagicMock()
+            state.state = "unavailable" if entity_id == unavailable_id else "20.0"
+            return state
+
+        return mock_get
+
+    @pytest.mark.anyio
+    async def test_warning_and_issue_when_grace_inactive(self, mock_bt_instance, caplog):
+        """No grace set → first degraded transition logs WARNING and raises issue."""
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        mock_bt_instance.hass.states.get.side_effect = self._mock_get_with_unavailable(
+            "binary_sensor.window"
+        )
+        mock_bt_instance._degraded_grace_until = None
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("WARNING"):
+                await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert any("Entering degraded mode" in r.message for r in caplog.records)
+        assert mock_ir.async_create_issue.called
+        assert mock_bt_instance._degraded_warning_emitted is True
+
+    @pytest.mark.anyio
+    async def test_silent_during_grace_period(self, mock_bt_instance, caplog):
+        """Grace active → degraded transition logs DEBUG, no issue, no WARNING."""
+        from datetime import timedelta
+
+        from homeassistant.util import dt as dt_util
+
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        mock_bt_instance.hass.states.get.side_effect = self._mock_get_with_unavailable(
+            "binary_sensor.window"
+        )
+        mock_bt_instance._degraded_grace_until = dt_util.now() + timedelta(minutes=5)
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("WARNING"):
+                await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert mock_bt_instance.degraded_mode is True
+        assert not any(
+            "Entering degraded mode" in r.message for r in caplog.records
+        )
+        assert not mock_ir.async_create_issue.called
+        assert mock_bt_instance._degraded_warning_emitted is False
+
+    @pytest.mark.anyio
+    async def test_warns_after_grace_expires(self, mock_bt_instance, caplog):
+        """Grace passed → still-degraded re-check logs WARNING and raises issue."""
+        from datetime import timedelta
+
+        from homeassistant.util import dt as dt_util
+
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        mock_bt_instance.hass.states.get.side_effect = self._mock_get_with_unavailable(
+            "binary_sensor.window"
+        )
+        # Grace expired 1 minute ago
+        mock_bt_instance._degraded_grace_until = dt_util.now() - timedelta(minutes=1)
+        # Simulate that the silent-during-grace check already set degraded=True
+        mock_bt_instance.degraded_mode = True
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("WARNING"):
+                await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert any("Entering degraded mode" in r.message for r in caplog.records)
+        assert mock_ir.async_create_issue.called
+        assert mock_bt_instance._degraded_warning_emitted is True
+
+    @pytest.mark.anyio
+    async def test_silent_recovery_during_grace(self, mock_bt_instance, caplog):
+        """Recover during grace → no INFO log, no issue deleted (none was created)."""
+        from datetime import timedelta
+
+        from homeassistant.util import dt as dt_util
+
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        # All sensors are available now
+        mock_state = MagicMock()
+        mock_state.state = "20.0"
+        mock_bt_instance.hass.states.get.return_value = mock_state
+        # Mock was previously set to degraded silently during grace
+        mock_bt_instance._degraded_grace_until = dt_util.now() + timedelta(minutes=5)
+        mock_bt_instance.degraded_mode = True
+        mock_bt_instance._degraded_warning_emitted = False
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("INFO"):
+                await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert mock_bt_instance.degraded_mode is False
+        assert not any(
+            "Exiting degraded mode" in r.message for r in caplog.records
+        )
+        assert not mock_ir.async_delete_issue.called
+
+    @pytest.mark.anyio
+    async def test_info_on_recovery_after_warned(self, mock_bt_instance, caplog):
+        """Recover after we'd warned → INFO log + issue deleted."""
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        mock_state = MagicMock()
+        mock_state.state = "20.0"
+        mock_bt_instance.hass.states.get.return_value = mock_state
+        mock_bt_instance.degraded_mode = True
+        mock_bt_instance._degraded_warning_emitted = True
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("INFO"):
+                await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert mock_bt_instance.degraded_mode is False
+        assert any("Exiting degraded mode" in r.message for r in caplog.records)
+        assert mock_ir.async_delete_issue.called
+        assert mock_bt_instance._degraded_warning_emitted is False
+
+    @pytest.mark.anyio
+    async def test_no_double_warning(self, mock_bt_instance, caplog):
+        """Subsequent check while already-warned → no second WARNING."""
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        mock_bt_instance.hass.states.get.side_effect = self._mock_get_with_unavailable(
+            "binary_sensor.window"
+        )
+        mock_bt_instance.degraded_mode = True
+        mock_bt_instance._degraded_warning_emitted = True
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("WARNING"):
+                await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert not any(
+            "Entering degraded mode" in r.message for r in caplog.records
+        )
+        assert not mock_ir.async_create_issue.called
 
 
 class TestAwaitOptionalSensors:

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -349,7 +349,9 @@ class TestDegradedModeGracePeriod:
         return mock_get
 
     @pytest.mark.anyio
-    async def test_warning_and_issue_when_grace_inactive(self, mock_bt_instance, caplog):
+    async def test_warning_and_issue_when_grace_inactive(
+        self, mock_bt_instance, caplog
+    ):
         """No grace set → first degraded transition logs WARNING and raises issue."""
         from custom_components.better_thermostat.utils.watcher import (
             check_and_update_degraded_mode,
@@ -389,9 +391,7 @@ class TestDegradedModeGracePeriod:
                 await check_and_update_degraded_mode(mock_bt_instance)
 
         assert mock_bt_instance.degraded_mode is True
-        assert not any(
-            "Entering degraded mode" in r.message for r in caplog.records
-        )
+        assert not any("Entering degraded mode" in r.message for r in caplog.records)
         assert not mock_ir.async_create_issue.called
         assert mock_bt_instance._degraded_warning_emitted is False
 
@@ -447,9 +447,7 @@ class TestDegradedModeGracePeriod:
                 await check_and_update_degraded_mode(mock_bt_instance)
 
         assert mock_bt_instance.degraded_mode is False
-        assert not any(
-            "Exiting degraded mode" in r.message for r in caplog.records
-        )
+        assert not any("Exiting degraded mode" in r.message for r in caplog.records)
         assert not mock_ir.async_delete_issue.called
 
     @pytest.mark.anyio
@@ -491,9 +489,7 @@ class TestDegradedModeGracePeriod:
             with caplog.at_level("WARNING"):
                 await check_and_update_degraded_mode(mock_bt_instance)
 
-        assert not any(
-            "Entering degraded mode" in r.message for r in caplog.records
-        )
+        assert not any("Entering degraded mode" in r.message for r in caplog.records)
         assert not mock_ir.async_create_issue.called
 
 


### PR DESCRIPTION
Closes #1902.

## Problem

After a HA reboot, slow integrations (Ecowitt weather, cloud APIs, MQTT bridges) sometimes take longer than the existing 58-second retry budget in `await_optional_sensors` to publish their first state. When that happens the user sees:

```
WARNING better_thermostat X: Entering degraded mode. Unavailable sensors: sensor.outdoor_temp
INFO    better_thermostat X: Exiting degraded mode. All sensors available.
```

…within a few seconds, plus a HA repair entry that immediately self-resolves. Nothing was actually wrong.

## Fix

Add a five-minute startup grace window. Inside the window, the first transition into degraded mode is logged at DEBUG and no HA repair issue is created. After the window expires a scheduled re-check fires; if optional sensors are still unavailable then, the normal WARNING and repair issue follow.

- `STARTUP_DEGRADED_GRACE_PERIOD` constant (5 min) in `utils/watcher.py`.
- `BetterThermostat` tracks `_degraded_grace_until` and `_degraded_warning_emitted` so the warning fires at most once per degraded episode, and "Exiting degraded mode" only logs when we had previously warned (no spurious INFO on silent recovery).
- `startup()` sets the grace, runs the existing `await_optional_sensors` + `check_and_update_degraded_mode` pair, then spawns a background task that re-runs the check once the grace expires.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Slow sensor recovers within ~60 s | WARNING + issue + INFO (noise) | DEBUG only (silent recovery) |
| Slow sensor recovers between 60 s and 5 min | WARNING + issue, later INFO + delete | DEBUG only (silent recovery) |
| Sensor genuinely unavailable | WARNING + issue (at ~60 s) | WARNING + issue (at ~5 min after startup) |
| Sensor recovers later after warning | INFO + delete | INFO + delete (unchanged) |

The trade-off is a longer delay before a *real* problem becomes user-visible (5 min instead of 1 min). For the kind of issue that's exposed here ("my outdoor sensor isn't configured"), that delay is acceptable — and avoids the false positives that triggered #1902.

## Test plan
- [x] 6 new unit tests in `tests/unit/test_watcher.py` (`TestDegradedModeGracePeriod`) covering: warning when grace inactive, silent during grace, warning after grace expires, silent recovery during grace, info on recovery after warning, no double warning.
- [x] All 28 pre-existing tests in `test_watcher.py` still pass.
- [x] `uv run pytest tests/ -p no:homeassistant` — 1119 passed (1113 baseline + 6 new).
- [ ] Manual smoke test on a real HA install with a slow integration (welcome from anyone who can reproduce #1902).
