### PR TITLE
fix: suppress hvac_action TRV-override at or above target

### DIFF
--- a/custom_components/better_thermostat/utils/hvac_action.py
+++ b/custom_components/better_thermostat/utils/hvac_action.py
@@ -151,9 +151,8 @@ def compute_hvac_action(
         tolerance_hold = False
 
     # TRV override: if base decision is IDLE but any TRV is active, show HEATING.
-    # Suppressed at or above target: a TRV's valve still bleeding off during
-    # overshoot must not lift the displayed action above IDLE — the hysteresis
-    # has already decided to stop. See issue #1850.
+    # Suppressed at or above target so a still-closing valve cannot lift the
+    # displayed action above IDLE once the hysteresis decided to stop.
     if action == HVACAction.IDLE:
         if ignore_states or window_open or cur_temp >= target_temp:
             return HvacActionResult(

--- a/custom_components/better_thermostat/utils/hvac_action.py
+++ b/custom_components/better_thermostat/utils/hvac_action.py
@@ -150,9 +150,12 @@ def compute_hvac_action(
         action = HVACAction.COOLING
         tolerance_hold = False
 
-    # TRV override: if base decision is IDLE but any TRV is active, show HEATING
+    # TRV override: if base decision is IDLE but any TRV is active, show HEATING.
+    # Suppressed at or above target: a TRV's valve still bleeding off during
+    # overshoot must not lift the displayed action above IDLE — the hysteresis
+    # has already decided to stop. See issue #1850.
     if action == HVACAction.IDLE:
-        if ignore_states or window_open:
+        if ignore_states or window_open or cur_temp >= target_temp:
             return HvacActionResult(
                 action=HVACAction.IDLE,
                 tolerance_decision=tolerance_decision,

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -278,7 +278,7 @@ class TestComputeHvacAction:
         assert self._call(mock_bt) == HVACAction.HEATING
 
     def test_trv_override_suppressed_above_target(self, mock_bt):
-        """Issue #1850: TRV still reports heating during overshoot → action stays IDLE."""
+        """Above target with TRV still reporting heating → action stays IDLE."""
         mock_bt.cur_temp = 22.3  # above target → BT has decided IDLE
         mock_bt.bt_target_temp = 22.0
         mock_bt._hysteresis.last_action = HVACAction.HEATING

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -254,16 +254,16 @@ class TestComputeHvacAction:
         assert self._call(mock_bt) == HVACAction.COOLING
 
     def test_trv_override_hvac_action_heating(self, mock_bt):
-        """TRV reports hvac_action='heating' → override to HEATING."""
-        mock_bt.cur_temp = 22.0  # at target → base decision is IDLE
+        """TRV reports hvac_action='heating' in band → override to HEATING."""
+        mock_bt.cur_temp = 21.7  # in band: target-tol(21.5) < cur < target(22.0)
         mock_bt.bt_target_temp = 22.0
         mock_bt._hysteresis.last_action = HVACAction.IDLE
         mock_bt.real_trvs = {"climate.trv1": {"hvac_action": "heating"}}
         assert self._call(mock_bt) == HVACAction.HEATING
 
     def test_trv_override_valve_position(self, mock_bt):
-        """TRV valve_position=50 → override to HEATING."""
-        mock_bt.cur_temp = 22.0
+        """TRV valve_position=50 in band → override to HEATING."""
+        mock_bt.cur_temp = 21.7
         mock_bt.bt_target_temp = 22.0
         mock_bt._hysteresis.last_action = HVACAction.IDLE
         mock_bt.real_trvs = {"climate.trv1": {"valve_position": 50}}
@@ -271,15 +271,23 @@ class TestComputeHvacAction:
 
     def test_trv_override_last_valve_percent_0_1_range(self, mock_bt):
         """TRV last_valve_percent=0.8 (0-1 range) → normalized to 80% → HEATING."""
-        mock_bt.cur_temp = 22.0
+        mock_bt.cur_temp = 21.7
         mock_bt.bt_target_temp = 22.0
         mock_bt._hysteresis.last_action = HVACAction.IDLE
         mock_bt.real_trvs = {"climate.trv1": {"last_valve_percent": 0.8}}
         assert self._call(mock_bt) == HVACAction.HEATING
 
+    def test_trv_override_suppressed_above_target(self, mock_bt):
+        """Issue #1850: TRV still reports heating during overshoot → action stays IDLE."""
+        mock_bt.cur_temp = 22.3  # above target → BT has decided IDLE
+        mock_bt.bt_target_temp = 22.0
+        mock_bt._hysteresis.last_action = HVACAction.HEATING
+        mock_bt.real_trvs = {"climate.trv1": {"hvac_action": "heating"}}
+        assert self._call(mock_bt) == HVACAction.IDLE
+
     def test_ignore_states_no_trv_override(self, mock_bt):
-        """ignore_states=True → TRV override skipped, returns IDLE."""
-        mock_bt.cur_temp = 22.0
+        """ignore_states=True in band → TRV override still skipped, returns IDLE."""
+        mock_bt.cur_temp = 21.7
         mock_bt.bt_target_temp = 22.0
         mock_bt._hysteresis.last_action = HVACAction.IDLE
         mock_bt.ignore_states = True
@@ -287,8 +295,8 @@ class TestComputeHvacAction:
         assert self._call(mock_bt) == HVACAction.IDLE
 
     def test_ignore_trv_states_per_trv(self, mock_bt):
-        """ignore_trv_states=True on specific TRV → that TRV is skipped."""
-        mock_bt.cur_temp = 22.0
+        """ignore_trv_states=True on specific TRV in band → that TRV is skipped."""
+        mock_bt.cur_temp = 21.7
         mock_bt.bt_target_temp = 22.0
         mock_bt._hysteresis.last_action = HVACAction.IDLE
         mock_bt.real_trvs = {
@@ -298,7 +306,7 @@ class TestComputeHvacAction:
 
     def test_tolerance_decision_saved_before_trv_override(self, mock_bt):
         """Hysteresis state uses tolerance decision, not TRV-overridden action."""
-        mock_bt.cur_temp = 22.0  # at target → tolerance says IDLE
+        mock_bt.cur_temp = 21.7  # in band → tolerance says IDLE
         mock_bt.bt_target_temp = 22.0
         mock_bt._hysteresis.last_action = HVACAction.IDLE
         mock_bt.real_trvs = {"climate.trv1": {"hvac_action": "heating"}}

--- a/tests/unit/test_hvac_action.py
+++ b/tests/unit/test_hvac_action.py
@@ -248,12 +248,7 @@ class TestComputeHvacAction:
     # --- TRV override suppressed above target (issue #1850) ----------------
 
     def test_trv_hvac_action_no_override_above_target(self):
-        """TRV reports heating but cur > target → action stays IDLE.
-
-        Issue #1850: BT used to show HEATING above target because any TRV
-        valve still bleeding off (during overshoot) tripped the override.
-        Override must only fire when we're below the heat-off threshold.
-        """
+        """Above target, a TRV reporting heating must not lift action above IDLE."""
         snap = TrvSnapshot(trv_id="trv1", hvac_action="heating")
         r = compute_hvac_action(
             **_default_kwargs(cur_temp=21.3, target_temp=21.0, trv_snapshots=[snap])
@@ -285,11 +280,7 @@ class TestComputeHvacAction:
         assert r.action == HVACAction.IDLE
 
     def test_trv_override_still_fires_in_band(self):
-        """Inside the hysteresis band (below target), TRV override still fires.
-
-        Regression guard for the #1850 fix: the override semantic for the
-        in-band case is unchanged.
-        """
+        """Inside the hysteresis band (below target), TRV override still fires."""
         snap = TrvSnapshot(trv_id="trv1", hvac_action="heating")
         r = compute_hvac_action(
             **_default_kwargs(cur_temp=20.7, target_temp=21.0, trv_snapshots=[snap])

--- a/tests/unit/test_hvac_action.py
+++ b/tests/unit/test_hvac_action.py
@@ -245,6 +245,57 @@ class TestComputeHvacAction:
         r = compute_hvac_action(**_default_kwargs(cur_temp=20.7, trv_snapshots=[snap]))
         assert r.action == HVACAction.IDLE
 
+    # --- TRV override suppressed above target (issue #1850) ----------------
+
+    def test_trv_hvac_action_no_override_above_target(self):
+        """TRV reports heating but cur > target → action stays IDLE.
+
+        Issue #1850: BT used to show HEATING above target because any TRV
+        valve still bleeding off (during overshoot) tripped the override.
+        Override must only fire when we're below the heat-off threshold.
+        """
+        snap = TrvSnapshot(trv_id="trv1", hvac_action="heating")
+        r = compute_hvac_action(
+            **_default_kwargs(cur_temp=21.3, target_temp=21.0, trv_snapshots=[snap])
+        )
+        assert r.action == HVACAction.IDLE
+
+    def test_trv_valve_position_no_override_above_target(self):
+        """Valve still partially open after overshoot must not lift action above IDLE."""
+        snap = TrvSnapshot(trv_id="trv1", valve_position=0.15)
+        r = compute_hvac_action(
+            **_default_kwargs(cur_temp=21.3, target_temp=21.0, trv_snapshots=[snap])
+        )
+        assert r.action == HVACAction.IDLE
+
+    def test_trv_last_valve_percent_no_override_above_target(self):
+        """Stale last_valve_percent above target must not lift action above IDLE."""
+        snap = TrvSnapshot(trv_id="trv1", last_valve_percent=30.0)
+        r = compute_hvac_action(
+            **_default_kwargs(cur_temp=21.3, target_temp=21.0, trv_snapshots=[snap])
+        )
+        assert r.action == HVACAction.IDLE
+
+    def test_trv_override_at_target_boundary(self):
+        """At cur == target, override is suppressed (heat-off threshold reached)."""
+        snap = TrvSnapshot(trv_id="trv1", hvac_action="heating")
+        r = compute_hvac_action(
+            **_default_kwargs(cur_temp=21.0, target_temp=21.0, trv_snapshots=[snap])
+        )
+        assert r.action == HVACAction.IDLE
+
+    def test_trv_override_still_fires_in_band(self):
+        """Inside the hysteresis band (below target), TRV override still fires.
+
+        Regression guard for the #1850 fix: the override semantic for the
+        in-band case is unchanged.
+        """
+        snap = TrvSnapshot(trv_id="trv1", hvac_action="heating")
+        r = compute_hvac_action(
+            **_default_kwargs(cur_temp=20.7, target_temp=21.0, trv_snapshots=[snap])
+        )
+        assert r.action == HVACAction.HEATING
+
     # --- idempotency -------------------------------------------------------
 
     def test_hysteresis_not_mutated(self):
@@ -270,16 +321,19 @@ class TestHysteresisTransitions:
     """Tests for hysteresis transitions."""
 
     def test_tolerance_decision_not_corrupted_by_trv(self):
-        """TRV override must not change tolerance_decision."""
-        hyst = ToleranceHysteresis(last_action=HVACAction.HEATING)
+        """TRV override must not change tolerance_decision.
+
+        Scenario: in-band (below target), previously IDLE → tolerance says IDLE
+        (no restart in band), TRV overrides displayed action to HEATING.
+        The FSM state and tolerance_decision must still reflect tolerance.
+        """
+        hyst = ToleranceHysteresis(last_action=HVACAction.IDLE)
         snap = TrvSnapshot(trv_id="trv1", hvac_action="heating")
         r = compute_hvac_action(
-            **_default_kwargs(hysteresis=hyst, cur_temp=21.0, trv_snapshots=[snap])
+            **_default_kwargs(hysteresis=hyst, cur_temp=20.7, trv_snapshots=[snap])
         )
-        # Tolerance says IDLE (at target), TRV overrides to HEATING
         assert r.tolerance_decision == HVACAction.IDLE
         assert r.action == HVACAction.HEATING
-        # Hysteresis state follows tolerance, not TRV
         assert r.new_last_action == HVACAction.IDLE
 
     def test_hold_active_set_in_band(self):

--- a/tests/unit/test_hvac_action.py
+++ b/tests/unit/test_hvac_action.py
@@ -245,7 +245,7 @@ class TestComputeHvacAction:
         r = compute_hvac_action(**_default_kwargs(cur_temp=20.7, trv_snapshots=[snap]))
         assert r.action == HVACAction.IDLE
 
-    # --- TRV override suppressed above target (issue #1850) ----------------
+    # --- TRV override suppressed above target ------------------------------
 
     def test_trv_hvac_action_no_override_above_target(self):
         """Above target, a TRV reporting heating must not lift action above IDLE."""


### PR DESCRIPTION
Closes #1850.

## Problem

`utils/hvac_action.py::compute_hvac_action` runs a TRV-override block after the tolerance-based heating decision: if the base decision is `IDLE` but any TRV reports `hvac_action == \"heating\"` or `valve_position > 0`, the displayed action is promoted to `HEATING`.

That override has no upper-bound check. During overshoot — when the hysteresis correctly decided `IDLE` at the target but the TRV's valve is still physically closing — the override fires and BT shows `HEATING` above the target temperature. Users see the integration \"keep heating\" up to `target + tolerance`, which is also the symptom described in #1850.

## Fix

Suppress the TRV override when ``cur_temp >= target_temp``. At that point the hysteresis has already decided to stop, and a still-trailing valve is no longer a reason to display HEATING.

- ``utils/hvac_action.py``: extend the early-return inside the override block by ``cur_temp >= target_temp``.
- Tolerance-band scenarios below target are unchanged: override still promotes IDLE → HEATING.

## Tests

- ``tests/unit/test_hvac_action.py``: four new tests covering
  - TRV `hvac_action=\"heating\"` above target → IDLE
  - `valve_position > 0` above target → IDLE
  - stale `last_valve_percent > 0` above target → IDLE
  - `cur == target` boundary → IDLE
  - plus a regression guard that in-band override still fires.
- ``tests/unit/test_climate_baseline.py``: three baseline tests that pinned the old behavior at ``cur == target`` moved to an in-band scenario (target=22.0, cur=21.7) so they exercise the actual override mechanic, plus one new baseline-level guard for the above-target case.
- ``uv run pytest tests/ -p no:homeassistant`` — 1119 passed.

## Test plan
- [x] Unit tests cover the boundary at and just above target, plus a regression for the in-band case.
- [ ] Reporter / users of #1850 confirm against next beta that ``hvac_action`` returns to `IDLE` as soon as the target is reached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined thermostatic radiator valve override behavior: radiator valves can now only override the heating action when the current temperature is below the target, alongside existing suppression conditions. This improves thermostat precision and prevents unnecessary heating signals when temperatures meet or exceed the target level.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KartoffelToby/better_thermostat/pull/1994?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->