### PR TITLE
fix: convert restored preset value to Celsius using saved unit

### DIFF
--- a/custom_components/better_thermostat/number.py
+++ b/custom_components/better_thermostat/number.py
@@ -153,9 +153,8 @@ class BetterThermostatPresetNumber(NumberEntity, RestoreEntity):
         last_state = await self.async_get_last_state()
         if last_state is None or last_state.state in (None, "unknown", "unavailable"):
             return
-        # ``last_state.state`` is in the unit HA exposed at save time (system
-        # unit, not native Celsius). PresetManager stores Celsius, so normalise
-        # via the saved ``unit_of_measurement`` attribute.
+        # ``last_state.state`` is in HA's display unit, not the native
+        # Celsius; normalise via the saved ``unit_of_measurement``.
         saved_unit = last_state.attributes.get("unit_of_measurement")
         val_celsius = convert_to_float_celsius(
             last_state.state,

--- a/custom_components/better_thermostat/number.py
+++ b/custom_components/better_thermostat/number.py
@@ -25,6 +25,7 @@ from .utils.const import (
     CalibrationMode,
     CalibrationType,
 )
+from .utils.helpers import convert_to_float_celsius
 
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = "better_thermostat"
@@ -150,21 +151,27 @@ class BetterThermostatPresetNumber(NumberEntity, RestoreEntity):
         """Run when entity about to be added."""
         await super().async_added_to_hass()
         last_state = await self.async_get_last_state()
-        if last_state is not None and last_state.state not in (
-            None,
-            "unknown",
-            "unavailable",
-        ):
-            try:
-                val = float(last_state.state)
-                self._bt_climate.preset_mgr.update_temperature(self._preset_mode, val)
-                _LOGGER.debug(
-                    "Restored preset %s to %s from number entity state",
-                    self._preset_mode,
-                    val,
-                )
-            except ValueError:
-                pass
+        if last_state is None or last_state.state in (None, "unknown", "unavailable"):
+            return
+        # ``last_state.state`` is in the unit HA exposed at save time (system
+        # unit, not native Celsius). PresetManager stores Celsius, so normalise
+        # via the saved ``unit_of_measurement`` attribute.
+        saved_unit = last_state.attributes.get("unit_of_measurement")
+        val_celsius = convert_to_float_celsius(
+            last_state.state,
+            self._bt_climate.device_name,
+            "BetterThermostatPresetNumber.async_added_to_hass",
+            unit_of_measurement=saved_unit,
+        )
+        if val_celsius is None:
+            return
+        self._bt_climate.preset_mgr.update_temperature(self._preset_mode, val_celsius)
+        _LOGGER.debug(
+            "Restored preset %s to %s°C from number entity state (saved unit=%s)",
+            self._preset_mode,
+            val_celsius,
+            saved_unit,
+        )
 
     @property
     def device_info(self):

--- a/tests/unit/test_preset_number_restore.py
+++ b/tests/unit/test_preset_number_restore.py
@@ -1,0 +1,104 @@
+"""Tests for BetterThermostatPresetNumber state restoration across unit systems.
+
+The preset number entity declares its native unit as Celsius. Home Assistant
+formats the entity's ``state`` in the system temperature unit (Fahrenheit on
+Fahrenheit installations), so the stored last_state may be either unit. The
+restore path must convert back to Celsius before writing the preset
+temperature dict that ``BetterThermostat`` consumes.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.climate.const import PRESET_HOME
+from homeassistant.const import UnitOfTemperature
+import pytest
+
+from custom_components.better_thermostat.number import BetterThermostatPresetNumber
+
+
+def _make_entity():
+    bt_climate = MagicMock()
+    bt_climate.unique_id = "test_bt"
+    bt_climate.device_name = "Test BT"
+    bt_climate.min_temp = 5.0
+    bt_climate.max_temp = 30.0
+    bt_climate.target_temperature_step = 0.5
+    stored: dict[str, float] = {}
+    bt_climate.preset_mgr.update_temperature.side_effect = stored.__setitem__
+    bt_climate.preset_mgr.get_temperature.side_effect = stored.get
+    bt_climate.preset_mgr.temperatures = stored
+    entity = BetterThermostatPresetNumber(bt_climate, PRESET_HOME)
+    return entity, bt_climate
+
+
+def _last_state(state_value, unit):
+    ls = MagicMock()
+    ls.state = state_value
+    ls.attributes = {"unit_of_measurement": unit} if unit is not None else {}
+    return ls
+
+
+class TestPresetNumberRestoreUnitConversion:
+    """``last_state.state`` is in HA's display unit and must be normalised to Celsius."""
+
+    @pytest.mark.asyncio
+    async def test_restore_fahrenheit_state_stored_as_celsius(self):
+        """``68 °F`` saved by HA is restored as ``20 °C`` in the preset dict."""
+        entity, bt_climate = _make_entity()
+        entity.async_get_last_state = AsyncMock(
+            return_value=_last_state("68", UnitOfTemperature.FAHRENHEIT)
+        )
+
+        await entity.async_added_to_hass()
+
+        assert bt_climate.preset_mgr.temperatures[PRESET_HOME] == pytest.approx(
+            20.0, abs=0.01
+        )
+
+    @pytest.mark.asyncio
+    async def test_restore_celsius_state_kept_as_is(self):
+        """A Celsius-saved value is restored verbatim."""
+        entity, bt_climate = _make_entity()
+        entity.async_get_last_state = AsyncMock(
+            return_value=_last_state("20.0", UnitOfTemperature.CELSIUS)
+        )
+
+        await entity.async_added_to_hass()
+
+        assert bt_climate.preset_mgr.temperatures[PRESET_HOME] == pytest.approx(
+            20.0, abs=0.01
+        )
+
+    @pytest.mark.asyncio
+    async def test_restore_without_unit_attribute_treated_as_celsius(self):
+        """When the saved state lacks a unit attribute the value is treated as native."""
+        entity, bt_climate = _make_entity()
+        entity.async_get_last_state = AsyncMock(return_value=_last_state("20.0", None))
+
+        await entity.async_added_to_hass()
+
+        assert bt_climate.preset_mgr.temperatures[PRESET_HOME] == pytest.approx(
+            20.0, abs=0.01
+        )
+
+    @pytest.mark.asyncio
+    async def test_restore_unknown_state_keeps_dict_empty(self):
+        """``unknown`` / ``unavailable`` last states do not write anything."""
+        entity, bt_climate = _make_entity()
+        entity.async_get_last_state = AsyncMock(
+            return_value=_last_state("unknown", UnitOfTemperature.FAHRENHEIT)
+        )
+
+        await entity.async_added_to_hass()
+
+        assert PRESET_HOME not in bt_climate.preset_mgr.temperatures
+
+    @pytest.mark.asyncio
+    async def test_restore_no_last_state_keeps_dict_empty(self):
+        """No prior state at all (fresh install) does not write anything."""
+        entity, bt_climate = _make_entity()
+        entity.async_get_last_state = AsyncMock(return_value=None)
+
+        await entity.async_added_to_hass()
+
+        assert PRESET_HOME not in bt_climate.preset_mgr.temperatures


### PR DESCRIPTION
Closes #1858.

## Context

``BetterThermostatPresetNumber`` declares its native unit as Celsius (``_attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS``). The preset dict in the climate entity (``_preset_temperatures``) stores Celsius. ``async_set_native_value`` already receives values in the native unit because Home Assistant converts UI input before delegating.

## Problem

On a Fahrenheit installation, ``Entity.state`` is formatted in the system unit (Fahrenheit) before HA persists it via ``RestoreEntity``. The restore path in ``async_added_to_hass`` did ``float(last_state.state)`` and wrote the result straight into the preset dict, treating it as Celsius. A user with HA system unit ``°F`` therefore saw their 20 °C Home preset reappear as 68 °C after a restart — HA then formatted that for display, producing the ``154.4 °F`` value in the original report. The sensor-side symptom from the same issue was already fixed by #1977, but the preset path is independent and still broken.

## Fix

Read the saved unit from ``last_state.attributes['unit_of_measurement']`` and pass it to ``convert_to_float_celsius`` (the helper added in #1977 for exactly this purpose). The stored value now always matches the Celsius contract of the preset dict regardless of the user's system unit.

## Tests

- ``tests/unit/test_preset_number_restore.py``:
  - 68 °F saved → restored as 20.0 °C
  - 20 °C saved → restored as 20.0 °C
  - Saved state without unit attribute → treated as native (Celsius)
  - ``unknown`` / no last state → preset dict left untouched
- ``uv run pytest tests/ -p no:homeassistant`` — 1118 passed.

## Test plan
- [x] Unit tests cover both unit systems and the missing-attribute fallback.
- [ ] Reporter (Fahrenheit installation) confirms preset values restore correctly after the next beta restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preset temperature restoration to properly convert units (Fahrenheit to Celsius) when retrieving saved values, ensuring correct display across different Home Assistant configurations.
  * Improved reliability by gracefully handling missing, unknown, or unavailable saved states during restoration.

* **Tests**
  * Added comprehensive unit tests validating preset temperature restoration behavior across different temperature units and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KartoffelToby/better_thermostat/pull/1997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->