### PR TITLE
fix: gate boost valve/setpoint override by calibration_type

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -49,9 +49,15 @@ def _get_valve_control(
     valve_settings_dict contains 'valve_percent' and 'apply_valve' keys.
     Returns (None, None) if no valve control should be applied.
     """
-    # Boost mode opens the valve up to the user-configured
-    # valve_max_opening (default 100%).
-    if _is_boost_heating_active(self):
+    # Boost mode opens the valve only on TRVs that support direct valve control,
+    # up to the user-configured valve_max_opening (default 100%).
+    # Offset- and target-temp-based TRVs reach their setpoint through the
+    # normal setpoint/calibration chain — bypassing it with a forced override
+    # leaves the valve stuck open when boost ends.
+    if (
+        _is_boost_heating_active(self)
+        and calibration_type == CalibrationType.DIRECT_VALVE_BASED
+    ):
         max_opening = (self.real_trvs.get(heater_entity_id) or {}).get(
             "valve_max_opening", 100
         )
@@ -422,8 +428,6 @@ async def control_trv(self, heater_entity_id=None):
             return False
 
         _temperature = _remapped_states.get("temperature", None)
-        if _is_boost_heating_active(self):
-            _temperature = self.real_trvs[heater_entity_id]["max_temp"]
         _calibration = _remapped_states.get("local_temperature_calibration", None)
         _calibration_mode = self.real_trvs[heater_entity_id]["advanced"].get(
             "calibration_mode", CalibrationMode.MPC_CALIBRATION
@@ -431,6 +435,14 @@ async def control_trv(self, heater_entity_id=None):
         _calibration_type = self.real_trvs[heater_entity_id]["advanced"].get(
             "calibration", CalibrationType.TARGET_TEMP_BASED
         )
+        # Boost on direct-valve TRVs drives the setpoint to max so the device
+        # matches BT's forced 100 % valve command. Offset- and target-temp
+        # modes reach the boost temperature through normal calibration.
+        if (
+            _is_boost_heating_active(self)
+            and _calibration_type == CalibrationType.DIRECT_VALVE_BASED
+        ):
+            _temperature = self.real_trvs[heater_entity_id]["max_temp"]
 
         # Optional: set valve position if supported (e.g., MQTT/Z2M)
         try:

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -49,11 +49,8 @@ def _get_valve_control(
     valve_settings_dict contains 'valve_percent' and 'apply_valve' keys.
     Returns (None, None) if no valve control should be applied.
     """
-    # Boost mode opens the valve only on TRVs that support direct valve control,
-    # up to the user-configured valve_max_opening (default 100%).
-    # Offset- and target-temp-based TRVs reach their setpoint through the
-    # normal setpoint/calibration chain — bypassing it with a forced override
-    # leaves the valve stuck open when boost ends.
+    # Forcing the valve on a non-direct-valve TRV bypasses the calibration chain
+    # and leaves the valve stuck open after boost ends.
     if (
         _is_boost_heating_active(self)
         and calibration_type == CalibrationType.DIRECT_VALVE_BASED
@@ -435,9 +432,8 @@ async def control_trv(self, heater_entity_id=None):
         _calibration_type = self.real_trvs[heater_entity_id]["advanced"].get(
             "calibration", CalibrationType.TARGET_TEMP_BASED
         )
-        # Boost on direct-valve TRVs drives the setpoint to max so the device
-        # matches BT's forced 100 % valve command. Offset- and target-temp
-        # modes reach the boost temperature through normal calibration.
+        # Pair the forced 100 % valve with a max-temp setpoint so the TRV
+        # firmware does not fight the valve command.
         if (
             _is_boost_heating_active(self)
             and _calibration_type == CalibrationType.DIRECT_VALVE_BASED

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -479,8 +479,14 @@ async def control_trv(self, heater_entity_id=None):
             _new_hvac_mode = HVACMode.OFF
 
         # Safety override: if boost mode was active but we forced OFF (window/no-heat),
-        # ensure valve is reset to 0% to prevent overheating.
-        if _is_boost_heating_active(self) and _new_hvac_mode == HVACMode.OFF:
+        # ensure valve is reset to 0% to prevent overheating. Only direct-valve
+        # calibration types accept valve commands; LOCAL_BASED and
+        # TARGET_TEMP_BASED control via offset / setpoint instead.
+        if (
+            _is_boost_heating_active(self)
+            and _new_hvac_mode == HVACMode.OFF
+            and _calibration_type == CalibrationType.DIRECT_VALVE_BASED
+        ):
             _LOGGER.debug(
                 "better_thermostat %s: Boost safety override - resetting valve to 0%% because HVAC mode is OFF",
                 self.device_name,

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -308,13 +308,21 @@ class TestControlTrvUnavailablePath:
 
     @pytest.mark.asyncio
     async def test_boost_mode_sets_max_temp(self):
-        """Test that boost mode sets temperature to max_temp."""
+        """Boost on a DIRECT_VALVE_BASED TRV sets temperature to max_temp."""
         mock_self = _make_mock_self(
             trv_state=STATE_UNAVAILABLE,
             preset_mode=PRESET_BOOST,
             cur_temp=18.0,
             bt_target_temp=22.0,
-            real_trvs={"climate.trv1": _default_trv_config()},
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    advanced={
+                        "calibration_mode": CalibrationMode.MPC_CALIBRATION,
+                        "calibration": CalibrationType.DIRECT_VALVE_BASED,
+                        "no_off_system_mode": False,
+                    }
+                )
+            },
         )
 
         with (
@@ -325,6 +333,8 @@ class TestControlTrvUnavailablePath:
                 _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
             ),
             patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+            patch(_PATCHES["get_current_offset"], new=AsyncMock(return_value=0.0)),
+            patch(_PATCHES["set_offset"], new=AsyncMock()),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -340,6 +350,51 @@ class TestControlTrvUnavailablePath:
             mock_set_temp.assert_called_once()
             args = mock_set_temp.call_args[0]
             assert args[2] == 30.0  # max_temp
+
+    @pytest.mark.asyncio
+    async def test_boost_mode_offset_does_not_override_temp(self):
+        """Boost on an offset-mode TRV keeps the calibrated setpoint, not max."""
+        mock_self = _make_mock_self(
+            trv_state=STATE_UNAVAILABLE,
+            preset_mode=PRESET_BOOST,
+            cur_temp=18.0,
+            bt_target_temp=22.0,
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    advanced={
+                        "calibration_mode": CalibrationMode.MPC_CALIBRATION,
+                        "calibration": CalibrationType.LOCAL_BASED,
+                        "no_off_system_mode": False,
+                    }
+                )
+            },
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["handle_window_open"]) as mock_window,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+            patch(_PATCHES["get_current_offset"], new=AsyncMock(return_value=0.0)),
+            patch(_PATCHES["set_offset"], new=AsyncMock()),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 22.0,
+                "local_temperature_calibration": -1.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_temp.return_value = None
+            mock_window.return_value = HVACMode.HEAT
+
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_set_temp.assert_called_once()
+            args = mock_set_temp.call_args[0]
+            assert args[2] == 22.0  # calibrated setpoint, not max_temp
 
     @pytest.mark.asyncio
     async def test_window_open_sets_mode_to_off(self):

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -373,6 +373,7 @@ class TestControlTrvUnavailablePath:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["set_valve"]) as mock_set_valve,
             patch(_PATCHES["handle_window_open"]) as mock_window,
             patch(
                 _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
@@ -395,6 +396,7 @@ class TestControlTrvUnavailablePath:
             mock_set_temp.assert_called_once()
             args = mock_set_temp.call_args[0]
             assert args[2] == 22.0  # calibrated setpoint, not max_temp
+            mock_set_valve.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_window_open_sets_mode_to_off(self):

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -439,6 +439,59 @@ class TestCheckTargetTemperature:
 
 
 # ---------------------------------------------------------------------------
+# _get_valve_control — boost mode is gated by calibration_type
+# ---------------------------------------------------------------------------
+
+
+class TestGetValveControlBoostCalibrationType:
+    """Boost mode controls the valve only on TRVs with direct valve control."""
+
+    def _mock_in_boost(self):
+        mock_self = MagicMock()
+        mock_self.preset_mode = "boost"
+        mock_self.cur_temp = 19.0
+        mock_self.bt_target_temp = 22.0
+        mock_self.real_trvs = {"climate.trv1": {}}
+        return mock_self
+
+    def test_boost_direct_valve_returns_valve_settings(self):
+        """DIRECT_VALVE_BASED + boost → valve_percent=100, source='boost_mode'."""
+        mock_self = self._mock_in_boost()
+        bal, source = _get_valve_control(
+            mock_self,
+            "climate.trv1",
+            CalibrationMode.MPC_CALIBRATION,
+            CalibrationType.DIRECT_VALVE_BASED,
+        )
+        assert source == "boost_mode"
+        assert bal == {"valve_percent": 100, "apply_valve": True}
+
+    def test_boost_local_based_returns_none(self):
+        """LOCAL_BASED (offset) + boost → no valve override (None, None)."""
+        mock_self = self._mock_in_boost()
+        bal, source = _get_valve_control(
+            mock_self,
+            "climate.trv1",
+            CalibrationMode.MPC_CALIBRATION,
+            CalibrationType.LOCAL_BASED,
+        )
+        assert bal is None
+        assert source is None
+
+    def test_boost_target_temp_based_returns_none(self):
+        """TARGET_TEMP_BASED + boost → no valve override (None, None)."""
+        mock_self = self._mock_in_boost()
+        bal, source = _get_valve_control(
+            mock_self,
+            "climate.trv1",
+            CalibrationMode.MPC_CALIBRATION,
+            CalibrationType.TARGET_TEMP_BASED,
+        )
+        assert bal is None
+        assert source is None
+
+
+# ---------------------------------------------------------------------------
 # _get_valve_control — boost mode honors valve_max_opening
 # ---------------------------------------------------------------------------
 
@@ -448,7 +501,6 @@ class TestGetValveControlBoostMaxOpening:
 
     def _mock_in_boost(self, max_opening):
         mock_self = MagicMock()
-        # Trigger boost branch via _is_boost_heating_active(...)
         mock_self.preset_mode = "boost"
         mock_self.cur_temp = 19.0
         mock_self.bt_target_temp = 22.0
@@ -458,13 +510,12 @@ class TestGetValveControlBoostMaxOpening:
     def test_no_setting_defaults_to_100(self):
         """Without a configured limit, boost still applies 100%."""
         mock_self = self._mock_in_boost(max_opening=None)
-        # Simulate "key missing" by removing it entirely
         mock_self.real_trvs["climate.trv1"] = {}
         bal, source = _get_valve_control(
             mock_self,
             "climate.trv1",
             CalibrationMode.MPC_CALIBRATION,
-            CalibrationType.TARGET_TEMP_BASED,
+            CalibrationType.DIRECT_VALVE_BASED,
         )
         assert source == "boost_mode"
         assert bal == {"valve_percent": 100, "apply_valve": True}
@@ -476,7 +527,7 @@ class TestGetValveControlBoostMaxOpening:
             mock_self,
             "climate.trv1",
             CalibrationMode.MPC_CALIBRATION,
-            CalibrationType.TARGET_TEMP_BASED,
+            CalibrationType.DIRECT_VALVE_BASED,
         )
         assert bal == {"valve_percent": 100, "apply_valve": True}
 
