### PR TITLE
fix: normalise weather forecast horizon and clarify averaging

### DIFF
--- a/custom_components/better_thermostat/utils/weather.py
+++ b/custom_components/better_thermostat/utils/weather.py
@@ -90,12 +90,17 @@ async def check_weather(self) -> bool:
 
 
 async def check_weather_prediction(self) -> bool | None:
-    """Check configured weather entity for next two days of temperature predictions.
+    """Check configured weather entity over roughly the next two days.
+
+    The forecast horizon is normalised to about two days regardless of the
+    entity's forecast granularity (daily, twice-daily or hourly), and the
+    sampled temperatures are averaged.
 
     Returns
     -------
     bool
-            True if the maximum forcast temperature is lower than the off temperature
+            True if the average forecast temperature (or the current
+            temperature) is below the off temperature, i.e. heat is required
     None
             if not successful
     """
@@ -130,6 +135,9 @@ async def check_weather_prediction(self) -> bool | None:
             )
             return None
 
+        # Sample roughly the next two days regardless of forecast granularity.
+        _forecast_samples = {"daily": 2, "twice_daily": 4, "hourly": 48}[ftype]
+
         forecasts = await self.hass.services.async_call(
             WEATHER_DOMAIN,
             "get_forecasts",
@@ -162,14 +170,14 @@ async def check_weather_prediction(self) -> bool | None:
                     else None
                 ),
             )
-            # compute simple average of first up-to-2 daily temps
+            # average the sampled forecast temps over the two-day horizon
             _entity_temp_unit = (
                 cur_state.attributes.get("temperature_unit")
                 if cur_state and cur_state.attributes
                 else None
             )
             temps = []
-            for i in range(min(2, len(forecast))):
+            for i in range(min(_forecast_samples, len(forecast))):
                 temps.append(
                     convert_to_float_celsius(
                         (
@@ -187,17 +195,17 @@ async def check_weather_prediction(self) -> bool | None:
                     )
                 )
             valid_temps: list[float] = [t for t in temps if isinstance(t, (int, float))]
-            max_forecast_temp = None
+            avg_forecast_temp = None
             if valid_temps:
-                max_forecast_temp = sum(valid_temps) / float(len(valid_temps))
+                avg_forecast_temp = sum(valid_temps) / float(len(valid_temps))
 
             cond_cur = (
                 isinstance(cur_outside_temp, (int, float))
                 and cur_outside_temp < self.off_temperature
             )
             cond_fc = (
-                isinstance(max_forecast_temp, (int, float))
-                and max_forecast_temp < self.off_temperature
+                isinstance(avg_forecast_temp, (int, float))
+                and avg_forecast_temp < self.off_temperature
             )
             return bool(cond_cur or cond_fc)
         else:

--- a/tests/unit/test_weather.py
+++ b/tests/unit/test_weather.py
@@ -306,11 +306,22 @@ class TestCheckWeatherPrediction:
         bt = make_bt(hass, weather_entity=WEATHER_ID, off_temperature=10.0)
         assert await check_weather_prediction(bt) is True
 
-    async def test_only_first_two_forecast_entries_are_used(self):
-        """Only the first two forecast entries are sampled.
+    async def test_daily_forecast_samples_two_entries(self):
+        """A daily forecast averages the first two entries (~two days)."""
+        states = {WEATHER_ID: weather_state(temperature=15.0)}
+        hass = make_hass(states=states)
+        # First two warm, later days freezing -> beyond the two-day horizon.
+        hass.services.async_call = AsyncMock(
+            return_value=forecast_resp(WEATHER_ID, [15.0, 15.0, -30.0, -30.0])
+        )
+        bt = make_bt(hass, weather_entity=WEATHER_ID, off_temperature=10.0)
+        assert await check_weather_prediction(bt) is False
 
-        With an hourly entity whose first two entries are warm and later ones
-        freezing, the result reflects only those first two entries.
+    async def test_hourly_forecast_samples_beyond_two_entries(self):
+        """An hourly forecast samples well past the first two hours.
+
+        With the first two hours warm and the rest freezing, the wider horizon
+        averages below the threshold, so heating is requested.
         """
         states = {
             WEATHER_ID: weather_state(
@@ -322,7 +333,7 @@ class TestCheckWeatherPrediction:
             return_value=forecast_resp(WEATHER_ID, [15.0, 15.0, -30.0, -30.0, -30.0])
         )
         bt = make_bt(hass, weather_entity=WEATHER_ID, off_temperature=10.0)
-        assert await check_weather_prediction(bt) is False
+        assert await check_weather_prediction(bt) is True
 
     async def test_forecast_entry_missing_temperature_is_filtered(self):
         """A forecast entry without a temperature is filtered out."""


### PR DESCRIPTION
## Background

Two related issues in `check_weather_prediction`, both about how the forecast is aggregated over the "two-day window".

## Bug #4 — forecast window ignores granularity

`min(2, len(forecast))` only ever sampled the **first two entries**. That matches the docstring ("next two days") only for a **daily** entity:

| Forecast type | sampled before | intended (~2 days) |
|---------------|----------------|--------------------|
| daily         | 2 days ✅       | 2 entries |
| twice_daily   | 1 day ❌        | 4 entries |
| hourly        | 2 hours ❌      | 48 entries |

**Fix:** scale the number of samples by forecast type:
```python
_forecast_samples = {"daily": 2, "twice_daily": 4, "hourly": 48}[ftype]
...
for i in range(min(_forecast_samples, len(forecast))):
```

## Bug #3 — "max" is in fact a mean (naming only)

The result was stored in `max_forecast_temp` and the docstring spoke of the *"maximum forcast temperature"*, even though the code computes `sum/len` (an average). The averaging behaviour is reasonable and stays **unchanged** — only the misleading name (`avg_forecast_temp`) and the docstring are corrected. **No behaviour change** for #3.

## Tests

- `test_daily_forecast_samples_two_entries` — daily still uses 2 entries.
- `test_hourly_forecast_samples_beyond_two_entries` — hourly now samples past the first two hours.

`uv run pytest tests/unit/test_weather.py -p no:homeassistant` → `49 passed, 2 xfailed` (the 2 xfails are the separate bugs fixed in #2016/#2017).

## Impact analysis

gitnexus `impact(check_weather_prediction, upstream)` = **LOW** (only direct caller `check_weather`). Behaviour change applies to #4 only (hourly/twice_daily forecasts); #3 is purely cosmetic.
