### PR TITLE
fix: emit repair issue when room sensor is unavailable at startup

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -939,6 +939,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             states = self._collect_trv_states()
             self._resolve_temperature_range(states)
             self._initialize_sensors(sensor_state)
+            await check_and_update_degraded_mode(self)
             await self._restore_state(states)
             self._validate_hvac_mode(states)
             await self._initialize_trvs()
@@ -1100,10 +1101,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     self.device_name,
                     self.sensor_entity_id,
                 )
-            if self.sensor_entity_id not in self.unavailable_sensors:
-                self.unavailable_sensors.append(self.sensor_entity_id)
-                self.degraded_mode = True
-            # Get temperature from first TRV whose reading is plausible
             self.cur_temp = None
             for trv_id in self.real_trvs:
                 trv_state = self.hass.states.get(trv_id)

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -289,7 +289,6 @@ class TestInitializeSensors:
         bt.hass.states.get.return_value = trv_state
         BetterThermostat._initialize_sensors(bt, sensor)
         assert bt.cur_temp is not None
-        assert bt.degraded_mode is True
 
     def test_no_sensor_no_trv_uses_default(self, bt):
         """Test No sensor no trv uses default."""
@@ -307,7 +306,6 @@ class TestInitializeSensors:
         bt.hass.states.get.return_value = trv_state
         BetterThermostat._initialize_sensors(bt, sensor)
         assert bt.cur_temp == 19.5
-        assert bt.degraded_mode is True
 
     def test_implausible_trv_value_falls_back_to_default(self, bt):
         """If both sensor and TRV are implausible, the default fallback is used."""


### PR DESCRIPTION
## Summary

Fixes a silent failure: when the configured room temperature sensor is unavailable at the moment Home Assistant starts, BT falls back to the TRV's internal temperature but the user never sees a repair notification — even though the same condition correctly raises one when the sensor goes unavailable *later*.

### Root cause

`_initialize_sensors` (in `climate.py`) used to set `self.degraded_mode = True` and append to `self.unavailable_sensors` directly when the sensor was unavailable at startup. The next call to `check_and_update_degraded_mode` then read `old_degraded == True`, evaluated the transition condition

```python
if self.degraded_mode and not old_degraded:
    ir.async_create_issue(...)
```

as `False`, and silently skipped issue creation. Effect: degraded mode is active, the state attribute reports it, but no HA Repair shows up.

### Fix

- Remove the manual `degraded_mode = True` / `unavailable_sensors.append(...)` writes from `_initialize_sensors`.
- Call `await check_and_update_degraded_mode(self)` from `startup()` immediately after `_initialize_sensors` returns, so the single source of truth in `utils/watcher.py` sees the real transition and creates the repair issue.

The existing `degraded_mode` repair-issue translation key and recovery logic (`ir.async_delete_issue` when the sensor comes back) are reused — no new strings.

## Test plan
- [x] `uv run pytest tests/ -p no:homeassistant` — 1113 passed
- [x] Updated `tests/unit/test_climate_startup.py::test_sensor_unavailable_falls_back_to_trv` to reflect the new ownership: `_initialize_sensors` no longer mutates `degraded_mode`; the TRV-fallback contract for `cur_temp` is preserved.
- [ ] Manual: start HA with the room sensor disabled / unavailable, confirm the `degraded_mode_{name}` repair notification appears; re-enable the sensor and confirm the notification clears on the next watcher cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved thermostat startup sequence for better handling of room temperature sensor unavailability scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KartoffelToby/better_thermostat/pull/2001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->