### PR TITLE
fix: TRV → BT sync for user setpoint changes in TARGET_TEMP_BASED mode

### DIFF
--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -288,13 +288,24 @@ async def trigger_trv_change(self, event):
             else:
                 _new_heating_setpoint = self.bt_max_temp
 
+        # Step-aware echo detection: changes strictly smaller than the device
+        # step are treated as device-side rounding echoes of a BT-written
+        # value, not as user input. User input on a TRV display moves the
+        # setpoint by at least one step.
+        _step = self.real_trvs[entity_id].get(
+            "target_temp_step"
+        ) or self.bt_target_temp_step or 0.5
+        _bt_known_values = (
+            self.bt_target_temp,
+            _old_heating_setpoint,
+            self.real_trvs[entity_id]["last_temperature"],
+        )
+        _is_echo = any(
+            v is not None and abs(_new_heating_setpoint - v) < _step
+            for v in _bt_known_values
+        )
         if (
-            _new_heating_setpoint
-            not in (
-                self.bt_target_temp,
-                _old_heating_setpoint,
-                self.real_trvs[entity_id]["last_temperature"],
-            )
+            not _is_echo
             and not child_lock
             and self.real_trvs[entity_id]["target_temp_received"] is True
             and self.real_trvs[entity_id]["system_mode_received"] is True
@@ -302,30 +313,21 @@ async def trigger_trv_change(self, event):
             and self.window_open is False
             and not self.real_trvs[entity_id].get("ignore_trv_states", False)
         ):
-            _calibration_type = self.real_trvs[entity_id]["advanced"].get("calibration")
-            if _calibration_type == CalibrationType.TARGET_TEMP_BASED:
-                _LOGGER.debug(
-                    "better_thermostat %s: TRV %s target temp change ignored because of calibration type %s",
-                    self.device_name,
-                    entity_id,
-                    _calibration_type,
-                )
-            else:
-                _LOGGER.debug(
-                    "better_thermostat %s: TRV %s decoded TRV target temp changed from %s to %s",
-                    self.device_name,
-                    entity_id,
-                    self.bt_target_temp,
-                    _new_heating_setpoint,
-                )
-                self.bt_target_temp = _new_heating_setpoint
-                if self.cooler_entity_id is not None:
-                    if self.bt_target_temp >= self.bt_target_cooltemp:
-                        self.bt_target_cooltemp = self.bt_target_temp + (
-                            self.bt_target_temp_step or 0.5
-                        )
+            _LOGGER.debug(
+                "better_thermostat %s: TRV %s decoded TRV target temp changed from %s to %s",
+                self.device_name,
+                entity_id,
+                self.bt_target_temp,
+                _new_heating_setpoint,
+            )
+            self.bt_target_temp = _new_heating_setpoint
+            if self.cooler_entity_id is not None:
+                if self.bt_target_temp >= self.bt_target_cooltemp:
+                    self.bt_target_cooltemp = self.bt_target_temp + (
+                        self.bt_target_temp_step or 0.5
+                    )
 
-                _main_change = True
+            _main_change = True
 
         if self.real_trvs[entity_id]["advanced"].get("no_off_system_mode", False):
             if _new_heating_setpoint == self.real_trvs[entity_id]["min_temp"]:

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -292,12 +292,22 @@ async def trigger_trv_change(self, event):
         # step are treated as device-side rounding echoes of a BT-written
         # value, not as user input. User input on a TRV display moves the
         # setpoint by at least one step.
