### PR TITLE
fix: reject implausible temperature readings at the BT input boundary

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -134,6 +134,7 @@ from .utils.helpers import (
     find_battery_entity,
     get_device_model,
     get_hvac_bt_mode,
+    is_reasonable_temperature,
     normalize_hvac_mode,
 )
 from .utils.hvac_action import (
@@ -1091,51 +1092,79 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.all_entities.append(self.sensor_entity_id)
 
         # Handle room temperature sensor with TRV fallback
+        room_candidate: float | None = None
         if sensor_state is not None and sensor_state.state not in (
             STATE_UNAVAILABLE,
             STATE_UNKNOWN,
             None,
         ):
-            self.cur_temp = convert_to_float_celsius(
+            room_candidate = convert_to_float_celsius(
                 str(sensor_state.state),
                 self.device_name,
                 "startup()",
                 unit_of_measurement=sensor_state.attributes.get("unit_of_measurement"),
             )
+            if not is_reasonable_temperature(room_candidate):
+                _LOGGER.warning(
+                    "better_thermostat %s: Room temperature sensor '%s' reports "
+                    "implausible value %s; falling back to TRV internal temperature.",
+                    self.device_name,
+                    self.sensor_entity_id,
+                    room_candidate,
+                )
+                room_candidate = None
+
+        if room_candidate is not None:
+            self.cur_temp = room_candidate
         else:
-            # Fallback to TRV internal temperature
-            _LOGGER.warning(
-                "better_thermostat %s: Room temperature sensor '%s' unavailable. "
-                "Falling back to TRV internal temperature.",
-                self.device_name,
-                self.sensor_entity_id,
-            )
+            if (
+                sensor_state is None
+                or sensor_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN, None)
+            ):
+                _LOGGER.warning(
+                    "better_thermostat %s: Room temperature sensor '%s' unavailable. "
+                    "Falling back to TRV internal temperature.",
+                    self.device_name,
+                    self.sensor_entity_id,
+                )
             if self.sensor_entity_id not in self.unavailable_sensors:
                 self.unavailable_sensors.append(self.sensor_entity_id)
                 self.degraded_mode = True
-            # Get temperature from first available TRV
+            # Get temperature from first TRV whose reading is plausible
             self.cur_temp = None
             for trv_id in self.real_trvs:
                 trv_state = self.hass.states.get(trv_id)
-                if trv_state is not None:
-                    trv_temp = trv_state.attributes.get("current_temperature")
-                    if trv_temp is not None:
-                        self.cur_temp = convert_to_float_celsius(
-                            str(trv_temp),
-                            self.device_name,
-                            "startup() TRV fallback",
-                            unit_of_measurement=trv_state.attributes.get(
-                                "temperature_unit",
-                                trv_state.attributes.get("unit_of_measurement"),
-                            ),
-                        )
-                        _LOGGER.info(
-                            "better_thermostat %s: Using TRV '%s' temperature: %.1f°C",
-                            self.device_name,
-                            trv_id,
-                            self.cur_temp if self.cur_temp else 0,
-                        )
-                        break
+                if trv_state is None:
+                    continue
+                trv_temp = trv_state.attributes.get("current_temperature")
+                if trv_temp is None:
+                    continue
+                candidate = convert_to_float_celsius(
+                    str(trv_temp),
+                    self.device_name,
+                    "startup() TRV fallback",
+                    unit_of_measurement=trv_state.attributes.get(
+                        "temperature_unit",
+                        trv_state.attributes.get("unit_of_measurement"),
+                    ),
+                )
+                if not is_reasonable_temperature(candidate):
+                    _LOGGER.warning(
+                        "better_thermostat %s: TRV '%s' reports implausible "
+                        "current_temperature %s; trying next TRV.",
+                        self.device_name,
+                        trv_id,
+                        candidate,
+                    )
+                    continue
+                self.cur_temp = candidate
+                _LOGGER.info(
+                    "better_thermostat %s: Using TRV '%s' temperature: %.1f°C",
+                    self.device_name,
+                    trv_id,
+                    candidate,
+                )
+                break
             if self.cur_temp is None:
                 self.cur_temp = DEFAULT_FALLBACK_TEMPERATURE
                 _LOGGER.warning(

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1117,9 +1117,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if room_candidate is not None:
             self.cur_temp = room_candidate
         else:
-            if (
-                sensor_state is None
-                or sensor_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN, None)
+            if sensor_state is None or sensor_state.state in (
+                STATE_UNAVAILABLE,
+                STATE_UNKNOWN,
+                None,
             ):
                 _LOGGER.warning(
                     "better_thermostat %s: Room temperature sensor '%s' unavailable. "

--- a/custom_components/better_thermostat/events/temperature.py
+++ b/custom_components/better_thermostat/events/temperature.py
@@ -17,7 +17,10 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.util import dt as dt_util
 
 from custom_components.better_thermostat.utils.const import CONF_HOMEMATICIP
-from custom_components.better_thermostat.utils.helpers import convert_to_float_celsius
+from custom_components.better_thermostat.utils.helpers import (
+    convert_to_float_celsius,
+    is_reasonable_temperature,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -212,11 +215,13 @@ async def trigger_temperature_change(self, event):
     except (KeyError, TypeError):
         pass
 
-    if _incoming_temperature_q is None or _incoming_temperature_q < -50:
-        # raise a ha repair notication
+    if not is_reasonable_temperature(_incoming_temperature_q):
+        # raise a ha repair notification
         _LOGGER.error(
-            "better_thermostat %s: external_temperature is not a valid number: %s",
+            "better_thermostat %s: external_temperature %s is outside the "
+            "plausible range; ignoring (raw state: %s)",
             self.device_name,
+            _incoming_temperature_q,
             new_state.state,
         )
         # Minimal kompatibler Aufruf (Parameter-Namen angepasst an aktuelle HA API)

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -28,6 +28,7 @@ from custom_components.better_thermostat.utils.helpers import (
     convert_to_float,
     convert_to_float_celsius,
     get_device_model,
+    is_reasonable_temperature,
     mode_remap,
 )
 
@@ -125,6 +126,17 @@ async def trigger_trv_change(self, event):
             "temperature_unit", _org_trv_state.attributes.get("unit_of_measurement")
         ),
     )
+    if _new_current_temp is not None and not is_reasonable_temperature(
+        _new_current_temp
+    ):
+        _LOGGER.warning(
+            "better_thermostat %s: TRV %s reports implausible current_temperature "
+            "%s; ignoring",
+            self.device_name,
+            entity_id,
+            _new_current_temp,
+        )
+        _new_current_temp = None
 
     _time_diff = 5
     try:

--- a/custom_components/better_thermostat/utils/const.py
+++ b/custom_components/better_thermostat/utils/const.py
@@ -127,6 +127,13 @@ class CalibrationMode(StrEnum):
     PID_CALIBRATION = "pid_calibration"
 
 
+# Plausibility bounds for incoming temperature readings (Celsius).
+# Values outside this window are treated as marker / garbage readings
+# (for example, AVM Fritz!DECT exposes 126.5 / 127 °C when the thermostat
+# is in OFF / ON mode) and rejected at the BT input boundary.
+MIN_REASONABLE_TEMPERATURE = -50.0
+MAX_REASONABLE_TEMPERATURE = 60.0
+
 # Heating power calibration constants
 # These bounds represent realistic heating rates for residential heating systems
 MIN_HEATING_POWER: Final = (

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -17,7 +17,9 @@ from homeassistant.util.unit_conversion import TemperatureConverter
 from custom_components.better_thermostat.utils.const import (
     CONF_HEAT_AUTO_SWAPPED,
     MAX_HEATING_POWER,
+    MAX_REASONABLE_TEMPERATURE,
     MIN_HEATING_POWER,
+    MIN_REASONABLE_TEMPERATURE,
     VALVE_MIN_BASE,
     VALVE_MIN_OPENING_LARGE_DIFF,
     VALVE_MIN_PROPORTIONAL_SLOPE,
@@ -275,6 +277,20 @@ def heating_power_valve_position(self, entity_id):
     # | 0.3       | 0.9139     |
     # | 0.4       | 1.0000     |
     # | 0.5       | 1.0000     |
+
+
+def is_reasonable_temperature(value: float | None) -> bool:
+    """Return ``True`` iff ``value`` is a plausible indoor temperature in °C.
+
+    Rejects ``None`` and any value outside ``MIN_REASONABLE_TEMPERATURE`` ..
+    ``MAX_REASONABLE_TEMPERATURE``. Out-of-range values are typically
+    marker / garbage readings produced by upstream integrations (for
+    example, AVM Fritz!DECT exposes 126.5 / 127 °C when the thermostat is
+    in OFF / ON mode).
+    """
+    if value is None:
+        return False
+    return MIN_REASONABLE_TEMPERATURE <= value <= MAX_REASONABLE_TEMPERATURE
 
 
 def convert_to_float(

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -296,6 +296,31 @@ class TestInitializeSensors:
         BetterThermostat._initialize_sensors(bt, sensor)
         assert bt.cur_temp == DEFAULT_FALLBACK_TEMPERATURE
 
+    def test_implausible_sensor_value_falls_back_to_trv(self, bt):
+        """AVM 126.5 °C marker from the room sensor falls back to a TRV reading."""
+        sensor = _make_sensor_state("126.5")
+        trv_state = _make_trv_state(attrs={"current_temperature": 19.5})
+        bt.hass.states.get.return_value = trv_state
+        BetterThermostat._initialize_sensors(bt, sensor)
+        assert bt.cur_temp == 19.5
+        assert bt.degraded_mode is True
+
+    def test_implausible_trv_value_falls_back_to_default(self, bt):
+        """If both sensor and TRV are implausible, the default fallback is used."""
+        sensor = State(SENSOR_ID, STATE_UNAVAILABLE)
+        trv_state = _make_trv_state(attrs={"current_temperature": 126.5})
+        bt.hass.states.get.return_value = trv_state
+        BetterThermostat._initialize_sensors(bt, sensor)
+        assert bt.cur_temp == DEFAULT_FALLBACK_TEMPERATURE
+
+    def test_implausible_sensor_implausible_trv_uses_default(self, bt):
+        """Implausible sensor AND implausible TRV → default fallback."""
+        sensor = _make_sensor_state("127.0")
+        trv_state = _make_trv_state(attrs={"current_temperature": 126.5})
+        bt.hass.states.get.return_value = trv_state
+        BetterThermostat._initialize_sensors(bt, sensor)
+        assert bt.cur_temp == DEFAULT_FALLBACK_TEMPERATURE
+
     def test_window_open_detected(self, bt):
         """Test Window open detected."""
         bt.window_id = WINDOW_ID

--- a/tests/unit/test_helpers_normalize.py
+++ b/tests/unit/test_helpers_normalize.py
@@ -10,6 +10,7 @@ from custom_components.better_thermostat.utils.const import CalibrationMode
 from custom_components.better_thermostat.utils.helpers import (
     convert_to_float,
     is_calibration_mode,
+    is_reasonable_temperature,
     normalize_calibration_mode,
     normalize_hvac_mode,
 )
@@ -233,3 +234,39 @@ class TestConvertToFloat:
         result = convert_to_float("1.5e-3", "test", "temperature")
         # Expected behavior: 0.0015 rounded to 0.0 due to 0.01 step
         assert result == 0.0
+
+
+class TestIsReasonableTemperature:
+    """Plausibility bounds for incoming temperature values."""
+
+    def test_typical_indoor_value_is_reasonable(self):
+        assert is_reasonable_temperature(21.5) is True
+
+    def test_lower_bound_inclusive(self):
+        assert is_reasonable_temperature(-50.0) is True
+
+    def test_upper_bound_inclusive(self):
+        assert is_reasonable_temperature(60.0) is True
+
+    def test_below_lower_bound_rejected(self):
+        assert is_reasonable_temperature(-50.01) is False
+
+    def test_above_upper_bound_rejected(self):
+        assert is_reasonable_temperature(60.01) is False
+
+    def test_avm_off_marker_rejected(self):
+        """AVM Fritz!DECT exposes 126.5 °C for OFF mode."""
+        assert is_reasonable_temperature(126.5) is False
+
+    def test_avm_on_marker_rejected(self):
+        """AVM Fritz!DECT exposes 127.0 °C for ON mode."""
+        assert is_reasonable_temperature(127.0) is False
+
+    def test_none_rejected(self):
+        assert is_reasonable_temperature(None) is False
+
+    def test_zero_is_reasonable(self):
+        assert is_reasonable_temperature(0.0) is True
+
+    def test_negative_realistic_value_reasonable(self):
+        assert is_reasonable_temperature(-20.0) is True

--- a/tests/unit/test_helpers_normalize.py
+++ b/tests/unit/test_helpers_normalize.py
@@ -240,18 +240,23 @@ class TestIsReasonableTemperature:
     """Plausibility bounds for incoming temperature values."""
 
     def test_typical_indoor_value_is_reasonable(self):
+        """A normal room reading falls within the plausibility window."""
         assert is_reasonable_temperature(21.5) is True
 
     def test_lower_bound_inclusive(self):
+        """The -50 °C lower bound is accepted (inclusive)."""
         assert is_reasonable_temperature(-50.0) is True
 
     def test_upper_bound_inclusive(self):
+        """The 60 °C upper bound is accepted (inclusive)."""
         assert is_reasonable_temperature(60.0) is True
 
     def test_below_lower_bound_rejected(self):
+        """Values just below -50 °C are rejected as implausible."""
         assert is_reasonable_temperature(-50.01) is False
 
     def test_above_upper_bound_rejected(self):
+        """Values just above 60 °C are rejected as implausible."""
         assert is_reasonable_temperature(60.01) is False
 
     def test_avm_off_marker_rejected(self):
@@ -263,10 +268,13 @@ class TestIsReasonableTemperature:
         assert is_reasonable_temperature(127.0) is False
 
     def test_none_rejected(self):
+        """A None reading is treated as missing, not as 0 °C."""
         assert is_reasonable_temperature(None) is False
 
     def test_zero_is_reasonable(self):
+        """0 °C is a valid reading (e.g. outdoor freezing point)."""
         assert is_reasonable_temperature(0.0) is True
 
     def test_negative_realistic_value_reasonable(self):
+        """Sub-zero values within the plausibility window are accepted."""
         assert is_reasonable_temperature(-20.0) is True

--- a/tests/unit/test_temperature_events.py
+++ b/tests/unit/test_temperature_events.py
@@ -668,10 +668,11 @@ class TestEdgeCasesAndRobustness:
 
         with patch(
             "custom_components.better_thermostat.events.temperature.ir.async_create_issue"
-        ):
+        ) as mock_create_issue:
             await trigger_temperature_change(mock_bt, event)
 
         assert mock_bt.cur_temp == 20.0
+        mock_create_issue.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_avm_off_marker_rejected(self, mock_bt):
@@ -681,10 +682,11 @@ class TestEdgeCasesAndRobustness:
 
         with patch(
             "custom_components.better_thermostat.events.temperature.ir.async_create_issue"
-        ):
+        ) as mock_create_issue:
             await trigger_temperature_change(mock_bt, event)
 
         assert mock_bt.cur_temp == 20.0
+        mock_create_issue.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_avm_on_marker_rejected(self, mock_bt):
@@ -694,10 +696,11 @@ class TestEdgeCasesAndRobustness:
 
         with patch(
             "custom_components.better_thermostat.events.temperature.ir.async_create_issue"
-        ):
+        ) as mock_create_issue:
             await trigger_temperature_change(mock_bt, event)
 
         assert mock_bt.cur_temp == 20.0
+        mock_create_issue.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_60_exactly_accepted(self, mock_bt):

--- a/tests/unit/test_temperature_events.py
+++ b/tests/unit/test_temperature_events.py
@@ -653,12 +653,60 @@ class TestEdgeCasesAndRobustness:
 
     @pytest.mark.asyncio
     async def test_minus_50_exactly_accepted(self, mock_bt):
-        """Temperature exactly -50.0 is accepted (guard is < -50, not <= -50)."""
+        """Temperature exactly -50.0 is on the inclusive lower bound."""
         mock_bt.cur_temp = None
         event = _make_event(State(SENSOR_ID, "-50.0"))
 
         await trigger_temperature_change(mock_bt, event)
         assert mock_bt.cur_temp == -50.0
+
+    @pytest.mark.asyncio
+    async def test_below_minus_50_rejected(self, mock_bt):
+        """Temperature below the lower plausibility bound is rejected."""
+        mock_bt.cur_temp = 20.0
+        event = _make_event(State(SENSOR_ID, "-100.0"))
+
+        with patch(
+            "custom_components.better_thermostat.events.temperature.ir.async_create_issue"
+        ):
+            await trigger_temperature_change(mock_bt, event)
+
+        assert mock_bt.cur_temp == 20.0
+
+    @pytest.mark.asyncio
+    async def test_avm_off_marker_rejected(self, mock_bt):
+        """AVM Fritz!DECT 126.5 °C (OFF marker) must not update cur_temp."""
+        mock_bt.cur_temp = 20.0
+        event = _make_event(State(SENSOR_ID, "126.5"))
+
+        with patch(
+            "custom_components.better_thermostat.events.temperature.ir.async_create_issue"
+        ):
+            await trigger_temperature_change(mock_bt, event)
+
+        assert mock_bt.cur_temp == 20.0
+
+    @pytest.mark.asyncio
+    async def test_avm_on_marker_rejected(self, mock_bt):
+        """AVM Fritz!DECT 127.0 °C (ON marker) must not update cur_temp."""
+        mock_bt.cur_temp = 20.0
+        event = _make_event(State(SENSOR_ID, "127.0"))
+
+        with patch(
+            "custom_components.better_thermostat.events.temperature.ir.async_create_issue"
+        ):
+            await trigger_temperature_change(mock_bt, event)
+
+        assert mock_bt.cur_temp == 20.0
+
+    @pytest.mark.asyncio
+    async def test_60_exactly_accepted(self, mock_bt):
+        """Temperature exactly 60.0 is on the inclusive upper bound."""
+        mock_bt.cur_temp = None
+        event = _make_event(State(SENSOR_ID, "60.0"))
+
+        await trigger_temperature_change(mock_bt, event)
+        assert mock_bt.cur_temp == 60.0
 
     @pytest.mark.asyncio
     async def test_control_queue_none_no_crash_in_apply(self, mock_bt):

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -233,9 +233,10 @@ class TestInternalTemperatureChange:
         assert mock_bt.real_trvs[ENTITY_ID]["current_temperature"] == new_temp
 
     @pytest.mark.asyncio
-    async def test_implausible_trv_temp_ignored(self, mock_bt):
-        """AVM-style 126.5 °C marker must not overwrite cached TRV temperature."""
-        trv_state = _make_state(attributes={"current_temperature": 126.5})
+    @pytest.mark.parametrize("marker_temp", [126.5, 127.0])
+    async def test_implausible_trv_temp_ignored(self, mock_bt, marker_temp):
+        """AVM marker values (126.5 °C OFF, 127.0 °C ON) must not overwrite the cache."""
+        trv_state = _make_state(attributes={"current_temperature": marker_temp})
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 20.0
         mock_bt.real_trvs[ENTITY_ID]["calibration_received"] = True

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -233,6 +233,24 @@ class TestInternalTemperatureChange:
         assert mock_bt.real_trvs[ENTITY_ID]["current_temperature"] == new_temp
 
     @pytest.mark.asyncio
+    async def test_implausible_trv_temp_ignored(self, mock_bt):
+        """AVM-style 126.5 °C marker must not overwrite cached TRV temperature."""
+        trv_state = _make_state(attributes={"current_temperature": 126.5})
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 20.0
+        mock_bt.real_trvs[ENTITY_ID]["calibration_received"] = True
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID]["current_temperature"] == 20.0
+
+    @pytest.mark.asyncio
     async def test_temp_change_respects_time_diff(self, mock_bt):
         """Changes within 5 s of the last internal sensor change are skipped."""
         mock_bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=2)


