### PR TITLE
fix: clean up repair-registry issues on config-entry removal

### DIFF
--- a/custom_components/better_thermostat/__init__.py
+++ b/custom_components/better_thermostat/__init__.py
@@ -4,15 +4,20 @@ from asyncio import Lock
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.typing import ConfigType
 import voluptuous as vol
 
 from .utils.const import (
     CONF_CALIBRATION_MODE,
     CONF_HEATER,
+    CONF_HUMIDITY,
     CONF_NO_SYSTEM_MODE_OFF,
+    CONF_OUTDOOR_SENSOR,
+    CONF_SENSOR,
+    CONF_SENSOR_WINDOW,
     CONF_WINDOW_TIMEOUT,
     CONF_WINDOW_TIMEOUT_AFTER,
     CalibrationMode,
@@ -67,6 +72,41 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Remove repair-registry issues created by this Better Thermostat instance.
+
+    Issues are scoped by ``device_name`` or by individual ``entity_id`` and
+    persist in HA's issue registry until explicitly deleted, so they have to
+    be cleaned up here to avoid stale warnings after a config entry is gone.
+    """
+    device_name = entry.data.get(CONF_NAME, entry.title)
+
+    for issue_id in (
+        f"invalid_external_temperature_{device_name}",
+        f"invalid_window_state_{device_name}",
+        f"degraded_mode_{device_name}",
+    ):
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
+
+    entity_ids: list[str] = []
+    for trv in entry.data.get(CONF_HEATER) or []:
+        trv_id = trv.get("trv")
+        if trv_id:
+            entity_ids.append(trv_id)
+    for conf_key in (
+        CONF_SENSOR,
+        CONF_HUMIDITY,
+        CONF_SENSOR_WINDOW,
+        CONF_OUTDOOR_SENSOR,
+    ):
+        eid = entry.data.get(conf_key)
+        if eid:
+            entity_ids.append(eid)
+
+    for eid in entity_ids:
+        ir.async_delete_issue(hass, DOMAIN, f"missing_entity_{eid}")
 
 
 async def async_reload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:

--- a/tests/unit/test_init_remove_entry.py
+++ b/tests/unit/test_init_remove_entry.py
@@ -1,0 +1,132 @@
+"""Tests for repair-issue cleanup on config-entry removal.
+
+Better Thermostat creates persistent ``issue_registry`` entries for various
+runtime conditions (invalid sensor reading, missing entity, degraded mode).
+Deleting the config entry must remove the associated repair issues so that
+they do not linger after the BT instance is gone.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.const import CONF_NAME
+import pytest
+
+from custom_components.better_thermostat import DOMAIN, async_remove_entry
+from custom_components.better_thermostat.utils.const import (
+    CONF_HEATER,
+    CONF_HUMIDITY,
+    CONF_OUTDOOR_SENSOR,
+    CONF_SENSOR,
+    CONF_SENSOR_WINDOW,
+)
+
+
+def _make_entry(**overrides):
+    entry = MagicMock()
+    entry.entry_id = "abcd1234"
+    entry.title = "Kinderzimmer"
+    data = {
+        CONF_NAME: "Kinderzimmer",
+        CONF_HEATER: [{"trv": "climate.fritz_kinderzimmer", "advanced": {}}],
+        CONF_SENSOR: "sensor.kinderzimmer_temperature",
+    }
+    data.update(overrides)
+    entry.data = data
+    return entry
+
+
+@pytest.fixture
+def patched_delete_issue():
+    """Patch ``ir.async_delete_issue`` and return the mock for assertions."""
+    with patch(
+        "custom_components.better_thermostat.ir.async_delete_issue"
+    ) as mock_delete:
+        yield mock_delete
+
+
+class TestAsyncRemoveEntryCleansRepairIssues:
+    """``async_remove_entry`` must clean up every repair-issue pattern BT creates."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_device_name_keyed_issues(self, patched_delete_issue):
+        """Issues keyed by device name are removed."""
+        hass = AsyncMock()
+        entry = _make_entry()
+
+        await async_remove_entry(hass, entry)
+
+        called_ids = {call.args[2] for call in patched_delete_issue.call_args_list}
+        assert "invalid_external_temperature_Kinderzimmer" in called_ids
+        assert "invalid_window_state_Kinderzimmer" in called_ids
+        assert "degraded_mode_Kinderzimmer" in called_ids
+
+    @pytest.mark.asyncio
+    async def test_deletes_missing_entity_for_each_trv(self, patched_delete_issue):
+        """``missing_entity_*`` issues are removed for every configured TRV."""
+        hass = AsyncMock()
+        entry = _make_entry(
+            **{
+                CONF_HEATER: [
+                    {"trv": "climate.trv_one", "advanced": {}},
+                    {"trv": "climate.trv_two", "advanced": {}},
+                ]
+            }
+        )
+
+        await async_remove_entry(hass, entry)
+
+        called_ids = {call.args[2] for call in patched_delete_issue.call_args_list}
+        assert "missing_entity_climate.trv_one" in called_ids
+        assert "missing_entity_climate.trv_two" in called_ids
+
+    @pytest.mark.asyncio
+    async def test_deletes_missing_entity_for_optional_sensors(
+        self, patched_delete_issue
+    ):
+        """Optional sensors (when configured) also get their issues cleaned up."""
+        hass = AsyncMock()
+        entry = _make_entry(
+            **{
+                CONF_HUMIDITY: "sensor.humidity",
+                CONF_SENSOR_WINDOW: "binary_sensor.window",
+                CONF_OUTDOOR_SENSOR: "sensor.outdoor",
+            }
+        )
+
+        await async_remove_entry(hass, entry)
+
+        called_ids = {call.args[2] for call in patched_delete_issue.call_args_list}
+        assert "missing_entity_sensor.kinderzimmer_temperature" in called_ids
+        assert "missing_entity_sensor.humidity" in called_ids
+        assert "missing_entity_binary_sensor.window" in called_ids
+        assert "missing_entity_sensor.outdoor" in called_ids
+
+    @pytest.mark.asyncio
+    async def test_skips_unconfigured_optional_sensors(self, patched_delete_issue):
+        """Sensors not configured on the entry do not trigger spurious deletes."""
+        hass = AsyncMock()
+        entry = _make_entry()  # no humidity / window / outdoor
+
+        await async_remove_entry(hass, entry)
+
+        called_ids = {call.args[2] for call in patched_delete_issue.call_args_list}
+        # Only the temperature sensor is configured on the default entry.
+        assert "missing_entity_sensor.kinderzimmer_temperature" in called_ids
+        assert not any(
+            cid.startswith("missing_entity_")
+            and cid != "missing_entity_sensor.kinderzimmer_temperature"
+            and "climate.fritz_kinderzimmer" not in cid
+            for cid in called_ids
+        )
+
+    @pytest.mark.asyncio
+    async def test_uses_domain_for_every_delete(self, patched_delete_issue):
+        """Every cleanup call targets BT's domain."""
+        hass = AsyncMock()
+        entry = _make_entry()
+
+        await async_remove_entry(hass, entry)
+
+        assert patched_delete_issue.call_args_list  # at least one call
+        for call in patched_delete_issue.call_args_list:
+            assert call.args[1] == DOMAIN

--- a/tests/unit/test_init_remove_entry.py
+++ b/tests/unit/test_init_remove_entry.py
@@ -105,12 +105,11 @@ class TestAsyncRemoveEntryCleansRepairIssues:
     async def test_skips_unconfigured_optional_sensors(self, patched_delete_issue):
         """Sensors not configured on the entry do not trigger spurious deletes."""
         hass = AsyncMock()
-        entry = _make_entry()  # no humidity / window / outdoor
+        entry = _make_entry()
 
         await async_remove_entry(hass, entry)
 
         called_ids = {call.args[2] for call in patched_delete_issue.call_args_list}
-        # Only the temperature sensor is configured on the default entry.
         assert "missing_entity_sensor.kinderzimmer_temperature" in called_ids
         assert not any(
             cid.startswith("missing_entity_")
@@ -127,6 +126,6 @@ class TestAsyncRemoveEntryCleansRepairIssues:
 
         await async_remove_entry(hass, entry)
 
-        assert patched_delete_issue.call_args_list  # at least one call
+        assert patched_delete_issue.call_args_list
         for call in patched_delete_issue.call_args_list:
             assert call.args[1] == DOMAIN


### PR DESCRIPTION
Related to #1984. Addresses the secondary symptom only — the primary "BT unavailable" complaint needs a debug log from the reporter.

## Problem

Better Thermostat creates persistent ``issue_registry`` entries from several runtime paths:

- ``events/temperature.py:226`` — ``invalid_external_temperature_{device_name}``
- ``events/window.py:66`` — ``invalid_window_state_{device_name}``
- ``utils/watcher.py:118`` and ``:197`` — ``missing_entity_{entity_id}`` (one per critical/optional entity)
- ``utils/watcher.py:365`` — ``degraded_mode_{device_name}``

The IDs are scoped by ``device_name`` or by individual ``entity_id`` and survive in HA's issue registry until they are explicitly deleted. Removing a config entry left every such issue in place, so HA's repair panel kept showing warnings for BT instances that no longer existed. The reporter on #1984 hit exactly this after deleting and recreating their seven BT instances.

## Fix

Implement ``async_remove_entry`` in ``custom_components/better_thermostat/__init__.py``. It derives the relevant issue IDs from the entry's ``device_name`` and the configured TRV / optional-sensor entity IDs and calls ``ir.async_delete_issue`` for each. ``async_delete_issue`` is a safe no-op for IDs that were never registered, so we can be liberal about what we try to delete.

The hook fires only when the user removes a config entry (not during reload), so legitimate runtime issues stay visible across normal restarts.

## Tests

- ``tests/unit/test_init_remove_entry.py``:
  - device-name-keyed issues removed
  - ``missing_entity_*`` removed for every TRV
  - ``missing_entity_*`` removed for every configured optional sensor
  - unconfigured optional sensors do not trigger spurious deletes
  - every delete call targets BT's domain
- ``uv run pytest tests/ -p no:homeassistant`` — 1118 passed.

## Test plan
- [x] Unit tests cover all known issue patterns.
- [ ] Manual smoke: create a BT, force a degraded-mode issue, delete the entry, verify the repair panel is empty.

## Note on the rest of #1984

The reporter's main symptom — newly created BT immediately ``unavailable`` while the underlying TRV reports values — is not addressed here. From a code read of ``climate.py:startup`` / ``_finalize_startup`` it could be a stuck startup loop or an exception before ``_available = True`` is set, but pinning that down needs the user's HA debug log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration cleanup: Better Thermostat now automatically removes all associated repair issues, entity warnings, and device-specific alerts when a configuration entry is removed from Home Assistant, preventing orphaned notifications.

* **Tests**
  * Added comprehensive unit tests to verify proper cleanup of repair issues, entity warnings, optional sensor alerts, and other device-specific issues upon configuration removal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KartoffelToby/better_thermostat/pull/1998?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->