### PR TITLE
fix: remove unreachable branches and correct a stale maintenance comment

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1481,35 +1481,18 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # if hvac mode could not be restored, turn heat off
         _LOGGER.debug("better_thermostat %s: checking hvac mode...", self.device_name)
         if self.bt_hvac_mode in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
+            # OFF is filtered out, so a non-empty list means at least one child
+            # is running -> adopt HEAT; otherwise (all OFF or none) stay OFF.
             current_hvac_modes = [x.state for x in states if x.state != HVACMode.OFF]
-            # return the most common hvac mode (what the thermostat is set to do) except OFF
             if current_hvac_modes:
-                _temp_bt_hvac_mode = max(
-                    set(current_hvac_modes), key=current_hvac_modes.count
-                )
-                if _temp_bt_hvac_mode != HVACMode.OFF:
-                    self.bt_hvac_mode = HVACMode.HEAT
-                else:
-                    self.bt_hvac_mode = HVACMode.OFF
-                _LOGGER.debug(
-                    "better_thermostat %s: No previously hvac mode found on startup, turn bt to trv mode %s",
-                    self.device_name,
-                    self.bt_hvac_mode,
-                )
-            # return off if all are off
-            elif all(x.state == HVACMode.OFF for x in states):
-                self.bt_hvac_mode = HVACMode.OFF
-                _LOGGER.debug(
-                    "better_thermostat %s: No previously hvac mode found on startup, turn bt to trv mode %s",
-                    self.device_name,
-                    self.bt_hvac_mode,
-                )
+                self.bt_hvac_mode = HVACMode.HEAT
             else:
-                _LOGGER.warning(
-                    "better_thermostat %s: No previously hvac mode found on startup, turn heat off",
-                    self.device_name,
-                )
                 self.bt_hvac_mode = HVACMode.OFF
+            _LOGGER.debug(
+                "better_thermostat %s: No previously hvac mode found on startup, turn bt to trv mode %s",
+                self.device_name,
+                self.bt_hvac_mode,
+            )
 
         _LOGGER.debug(
             "better_thermostat %s: Startup config, BT hvac mode is %s, Target temp %s",

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -793,8 +793,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             # Fallback (sollte i.d.R. nicht benötigt werden)
             if not trv_ids and hasattr(self, "entity_ids"):
                 trv_ids = list(self.entity_ids or [])
-            if not trv_ids and hasattr(self, "heater_entity_id"):
-                trv_ids = [self.heater_entity_id]
             if not trv_ids:
                 _LOGGER.debug(
                     "better_thermostat %s: external_temperature keepalive: no TRVs found",
@@ -1963,7 +1961,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         # Skip when device is OFF or window open
         if self.window_open:
-            # postpone by 6 hours to avoid hammering
+            # postpone by an hour to avoid hammering
             self.next_valve_maintenance = now + timedelta(hours=1)
             _LOGGER.debug(
                 "better_thermostat %s: valve maintenance postponed (window open)",

--- a/custom_components/better_thermostat/events/temperature.py
+++ b/custom_components/better_thermostat/events/temperature.py
@@ -128,8 +128,6 @@ async def _apply_temperature_update(self, new_temp):
         trv_ids = list(self.real_trvs.keys())
         if not trv_ids and hasattr(self, "entity_ids"):
             trv_ids = list(self.entity_ids or [])
-        if not trv_ids and hasattr(self, "heater_entity_id"):
-            trv_ids = [self.heater_entity_id]
         for trv_id in trv_ids:
             quirks = (
                 self.real_trvs.get(trv_id, {}).get("model_quirks")
@@ -336,8 +334,6 @@ async def trigger_temperature_change(self, event):
                                 trv_ids = list(self.real_trvs.keys())
                                 if not trv_ids and hasattr(self, "entity_ids"):
                                     trv_ids = list(self.entity_ids or [])
-                                if not trv_ids and hasattr(self, "heater_entity_id"):
-                                    trv_ids = [self.heater_entity_id]
                                 for trv_id in trv_ids:
                                     quirks = (
                                         self.real_trvs.get(trv_id, {}).get(


### PR DESCRIPTION
Three small correctness cleanups found while reviewing the maintenance / startup
code for test coverage. No functional change — every removed branch is
unreachable, and the comment fix is documentation only.

### 1. Unreachable keepalive fallback
`_external_temperature_keepalive` had a fallback guarded by
`hasattr(self, "heater_entity_id")`. That attribute is never set — the
constructor stores the configured heater under `self.all_trvs` — so the branch
was dead. The `real_trvs` and `entity_ids` lookups already cover it.

### 2. Unreachable branches in `_validate_hvac_mode`
`current_hvac_modes` is built by filtering OUT `OFF`, so its most-common value is
never `OFF` — the inner `else -> OFF` branch could not run. And when
`current_hvac_modes` is empty, every child reports `OFF` (or there are none), so
`elif all(... == OFF)` is always true, leaving the trailing `else` (warn + OFF)
unreachable too. Collapsed to: non-empty list -> `HEAT`, otherwise -> `OFF`,
which is identical for every reachable input.

### 3. Stale comment
The valve-maintenance tick postpones by one hour on an open window; the comment
said "6 hours". Corrected to match the code (and the HVAC-OFF branch below it).