### PR TITLE
refactor: type thermal telemetry records and make TelemetrySource read-only

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -135,7 +135,13 @@ from .utils.telemetry import (
     collect_cycle_telemetry,
     collect_pid_debug_attrs,
 )
-from .utils.thermal_learning import HeatingPowerTracker, HeatLossTracker
+from .utils.thermal_learning import (
+    HeatingCycle,
+    HeatingPowerTracker,
+    HeatLossTracker,
+    LossCycle,
+    LossStats,
+)
 from .utils.valve_maintenance import (
     build_trv_snapshots,
     collect_maintenance_trvs,
@@ -294,7 +300,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         return self._heating_tracker.stats
 
     @property
-    def heating_cycles(self) -> deque:
+    def heating_cycles(self) -> deque[HeatingCycle]:
         """Return recorded heating cycles."""
         return self._heating_tracker.cycles
 
@@ -308,12 +314,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self._loss_tracker.heat_loss_rate = value
 
     @property
-    def last_heat_loss_stats(self) -> deque:
+    def last_heat_loss_stats(self) -> deque[LossStats]:
         """Return recent heat loss statistics."""
         return self._loss_tracker.stats
 
     @property
-    def loss_cycles(self) -> deque:
+    def loss_cycles(self) -> deque[LossCycle]:
         """Return recorded heat loss cycles."""
         return self._loss_tracker.cycles
 

--- a/custom_components/better_thermostat/utils/telemetry.py
+++ b/custom_components/better_thermostat/utils/telemetry.py
@@ -9,6 +9,11 @@ from typing import Any, Literal, Protocol, TypedDict, cast
 
 from custom_components.better_thermostat.utils.calibration.pid import PIDDebugInfo
 from custom_components.better_thermostat.utils.const import ATTR_STATE_HEAT_LOSS_STATS
+from custom_components.better_thermostat.utils.thermal_learning import (
+    HeatingCycle,
+    LossCycle,
+    LossStats,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,14 +38,42 @@ class TrvInfo(TypedDict, total=False):
 
 
 class TelemetrySource(Protocol):
-    """Structural contract for objects telemetry helpers consume."""
+    """Structural read-only contract for objects telemetry helpers consume.
 
-    real_trvs: Mapping[str, TrvInfo]
-    heating_cycles: Sequence[Mapping[str, object]] | None
-    loss_cycles: Sequence[Mapping[str, object]] | None
-    last_heat_loss_stats: Sequence[object] | None
-    heating_power_normalized: float | None
-    temp_slope: float | None
+    Members are declared as read-only properties: the helpers only read these,
+    and read-only members match covariantly, so a source whose ``real_trvs`` is
+    a plain ``dict`` still satisfies the contract.
+    """
+
+    @property
+    def real_trvs(self) -> Mapping[str, TrvInfo]:
+        """Per-TRV info dicts, keyed by entity id."""
+        ...
+
+    @property
+    def heating_cycles(self) -> Sequence[HeatingCycle] | None:
+        """Finalized heating cycles (most recent last)."""
+        ...
+
+    @property
+    def loss_cycles(self) -> Sequence[LossCycle] | None:
+        """Finalized idle-cooling cycles (most recent last)."""
+        ...
+
+    @property
+    def last_heat_loss_stats(self) -> Sequence[LossStats] | None:
+        """Recent heat-loss learning samples."""
+        ...
+
+    @property
+    def heating_power_normalized(self) -> float | None:
+        """Outdoor-normalized heating power, if known."""
+        ...
+
+    @property
+    def temp_slope(self) -> float | None:
+        """Current temperature slope in °C/min, if known."""
+        ...
 
 
 def _to_float(val: object) -> float | None:

--- a/custom_components/better_thermostat/utils/thermal_learning.py
+++ b/custom_components/better_thermostat/utils/thermal_learning.py
@@ -11,7 +11,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 if TYPE_CHECKING:
     from homeassistant.components.climate.const import HVACAction
@@ -32,6 +32,58 @@ _ALPHA_MAX: float = 0.25
 # Telemetry deque sizes
 _STATS_MAXLEN: int = 10
 _CYCLES_MAXLEN: int = 50
+
+
+# ---------------------------------------------------------------------------
+# Telemetry record types (one entry per finalized cycle / stats sample)
+# ---------------------------------------------------------------------------
+
+
+class HeatingCycle(TypedDict):
+    """One finalized heating cycle (start → peak)."""
+
+    start: str | None
+    end: str | None
+    temp_start: float | None
+    temp_peak: float | None
+    delta_t: float
+    minutes: float
+    rate_c_min: float
+    target: float | None
+    outdoor: float | None
+    norm_power: float | None
+
+
+class HeatingStats(TypedDict):
+    """Compact heating-power learning sample."""
+
+    dT: float
+    min: float
+    rate: float
+    alpha: float
+    envf: float
+    hp: float
+    norm: float | None
+
+
+class LossCycle(TypedDict):
+    """One finalized idle cooling cycle (start → minimum)."""
+
+    start: str | None
+    end: str | None
+    temp_start: float | None
+    temp_min: float | None
+    rate: float
+
+
+class LossStats(TypedDict):
+    """Compact heat-loss learning sample."""
+
+    dT: float
+    min: float
+    rate: float
+    alpha: float
+    loss: float
 
 
 # ---------------------------------------------------------------------------
@@ -97,7 +149,7 @@ class HeatingPowerUpdate:
     """Return value of :meth:`HeatingPowerTracker.update`."""
 
     action_changed: bool = False
-    current_action: object = None  # HVACAction at runtime
+    current_action: HVACAction | None = None
     cycle_result: CycleResult | None = None
 
 
@@ -127,13 +179,13 @@ class HeatingPowerTracker:
     start_ts: datetime | None = None
     end_temp: float | None = None  # peak temperature after heating stops
     end_ts: datetime | None = None
-    _prev_action: object = None  # HVACAction – kept as object to avoid runtime import
+    _prev_action: HVACAction | None = None
     min_target: float = 18.0
     max_target: float = 21.0
-    stats: deque[dict[str, object]] = field(
+    stats: deque[HeatingStats] = field(
         default_factory=lambda: deque(maxlen=_STATS_MAXLEN)
     )
-    cycles: deque[dict[str, object]] = field(
+    cycles: deque[HeatingCycle] = field(
         default_factory=lambda: deque(maxlen=_CYCLES_MAXLEN)
     )
 
@@ -361,11 +413,9 @@ class HeatLossTracker:
     start_ts: datetime | None = None
     end_temp: float | None = None  # lowest observed temperature
     end_ts: datetime | None = None
-    _prev_action: object = None  # HVACAction
-    stats: deque[dict[str, object]] = field(
-        default_factory=lambda: deque(maxlen=_STATS_MAXLEN)
-    )
-    cycles: deque[dict[str, object]] = field(
+    _prev_action: HVACAction | None = None
+    stats: deque[LossStats] = field(default_factory=lambda: deque(maxlen=_STATS_MAXLEN))
+    cycles: deque[LossCycle] = field(
         default_factory=lambda: deque(maxlen=_CYCLES_MAXLEN)
     )
 


### PR DESCRIPTION
Tightens the typing around the telemetry source. No functional change.

### Problem
`TelemetrySource` (the structural contract the telemetry helpers consume)
declared its members as **mutable attributes**, e.g. `real_trvs: Mapping[str, TrvInfo]`.
Mutable protocol members match **invariantly**, so a `BetterThermostat` whose
`real_trvs` is a plain `dict` did not satisfy the contract — the three
`collect_*` calls were type errors.

The cycle/stats containers were also typed `dict[str, object]`, so the telemetry
records carried no field-level types.

### Changes
1. **`TelemetrySource` members are now read-only `@property` declarations.** The
   helpers only read these, and read-only members match **covariantly**, so the
   entity satisfies the contract without forcing an artificial type onto
   `real_trvs`. This is the semantically correct shape: it is a read-only view.
2. **Precise `TypedDict`s for the telemetry records** — `HeatingCycle`,
   `HeatingStats`, `LossCycle`, `LossStats` — defined in `thermal_learning.py`
   where they are built, and threaded through the trackers' `deque`s, the
   protocol, and the `climate` properties (replacing `dict[str, object]` /
   bare `deque`).

`start`/`end` are intentionally `str | None`: the records store the
`.isoformat()` string and are JSON-serialized (`json.dumps`) by the telemetry
helper, so the string is the honest stored type.

### Effect
Eliminates the 3 `TelemetrySource` errors under strict type checking; the
records are now self-documenting. Verified locally:
- ruff clean
- full test suite green (1214)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined type definitions and contracts for internal thermal tracking systems, enhancing code consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->