### PR TITLE
fix: keep heating when weather forecast data is momentarily unavailable

### DIFF
--- a/custom_components/better_thermostat/utils/weather.py
+++ b/custom_components/better_thermostat/utils/weather.py
@@ -206,7 +206,9 @@ async def check_weather_prediction(self) -> bool | None:
         _LOGGER.warning(
             "better_thermostat %s: no weather entity data found.", self.device_name
         )
-        return False
+        # Return None (no opinion) on a transient failure so check_weather keeps
+        # the current call_for_heat decision while weather data is unavailable.
+        return None
 
 
 async def check_ambient_air_temperature(self):

--- a/tests/unit/test_weather.py
+++ b/tests/unit/test_weather.py
@@ -264,33 +264,33 @@ class TestCheckWeatherPrediction:
         bt = make_bt(hass, weather_entity=WEATHER_ID, off_temperature=10.0)
         assert await check_weather_prediction(bt) is True
 
-    async def test_empty_forecast_returns_false(self):
-        """An empty forecast list resolves to False."""
+    async def test_empty_forecast_returns_none(self):
+        """An empty forecast list resolves to None (no opinion)."""
         states = {WEATHER_ID: weather_state()}
         hass = make_hass(states=states)
         hass.services.async_call = AsyncMock(
             return_value={WEATHER_ID: {"forecast": []}}
         )
         bt = make_bt(hass, weather_entity=WEATHER_ID)
-        assert await check_weather_prediction(bt) is False
+        assert await check_weather_prediction(bt) is None
 
-    async def test_service_error_returns_false(self):
-        """A HomeAssistantError from the service resolves to False."""
+    async def test_service_error_returns_none(self):
+        """A HomeAssistantError from the service resolves to None."""
         states = {WEATHER_ID: weather_state()}
         hass = make_hass(states=states)
         hass.services.async_call = AsyncMock(side_effect=HomeAssistantError("boom"))
         bt = make_bt(hass, weather_entity=WEATHER_ID)
-        assert await check_weather_prediction(bt) is False
+        assert await check_weather_prediction(bt) is None
 
-    async def test_service_not_supported_returns_false(self):
-        """A ServiceNotSupported error resolves to False."""
+    async def test_service_not_supported_returns_none(self):
+        """A ServiceNotSupported error resolves to None."""
         states = {WEATHER_ID: weather_state()}
         hass = make_hass(states=states)
         hass.services.async_call = AsyncMock(
             side_effect=ServiceNotSupported("weather", "get_forecasts", WEATHER_ID)
         )
         bt = make_bt(hass, weather_entity=WEATHER_ID)
-        assert await check_weather_prediction(bt) is False
+        assert await check_weather_prediction(bt) is None
 
     async def test_forecast_temps_are_averaged(self):
         """Up to two forecast temps are averaged before the comparison.
@@ -677,26 +677,12 @@ class TestCheckWeather:
         # The outdoor sensor's verdict replaces the weather prediction.
         assert bt.call_for_heat is False
 
+    async def test_transient_weather_failure_keeps_heating(self):
+        """A transient weather-service failure leaves heating enabled.
 
-# ===========================================================================
-# Behaviour the current implementation does not yet provide (xfail).
-# ===========================================================================
-
-
-class TestSuspectedBugs:
-    """Assertions of intended behaviour the implementation does not yet meet.
-
-    These are marked strict xfail; a strict XPASS signals the behaviour now
-    holds and the test should become a plain assertion.
-    """
-
-    @pytest.mark.xfail(
-        strict=True,
-        reason="check_weather_prediction returns False on a transient service "
-        "failure, so check_weather sets call_for_heat to False.",
-    )
-    async def test_transient_weather_failure_should_not_stop_heat(self):
-        """A transient weather-service failure leaves heating enabled."""
+        A HomeAssistantError from the forecast service yields no opinion, so
+        check_weather keeps call_for_heat at its current value.
+        """
         states = {WEATHER_ID: weather_state()}
         hass = make_hass(states=states)
         hass.services.async_call = AsyncMock(side_effect=HomeAssistantError("boom"))


### PR DESCRIPTION
## Bug

`check_weather_prediction` returned `False` on **any transient failure** — `HomeAssistantError`, `ServiceNotSupported`, or an empty forecast. `check_weather` applies a `bool` return value directly to `call_for_heat`. A single failed forecast poll (e.g. the weather integration is briefly unreachable) therefore set `call_for_heat = False` and **switched off heating** until the next successful poll.

## Fix

Return `None` (no opinion) on those transient failures instead of `False` — matching the existing "entity advertises no forecast" path. `check_weather` then leaves the previous `call_for_heat` decision untouched rather than disabling heating on a glitch.

```diff
     except (TypeError, ServiceNotSupported, HomeAssistantError):
         _LOGGER.warning(...)
-        return False
+        return None
```

## Tests

- Adds `test_transient_weather_failure_keeps_heating`.
- Updates the three forecast-error tests (`is False` → `is None`).

`uv run pytest tests/unit/test_weather.py -p no:homeassistant` → `49 passed, 1 xfailed` (the remaining xfail is the separate integer `off_temperature` bug, fixed in #2017).

## Impact analysis

gitnexus `impact(check_weather_prediction, upstream)` = **LOW**. The only direct caller is `check_weather`, which already handles `None` correctly (`isinstance(..., bool)` guard).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves existing heating state when weather predictions are temporarily unavailable; the system no longer overrides the current heating decision during transient forecast failures.
* **Tests**
  * Updated unit and orchestration tests to reflect the new behavior for unavailable weather data and to verify heating state is retained during transient forecast errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->