### PR TITLE
fix: start BT after Home Assistant has finished booting

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -38,19 +38,11 @@ from homeassistant.components.climate.const import (
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_NAME,
-    EVENT_HOMEASSISTANT_START,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     UnitOfTemperature,
 )
-from homeassistant.core import (
-    CALLBACK_TYPE,
-    Context,
-    CoreState,
-    ServiceCall,
-    State,
-    callback,
-)
+from homeassistant.core import CALLBACK_TYPE, Context, ServiceCall, State, callback
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers.event import (
@@ -60,6 +52,7 @@ from homeassistant.helpers.event import (
     async_track_time_interval,
 )
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.start import async_at_started
 
 # preferred for HA time handling (UTC aware)
 from homeassistant.util import dt as dt_util
@@ -748,10 +741,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 self.startup(), name=f"better_thermostat_startup_{self.device_name}"
             )
 
-        if self.hass.state == CoreState.running:
-            _async_startup()
-        else:
-            self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _async_startup)
+        # Run after Home Assistant has finished starting (CoreState.running),
+        # so dependent integrations like ZHA / MQTT have published their
+        # entities and are ready to accept service calls. Runs immediately
+        # if BT is added after HA is already up.
+        self.async_on_remove(async_at_started(self.hass, _async_startup))
 
     async def _trigger_check_weather(self, event=None):
         _check = await check_critical_entities(self)


### PR DESCRIPTION
Closes #1167.
Closes #1833.

## Problem

On a fresh HA boot, BT listens for \`EVENT_HOMEASSISTANT_START\`, which is emitted *while* integrations are still loading. The first \`control_trv\` attempt can therefore reach Zigbee before ZHA has finished initialising and fail with:

\`\`\`
zigpy.exceptions.DeliveryError: Request failed after 5 attempts: <Status.MAC_NO_ACK: 233>
HomeAssistantError: Failed to send request: Request failed after 5 attempts: <Status.MAC_NO_ACK: 233>
\`\`\`

The async-retry decorator on the adapter does five exponential-backoff attempts (~31 s total), but the outer \`asyncio.wait_for(control_trv(...), timeout=10)\` cancels the retry loop after 10 s. The control attempt is abandoned, the TRV remains uncontrolled until a later state event triggers another \`control_trv\`, and users see an ERROR plus often resort to manually reloading the integration.

The same race manifests during TRV init via \`wait_for_calibration_entity_or_timeout\` (#1833): when ZHA has not yet published the calibration entity, the wait polls for ~30 s and the outer 30 s \`wait_for\` cancels the whole init, leaving the TRV uninitialised.

## Fix

Use \`homeassistant.helpers.start.async_at_started\` instead of a manual \`EVENT_HOMEASSISTANT_START\` listener. The helper:

- Waits for \`EVENT_HOMEASSISTANT_STARTED\` (\`CoreState.running\`) — fired *after* HA has finished booting, with ZHA / MQTT / Tuya / etc. already loaded.
- Runs the callback immediately if BT is added after HA is already up (e.g. a fresh config entry on a running instance).
- Returns an unsubscribe handle that's registered via \`async_on_remove\` so the listener is cleaned up on entity removal.

The first BT control attempt now lands on a ready Zigbee transport, eliminating the \`MAC_NO_ACK\` race for the boot path. TRV calibration-entity lookup succeeds on the first poll, so the 30 s init timeout becomes academic.

## Diff size

One file, ~7 / -6 lines: drop \`EVENT_HOMEASSISTANT_START\` + \`CoreState\` imports + the manual branching, add the \`async_at_started\` import + a single call.

## Test plan
- [x] \`uv run pytest tests/ -p no:homeassistant\` — 1113 passed.
- [ ] Manual smoke test: reboot HA on a system with a Zigbee TRV and verify no \`MAC_NO_ACK\` ERROR for BT during startup, and no \"Timeout initializing TRV\" warnings.

## Notes
- This is orthogonal to PR #1989 (degraded-mode startup grace period), which handles slow *optional* sensors. This PR handles the *critical* TRV transport readiness.
- Adapter-level \`@async_retry\` decorators are kept — they still protect against transient failures during normal operation.