### PR TITLE
test: run cleanup test in an isolated event loop

### DIFF
--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -1280,9 +1280,14 @@ class TestEdgeCasesAndPotentialBugs:
         bt = _make_bt_climate()
         import asyncio
 
-        asyncio.get_event_loop().run_until_complete(
-            _cleanup_stale_algorithm_entities(hass, "entry_1", bt, set())
-        )
+        # Fresh event loop avoids HA pytest plugin issues with the current loop.
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(
+                _cleanup_stale_algorithm_entities(hass, "entry_1", bt, set())
+            )
+        finally:
+            loop.close()
         # The function checks `if not _ACTIVE_ALGORITHM_ENTITIES[entry_id]`
         # and deletes it → entry should be gone
         assert "entry_1" not in _ACTIVE_ALGORITHM_ENTITIES


### PR DESCRIPTION
### Problem
`test_sensor.py::test_cleanup_stale_empty_entry_removed` drives an async helper
with `asyncio.get_event_loop().run_until_complete(...)`. Under Python 3.13 with
the Home Assistant pytest plugin active, `asyncio.get_event_loop()` raises
`RuntimeError: There is no current event loop in thread 'MainThread'` when no
loop is current — which depends on the order the tests run in. The suite is
therefore order-fragile: any change that shifts test ordering (e.g. adding async
tests elsewhere) can make this one fail in CI while passing locally.

### Fix
Create a fresh `asyncio.new_event_loop()`, run the coroutine, and close it in a
`finally` — the exact pattern already used in `test_watcher.py` (whose comment
notes it "avoids HA pytest plugin issues"). The test no longer depends on the
ambient event-loop state.

It is the only `get_event_loop()` use in the repo, so this removes the last
order-dependent loop usage.

### Verification
- `test_cleanup_stale_empty_entry_removed` passes under Python 3.13
- Full suite green
- ruff clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for async operations to ensure proper event loop cleanup and resource management.

**Note:** This release contains only internal test improvements with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->