### PR TITLE
refactor: extract startup-restore parsing into pure, tested helpers

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -10,7 +10,6 @@ from functools import cached_property
 import json
 import logging
 from random import randint
-from statistics import mean
 from time import monotonic
 from typing import Any
 
@@ -98,10 +97,6 @@ from .utils.const import (
     CONF_WEATHER,
     CONF_WINDOW_TIMEOUT,
     CONF_WINDOW_TIMEOUT_AFTER,
-    MAX_HEAT_LOSS,
-    MAX_HEATING_POWER,
-    MIN_HEAT_LOSS,
-    MIN_HEATING_POWER,
     SERVICE_RESET_HEATING_POWER,
     SERVICE_RESET_PID_LEARNINGS,
     SUPPORT_FLAGS,
@@ -126,6 +121,12 @@ from .utils.hvac_action import (
     should_heat_with_tolerance,
 )
 from .utils.preset_manager import PresetManager
+from .utils.restore import (
+    clamp_heat_loss,
+    clamp_heating_power,
+    mean_trv_target,
+    restore_target_temperature,
+)
 from .utils.state_manager import StateManager
 from .utils.telemetry import (
     collect_balance_attrs,
@@ -1272,54 +1273,16 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 "better_thermostat %s: restoring target temperature...",
                 self.device_name,
             )
-            # If we have no initial temperature, restore
-            # If we have a previously saved temperature
-            if old_state.attributes.get(ATTR_TEMPERATURE) is None:
-                _target_temps = []
-                for _s in states:
-                    _raw = _s.attributes.get(ATTR_TEMPERATURE)
-                    if _raw is not None:
-                        _unit = _s.attributes.get(
-                            "temperature_unit", _s.attributes.get("unit_of_measurement")
-                        )
-                        _c = convert_to_float_celsius(
-                            str(_raw),
-                            self.device_name,
-                            "_restore_state(target)",
-                            unit_of_measurement=_unit,
-                        )
-                        if _c is not None:
-                            _target_temps.append(_c)
-                if _target_temps:
-                    self.bt_target_temp = mean(_target_temps)
-                _LOGGER.debug(
-                    "better_thermostat %s: Undefined target temperature, falling back to %s",
-                    self.device_name,
-                    self.bt_target_temp,
-                )
-            else:
-                _oldtarget_temperature = float(old_state.attributes[ATTR_TEMPERATURE])
-                _bt_min = self.bt_min_temp if self.bt_min_temp is not None else 5.0
-                _bt_max = self.bt_max_temp if self.bt_max_temp is not None else 30.0
-                # if the saved temperature is lower than the min_temp, set it to min_temp
-                if _oldtarget_temperature < _bt_min:
-                    _LOGGER.warning(
-                        "better_thermostat %s: Saved target temperature %s is lower than min_temp %s, setting to min_temp",
-                        self.device_name,
-                        _oldtarget_temperature,
-                        _bt_min,
-                    )
-                    _oldtarget_temperature = _bt_min
-                # if the saved temperature is higher than the max_temp, set it to max_temp
-                elif _oldtarget_temperature > _bt_max:
-                    _LOGGER.warning(
-                        "better_thermostat %s: Saved target temperature %s is higher than max_temp %s, setting to max_temp",
-                        self.device_name,
-                        _oldtarget_temperature,
-                        _bt_max,
-                    )
-                    _oldtarget_temperature = _bt_max
-                self.bt_target_temp = _oldtarget_temperature
+            # Clamp the saved target, or fall back to the TRV mean.
+            _restored_target = restore_target_temperature(
+                old_state.attributes.get(ATTR_TEMPERATURE),
+                states,
+                self.bt_min_temp,
+                self.bt_max_temp,
+                self.device_name,
+            )
+            if _restored_target is not None:
+                self.bt_target_temp = _restored_target
             _LOGGER.debug(
                 "better_thermostat %s: target temperature restored", self.device_name
             )
@@ -1385,42 +1348,17 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     old_state.attributes[ATTR_STATE_MAIN_MODE]
                 )
             if old_state.attributes.get(ATTR_STATE_HEATING_POWER, None) is not None:
