### PR TITLE
fix: stop exposing current humidity under the reserved attribute key

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2309,8 +2309,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             ATTR_STATE_SAVED_TEMPERATURE: self._saved_temperature,
             ATTR_STATE_PRESET_TEMPERATURE: self.preset_mgr.saved_temperature,
             # ``humidity`` is reserved by HA for the target-humidity attribute
-            # consumed by ``climate.set_humidity``; the current sensor reading
-            # is exposed via the ``current_humidity`` property instead.
+            # consumed by ``climate.set_humidity``; the current reading is
+            # published via the ``current_humidity`` property.
             ATTR_STATE_MAIN_MODE: self.last_main_hvac_mode,
             ATTR_STATE_OFF_TEMPERATURE: self.off_temperature,
             CONF_TOLERANCE: self.tolerance,

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2308,9 +2308,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             ATTR_STATE_LAST_CHANGE: self.last_change.isoformat(),
             ATTR_STATE_SAVED_TEMPERATURE: self._saved_temperature,
             ATTR_STATE_PRESET_TEMPERATURE: self.preset_mgr.saved_temperature,
-            # ``humidity`` is reserved by HA for the target-humidity attribute
-            # consumed by ``climate.set_humidity``; the current reading is
-            # published via the ``current_humidity`` property.
             ATTR_STATE_MAIN_MODE: self.last_main_hvac_mode,
             ATTR_STATE_OFF_TEMPERATURE: self.off_temperature,
             CONF_TOLERANCE: self.tolerance,

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2308,7 +2308,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             ATTR_STATE_LAST_CHANGE: self.last_change.isoformat(),
             ATTR_STATE_SAVED_TEMPERATURE: self._saved_temperature,
             ATTR_STATE_PRESET_TEMPERATURE: self.preset_mgr.saved_temperature,
-            ATTR_STATE_HUMIDIY: self._current_humidity,
+            # ``humidity`` is reserved by HA for the target-humidity attribute
+            # consumed by ``climate.set_humidity``; the current sensor reading
+            # is exposed via the ``current_humidity`` property instead.
             ATTR_STATE_MAIN_MODE: self.last_main_hvac_mode,
             ATTR_STATE_OFF_TEMPERATURE: self.off_temperature,
             CONF_TOLERANCE: self.tolerance,

--- a/tests/unit/test_humidity_attribute_exposure.py
+++ b/tests/unit/test_humidity_attribute_exposure.py
@@ -87,7 +87,7 @@ class TestExtraStateAttributesSmoke:
     """Sanity check that the property still returns a usable dict."""
 
     def test_returns_dict_with_expected_keys(self):
-        """A small smoke test for the property’s shape after the humidity fix."""
+        """The property returns a dict with the documented top-level keys."""
         bt = _make_mock_bt()
         attrs = BetterThermostat.extra_state_attributes.fget(bt)
         assert isinstance(attrs, dict)

--- a/tests/unit/test_humidity_attribute_exposure.py
+++ b/tests/unit/test_humidity_attribute_exposure.py
@@ -99,6 +99,5 @@ class TestExtraStateAttributesSmoke:
             "degraded_mode",
         ):
             assert required in attrs
-        # devices_errors / devices_states are JSON-serialised
         assert json.loads(attrs["errors"]) == []
         assert json.loads(attrs["batteries"]) == {}