### PR DESCRIPTION
Closes #1591.

## Problem

Some upstream integrations expose protocol marker values as if they were real temperature readings. The clearest example is AVM Fritz!DECT, where the thermostat returns **126.5 °C** for OFF mode and **127.0 °C** for ON mode. The HA `fritzbox` integration filters these markers in `target_temperature` (`ON_API_TEMPERATURE = 127.0`, `OFF_API_TEMPERATURE = 126.5` are excluded), but lets them pass through `current_temperature`.

With no upper-bound check in BT, those markers used to overwrite `cur_temp`. The regulator then believes the room is at 126 °C and shuts the heating off — exactly what #1591 reports.

BT already has a lower-bound sanity check (`< -50` in `events/temperature.py`); it just never had a symmetric upper one.

## Fix

Single plausibility window of **[-50 °C, 60 °C]** (inclusive). Anything outside is treated as garbage at every place a temperature enters BT.

### Constants and helper
- `utils/const.py`: `MIN_REASONABLE_TEMPERATURE` / `MAX_REASONABLE_TEMPERATURE`.
- `utils/helpers.py`: `is_reasonable_temperature(value)` — rejects `None` and values outside the window.

### Ingress points

| Where | What changes |
|---|---|
| `events/temperature.py` (external room sensor state changes) | Existing `< -50` check replaced by `is_reasonable_temperature(...)`; log message now includes the rejected value for diagnosis. HA repair issue still raised. |
| `climate.py:_initialize_sensors` (startup room sensor read) | Implausible value triggers the existing TRV-fallback path with a clear log line. |
| `climate.py:_initialize_sensors` (TRV current_temperature fallback) | Skip TRVs whose reading is implausible; if none are valid, the default fallback applies. |
| `events/trv.py` (TRV state-change handler) | Implausible `current_temperature` is ignored (cache not poisoned). |