-                try:
-                    _power_value = old_state.attributes.get(ATTR_STATE_HEATING_POWER)
-                    if _power_value is not None:
-                        loaded_power = float(_power_value)
-                    else:
-                        loaded_power = 0.01
-                except (TypeError, ValueError):
-                    loaded_power = 0.01
-                # Bound to realistic values to prevent issues from incorrectly learned values
-                bounded_power = max(
-                    MIN_HEATING_POWER, min(MAX_HEATING_POWER, loaded_power)
+                self.heating_power = clamp_heating_power(
+                    old_state.attributes.get(ATTR_STATE_HEATING_POWER), self.device_name
                 )
-                if bounded_power != loaded_power:
-                    _LOGGER.info(
-                        "better_thermostat %s: Restored heating_power %.3f "
-                        "is outside allowed range [%s, %s]; clamped to %.3f",
-                        self.device_name,
-                        loaded_power,
-                        MIN_HEATING_POWER,
-                        MAX_HEATING_POWER,
-                        bounded_power,
-                    )
-                self.heating_power = bounded_power
 
             # Restore heat loss if available
             if old_state.attributes.get(ATTR_STATE_HEAT_LOSS, None) is not None:
-                try:
-                    _loss_value = old_state.attributes.get(ATTR_STATE_HEAT_LOSS)
-                    if _loss_value is not None:
-                        loaded_loss = float(_loss_value)
-                    else:
-                        loaded_loss = 0.01
-                    bounded_loss = max(MIN_HEAT_LOSS, min(MAX_HEAT_LOSS, loaded_loss))
-                    self.heat_loss_rate = bounded_loss
-                except (TypeError, ValueError):
-                    pass
+                _restored_loss = clamp_heat_loss(
+                    old_state.attributes.get(ATTR_STATE_HEAT_LOSS)
+                )
+                if _restored_loss is not None:
+                    self.heat_loss_rate = _restored_loss
             if (
                 old_state.attributes.get(ATTR_STATE_PRESET_TEMPERATURE, None)
                 is not None
@@ -1459,23 +1397,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     "better_thermostat %s: No previously saved temperature found on startup, get it from the TRV",
                     self.device_name,
                 )
-                _target_temps = []
-                for _s in states:
-                    _raw = _s.attributes.get(ATTR_TEMPERATURE)
-                    if _raw is not None:
-                        _unit = _s.attributes.get(
-                            "temperature_unit", _s.attributes.get("unit_of_measurement")
-                        )
-                        _c = convert_to_float_celsius(
-                            str(_raw),
-                            self.device_name,
-                            "_restore_defaults(target)",
-                            unit_of_measurement=_unit,
-                        )
-                        if _c is not None:
-                            _target_temps.append(_c)
-                if _target_temps:
-                    self.bt_target_temp = mean(_target_temps)
+                _restored_target = mean_trv_target(states, self.device_name)
+                if _restored_target is not None:
+                    self.bt_target_temp = _restored_target
             _LOGGER.debug("better_thermostat %s: defaults restored", self.device_name)
 
     def _validate_hvac_mode(self, states: list[State]) -> None:

--- a/custom_components/better_thermostat/utils/restore.py
+++ b/custom_components/better_thermostat/utils/restore.py
@@ -53,14 +53,25 @@ def restore_target_temperature(
 ) -> float | None:
     """Resolve the restored heating target.
 
-    With a *saved* value, clamp it into ``[min_temp, max_temp]`` (defaults
-    5.0 / 30.0).  Without one, fall back to the mean of the TRV targets.
-    Returns ``None`` only when neither source yields a value.
+    With a usable numeric *saved* value, clamp it into ``[min_temp, max_temp]``
+    (defaults 5.0 / 30.0).  When *saved* is missing or non-numeric, fall back to
+    the mean of the TRV targets.  Returns ``None`` only when neither source
+    yields a value.
     """
     if saved is None:
         return mean_trv_target(states, device_name)
 
-    value = float(saved)
+    try:
+        value = float(saved)
+    except (TypeError, ValueError):
+        _LOGGER.warning(
+            "better_thermostat %s: Saved target temperature %r is not numeric, "
+            "falling back to the TRV mean",
+            device_name,
+            saved,
+        )
+        return mean_trv_target(states, device_name)
+
     low = min_temp if min_temp is not None else 5.0
     high = max_temp if max_temp is not None else 30.0
     if value < low:

--- a/custom_components/better_thermostat/utils/restore.py
+++ b/custom_components/better_thermostat/utils/restore.py
@@ -1,0 +1,118 @@
+"""Pure parsing/clamping helpers for restoring state on startup.
+
+These functions take primitive inputs (raw attribute values, TRV ``State``
+objects, bounds) and return parsed/clamped values.  They are free of any
+``BetterThermostat`` entity dependency so they can be unit-tested in isolation;
+``climate.py`` keeps the thin orchestration that reads ``async_get_last_state``
+and assigns the results to entity attributes.
+"""
+
+from __future__ import annotations
+
+import logging
+from statistics import mean
+
+from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.core import State
+
+from .const import MAX_HEAT_LOSS, MAX_HEATING_POWER, MIN_HEAT_LOSS, MIN_HEATING_POWER
+from .helpers import convert_to_float_celsius
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def mean_trv_target(
+    states: list[State], device_name: str, context: str = "restore(target)"
+) -> float | None:
+    """Mean of the valid TRV target temperatures, each converted to Celsius.
+
+    Returns ``None`` when no TRV exposes a usable target temperature.
+    """
+    temps: list[float] = []
+    for state in states:
+        raw = state.attributes.get(ATTR_TEMPERATURE)
+        if raw is None:
+            continue
+        unit = state.attributes.get(
+            "temperature_unit", state.attributes.get("unit_of_measurement")
+        )
+        celsius = convert_to_float_celsius(
+            str(raw), device_name, context, unit_of_measurement=unit
+        )
+        if celsius is not None:
+            temps.append(celsius)
+    return mean(temps) if temps else None
+
+
+def restore_target_temperature(
+    saved: str | int | float | None,
+    states: list[State],
+    min_temp: float | None,
+    max_temp: float | None,
+    device_name: str,
+) -> float | None:
+    """Resolve the restored heating target.
+
+    With a *saved* value, clamp it into ``[min_temp, max_temp]`` (defaults
+    5.0 / 30.0).  Without one, fall back to the mean of the TRV targets.
+    Returns ``None`` only when neither source yields a value.
+    """
+    if saved is None:
+        return mean_trv_target(states, device_name)
+
+    value = float(saved)
+    low = min_temp if min_temp is not None else 5.0
+    high = max_temp if max_temp is not None else 30.0
+    if value < low:
+        _LOGGER.warning(
+            "better_thermostat %s: Saved target temperature %s is lower than "
+            "min_temp %s, setting to min_temp",
+            device_name,
+            value,
+            low,
+        )
+        return low
+    if value > high:
+        _LOGGER.warning(
+            "better_thermostat %s: Saved target temperature %s is higher than "
+            "max_temp %s, setting to max_temp",
+            device_name,
+            value,
+            high,
+        )
+        return high
+    return value
+
+
+def clamp_heating_power(raw: str | int | float | None, device_name: str) -> float:
+    """Parse and clamp a restored heating-power value to its valid range.
+
+    A missing or non-numeric value falls back to ``0.01`` before clamping.
+    """
+    try:
+        value = 0.01 if raw is None else float(raw)
+    except (TypeError, ValueError):
+        value = 0.01
+    bounded = max(MIN_HEATING_POWER, min(MAX_HEATING_POWER, value))
+    if bounded != value:
+        _LOGGER.info(
+            "better_thermostat %s: Restored heating_power %.3f is outside allowed "
+            "range [%s, %s]; clamped to %.3f",
+            device_name,
+            value,
+            MIN_HEATING_POWER,
+            MAX_HEATING_POWER,
+            bounded,
+        )
+    return bounded
+
+
+def clamp_heat_loss(raw: str | int | float | None) -> float | None:
+    """Parse and clamp a restored heat-loss value, or ``None`` if not numeric."""
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return max(MIN_HEAT_LOSS, min(MAX_HEAT_LOSS, value))

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -17,7 +17,9 @@ from custom_components.better_thermostat.climate import (
 )
 from custom_components.better_thermostat.utils.const import (
     ATTR_STATE_CALL_FOR_HEAT,
+    ATTR_STATE_HEAT_LOSS,
     ATTR_STATE_HEATING_POWER,
+    MAX_HEAT_LOSS,
     MAX_HEATING_POWER,
 )
 
@@ -479,6 +481,37 @@ class TestRestoreState:
         await BetterThermostat._restore_state(bt, states)
 
         assert bt.call_for_heat is True
+
+    @pytest.mark.asyncio
+    async def test_restores_heat_loss_clamped(self, bt):
+        """An out-of-range restored heat-loss rate is clamped to the max."""
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {ATTR_TEMPERATURE: 21.0, ATTR_STATE_HEAT_LOSS: "5.0"}
+        bt.async_get_last_state = AsyncMock(return_value=old)
+        bt.preset_mgr.temperatures = {}
+
+        states = [_make_trv_state()]
+        await BetterThermostat._restore_state(bt, states)
+
+        assert bt.heat_loss_rate == MAX_HEAT_LOSS
+
+    @pytest.mark.asyncio
+    async def test_old_state_without_target_falls_back_to_trv_mean(self, bt):
+        """An old state lacking a target temperature falls back to the TRV mean."""
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {}  # no ATTR_TEMPERATURE
+        bt.async_get_last_state = AsyncMock(return_value=old)
+        bt.preset_mgr.temperatures = {}
+
+        states = [
+            _make_trv_state(attrs={ATTR_TEMPERATURE: 20.0}),
+            _make_trv_state(attrs={ATTR_TEMPERATURE: 24.0}),
+        ]
+        await BetterThermostat._restore_state(bt, states)
+
+        assert bt.bt_target_temp == 22.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -1,0 +1,191 @@
+"""Tests for the pure startup-restore helpers in utils/restore.py."""
+
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.utils.const import (
+    MAX_HEAT_LOSS,
+    MAX_HEATING_POWER,
+    MIN_HEAT_LOSS,
+    MIN_HEATING_POWER,
+)
+from custom_components.better_thermostat.utils.restore import (
+    clamp_heat_loss,
+    clamp_heating_power,
+    mean_trv_target,
+    restore_target_temperature,
+)
+
+DEV = "Test BT"
+
+
+def _trv(temp, unit=None, entity_id="climate.trv"):
+    """Build a TRV State carrying a target temperature (and optional unit)."""
+    attrs: dict = {}
+    if temp is not None:
+        attrs[ATTR_TEMPERATURE] = temp
+    if unit is not None:
+        attrs["temperature_unit"] = unit
+    return State(entity_id, "heat", attributes=attrs)
+
+
+# ---------------------------------------------------------------------------
+# mean_trv_target
+# ---------------------------------------------------------------------------
+
+
+class TestMeanTrvTarget:
+    """mean_trv_target averages valid TRV targets, converting to Celsius."""
+
+    def test_empty_list_returns_none(self):
+        """No states → None."""
+        assert mean_trv_target([], DEV) is None
+
+    def test_single_trv(self):
+        """One TRV target is returned unchanged."""
+        assert mean_trv_target([_trv(21.0)], DEV) == 21.0
+
+    def test_multiple_trvs_averaged(self):
+        """Multiple targets are averaged."""
+        assert mean_trv_target([_trv(20.0), _trv(24.0)], DEV) == 22.0
+
+    def test_missing_target_attr_skipped(self):
+        """A TRV without a target temperature is ignored."""
+        assert mean_trv_target([_trv(20.0), _trv(None)], DEV) == 20.0
+
+    def test_all_missing_returns_none(self):
+        """No usable targets → None."""
+        assert mean_trv_target([_trv(None), _trv(None)], DEV) is None
+
+    def test_non_numeric_skipped(self):
+        """A non-numeric target is skipped, not crashing."""
+        assert mean_trv_target([_trv("bad"), _trv(21.0)], DEV) == 21.0
+
+    def test_fahrenheit_converted_to_celsius(self):
+        """A Fahrenheit target is converted before averaging."""
+        result = mean_trv_target([_trv(68.0, unit=UnitOfTemperature.FAHRENHEIT)], DEV)
+        assert result == pytest.approx(20.0)
+
+    def test_unit_of_measurement_fallback_key(self):
+        """The unit may also be supplied via unit_of_measurement."""
+        s = State(
+            "climate.trv",
+            "heat",
+            attributes={
+                ATTR_TEMPERATURE: 68.0,
+                "unit_of_measurement": UnitOfTemperature.FAHRENHEIT,
+            },
+        )
+        assert mean_trv_target([s], DEV) == pytest.approx(20.0)
+
+
+# ---------------------------------------------------------------------------
+# restore_target_temperature
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreTargetTemperature:
+    """restore_target_temperature clamps a saved value or falls back to TRVs."""
+
+    def test_saved_in_range_passthrough(self):
+        """An in-range saved value is returned unchanged."""
+        assert restore_target_temperature(22.0, [], 5.0, 30.0, DEV) == 22.0
+
+    def test_saved_below_min_clamped(self):
+        """A saved value below min is clamped up."""
+        assert restore_target_temperature(2.0, [], 5.0, 30.0, DEV) == 5.0
+
+    def test_saved_above_max_clamped(self):
+        """A saved value above max is clamped down."""
+        assert restore_target_temperature(35.0, [], 5.0, 30.0, DEV) == 30.0
+
+    def test_saved_at_boundaries_unchanged(self):
+        """Values exactly on the bounds are not altered."""
+        assert restore_target_temperature(5.0, [], 5.0, 30.0, DEV) == 5.0
+        assert restore_target_temperature(30.0, [], 5.0, 30.0, DEV) == 30.0
+
+    def test_none_bounds_use_defaults(self):
+        """None bounds fall back to 5.0 / 30.0."""
+        assert restore_target_temperature(2.0, [], None, None, DEV) == 5.0
+        assert restore_target_temperature(99.0, [], None, None, DEV) == 30.0
+
+    def test_saved_string_parsed(self):
+        """A numeric string saved value is parsed."""
+        assert restore_target_temperature("21.5", [], 5.0, 30.0, DEV) == 21.5
+
+    def test_no_saved_falls_back_to_trv_mean(self):
+        """Without a saved value the TRV mean is used."""
+        assert (
+            restore_target_temperature(None, [_trv(20.0), _trv(22.0)], 5.0, 30.0, DEV)
+            == 21.0
+        )
+
+    def test_no_saved_no_trv_returns_none(self):
+        """No saved value and no TRV target → None."""
+        assert restore_target_temperature(None, [], 5.0, 30.0, DEV) is None
+
+
+# ---------------------------------------------------------------------------
+# clamp_heating_power
+# ---------------------------------------------------------------------------
+
+
+class TestClampHeatingPower:
+    """clamp_heating_power parses and bounds the restored heating power."""
+
+    def test_in_range_passthrough(self):
+        """A value inside the range is returned unchanged."""
+        mid = (MIN_HEATING_POWER + MAX_HEATING_POWER) / 2
+        assert clamp_heating_power(mid, DEV) == mid
+
+    def test_above_max_clamped(self):
+        """A value above the max is clamped down."""
+        assert clamp_heating_power(999.0, DEV) == MAX_HEATING_POWER
+
+    def test_below_min_clamped(self):
+        """A value below the min is clamped up."""
+        assert clamp_heating_power(-1.0, DEV) == MIN_HEATING_POWER
+
+    def test_string_value_parsed(self):
+        """A numeric string is parsed then clamped."""
+        assert clamp_heating_power("999.0", DEV) == MAX_HEATING_POWER
+
+    def test_non_numeric_falls_back_to_default(self):
+        """A non-numeric value falls back to 0.01 before clamping (stays in range)."""
+        result = clamp_heating_power("bad", DEV)
+        assert MIN_HEATING_POWER <= result <= MAX_HEATING_POWER
+
+
+# ---------------------------------------------------------------------------
+# clamp_heat_loss
+# ---------------------------------------------------------------------------
+
+
+class TestClampHeatLoss:
+    """clamp_heat_loss parses and bounds the restored heat-loss rate."""
+
+    def test_in_range_passthrough(self):
+        """A value inside the range is returned unchanged."""
+        mid = (MIN_HEAT_LOSS + MAX_HEAT_LOSS) / 2
+        assert clamp_heat_loss(mid) == mid
+
+    def test_above_max_clamped(self):
+        """A value above the max is clamped down."""
+        assert clamp_heat_loss(1.0) == MAX_HEAT_LOSS
+
+    def test_below_min_clamped(self):
+        """A value below the min is clamped up."""
+        assert clamp_heat_loss(-1.0) == MIN_HEAT_LOSS
+
+    def test_string_value_parsed(self):
+        """A numeric string is parsed then clamped."""
+        assert clamp_heat_loss("1.0") == MAX_HEAT_LOSS
+
+    def test_non_numeric_returns_none(self):
+        """A non-numeric value returns None (caller keeps the existing value)."""
+        assert clamp_heat_loss("bad") is None
+
+    def test_none_returns_none(self):
+        """None returns None."""
+        assert clamp_heat_loss(None) is None

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -125,6 +125,19 @@ class TestRestoreTargetTemperature:
         """No saved value and no TRV target → None."""
         assert restore_target_temperature(None, [], 5.0, 30.0, DEV) is None
 
+    def test_malformed_saved_falls_back_to_trv_mean(self):
+        """A non-numeric saved value falls back to the TRV mean instead of raising."""
+        assert (
+            restore_target_temperature(
+                "unknown", [_trv(20.0), _trv(22.0)], 5.0, 30.0, DEV
+            )
+            == 21.0
+        )
+
+    def test_malformed_saved_no_trv_returns_none(self):
+        """A non-numeric saved value with no TRV target → None, not a crash."""
+        assert restore_target_temperature("n/a", [], 5.0, 30.0, DEV) is None
+
 
 # ---------------------------------------------------------------------------
 # clamp_heating_power


### PR DESCRIPTION
Adds `utils/restore.py` with pure functions for restoring entity state from Home
Assistant's `RestoreEntity` attributes, and routes `_restore_state` through them.
No functional change.

### Helpers (`utils/restore.py`)
Each takes primitive inputs (raw attribute values, TRV `State`s, bounds) and
needs no `BetterThermostat` instance, so they are unit-testable in isolation:
- **`mean_trv_target`** — mean of the valid TRV targets, each converted to Celsius
- **`restore_target_temperature`** — clamp a saved target into `[min, max]`, or
  fall back to the TRV mean
- **`clamp_heating_power`** / **`clamp_heat_loss`** — parse and bound restored
  thermal values

`_restore_state` keeps only the orchestration: read `async_get_last_state` and
assign the parsed values to entity attributes. Restore reads from HA's
`RestoreEntity`, not the unified `StateManager` store, so the helpers live in
their own module.

### Tests
- `tests/unit/test_restore.py` — 27 cases across the four helpers (averaging,
  Fahrenheit conversion, clamping at/over/under bounds, non-numeric fallbacks,
  string parsing, empty inputs)
- additional `_restore_state` cases for heat-loss clamping and the
  target-from-TRV fallback

The only caller is the startup path (`async_added_to_hass`); the existing
`_restore_state` tests cover behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced thermostat state restoration with improved handling of temperature bounds and thermal parameters on startup.

* **Tests**
  * Added comprehensive tests for state restoration helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->