@@ -487,7 +538,7 @@ class TestGetValveControlBoostMaxOpening:
             mock_self,
             "climate.trv1",
             CalibrationMode.MPC_CALIBRATION,
-            CalibrationType.TARGET_TEMP_BASED,
+            CalibrationType.DIRECT_VALVE_BASED,
         )
         assert source == "boost_mode"
         assert bal == {"valve_percent": 60, "apply_valve": True}
@@ -499,7 +550,7 @@ class TestGetValveControlBoostMaxOpening:
             mock_self,
             "climate.trv1",
             CalibrationMode.MPC_CALIBRATION,
-            CalibrationType.TARGET_TEMP_BASED,
+            CalibrationType.DIRECT_VALVE_BASED,
         )
         assert bal == {"valve_percent": 73, "apply_valve": True}
 
@@ -510,7 +561,7 @@ class TestGetValveControlBoostMaxOpening:
             mock_self,
             "climate.trv1",
             CalibrationMode.MPC_CALIBRATION,
-            CalibrationType.TARGET_TEMP_BASED,
+            CalibrationType.DIRECT_VALVE_BASED,
         )
         assert bal == {"valve_percent": 100, "apply_valve": True}
 
@@ -521,6 +572,6 @@ class TestGetValveControlBoostMaxOpening:
             mock_self,
             "climate.trv1",
             CalibrationMode.MPC_CALIBRATION,
