### PR TITLE
refactor: extract preset-record and cool-target guard from async_set_temperature

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2605,6 +2605,30 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         await self.control_queue_task.put(self)
 
+    def _enforce_cool_above_heat(self) -> None:
+        """Keep the cooling target strictly above the heating target.
+
+        In HEAT_COOL mode the two setpoints must not cross. If the cool target is
+        at or below the heat target, bump it up by one temperature step.
+        """
+        if (
+            self.hvac_mode != HVACMode.HEAT_COOL
+            or self.bt_target_cooltemp is None
+            or self.bt_target_temp is None
+            or self.bt_target_cooltemp > self.bt_target_temp
+        ):
+            return
+        step = self.bt_target_temp_step or 0.5
+        adjusted = self.bt_target_temp + step
+        _LOGGER.warning(
+            "better_thermostat %s: cooling target %.2f adjusted to %.2f to stay above heating target %.2f",
+            self.device_name,
+            self.bt_target_cooltemp,
+            adjusted,
+            self.bt_target_temp,
+        )
+        self.bt_target_cooltemp = adjusted
+
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         _LOGGER.debug(
@@ -2686,52 +2710,26 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if _new_setpointhigh is not None:
             self.bt_target_cooltemp = _new_setpointhigh
 
-        # Enforce ordering: cool target should be above heat target (if both in heat_cool mode)
-        if (
-            self.hvac_mode in (HVACMode.HEAT_COOL,)
-            and self.bt_target_cooltemp is not None
-            and self.bt_target_temp is not None
-            and self.bt_target_cooltemp <= self.bt_target_temp
-        ):
-            step = self.bt_target_temp_step or 0.5
-            adjusted = self.bt_target_temp + step
-            _LOGGER.warning(
-                "better_thermostat %s: cooling target %.2f adjusted to %.2f to stay above heating target %.2f",
-                self.device_name,
-                self.bt_target_cooltemp,
-                adjusted,
-                self.bt_target_temp,
-            )
-            self.bt_target_cooltemp = adjusted
+        # Enforce ordering: cool target should be above heat target in HEAT_COOL.
+        self._enforce_cool_above_heat()
 
-        # If user manually changes the temperature while a preset is active,
-        # we ONLY update the stored preset temperature if we are in PRESET_NONE (Manual).
-        # For specific presets (Comfort, Eco, etc.), the value is now managed via
-        # separate Number entities and should NOT be overwritten by manual setpoint changes.
+        # If the user manually changes the temperature while in PRESET_NONE (Manual),
+        # record it as the stored manual temperature. Specific presets (Comfort, Eco,
+        # etc.) are managed via separate Number entities and must NOT be overwritten
+        # by manual setpoint changes.
         if (
-            self.preset_mgr.mode == PRESET_NONE
-            and self.preset_mgr.mode in self.preset_mgr.temperatures
-            and (_new_setpoint is not None or _new_setpointlow is not None)
-        ):
-            if self.bt_target_temp is not None:
-                applied = float(self.bt_target_temp)
-                old_value = self.preset_mgr.temperatures.get(self.preset_mgr.mode)
-                if old_value != applied:
-                    self.preset_mgr.temperatures[self.preset_mgr.mode] = applied
-                    _LOGGER.debug(
-                        "better_thermostat %s: Updated stored preset temperature for %s from %s to %s due to manual change",
-                        self.device_name,
-                        self.preset_mgr.mode,
-                        old_value,
-                        applied,
-                    )
-                else:
-                    _LOGGER.debug(
-                        "better_thermostat %s: Manual change equals current stored preset %s value=%s; no update",
-                        self.device_name,
-                        self.preset_mgr.mode,
-                        applied,
-                    )
+            _new_setpoint is not None or _new_setpointlow is not None
+        ) and self.bt_target_temp is not None:
+            applied = float(self.bt_target_temp)
+            old_value = self.preset_mgr.record_manual_change(applied)
+            if old_value is not None:
+                _LOGGER.debug(
+                    "better_thermostat %s: Updated stored preset temperature for %s from %s to %s due to manual change",
+                    self.device_name,
+                    self.preset_mgr.mode,
+                    old_value,
+                    applied,
+                )
 
         _LOGGER.debug(
             "better_thermostat %s: HA set target temperature to %s & %s",

--- a/custom_components/better_thermostat/utils/preset_manager.py
+++ b/custom_components/better_thermostat/utils/preset_manager.py
@@ -96,6 +96,23 @@ class PresetManager:
         """Set the stored temperature for *preset*."""
         self.temperatures[preset] = value
 
+    def record_manual_change(self, applied: float) -> float | None:
+        """Record a manual setpoint as the active preset's stored temperature.
+
+        Only applies in PRESET_NONE (Manual): specific presets (Comfort, Eco, …)
+        are managed via their own Number entities and must not be overwritten by
+        manual setpoint changes. Returns the previous stored value when it was
+        updated, or ``None`` when nothing changed (not in PRESET_NONE, or the
+        value already matches).
+        """
+        if self.mode != PRESET_NONE or self.mode not in self.temperatures:
+            return None
+        old_value = self.temperatures[self.mode]
+        if old_value == applied:
+            return None
+        self.temperatures[self.mode] = applied
+        return old_value
+
     def get_temperature(self, preset: str) -> float | None:
         """Return the stored temperature for *preset*, or ``None``."""
         return self.temperatures.get(preset)

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -118,6 +118,7 @@ def mock_bt():
         bt, result
     )
     bt._get_outdoor_temp = lambda: BetterThermostat._get_outdoor_temp(bt)
