### PR TITLE
fix: accept an integer off_temperature in the weather checks

### DIFF
--- a/custom_components/better_thermostat/utils/weather.py
+++ b/custom_components/better_thermostat/utils/weather.py
@@ -105,9 +105,11 @@ async def check_weather_prediction(self) -> bool | None:
         )
         return False
 
-    if self.off_temperature is None or not isinstance(self.off_temperature, float):
+    if self.off_temperature is None or not isinstance(
+        self.off_temperature, (int, float)
+    ):
         _LOGGER.warning(
-            "better_thermostat %s: off_temperature not set or not a float.",
+            "better_thermostat %s: off_temperature not set or not a number.",
             self.device_name,
         )
         return False
@@ -222,9 +224,11 @@ async def check_ambient_air_temperature(self):
     if self.outdoor_sensor is None:
         return None
 
-    if self.off_temperature is None or not isinstance(self.off_temperature, float):
+    if self.off_temperature is None or not isinstance(
+        self.off_temperature, (int, float)
+    ):
         _LOGGER.warning(
-            "better_thermostat %s: off_temperature not set or not a float.",
+            "better_thermostat %s: off_temperature not set or not a number.",
             self.device_name,
         )
         return None

--- a/tests/unit/test_weather.py
+++ b/tests/unit/test_weather.py
@@ -215,6 +215,16 @@ class TestCheckWeatherPrediction:
         bt = make_bt(make_hass(), weather_entity=WEATHER_ID, off_temperature=None)
         assert await check_weather_prediction(bt) is False
 
+    async def test_integer_off_temperature_is_honoured(self):
+        """An integer off_temperature is accepted by the type guard."""
+        states = {WEATHER_ID: weather_state(temperature=2.0)}
+        hass = make_hass(states=states)
+        hass.services.async_call = AsyncMock(
+            return_value=forecast_resp(WEATHER_ID, [1.0, 1.0])
+        )
+        bt = make_bt(hass, weather_entity=WEATHER_ID, off_temperature=10)  # int!
+        assert await check_weather_prediction(bt) is True
+
     async def test_no_forecast_support_returns_none(self):
         """An entity without any forecast feature yields None (no opinion)."""
         states = {WEATHER_ID: weather_state(features=0)}
@@ -384,6 +394,20 @@ class TestCheckAmbientAirTemperature:
         """A missing off_temperature short-circuits to None."""
         bt = make_bt(make_hass(), outdoor_sensor=OUTDOOR_ID, off_temperature=None)
         assert await check_ambient_air_temperature(bt) is None
+
+    async def test_integer_off_temperature_is_honoured(self):
+        """An integer off_temperature is accepted by the ambient check too."""
+        states = {
+            OUTDOOR_ID: make_state(state="2.0", attrs={"unit_of_measurement": "°C"})
+        }
+        bt = make_bt(
+            make_hass(states=states, components=set()),
+            outdoor_sensor=OUTDOOR_ID,
+            off_temperature=10,  # int!
+        )
+        await check_ambient_air_temperature(bt)
+        assert bt.last_avg_outdoor_temp == 2.0
+        assert bt.call_for_heat is True
 
     async def test_unavailable_sensor_without_cache_forces_heat(self):
         """An unavailable sensor with no cached value forces heating on."""
@@ -704,18 +728,3 @@ class TestSuspectedBugs:
         bt.call_for_heat = True
         await check_weather(bt)
         assert bt.call_for_heat is True
-
-    @pytest.mark.xfail(
-        strict=True,
-        reason="check_weather_prediction rejects an integer off_temperature "
-        "via the isinstance(..., float) guard.",
-    )
-    async def test_integer_off_temperature_should_be_honoured(self):
-        """An integer off_temperature is honoured like a float."""
-        states = {WEATHER_ID: weather_state(temperature=2.0)}
-        hass = make_hass(states=states)
-        hass.services.async_call = AsyncMock(
-            return_value=forecast_resp(WEATHER_ID, [1.0, 1.0])
-        )
-        bt = make_bt(hass, weather_entity=WEATHER_ID, off_temperature=10)  # int!
-        assert await check_weather_prediction(bt) is True


### PR DESCRIPTION
## Bug

Both `check_weather_prediction` **and** `check_ambient_air_temperature` guarded the threshold with `isinstance(self.off_temperature, float)`. An **integer** value (e.g. `10`) failed that guard — the function logged a warning and bailed out, silently disabling both the forecast and the outdoor-sensor evaluation.

## Fix

Widen the guard to `(int, float)` and reword the log message from "not a float" to "not a number" — in both functions.

```diff
-    if self.off_temperature is None or not isinstance(self.off_temperature, float):
+    if self.off_temperature is None or not isinstance(
+        self.off_temperature, (int, float)
+    ):
```

Purely a widening of the type guard: behaviour is identical for existing float configurations, only integer values are additionally accepted.

## Tests

- Adds a forecast regression test (`TestCheckWeatherPrediction.test_integer_off_temperature_is_honoured`).
- Adds a matching one for `check_ambient_air_temperature`.

`uv run pytest tests/unit/test_weather.py -p no:homeassistant` → `50 passed, 1 xfailed` (the remaining xfail is the separate transient-weather-failure bug, fixed in #2016).

## Impact analysis ⚠️

- `impact(check_weather_prediction, upstream)` = **LOW**.
- `impact(check_ambient_air_temperature, upstream)` = **HIGH** — the function sits on the startup / trigger-time path (`_trigger_time` → `_finalize_startup` → `startup`). The HIGH rating is **topological** (many callers); the change itself only widens the type guard and is behaviour-neutral for all existing float configurations.