The 60 °C upper bound is comfortably above any realistic indoor temperature (sauna users excluded — and they probably shouldn't use a heating regulator there either).

## Tests

18 new cases:
- `tests/unit/test_helpers_normalize.py` — bounds inclusivity, AVM 126.5 / 127.0, None, zero, negative-but-realistic.
- `tests/unit/test_temperature_events.py` — `trigger_temperature_change` rejects 126.5 / 127.0, accepts -50.0 and 60.0 on the inclusive edges, rejects -100. Repair-issue emission is asserted for each rejection path.
- `tests/unit/test_climate_startup.py` — startup fallback chain (implausible sensor → TRV; implausible TRV → default; both implausible → default).
- `tests/unit/test_trv_events.py` — TRV cache not poisoned by 126.5 / 127.0 (parametrized over both AVM markers).

`uv run pytest tests/ -p no:homeassistant` — 1115 passed (1113 baseline + 18 new − the obsolete check supersedes nothing).

## Notes

- This is a defensive guard *in BT*. The cleaner long-term fix is upstream in the HA `fritzbox` integration: mirror the `target_temperature` marker filter into `current_temperature`. I plan to file that separately. Either fix solves #1591 in isolation; both together are belt-and-suspenders.
- The 60 °C bound is a configuration-free constant. If a use case for higher values emerges, the constant can be raised in one place.
