### PR TITLE
refactor: move controller/thermal state bridging into StateManager

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -66,13 +66,10 @@ from .events.temperature import trigger_temperature_change
 from .events.trv import trigger_trv_change
 from .events.window import trigger_window_change, window_queue
 from .model_fixes.model_quirks import inital_tweak, load_model_quirks
-from .utils.calibration.mpc import export_mpc_state_map, import_mpc_state_map
 from .utils.calibration.pid import (
     export_pid_states as pid_export_states,
-    import_pid_states as pid_import_states,
     reset_pid_state as pid_reset_state,
 )
-from .utils.calibration.tpi import export_tpi_state_map, import_tpi_state_map
 from .utils.const import (
     ATTR_STATE_BATTERIES,
     ATTR_STATE_CALL_FOR_HEAT,
@@ -2086,103 +2083,29 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
     # -- Unified state persistence helpers ------------------------------------
 
     def _hydrate_controllers_from_state(self) -> None:
-        """Push loaded state into the module-level controller caches.
-
-        During the transition period the controllers still maintain their
-        own global ``_*_STATES`` dicts.  This method seeds them from the
-        StateManager so that ``compute_*()`` calls work immediately after
-        startup.
-        """
+        """Seed the module-level controller caches from persisted state."""
         if self.state_mgr is None:
             return
-        from dataclasses import asdict as _asdict
-
-        prefix = f"{self._unique_id}:"
-
-        # MPC
-        mpc_data: dict[str, dict[str, Any]] = {}
-        for key, mpc in self.state_mgr.state.mpc.items():
-            if key.startswith(prefix):
-                mpc_data[key] = _asdict(mpc)
-        if mpc_data:
-            import_mpc_state_map(mpc_data)
-
-        # PID
-        pid_data: dict[str, dict[str, Any]] = {}
-        for key, pid in self.state_mgr.state.pid.items():
-            if key.startswith(prefix):
-                pid_data[key] = _asdict(pid)
-        if pid_data:
-            pid_import_states(pid_data, prefix_filter=prefix)
-
-        # TPI
-        tpi_data: dict[str, dict[str, Any]] = {}
-        for key, tpi in self.state_mgr.state.tpi.items():
-            if key.startswith(prefix):
-                tpi_data[key] = _asdict(tpi)
-        if tpi_data:
-            import_tpi_state_map(tpi_data)
+        self.state_mgr.hydrate_controllers(f"{self._unique_id}:")
 
     def _hydrate_thermal_from_state(self) -> None:
-        """Apply thermal stats from StateManager to entity attributes."""
+        """Apply persisted, clamped thermal stats to entity attributes."""
         if self.state_mgr is None:
             return
-        thermal = self.state_mgr.thermal
-        if thermal.heating_power is not None:
-            try:
-                self.heating_power = max(
-                    MIN_HEATING_POWER,
-                    min(MAX_HEATING_POWER, float(thermal.heating_power)),
-                )
-            except (TypeError, ValueError):
-                pass
-        if thermal.heat_loss_rate is not None:
-            try:
-                self.heat_loss_rate = max(
-                    MIN_HEAT_LOSS, min(MAX_HEAT_LOSS, float(thermal.heat_loss_rate))
-                )
-            except (TypeError, ValueError):
-                pass
+        heating_power, heat_loss_rate = self.state_mgr.clamped_thermal()
+        if heating_power is not None:
+            self.heating_power = heating_power
+        if heat_loss_rate is not None:
+            self.heat_loss_rate = heat_loss_rate
 
     def _sync_controllers_to_state(self) -> None:
-        """Export current module-level controller state back to StateManager.
-
-        Called before save to ensure the unified store reflects the latest
-        runtime state from the global controller caches.
-        """
+        """Push current controller caches and thermal stats into the StateManager."""
         if self.state_mgr is None:
             return
-        from .utils.state_manager import (
-            ThermalStats,
-            deserialize_mpc,
-            deserialize_pid,
-            deserialize_tpi,
-        )
-
-        prefix = f"{self._unique_id}:"
-
-        # MPC: export from module cache → StateManager
-        mpc_exported = export_mpc_state_map(prefix)
-        for key, state_dict in mpc_exported.items():
-            if isinstance(state_dict, dict):
-                self.state_mgr.set_mpc(key, deserialize_mpc(state_dict))
-
-        # PID: export from module cache → StateManager
-        pid_exported = pid_export_states(prefix=prefix)
-        for key, state_dict in pid_exported.items():
-            if isinstance(state_dict, dict):
-                self.state_mgr.set_pid(key, deserialize_pid(state_dict))
-
-        # TPI: export from module cache → StateManager
-        tpi_exported = export_tpi_state_map(prefix)
-        for key, state_dict in tpi_exported.items():
-            if isinstance(state_dict, dict):
-                self.state_mgr.set_tpi(key, deserialize_tpi(state_dict))
-
-        # Thermal: sync from entity attributes → StateManager
-        self.state_mgr.thermal = ThermalStats(
-            heating_power=getattr(self, "heating_power", None),
-            heat_loss_rate=getattr(self, "heat_loss_rate", None),
+        self.state_mgr.sync_controllers(
+            f"{self._unique_id}:",
+            getattr(self, "heating_power", None),
+            getattr(self, "heat_loss_rate", None),
         )
 
     @callback

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -40,9 +40,10 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
-from .calibration.mpc import MpcState
-from .calibration.pid import PIDState
-from .calibration.tpi import TpiState
+from .calibration.mpc import MpcState, export_mpc_state_map, import_mpc_state_map
+from .calibration.pid import PIDState, export_pid_states, import_pid_states
+from .calibration.tpi import TpiState, export_tpi_state_map, import_tpi_state_map
+from .const import MAX_HEAT_LOSS, MAX_HEATING_POWER, MIN_HEAT_LOSS, MIN_HEATING_POWER
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -376,6 +377,93 @@ class StateManager:
     def mark_dirty(self) -> None:
         """Manually mark state as needing persistence."""
         self._dirty = True
+
+    # -- Controller bridging -------------------------------------------------
+
+    def hydrate_controllers(self, prefix: str) -> None:
+        """Seed the module-level controller caches from persisted state.
+
+        The MPC/PID/TPI controllers keep their own global ``_*_STATES`` dicts.
+        This copies the persisted entries whose key starts with *prefix* into
+        those caches so ``compute_*()`` works immediately after startup.
+        """
+        mpc_data = {
+            key: asdict(mpc)
+            for key, mpc in self._state.mpc.items()
+            if key.startswith(prefix)
+        }
+        if mpc_data:
+            import_mpc_state_map(mpc_data)
+
+        pid_data = {
+            key: asdict(pid)
+            for key, pid in self._state.pid.items()
+            if key.startswith(prefix)
+        }
+        if pid_data:
+            import_pid_states(pid_data, prefix_filter=prefix)
+
+        tpi_data = {
+            key: asdict(tpi)
+            for key, tpi in self._state.tpi.items()
+            if key.startswith(prefix)
+        }
+        if tpi_data:
+            import_tpi_state_map(tpi_data)
+
+    def clamped_thermal(self) -> tuple[float | None, float | None]:
+        """Return persisted thermal stats clamped to their valid bounds.
+
+        Returns ``(heating_power, heat_loss_rate)``; an element is ``None`` when
+        the persisted value is absent or cannot be parsed as a float.
+        """
+        thermal = self._state.thermal
+
+        heating_power: float | None = None
+        if thermal.heating_power is not None:
+            try:
+                heating_power = max(
+                    MIN_HEATING_POWER,
+                    min(MAX_HEATING_POWER, float(thermal.heating_power)),
+                )
+            except (TypeError, ValueError):
+                heating_power = None
+
+        heat_loss_rate: float | None = None
+        if thermal.heat_loss_rate is not None:
+            try:
+                heat_loss_rate = max(
+                    MIN_HEAT_LOSS, min(MAX_HEAT_LOSS, float(thermal.heat_loss_rate))
+                )
+            except (TypeError, ValueError):
+                heat_loss_rate = None
+
+        return heating_power, heat_loss_rate
+
+    def sync_controllers(
+        self, prefix: str, heating_power: float | None, heat_loss_rate: float | None
+    ) -> None:
+        """Export the module-level controller caches back into the store.
+
+        Pulls the latest MPC/PID/TPI runtime state for *prefix* from the global
+        controller caches and records the supplied thermal stats, so a following
+        save reflects current runtime values.
+        """
+        for key, state_dict in export_mpc_state_map(prefix).items():
+            if isinstance(state_dict, dict):
+                self.set_mpc(key, deserialize_mpc(state_dict))
+
+        for key, state_dict in export_pid_states(prefix=prefix).items():
+            if isinstance(state_dict, dict):
+                self.set_pid(key, deserialize_pid(state_dict))
+
+        for key, state_dict in export_tpi_state_map(prefix).items():
+            if isinstance(state_dict, dict):
+                self.set_tpi(key, deserialize_tpi(state_dict))
+
+        self.thermal = ThermalStats(
+            heating_power=heating_power, heat_loss_rate=heat_loss_rate
+        )
 
     # -- Load / Save ---------------------------------------------------------
 

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -19,6 +19,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from custom_components.better_thermostat.utils.const import (
+    MAX_HEAT_LOSS,
+    MAX_HEATING_POWER,
+    MIN_HEAT_LOSS,
+    MIN_HEATING_POWER,
+)
 from custom_components.better_thermostat.utils.state_manager import (
     CURRENT_VERSION,
     MpcState,
@@ -34,6 +40,8 @@ from custom_components.better_thermostat.utils.state_manager import (
     deserialize_pid,
     deserialize_tpi,
 )
+
+_SM = "custom_components.better_thermostat.utils.state_manager"
 
 # ---------------------------------------------------------------------------
 # Dataclass defaults
@@ -633,3 +641,168 @@ class TestStateManagerStateAccess:
 
         assert mgr.get_mpc("trv1__20").gain_est == 0.5
         assert mgr.get_mpc("trv1__22").gain_est == 0.8
+
+
+# ---------------------------------------------------------------------------
+# Controller bridging: clamped_thermal
+# ---------------------------------------------------------------------------
+
+
+def _make_manager() -> StateManager:
+    """Create a StateManager with a mocked Store."""
+    mock_hass = AsyncMock()
+    with patch(f"{_SM}.Store"):
+        return StateManager(mock_hass, "test_entry")
+
+
+class TestClampedThermal:
+    """clamped_thermal() returns persisted thermal stats clamped to valid bounds."""
+
+    def test_both_none_returns_none(self):
+        """Absent thermal stats yield (None, None)."""
+        mgr = _make_manager()
+        assert mgr.clamped_thermal() == (None, None)
+
+    def test_valid_values_passed_through(self):
+        """In-range values are returned unchanged."""
+        mgr = _make_manager()
+        hp = (MIN_HEATING_POWER + MAX_HEATING_POWER) / 2
+        hl = (MIN_HEAT_LOSS + MAX_HEAT_LOSS) / 2
+        mgr.thermal = ThermalStats(heating_power=hp, heat_loss_rate=hl)
+        assert mgr.clamped_thermal() == (hp, hl)
+
+    def test_heating_power_clamped_to_max(self):
+        """A heating_power above the max is clamped down."""
+        mgr = _make_manager()
+        mgr.thermal = ThermalStats(heating_power=MAX_HEATING_POWER * 10)
+        hp, _ = mgr.clamped_thermal()
+        assert hp == MAX_HEATING_POWER
+
+    def test_heating_power_clamped_to_min(self):
+        """A heating_power below the min is clamped up."""
+        mgr = _make_manager()
+        mgr.thermal = ThermalStats(heating_power=-5.0)
+        hp, _ = mgr.clamped_thermal()
+        assert hp == MIN_HEATING_POWER
+
+    def test_heat_loss_clamped_to_bounds(self):
+        """heat_loss_rate is clamped to its min/max."""
+        mgr = _make_manager()
+        mgr.thermal = ThermalStats(heat_loss_rate=MAX_HEAT_LOSS * 10)
+        assert mgr.clamped_thermal()[1] == MAX_HEAT_LOSS
+        mgr.thermal = ThermalStats(heat_loss_rate=-1.0)
+        assert mgr.clamped_thermal()[1] == MIN_HEAT_LOSS
+
+    def test_unparseable_value_yields_none(self):
+        """A non-numeric persisted value degrades to None instead of raising."""
+        mgr = _make_manager()
+        mgr.thermal = ThermalStats(heating_power="oops")  # type: ignore[arg-type]
+        assert mgr.clamped_thermal()[0] is None
+
+
+# ---------------------------------------------------------------------------
+# Controller bridging: hydrate_controllers
+# ---------------------------------------------------------------------------
+
+
+class TestHydrateControllers:
+    """hydrate_controllers() seeds module caches with the prefix-filtered state."""
+
+    def test_imports_only_prefixed_keys(self):
+        """Only keys starting with the prefix are pushed into the caches."""
+        mgr = _make_manager()
+        mgr.set_mpc("p:trv1", MpcState(gain_est=0.5))
+        mgr.set_mpc("other:trvX", MpcState(gain_est=9.9))
+        mgr.set_pid("p:trv1", PIDState())
+        mgr.set_tpi("p:trv1", TpiState())
+
+        with (
+            patch(f"{_SM}.import_mpc_state_map") as imp_mpc,
+            patch(f"{_SM}.import_pid_states") as imp_pid,
+            patch(f"{_SM}.import_tpi_state_map") as imp_tpi,
+        ):
+            mgr.hydrate_controllers("p:")
+
+        imp_mpc.assert_called_once()
+        assert set(imp_mpc.call_args[0][0]) == {"p:trv1"}
+        imp_pid.assert_called_once()
+        assert imp_pid.call_args.kwargs["prefix_filter"] == "p:"
+        assert set(imp_pid.call_args[0][0]) == {"p:trv1"}
+        imp_tpi.assert_called_once()
+        assert set(imp_tpi.call_args[0][0]) == {"p:trv1"}
+
+    def test_no_matching_keys_skips_import(self):
+        """When nothing matches the prefix, the import functions are not called."""
+        mgr = _make_manager()
+        mgr.set_mpc("other:trvX", MpcState())
+
+        with (
+            patch(f"{_SM}.import_mpc_state_map") as imp_mpc,
+            patch(f"{_SM}.import_pid_states") as imp_pid,
+            patch(f"{_SM}.import_tpi_state_map") as imp_tpi,
+        ):
+            mgr.hydrate_controllers("p:")
+
+        imp_mpc.assert_not_called()
+        imp_pid.assert_not_called()
+        imp_tpi.assert_not_called()
+
+    def test_hydrate_does_not_mark_dirty(self):
+        """Seeding caches from persisted state must not dirty the store."""
+        mgr = _make_manager()
+        mgr.set_mpc("p:trv1", MpcState())
+        mgr._dirty = False
+        with (
+            patch(f"{_SM}.import_mpc_state_map"),
+            patch(f"{_SM}.import_pid_states"),
+            patch(f"{_SM}.import_tpi_state_map"),
+        ):
+            mgr.hydrate_controllers("p:")
+        assert mgr.dirty is False
+
+
+# ---------------------------------------------------------------------------
+# Controller bridging: sync_controllers
+# ---------------------------------------------------------------------------
+
+
+class TestSyncControllers:
+    """sync_controllers() exports module caches and records thermal stats."""
+
+    def test_records_thermal_and_dirties(self):
+        """Supplied thermal stats are stored and the store is marked dirty."""
+        mgr = _make_manager()
+        with (
+            patch(f"{_SM}.export_mpc_state_map", return_value={}),
+            patch(f"{_SM}.export_pid_states", return_value={}),
+            patch(f"{_SM}.export_tpi_state_map", return_value={}),
+        ):
+            mgr.sync_controllers("p:", 0.07, 0.02)
+        assert mgr.thermal.heating_power == 0.07
+        assert mgr.thermal.heat_loss_rate == 0.02
+        assert mgr.dirty is True
+
+    def test_exports_controller_caches_into_store(self):
+        """Exported controller dicts are deserialized back into the store."""
+        mgr = _make_manager()
+        with (
+            patch(
+                f"{_SM}.export_mpc_state_map",
+                return_value={"p:trv1": asdict(MpcState(gain_est=1.23))},
+            ),
+            patch(f"{_SM}.export_pid_states", return_value={}),
+            patch(f"{_SM}.export_tpi_state_map", return_value={}),
+        ):
+            mgr.sync_controllers("p:", None, None)
+        assert mgr.state.mpc["p:trv1"].gain_est == 1.23
+
+    def test_non_dict_export_entry_is_skipped(self):
+        """A malformed (non-dict) export entry is ignored, not stored."""
+        mgr = _make_manager()
+        with (
+            patch(f"{_SM}.export_mpc_state_map", return_value={"p:bad": "notadict"}),
+            patch(f"{_SM}.export_pid_states", return_value={}),
+            patch(f"{_SM}.export_tpi_state_map", return_value={}),
+        ):
+            mgr.sync_controllers("p:", None, None)
+        assert "p:bad" not in mgr.state.mpc


### PR DESCRIPTION
Moves the controller-cache and thermal-stat bridging logic out of the climate
entity and onto `StateManager`, where it belongs and can be tested in isolation.
No functional change.

### Changes
Three new `StateManager` methods absorb logic that `BetterThermostat` previously
inlined:
- **`hydrate_controllers(prefix)`** — seeds the module-level MPC/PID/TPI caches
  from persisted state, filtered to the entity's key prefix.
- **`clamped_thermal()`** — returns the persisted heating-power / heat-loss
  values clamped to their valid bounds (or `None` when absent/unparseable).
- **`sync_controllers(prefix, heating_power, heat_loss_rate)`** — exports the
  current controller caches back into the store and records the thermal stats.

The entity keeps three thin wrappers (`_hydrate_controllers_from_state`,
`_hydrate_thermal_from_state`, `_sync_controllers_to_state`) that just pass the
entity's key prefix and thermal attributes through; all call sites are unchanged.

The MPC/TPI import/export and PID import symbols that climate.py no longer
references are removed from its imports.

### Why
The serialization, prefix filtering and clamping are persistence concerns and
had no business living on the entity. On `StateManager` they are unit-testable
without constructing a Home Assistant entity, and the entity shrinks by ~90
lines of bookkeeping.

### Tests
- `TestClampedThermal` (6 cases): pass-through, min/max clamping for both stats,
  unparseable value → `None`
- `TestHydrateControllers` (3 cases): prefix filtering, no-match skip, no dirtying
- `TestSyncControllers` (3 cases): thermal recorded + dirtied, export deserialized
  into the store, malformed entry skipped
- Full suite green: **1226 passed**

### Risk
Low. Impact analysis on the three moved methods: all callers are within the
entity (`async_added_to_hass`, `on_remove`, the debounced save), risk LOW;
behavior is preserved by the thin wrappers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state persistence architecture for thermostat controller management.
  * Streamlined thermal value clamping and synchronization logic.

* **Tests**
  * Extended test coverage for state persistence and controller hydration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->