-            CalibrationType.TARGET_TEMP_BASED,
+            CalibrationType.DIRECT_VALVE_BASED,
         )
         assert bal == {"valve_percent": 100, "apply_valve": True}


### PR DESCRIPTION
Closes #1956.

## Problem

In ``utils/controlling.py`` the boost preset took two device-level shortcuts unconditionally:

1. ``_get_valve_control`` returned ``{\"valve_percent\": 100, \"apply_valve\": True}`` for every calibration type.
2. ``control_trv`` overrode the calibrated setpoint with ``max_temp`` whenever boost was active.

Both were designed for ``DIRECT_VALVE_BASED`` TRVs where BT drives the valve directly and the device's own setpoint is largely cosmetic. On ``LOCAL_BASED`` (offset) and ``TARGET_TEMP_BASED`` TRVs the device reaches the boost temperature through its own valve logic, so:

- the configured Boost preset temperature was discarded — the TRV always saw ``max_temp``;
- the valve was forced fully open even though the calibration chain was meant to be in charge;
- because nothing in the non-boost path issues a follow-up ``set_valve`` for those calibration types, the valve stayed open after switching to another preset.

Reporter saw all three symptoms on a Sonoff TRVZB in offset-only mode.

## Fix

Gate both overrides on ``calibration_type == CalibrationType.DIRECT_VALVE_BASED``:

- ``_get_valve_control`` returns ``(None, None)`` for boost when the TRV is not direct-valve-based. The DIRECT_VALVE_BASED branch is unchanged.
- ``control_trv`` only overrides ``_temperature`` to ``max_temp`` for direct-valve TRVs; offset- and target-temp TRVs use the value returned by ``convert_outbound_states``, which is already the (calibrated) boost setpoint.

Because the boost branch in offset/target-temp mode no longer issues any ``set_valve`` call, there is nothing to undo on preset exit — the third symptom resolves without an extra reset path.

## Relationship with PR #1987

PR #1987 (``fix/boost-honor-valve-max-opening``) modifies the same boost branch in ``_get_valve_control`` to clamp ``valve_percent`` against ``valve_max_opening``. That logic is still useful, but for ``DIRECT_VALVE_BASED`` only. Whichever PR merges first, the other needs a small rebase: keep the calibration_type gate from this PR and apply ``valve_max_opening`` clamping from #1987 inside the gated branch.

## Tests

- ``tests/unit/controlling/test_helpers.py``: three new tests covering ``_get_valve_control`` for boost across DIRECT_VALVE_BASED, LOCAL_BASED, TARGET_TEMP_BASED.
- ``tests/unit/controlling/test_control_trv.py``: existing ``test_boost_mode_sets_max_temp`` made explicit about DIRECT_VALVE_BASED; new ``test_boost_mode_offset_does_not_override_temp`` covers the offset-mode case.
- ``uv run pytest tests/ -p no:homeassistant`` — 1117 passed.

## Test plan
- [x] Unit tests cover all three calibration types under boost.
- [ ] Reporter confirms on the next beta that Sonoff TRVZB in offset mode honors the configured boost temperature and that the valve closes when exiting boost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Boost-mode now only forces full valve and max-temperature behavior for compatible valve-type thermostats; other calibration types no longer get forced max setpoints or forced valve resets when mode becomes OFF.
* **Tests**
  * Updated and added unit tests validating boost behavior across different calibration types and valve-control outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KartoffelToby/better_thermostat/pull/1995?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->