+    bt._enforce_cool_above_heat = lambda: BetterThermostat._enforce_cool_above_heat(bt)
     return bt
 
 
@@ -1058,3 +1059,66 @@ class TestAsyncSetTemperature:
         mock_bt.max_temp = mock_bt.bt_max_temp
         await self._call(mock_bt, **{ATTR_TEMPERATURE: 22.0})
         mock_bt.control_queue_task.put.assert_awaited_once_with(mock_bt)
+
+
+# ===========================================================================
+# 7. TestEnforceCoolAboveHeat
+# ===========================================================================
+
+
+class TestEnforceCoolAboveHeat:
+    """_enforce_cool_above_heat keeps the cool target strictly above the heat target."""
+
+    def _call(self, bt):
+        return BetterThermostat._enforce_cool_above_heat(bt)
+
+    def test_not_heat_cool_mode_is_noop(self, mock_bt):
+        """Outside HEAT_COOL the cool target is left untouched even if below heat."""
+        mock_bt.hvac_mode = HVACMode.HEAT
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_cooltemp = 20.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 20.0
+
+    def test_cool_above_heat_is_noop(self, mock_bt):
+        """A cool target already above the heat target is unchanged."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_cooltemp = 26.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 26.0
+
+    def test_cool_below_heat_is_bumped_by_step(self, mock_bt):
+        """A cool target below the heat target is bumped up by one step."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 20.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 22.5
+
+    def test_cool_equal_heat_is_bumped(self, mock_bt):
+        """A cool target equal to the heat target is bumped above it."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 22.5
+
+    def test_step_falls_back_to_half_degree(self, mock_bt):
+        """A missing/zero step falls back to 0.5."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0
+        mock_bt.bt_target_cooltemp = 21.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 22.5
+
+    def test_none_cool_target_is_noop(self, mock_bt):
+        """A None cool target does not raise and stays None."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_cooltemp = None
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp is None

--- a/tests/unit/test_preset_manager.py
+++ b/tests/unit/test_preset_manager.py
@@ -250,6 +250,38 @@ class TestSavedTemperatureLifecycle:
 # ---------------------------------------------------------------------------
 
 
+class TestRecordManualChange:
+    """record_manual_change() stores manual setpoints only while in PRESET_NONE."""
+
+    def test_updates_stored_temp_in_none_and_returns_old(self, mgr: PresetManager):
+        """In PRESET_NONE a changed value is stored and the old value returned."""
+        mgr.mode = PRESET_NONE
+        old = mgr.record_manual_change(23.0)
+        assert old == _DEFAULT_TEMPERATURES[PRESET_NONE]
+        assert mgr.temperatures[PRESET_NONE] == 23.0
+
+    def test_unchanged_value_is_noop_and_returns_none(self, mgr: PresetManager):
+        """A value equal to the stored one is not written and returns None."""
+        mgr.mode = PRESET_NONE
+        mgr.temperatures[PRESET_NONE] = 21.0
+        assert mgr.record_manual_change(21.0) is None
+        assert mgr.temperatures[PRESET_NONE] == 21.0
+
+    def test_specific_preset_is_not_overwritten(self, mgr: PresetManager):
+        """Outside PRESET_NONE the stored preset temp must not be touched."""
+        mgr.mode = PRESET_COMFORT
+        before = mgr.temperatures[PRESET_COMFORT]
+        assert mgr.record_manual_change(99.0) is None
+        assert mgr.temperatures[PRESET_COMFORT] == before
+
+    def test_none_missing_from_temperatures_is_noop(self):
+        """If PRESET_NONE has no stored temp, nothing is recorded."""
+        mgr = PresetManager(temperatures={PRESET_COMFORT: 21.0})
+        mgr.mode = PRESET_NONE
+        assert mgr.record_manual_change(23.0) is None
+        assert PRESET_NONE not in mgr.temperatures
+
+
 class TestDefaults:
     """Dataclass defaults isolate state between instances and start in the NONE preset."""
 


### PR DESCRIPTION
Two small cohesion improvements in `async_set_temperature`, no functional change.

### Changes
1. **`PresetManager.record_manual_change(applied)`** — encapsulates the manual-setpoint
   write that `async_set_temperature` previously performed by reaching directly into
   `preset_mgr.temperatures[...]` (the only such direct dict write in the codebase).
   The rule — only record while in `PRESET_NONE`; specific presets are managed via their
   Number entities — now lives with the data it guards.
2. **`_enforce_cool_above_heat()`** — extracts the HEAT_COOL ordering guard (the cool
   target must stay above the heat target) into a named, independently unit-tested helper.

`async_set_temperature` drops from 146 to 120 lines and reads linearly.

### Behavior
No functional change. One redundant **debug-level** log on the no-op path ("manual change
equals current stored preset; no update") is dropped.

### Tests
- New `TestRecordManualChange` (4 cases) in `test_preset_manager.py`
- New `TestEnforceCoolAboveHeat` (6 cases) in `test_climate_baseline.py`
- Existing `async_set_temperature` coverage retained as the regression net
- Full suite green: **1224 passed**

Low risk: `async_set_temperature` has no internal callers (Home Assistant framework callback);
adding a `PresetManager` method is non-breaking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Thermostat now automatically prevents invalid temperature configurations in HEAT_COOL mode by ensuring the cool target remains above the heat target. When both targets are set and the cool target is at or below the heat target, it automatically adjusts the cool target upward by the configured temperature step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->