### PR TITLE
refactor: drop unreachable async_retry on delegate.init

### DIFF
--- a/custom_components/better_thermostat/adapters/delegate.py
+++ b/custom_components/better_thermostat/adapters/delegate.py
@@ -45,9 +45,13 @@ async def load_adapter(self, integration, entity_id, get_name=False):
     return self.adapter
 
 
-@async_retry(retries=5)
 async def init(self, entity_id):
-    """Init adapter."""
+    """Init adapter.
+
+    Transient unavailability is handled inside the adapter's
+    ``wait_for_calibration_entity_or_timeout`` (6 × 5 s polls). The call
+    is invoked under a 30 s outer budget in ``_initialize_trvs``.
+    """
     return await self.real_trvs[entity_id]["adapter"].init(self, entity_id)
 
 


### PR DESCRIPTION
## Observation

`delegate.init` is decorated with `@async_retry(retries=5)`, and `_initialize_trvs` in `climate.py` calls it under a 30 s outer budget:

```python
await asyncio.wait_for(init(self, trv), timeout=30)   # climate.py
```

`async_retry(retries=5)` performs exponential backoff before each retry: 1 + 2 + 4 + 8 + 16 = **31 s of sleeps**, plus per-attempt call time. The outer 30 s budget cancels everything before the second attempt finishes — only one attempt actually runs. The retry layer is unreachable, even though the log lines suggest otherwise on rare timeouts.

Transient unavailability of the TRV's calibration entity is already handled inside the adapter via `wait_for_calibration_entity_or_timeout` (6 × 5 s polls in `adapters/base.py`), which is the call that actually consumes the budget. Stacking another retry decorator on top buys nothing.

## Change

Drop the `@async_retry` decorator on `delegate.init` and document the timing in the docstring. No other call sites or behavior change. Other adapter functions (`set_temperature`, `set_hvac_mode`, `get_*`, `set_valve`) keep their decorator — those calls *do* benefit from retries during normal operation, when the outer code path has no comparable timeout wrapper.

## Test plan
- [x] `uv run pytest tests/ -p no:homeassistant` — 1113 passed.

## Notes
- Discovered while diagnosing #1833 (TRV init timeouts). The observable behavior was already "one attempt within 30 s"; this PR removes the misleading retry indirection without changing what users see.
- Once #1990 lands (BT startup deferred to `CoreState.running`), `wait_for_calibration_entity_or_timeout` should succeed on the first poll for properly-published entities, making the whole timing structure a non-issue. This refactor is independent of that.