--- a/tests/unit/test_humidity_attribute_exposure.py
+++ b/tests/unit/test_humidity_attribute_exposure.py
@@ -1,0 +1,104 @@
+"""Tests for humidity attribute exposure in extra_state_attributes.
+
+HA reserves the ``humidity`` state attribute for the target humidity used by
+the ``climate.set_humidity`` service. BT does not implement that service, so
+exposing the current-humidity reading under that key triggers the scene
+reproduce-state path to call an unsupported action.
+"""
+
+from datetime import UTC, datetime
+import json
+from unittest.mock import MagicMock
+
+from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
+
+from custom_components.better_thermostat.climate import BetterThermostat
+
+
+def _make_mock_bt(**overrides):
+    """Construct a mock_bt sufficient for the ``extra_state_attributes`` property."""
+    bt = MagicMock()
+    bt.window_open = False
+    bt.call_for_heat = True
+    bt.last_change = datetime(2026, 5, 18, tzinfo=UTC)
+    bt._saved_temperature = None
+    bt._preset_temperature = None
+    bt._current_humidity = None
+    bt.last_main_hvac_mode = HVACMode.HEAT
+    bt.off_temperature = None
+    bt.tolerance = 0.5
+    bt.bt_target_temp_step = 0.5
+    bt.heating_power = 0.1
+    bt.heat_loss_rate = 0.0
+    bt.devices_errors = []
+    bt.devices_states = {}
+    bt.cur_temp_filtered = 20.5
+    bt.degraded_mode = False
+    bt.unavailable_sensors = []
+    bt.real_trvs = {}
+    bt.heating_cycles = []
+    bt.loss_cycles = []
+    bt.last_heating_power_stats = {}
+    bt.last_heat_loss_stats = {}
+    bt.next_valve_maintenance = None
+    for k, v in overrides.items():
+        setattr(bt, k, v)
+    return bt
+
+
+class TestHumidityAttributeExposure:
+    """Humidity must not leak into the reserved ``humidity`` state attribute."""
+
+    def test_no_humidity_key_in_attributes_without_sensor(self):
+        """Without a configured humidity sensor, no ``humidity`` key is exposed."""
+        bt = _make_mock_bt(humidity_sensor_entity_id=None, _current_humidity=None)
+        attrs = BetterThermostat.extra_state_attributes.fget(bt)
+        assert "humidity" not in attrs
+
+    def test_no_humidity_key_in_attributes_with_sensor(self):
+        """Even with a sensor configured the reserved ``humidity`` key stays absent.
+
+        The current-humidity reading is exposed via the ``current_humidity``
+        property — using the reserved key collides with the climate target
+        humidity attribute that drives ``climate.set_humidity``.
+        """
+        bt = _make_mock_bt(
+            humidity_sensor_entity_id="sensor.room_humidity", _current_humidity=42.5
+        )
+        attrs = BetterThermostat.extra_state_attributes.fget(bt)
+        assert "humidity" not in attrs
+
+    def test_target_humidity_feature_not_advertised(self):
+        """BT must not advertise ``TARGET_HUMIDITY`` in its supported feature set."""
+        bt = _make_mock_bt(cooler_entity_id=None)
+        bt._support_flags = (
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.PRESET_MODE
+            | ClimateEntityFeature.TURN_OFF
+            | ClimateEntityFeature.TURN_ON
+        )
+        features = BetterThermostat.supported_features.fget(bt)
+        assert ClimateEntityFeature.TARGET_HUMIDITY not in ClimateEntityFeature(
+            features
+        )
+
+
+class TestExtraStateAttributesSmoke:
+    """Sanity check that the property still returns a usable dict."""
+
+    def test_returns_dict_with_expected_keys(self):
+        """A small smoke test for the property’s shape after the humidity fix."""
+        bt = _make_mock_bt()
+        attrs = BetterThermostat.extra_state_attributes.fget(bt)
+        assert isinstance(attrs, dict)
+        for required in (
+            "window_open",
+            "call_for_heat",
+            "last_change",
+            "external_temp_ema",
+            "degraded_mode",
+        ):
+            assert required in attrs
+        # devices_errors / devices_states are JSON-serialised
+        assert json.loads(attrs["errors"]) == []
+        assert json.loads(attrs["batteries"]) == {}


### PR DESCRIPTION
Closes #1981 (re-open of #1626).

## Problem

``extra_state_attributes`` exposed the current humidity reading under the key ``humidity`` (via ``ATTR_STATE_HUMIDIY = \"humidity\"`` in ``utils/const.py``). Home Assistant reserves that attribute name for the *target* humidity consumed by ``climate.set_humidity``.

HA's climate scene reproduce-state checks ``state.attributes.get(ATTR_HUMIDITY)`` to decide whether to call the service. With BT exposing the current sensor reading under that key, every scene containing a BT entity tries to reproduce a humidity value via ``climate.set_humidity`` — a service BT does not implement (``TARGET_HUMIDITY`` is intentionally absent from ``supported_features``). The result is the user-visible error ``Entity does not support action climate.set_humidity`` and silently dropped scene edits in the UI.

## Fix

Stop publishing the reading under the reserved key in ``extra_state_attributes``. The value is still available to consumers via the regular ``current_humidity`` property (HA exposes that as the ``current_humidity`` attribute automatically).

The old restore path in ``async_added_to_hass`` that reads ``ATTR_STATE_HUMIDIY`` from the previous state is left untouched: on a fresh save after this lands the key is gone, the conditional silently no-ops, and the sensor read on startup populates the value. It can be removed in a follow-up once we are sure no upgrade path depends on it.

## Tests

- ``tests/unit/test_humidity_attribute_exposure.py``:
  - ``humidity`` key absent from ``extra_state_attributes`` with and without a configured humidity sensor.
  - ``ClimateEntityFeature.TARGET_HUMIDITY`` is not in the advertised feature set.
  - Smoke test that ``extra_state_attributes`` still returns the expected dict shape.
- ``uv run pytest tests/ -p no:homeassistant`` — 1117 passed.

## Test plan
- [x] Unit tests guard against re-introducing the reserved key.
- [ ] Reporter confirms on the next beta that BT entities can be saved/edited in scenes via the UI without the ``set_humidity`` error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the humidity attribute from device state attributes.

* **Tests**
  * Added unit tests to verify humidity is not exposed in device state attributes and confirm it is not a supported feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KartoffelToby/better_thermostat/pull/1996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->