-        _step = self.real_trvs[entity_id].get(
-            "target_temp_step"
-        ) or self.bt_target_temp_step or 0.5
+        _step_raw = (
+            self.real_trvs[entity_id].get("target_temp_step")
+            or self.bt_target_temp_step
+            or 0.5
+        )
+        try:
+            _step = float(_step_raw)
+        except (TypeError, ValueError):
+            _step = 0.5
+        if _step <= 0:
+            _step = 0.5
+        # Compare only against values BT itself wrote. ``_old_heating_setpoint``
+        # is the TRV's previously published state and is not necessarily a
+        # BT-written value, so it does not belong in the echo-suppression set.
         _bt_known_values = (
             self.bt_target_temp,
-            _old_heating_setpoint,
             self.real_trvs[entity_id]["last_temperature"],
         )
         _is_echo = any(

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -933,9 +933,10 @@ class TestTargetTempAdoption:
 
 
 class TestTargetTempBasedSync:
-    """User-initiated TRV setpoint changes must propagate to BT even when
-    calibration is TARGET_TEMP_BASED. Device-side echoes within step distance
-    of BT's known values are still suppressed.
+    """User-initiated TRV setpoint changes must propagate to BT.
+
+    Even when calibration is TARGET_TEMP_BASED. Device-side echoes within step
+    distance of BT's known values are still suppressed.
     """
 
     def _set_target_temp_based(self, mock_bt):

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -1034,6 +1034,43 @@ class TestTargetTempBasedSync:
 
         assert mock_bt.bt_target_temp == 21.5
 
+    @pytest.mark.asyncio
+    async def test_user_change_after_echo_not_suppressed(self, mock_bt):
+        """A user change following a device echo is still adopted.
+
+        Setup mimics the post-echo state: BT wrote 21.0, device echoed
+        21.3 (within step), so the TRV's currently-published state is 21.3.
+        The user then dials to 21.5. ``_old_heating_setpoint`` is 21.3 (the
+        echo), not a BT-written value — it must not feed into echo detection.
+        """
+        self._set_target_temp_based(mock_bt)
+        mock_bt.bt_target_temp = 21.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 21.0
+        mock_bt.real_trvs[ENTITY_ID]["target_temp_step"] = 0.5
+
+        old_state = _make_state(
+            attributes={"temperature": 21.3, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 21.5, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 21.5},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 21.5
+
 
 # ---------------------------------------------------------------------------
 # 6. Control queue trigger

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -755,35 +755,6 @@ class TestTargetTempAdoption:
         assert mock_bt.bt_target_temp == 19.0
 
     @pytest.mark.asyncio
-    async def test_setpoint_blocked_target_temp_based_calibration(self, mock_bt):
-        """TARGET_TEMP_BASED calibration type blocks setpoint adoption."""
-        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = (
-            CalibrationType.TARGET_TEMP_BASED
-        )
-        old_state = _make_state(
-            attributes={"temperature": 19.0, "current_temperature": 18.0}
-        )
-        new_state = _make_state(
-            attributes={"temperature": 22.0, "current_temperature": 18.0}
-        )
-        trv_state = _make_state(
-            state_str="heat",
-            attributes={"current_temperature": 18.0, "temperature": 22.0},
-        )
-        mock_bt.hass.states.get.return_value = trv_state
-        mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
-
-        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
-
-        with patch(
-            "custom_components.better_thermostat.events.trv.convert_inbound_states",
-            return_value=HVACMode.HEAT,
-        ):
-            await trigger_trv_change(mock_bt, event)
-
-        assert mock_bt.bt_target_temp == 19.0
-
-    @pytest.mark.asyncio
     async def test_setpoint_uses_target_temp_low_fallback(self, mock_bt):
         """When 'temperature' is missing, 'target_temp_low' is used."""
         old_state = State(
@@ -959,6 +930,109 @@ class TestTargetTempAdoption:
             await trigger_trv_change(mock_bt, event)
 
         assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+
+
+class TestTargetTempBasedSync:
+    """User-initiated TRV setpoint changes must propagate to BT even when
+    calibration is TARGET_TEMP_BASED. Device-side echoes within step distance
+    of BT's known values are still suppressed.
+    """
+
+    def _set_target_temp_based(self, mock_bt):
+        mock_bt.real_trvs[ENTITY_ID]["advanced"]["calibration"] = (
+            CalibrationType.TARGET_TEMP_BASED
+        )
+
+    @pytest.mark.asyncio
+    async def test_user_change_picked_up(self, mock_bt):
+        """User raises TRV from 19.0 to 22.0 — bt_target_temp follows."""
+        self._set_target_temp_based(mock_bt)
+        mock_bt.bt_target_temp = 19.0
+        mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 19.0
+
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 22.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 22.0},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 22.0
+
+    @pytest.mark.asyncio
+    async def test_echo_within_step_suppressed(self, mock_bt):
+        """Device echoes 21.3 after BT wrote 21.0 (step=0.5) — treated as echo."""
+        self._set_target_temp_based(mock_bt)
+        mock_bt.bt_target_temp = 21.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 21.0
+        mock_bt.real_trvs[ENTITY_ID]["target_temp_step"] = 0.5
+
+        old_state = _make_state(
+            attributes={"temperature": 21.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 21.3, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 21.3},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 21.0
+
+    @pytest.mark.asyncio
+    async def test_change_at_one_step_is_user(self, mock_bt):
+        """Change equal to one full step is a user change, not an echo."""
+        self._set_target_temp_based(mock_bt)
+        mock_bt.bt_target_temp = 21.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.real_trvs[ENTITY_ID]["last_temperature"] = 21.0
+        mock_bt.real_trvs[ENTITY_ID]["target_temp_step"] = 0.5
+
+        old_state = _make_state(
+            attributes={"temperature": 21.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 21.5, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 21.5},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 21.5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1706.

## Problem

When calibration type is `TARGET_TEMP_BASED` (the default for most TRVs — Tado, eQ-3 MAX!, Aqara, Sonoff, …), changing the target temperature on the TRV (TRV display, vendor app, external wall thermostat) was **not picked up by Better Thermostat**. One-way sync only: BT → TRV worked, TRV → BT did not.

Root cause: the `trigger_trv_change` handler had an explicit `if _calibration_type == CalibrationType.TARGET_TEMP_BASED: skip` branch that ignored *every* TRV setpoint change in this mode. The intent was to prevent ping-pong from device-side rounding echoes (BT writes 21.0, some devices echo 21.5 because they round differently), but the rule was too broad and also dropped legitimate user input.

The outer filter (`_new_heating_setpoint not in (bt_target_temp, _old, last_temperature)`) was meant to catch echoes, but exact equality misses rounded values, leaving the calibration-type ignore as the catch-all that broke this feature.

## Fix

Replace exact-value with step-aware echo detection:

```python
_step = self.real_trvs[entity_id].get("target_temp_step") or self.bt_target_temp_step or 0.5
_is_echo = any(
    v is not None and abs(_new_heating_setpoint - v) < _step
    for v in (self.bt_target_temp, _old_heating_setpoint, self.real_trvs[entity_id]["last_temperature"])
)
```

A new setpoint is an echo iff its absolute difference from any known BT value is **strictly less than** the device's step. User input on a TRV display moves the setpoint by at least one full step, so it falls outside the echo window.

Remove the calibration-type special case. The step-aware check plus the existing `target_temp_received` / `ignore_trv_states` guards now cover both directions for every calibration type.

## Behavior matrix

| Scenario (step = 0.5) | Before | After |
|---|---|---|
| BT writes 21.0, device echoes 21.0 | suppressed (exact match) | suppressed (diff 0 < step) |
| BT writes 21.0, device echoes 21.3 (rounding) | TARGET_TEMP_BASED: suppressed; others: **adopted (ping-pong)** | suppressed (diff 0.3 < step) |
| User dials TRV to 22.0 (≥1 step away) | TARGET_TEMP_BASED: **dropped (#1706)**; others: adopted | adopted |
| BT writes 21.0, TRV reports 21.5 (exactly one step) | TARGET_TEMP_BASED: dropped; others: adopted | adopted (diff 0.5 ≮ step) |

## Tests

Test-driven, three new cases in `TestTargetTempBasedSync`:
- `test_user_change_picked_up` — 19.0 → 22.0 user change is adopted.
- `test_echo_within_step_suppressed` — 21.0 → 21.3 device echo is ignored.
- `test_change_at_one_step_is_user` — 21.0 → 21.5 (exact step) is treated as user input.

`test_setpoint_blocked_target_temp_based_calibration` removed — it asserted the old broken behavior.

`uv run pytest tests/ -p no:homeassistant` — 1115 passed.

## Risk

Low. The step-aware check is at least as strict as the previous exact-equality check for the echo case (any value equal to a known BT value also satisfies `abs(diff) < step`). For non-TARGET_TEMP_BASED modes, behavior is unchanged for round-trip exact echoes and slightly more tolerant for rounded echoes (previously these caused a one-time re-write to converge with device rounding; now they are simply ignored).

The 0.5 °C fallback step matches the existing default used elsewhere in the codebase (`delegate.py`, `cooler.py`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined radiator valve target temperature update handling to improve accuracy when processing device temperature changes, reducing unnecessary adjustments.

* **Tests**
  * Enhanced test coverage for temperature synchronization scenarios to ensure reliable target temperature handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KartoffelToby/better_thermostat/pull/1992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->