### PR TITLE
test: expand climate.py unit-test coverage

### DIFF
--- a/tests/unit/test_climate_build_snapshots.py
+++ b/tests/unit/test_climate_build_snapshots.py
@@ -1,0 +1,93 @@
+"""Branch coverage for BetterThermostat._build_trv_snapshots.
+
+Resolves each TRV's hvac_action from the cached info dict, falling back to the
+live hass state ("hvac_action" or legacy "action" attribute) and caching the
+result.  Non-dict entries are skipped.
+"""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.climate.const import HVACAction
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+
+
+@pytest.fixture
+def bt():
+    """Minimal BetterThermostat mock for snapshot building."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.real_trvs = {}
+    mock.hass = MagicMock()
+    mock.hass.states.get.return_value = None
+    return mock
+
+
+def _snaps(bt):
+    return BetterThermostat._build_trv_snapshots(bt)
+
+
+def test_non_dict_entry_skipped(bt):
+    """A non-dict real_trvs entry is ignored."""
+    bt.real_trvs = {"climate.trv": "not-a-dict"}
+    assert _snaps(bt) == []
+
+
+def test_cached_action_used(bt):
+    """A cached hvac_action is used directly (lowercased)."""
+    bt.real_trvs = {"climate.trv": {"hvac_action": "HEATING"}}
+    snaps = _snaps(bt)
+    assert len(snaps) == 1
+    assert snaps[0].hvac_action == "heating"
+
+
+def test_fallback_to_hass_hvac_action_and_caches(bt):
+    """Without a cached value, the live hvac_action is read and cached."""
+    info = {}
+    bt.real_trvs = {"climate.trv": info}
+    bt.hass.states.get.return_value = State(
+        "climate.trv", "heat", attributes={"hvac_action": "idle"}
+    )
+    snaps = _snaps(bt)
+    assert snaps[0].hvac_action == "idle"
+    assert info["hvac_action"] == "idle"  # cached back
+
+
+def test_fallback_to_legacy_action_attribute(bt):
+    """The legacy 'action' attribute is used when 'hvac_action' is absent."""
+    bt.real_trvs = {"climate.trv": {}}
+    bt.hass.states.get.return_value = State(
+        "climate.trv", "heat", attributes={"action": "heating"}
+    )
+    assert _snaps(bt)[0].hvac_action == "heating"
+
+
+def test_no_state_yields_none_action(bt):
+    """No cached value and no live state -> hvac_action None."""
+    bt.real_trvs = {"climate.trv": {}}
+    bt.hass.states.get.return_value = None
+    assert _snaps(bt)[0].hvac_action is None
+
+
+def test_heating_enum_normalized(bt):
+    """A cached HVACAction.HEATING enum resolves to the 'heating' string."""
+    bt.real_trvs = {"climate.trv": {"hvac_action": HVACAction.HEATING}}
+    assert _snaps(bt)[0].hvac_action == "heating"
+
+
+def test_snapshot_carries_valve_fields(bt):
+    """Valve fields pass through to the snapshot."""
+    bt.real_trvs = {
+        "climate.trv": {
+            "hvac_action": "idle",
+            "ignore_trv_states": True,
+            "valve_position": 42,
+            "last_valve_percent": 17,
+        }
+    }
+    snap = _snaps(bt)[0]
+    assert snap.ignore_trv_states is True
+    assert snap.valve_position == 42
+    assert snap.last_valve_percent == 17

--- a/tests/unit/test_climate_ema_periodic.py
+++ b/tests/unit/test_climate_ema_periodic.py
@@ -1,0 +1,110 @@
+"""Branch coverage for BetterThermostat._async_update_ema_periodic.
+
+The periodic EMA tick keeps the external-temperature filter converging when the
+sensor is silent, and derives a temperature slope from the EMA change.  These
+tests pin the skip conditions and the slope math.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+
+_CLIMATE = "custom_components.better_thermostat.climate"
+_EMA = (
+    "custom_components.better_thermostat.events.temperature._update_external_temp_ema"
+)
+
+
+@pytest.fixture
+def bt():
+    """Minimal BetterThermostat mock for the periodic EMA tick."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.startup_running = False
+    mock.last_known_external_temp = 20.0
+    mock.external_temp_ema = None
+    mock._slope_periodic_last_ts = None
+    mock.temp_slope = None
+    mock.async_write_ha_state = MagicMock()
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_skips_while_startup_running(bt):
+    """During startup the tick is a no-op (no EMA update, no state write)."""
+    bt.startup_running = True
+    with patch(_EMA) as ema:
+        await BetterThermostat._async_update_ema_periodic(bt)
+    ema.assert_not_called()
+    bt.async_write_ha_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skips_without_last_known_temp(bt):
+    """Without a last known external temperature, nothing is updated."""
+    bt.last_known_external_temp = None
+    with patch(_EMA) as ema:
+        await BetterThermostat._async_update_ema_periodic(bt)
+    ema.assert_not_called()
+    bt.async_write_ha_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_updates_ema_and_writes_state_without_slope(bt):
+    """First run (no previous EMA) updates the filter and writes state, no slope."""
+    bt.external_temp_ema = None
+    bt._slope_periodic_last_ts = None
+    with (
+        patch(_EMA, MagicMock(return_value=20.5)),
+        patch(f"{_CLIMATE}.monotonic", return_value=1000.0),
+    ):
+        await BetterThermostat._async_update_ema_periodic(bt)
+    assert bt.temp_slope is None
+    assert bt._slope_periodic_last_ts == 1000.0
+    bt.async_write_ha_state.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_computes_slope_from_ema_change(bt):
+    """With a previous EMA and timestamp, the slope is (Δema / Δt_min)."""
+    bt.external_temp_ema = 20.0
+    bt._slope_periodic_last_ts = 1000.0  # 600 s before "now"
+    with (
+        patch(_EMA, MagicMock(return_value=21.0)),
+        patch(f"{_CLIMATE}.monotonic", return_value=1600.0),
+    ):
+        await BetterThermostat._async_update_ema_periodic(bt)
+    # Δt = 600 s = 10 min, Δema = 1.0 K  ->  slope = 0.1 K/min
+    assert bt.temp_slope == pytest.approx(0.1)
+    assert bt._slope_periodic_last_ts == 1600.0
+
+
+@pytest.mark.asyncio
+async def test_tiny_interval_skips_slope(bt):
+    """A sub-0.1-minute interval does not produce a slope (avoids noise/div issues)."""
+    bt.external_temp_ema = 20.0
+    bt._slope_periodic_last_ts = 1599.0  # 1 s before "now"
+    with (
+        patch(_EMA, MagicMock(return_value=21.0)),
+        patch(f"{_CLIMATE}.monotonic", return_value=1600.0),
+    ):
+        await BetterThermostat._async_update_ema_periodic(bt)
+    assert bt.temp_slope is None
+    assert bt._slope_periodic_last_ts == 1600.0
+
+
+@pytest.mark.asyncio
+async def test_ema_error_is_caught(bt):
+    """An error from the EMA update is swallowed (tick must not crash)."""
+    bt.external_temp_ema = 20.0
+    bt._slope_periodic_last_ts = 1000.0
+    with (
+        patch(_EMA, MagicMock(side_effect=RuntimeError("boom"))),
+        patch(f"{_CLIMATE}.monotonic", return_value=1600.0),
+    ):
+        await BetterThermostat._async_update_ema_periodic(bt)
+    # No slope written, no crash
+    assert bt.temp_slope is None
+    bt.async_write_ha_state.assert_not_called()

--- a/tests/unit/test_climate_hvac_mode_property.py
+++ b/tests/unit/test_climate_hvac_mode_property.py
@@ -1,0 +1,75 @@
+"""Branch coverage for the BetterThermostat.hvac_mode property.
+
+The property maps the internal bt_hvac_mode onto a mode HA accepts, coercing
+strings to HVACMode and falling back to the cooler-mapped mode or OFF when the
+result is not in the entity's available list.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.climate.const import HVACMode
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+
+_CLIMATE = "custom_components.better_thermostat.climate"
+_FULL_LIST = [HVACMode.HEAT, HVACMode.HEAT_COOL, HVACMode.OFF]
+
+
+@pytest.fixture
+def bt():
+    """Minimal BetterThermostat mock for the hvac_mode property."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.bt_hvac_mode = HVACMode.HEAT
+    mock._hvac_list = list(_FULL_LIST)
+    mock.map_on_hvac_mode = HVACMode.HEAT_COOL
+    return mock
+
+
+def _hvac_mode(bt):
+    return BetterThermostat.hvac_mode.fget(bt)
+
+
+def test_none_maps_to_off(bt):
+    """A missing internal mode reads as OFF."""
+    bt.bt_hvac_mode = None
+    assert _hvac_mode(bt) == HVACMode.OFF
+
+
+def test_enum_in_list_passthrough(bt):
+    """An HVACMode already in the available list is returned unchanged."""
+    with patch(f"{_CLIMATE}.get_hvac_bt_mode", return_value=HVACMode.HEAT):
+        assert _hvac_mode(bt) == HVACMode.HEAT
+
+
+def test_lowercase_string_coerced(bt):
+    """A lowercase string is coerced via HVACMode(value)."""
+    with patch(f"{_CLIMATE}.get_hvac_bt_mode", return_value="heat"):
+        assert _hvac_mode(bt) == HVACMode.HEAT
+
+
+def test_name_string_coerced_via_upper(bt):
+    """An enum-name string falls back to HVACMode[name.upper()]."""
+    with patch(f"{_CLIMATE}.get_hvac_bt_mode", return_value="HEAT"):
+        assert _hvac_mode(bt) == HVACMode.HEAT
+
+
+def test_garbage_string_maps_to_off(bt):
+    """An unrecognized string degrades to OFF."""
+    with patch(f"{_CLIMATE}.get_hvac_bt_mode", return_value="nonsense"):
+        assert _hvac_mode(bt) == HVACMode.OFF
+
+
+def test_heat_not_in_list_maps_to_cooler_mode(bt):
+    """When HEAT is unavailable, it maps to the cooler-mapped mode."""
+    bt._hvac_list = [HVACMode.HEAT_COOL, HVACMode.OFF]
+    with patch(f"{_CLIMATE}.get_hvac_bt_mode", return_value=HVACMode.HEAT):
+        assert _hvac_mode(bt) == HVACMode.HEAT_COOL
+
+
+def test_unavailable_non_heat_maps_to_off(bt):
+    """A result that is unavailable and not HEAT degrades to OFF."""
+    bt._hvac_list = [HVACMode.HEAT, HVACMode.OFF]
+    with patch(f"{_CLIMATE}.get_hvac_bt_mode", return_value=HVACMode.HEAT_COOL):
+        assert _hvac_mode(bt) == HVACMode.OFF

--- a/tests/unit/test_climate_maintenance.py
+++ b/tests/unit/test_climate_maintenance.py
@@ -1,0 +1,146 @@
+"""Branch coverage for BetterThermostat._maintenance_tick.
+
+_maintenance_tick decides, on each periodic tick, whether to run valve
+maintenance now, postpone it, or schedule it far out.  These tests pin every
+decision branch so the scheduling contract is locked down.
+"""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.climate.const import HVACMode
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+
+_CLIMATE = "custom_components.better_thermostat.climate"
+_NOW = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def bt():
+    """Minimal BetterThermostat mock for maintenance scheduling."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.in_maintenance = False
+    mock.next_valve_maintenance = None
+    mock.window_open = False
+    mock.hvac_mode = HVACMode.HEAT
+    mock.bt_hvac_mode = HVACMode.HEAT
+    mock.real_trvs = {"climate.trv": {}}
+    mock.hass = MagicMock()
+    mock.hass.async_create_background_task = MagicMock()
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_critical_entities_unavailable_returns_early(bt):
+    """When critical entities are unavailable, nothing is scheduled or dispatched."""
+    with (
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=False)),
+        patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
+    ):
+        await BetterThermostat._maintenance_tick(bt)
+    assert bt.next_valve_maintenance is None
+    bt.hass.async_create_background_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_availability_check_exception_returns(bt):
+    """An exception during the availability check aborts the tick safely."""
+    with patch(
+        f"{_CLIMATE}.check_critical_entities",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        await BetterThermostat._maintenance_tick(bt)
+    bt.hass.async_create_background_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_already_in_maintenance_returns(bt):
+    """A tick during an in-flight maintenance run does nothing."""
+    bt.in_maintenance = True
+    with (
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
+        patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
+        patch(f"{_CLIMATE}.dt_util") as dt,
+    ):
+        dt.now.return_value = _NOW
+        await BetterThermostat._maintenance_tick(bt)
+    bt.hass.async_create_background_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_not_due_yet_returns(bt):
+    """When the next run is still in the future, the tick is a no-op."""
+    bt.next_valve_maintenance = _NOW + timedelta(hours=2)
+    with (
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
+        patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
+        patch(f"{_CLIMATE}.dt_util") as dt,
+    ):
+        dt.now.return_value = _NOW
+        await BetterThermostat._maintenance_tick(bt)
+    bt.hass.async_create_background_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_window_open_postpones_one_hour(bt):
+    """An open window postpones maintenance by one hour."""
+    bt.window_open = True
+    with (
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
+        patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
+        patch(f"{_CLIMATE}.dt_util") as dt,
+    ):
+        dt.now.return_value = _NOW
+        await BetterThermostat._maintenance_tick(bt)
+    assert bt.next_valve_maintenance == _NOW + timedelta(hours=1)
+    bt.hass.async_create_background_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hvac_off_postpones_one_hour(bt):
+    """HVAC OFF (on either mode) postpones maintenance by one hour."""
+    bt.bt_hvac_mode = HVACMode.OFF
+    with (
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
+        patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
+        patch(f"{_CLIMATE}.dt_util") as dt,
+    ):
+        dt.now.return_value = _NOW
+        await BetterThermostat._maintenance_tick(bt)
+    assert bt.next_valve_maintenance == _NOW + timedelta(hours=1)
+    bt.hass.async_create_background_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_no_enabled_trvs_schedules_far_future(bt):
+    """With no TRV enabled for maintenance, the next run is pushed out a week."""
+    with (
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
+        patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
+        patch(f"{_CLIMATE}.collect_maintenance_trvs", MagicMock(return_value=[])),
+        patch(f"{_CLIMATE}.dt_util") as dt,
+    ):
+        dt.now.return_value = _NOW
+        await BetterThermostat._maintenance_tick(bt)
+    assert bt.next_valve_maintenance == _NOW + timedelta(days=7)
+    bt.hass.async_create_background_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_due_and_enabled_dispatches_maintenance(bt):
+    """When due, heating, window closed and TRVs enabled, maintenance is dispatched."""
+    with (
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
+        patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
+        patch(
+            f"{_CLIMATE}.collect_maintenance_trvs",
+            MagicMock(return_value=["climate.trv"]),
+        ),
+        patch(f"{_CLIMATE}.dt_util") as dt,
+    ):
+        dt.now.return_value = _NOW
+        await BetterThermostat._maintenance_tick(bt)
+    bt.hass.async_create_background_task.assert_called_once()

--- a/tests/unit/test_climate_properties.py
+++ b/tests/unit/test_climate_properties.py
@@ -1,0 +1,123 @@
+"""Branch coverage for BetterThermostat temperature/feature properties.
+
+Covers the clamping in target_temperature, the cooler-gated low/high targets,
+the configured min/max bounds, and the cooler-dependent supported_features.
+"""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.climate.const import ClimateEntityFeature
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+
+
+@pytest.fixture
+def bt():
+    """Minimal BetterThermostat mock for property access."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.bt_target_temp = 21.0
+    mock.bt_target_cooltemp = 25.0
+    mock.bt_min_temp = 5.0
+    mock.bt_max_temp = 30.0
+    mock.cooler_entity_id = None
+    return mock
+
+
+def _prop(name, bt):
+    return getattr(BetterThermostat, name).fget(bt)
+
+
+# --- target_temperature (clamping) -----------------------------------------
+
+
+def test_target_temperature_none(bt):
+    """No internal target -> None."""
+    bt.bt_target_temp = None
+    assert _prop("target_temperature", bt) is None
+
+
+def test_target_temperature_without_bounds(bt):
+    """Without bounds the raw target is returned."""
+    bt.bt_min_temp = None
+    bt.bt_max_temp = None
+    bt.bt_target_temp = 99.0
+    assert _prop("target_temperature", bt) == 99.0
+
+
+def test_target_temperature_clamped_below_min(bt):
+    """A target below min reads as min."""
+    bt.bt_target_temp = 2.0
+    assert _prop("target_temperature", bt) == 5.0
+
+
+def test_target_temperature_clamped_above_max(bt):
+    """A target above max reads as max."""
+    bt.bt_target_temp = 99.0
+    assert _prop("target_temperature", bt) == 30.0
+
+
+def test_target_temperature_in_range(bt):
+    """An in-range target is returned unchanged."""
+    bt.bt_target_temp = 21.0
+    assert _prop("target_temperature", bt) == 21.0
+
+
+# --- target_temperature_low / _high (cooler gated) -------------------------
+
+
+def test_target_low_none_without_cooler(bt):
+    """Without a cooler the low target is None."""
+    bt.cooler_entity_id = None
+    assert _prop("target_temperature_low", bt) is None
+
+
+def test_target_low_is_heat_target_with_cooler(bt):
+    """With a cooler the low target is the heat target."""
+    bt.cooler_entity_id = "climate.cooler"
+    assert _prop("target_temperature_low", bt) == 21.0
+
+
+def test_target_high_none_without_cooler(bt):
+    """Without a cooler the high target is None."""
+    bt.cooler_entity_id = None
+    assert _prop("target_temperature_high", bt) is None
+
+
+def test_target_high_is_cool_target_with_cooler(bt):
+    """With a cooler the high target is the cool target."""
+    bt.cooler_entity_id = "climate.cooler"
+    assert _prop("target_temperature_high", bt) == 25.0
+
+
+# --- min_temp / max_temp (configured bounds) -------------------------------
+
+
+def test_min_temp_uses_configured(bt):
+    """A configured min is returned directly."""
+    assert _prop("min_temp", bt) == 5.0
+
+
+def test_max_temp_uses_configured(bt):
+    """A configured max is returned directly."""
+    assert _prop("max_temp", bt) == 30.0
+
+
+# --- supported_features (cooler dependent) ---------------------------------
+
+
+def test_features_target_temperature_without_cooler(bt):
+    """Without a cooler the single-setpoint feature is advertised."""
+    bt.cooler_entity_id = None
+    feats = _prop("supported_features", bt)
+    assert feats & ClimateEntityFeature.TARGET_TEMPERATURE
+    assert not (feats & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE)
+
+
+def test_features_target_range_with_cooler(bt):
+    """With a cooler the range feature is advertised instead."""
+    bt.cooler_entity_id = "climate.cooler"
+    feats = _prop("supported_features", bt)
+    assert feats & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+    assert not (feats & ClimateEntityFeature.TARGET_TEMPERATURE)

--- a/tests/unit/test_climate_reset_pid.py
+++ b/tests/unit/test_climate_reset_pid.py
@@ -1,0 +1,147 @@
+"""Branch coverage for BetterThermostat.reset_pid_learnings_service.
+
+The service clears cached PID state for the entity and can optionally seed PID
+defaults into the current target bucket and its ±0.5 °C neighbours.  These tests
+pin the reset count, the bucket key construction, and the seed conditions.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+from custom_components.better_thermostat.utils.calibration.pid import PIDParams
+
+_CLIMATE = "custom_components.better_thermostat.climate"
+_PID = "custom_components.better_thermostat.utils.calibration.pid"
+
+
+@pytest.fixture
+def bt():
+    """Minimal BetterThermostat mock for the reset-PID service."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock._unique_id = "uid"
+    mock.unique_id = "uid"
+    mock.bt_target_temp = 21.0
+    mock.real_trvs = {"climate.trv": {}}
+    mock.schedule_save_state = MagicMock()
+    mock.control_queue_task = AsyncMock()
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_resets_each_cached_key(bt):
+    """Every exported PID key for this entity is reset and persistence scheduled."""
+    keys = {"uid:climate.trv:t21.0": {}, "uid:climate.trv:t20.0": {}}
+    with (
+        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value=keys)),
+        patch(f"{_CLIMATE}.pid_reset_state") as reset,
+    ):
+        await BetterThermostat.reset_pid_learnings_service(bt)
+    assert reset.call_count == 2
+    bt.schedule_save_state.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_no_keys_still_schedules_save(bt):
+    """With nothing cached, no reset happens but a save is still scheduled."""
+    with (
+        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
+        patch(f"{_CLIMATE}.pid_reset_state") as reset,
+    ):
+        await BetterThermostat.reset_pid_learnings_service(bt)
+    reset.assert_not_called()
+    bt.schedule_save_state.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_no_defaults_does_not_seed(bt):
+    """Without apply_pid_defaults, no gains are seeded."""
+    with (
+        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
+        patch(f"{_CLIMATE}.pid_reset_state"),
+        patch(f"{_PID}.seed_pid_gains") as seed,
+    ):
+        await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=False)
+    seed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_seeds_current_and_neighbour_buckets(bt):
+    """Defaults seed the current bucket and its ±0.5 °C neighbours per TRV."""
+    with (
+        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
+        patch(f"{_CLIMATE}.pid_reset_state"),
+        patch(f"{_PID}.seed_pid_gains", MagicMock(return_value=True)) as seed,
+    ):
+        await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=True)
+    seeded_keys = {call.args[0] for call in seed.call_args_list}
+    assert seeded_keys == {
+        "uid:climate.trv:t21.0",
+        "uid:climate.trv:t21.5",
+        "uid:climate.trv:t20.5",
+    }
+    # Seeding happened -> control loop is kicked
+    bt.control_queue_task.put.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_defaults_use_pidparams_values(bt):
+    """Without overrides, the PIDParams defaults are seeded."""
+    defaults = PIDParams()
+    with (
+        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
+        patch(f"{_CLIMATE}.pid_reset_state"),
+        patch(f"{_PID}.seed_pid_gains", MagicMock(return_value=True)) as seed,
+    ):
+        await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=True)
+    kwargs = seed.call_args_list[0].kwargs
+    assert kwargs == {"kp": defaults.kp, "ki": defaults.ki, "kd": defaults.kd}
+
+
+@pytest.mark.asyncio
+async def test_overrides_are_passed_through(bt):
+    """Explicit kp/ki/kd overrides are forwarded to seeding."""
+    with (
+        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
+        patch(f"{_CLIMATE}.pid_reset_state"),
+        patch(f"{_PID}.seed_pid_gains", MagicMock(return_value=True)) as seed,
+    ):
+        await BetterThermostat.reset_pid_learnings_service(
+            bt,
+            apply_pid_defaults=True,
+            defaults_kp=1.5,
+            defaults_ki=0.2,
+            defaults_kd=0.05,
+        )
+    kwargs = seed.call_args_list[0].kwargs
+    assert kwargs == {"kp": 1.5, "ki": 0.2, "kd": 0.05}
+
+
+@pytest.mark.asyncio
+async def test_no_trvs_seeds_nothing(bt):
+    """With no TRVs, nothing is seeded and the control loop is not kicked."""
+    bt.real_trvs = {}
+    with (
+        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
+        patch(f"{_CLIMATE}.pid_reset_state"),
+        patch(f"{_PID}.seed_pid_gains", MagicMock(return_value=True)) as seed,
+    ):
+        await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=True)
+    seed.assert_not_called()
+    bt.control_queue_task.put.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_numeric_target_seeds_nothing(bt):
+    """A non-numeric target yields no buckets, so nothing is seeded."""
+    bt.bt_target_temp = None
+    with (
+        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
+        patch(f"{_CLIMATE}.pid_reset_state"),
+        patch(f"{_PID}.seed_pid_gains", MagicMock(return_value=True)) as seed,
+    ):
+        await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=True)
+    seed.assert_not_called()
+    bt.control_queue_task.put.assert_not_awaited()

--- a/tests/unit/test_climate_run_maintenance.py
+++ b/tests/unit/test_climate_run_maintenance.py
@@ -1,0 +1,91 @@
+"""Coverage for BetterThermostat._run_valve_maintenance.
+
+Focus is the state-flag contract around the valve exercise: in_maintenance and
+ignore_states MUST always be released (even on error), otherwise the control
+loop can stall.  Also covers the re-entry guard, reschedule, and control kick.
+"""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.climate.const import HVACMode
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+
+_CLIMATE = "custom_components.better_thermostat.climate"
+_NEXT = datetime(2026, 1, 8, 12, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def bt():
+    """Minimal BetterThermostat mock for the valve-maintenance run."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.in_maintenance = False
+    mock.ignore_states = False
+    mock.real_trvs = {"climate.trv": {}}
+    mock.bt_hvac_mode = HVACMode.HEAT
+    mock.hass = MagicMock()
+    mock.control_queue_task = MagicMock()
+    return mock
+
+
+def _snapshots():
+    """build_trv_snapshots stand-in: one serviced TRV."""
+    return MagicMock(return_value=[SimpleNamespace(entity_id="climate.trv")])
+
+
+@pytest.mark.asyncio
+async def test_reentry_guard(bt):
+    """A run while already in maintenance returns without doing work."""
+    bt.in_maintenance = True
+    with patch(f"{_CLIMATE}.build_trv_snapshots") as snap:
+        await BetterThermostat._run_valve_maintenance(bt, ["climate.trv"])
+    snap.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_happy_path_resets_flags_and_reschedules(bt):
+    """A successful run releases the flags, reschedules, and kicks control."""
+    with (
+        patch(f"{_CLIMATE}.build_trv_snapshots", _snapshots()),
+        patch(f"{_CLIMATE}.run_valve_maintenance", AsyncMock()),
+        patch(f"{_CLIMATE}.compute_next_maintenance", MagicMock(return_value=_NEXT)),
+    ):
+        await BetterThermostat._run_valve_maintenance(bt, ["climate.trv"])
+    assert bt.in_maintenance is False
+    assert bt.ignore_states is False
+    assert bt.next_valve_maintenance == _NEXT
+    bt.control_queue_task.put_nowait.assert_called_once_with(bt)
+
+
+@pytest.mark.asyncio
+async def test_flags_released_even_on_error(bt):
+    """If the exercise raises, in_maintenance and ignore_states are still cleared."""
+    with (
+        patch(f"{_CLIMATE}.build_trv_snapshots", _snapshots()),
+        patch(
+            f"{_CLIMATE}.run_valve_maintenance",
+            AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        patch(f"{_CLIMATE}.compute_next_maintenance", MagicMock(return_value=_NEXT)),
+    ):
+        with pytest.raises(RuntimeError):
+            await BetterThermostat._run_valve_maintenance(bt, ["climate.trv"])
+    assert bt.in_maintenance is False
+    assert bt.ignore_states is False
+
+
+@pytest.mark.asyncio
+async def test_no_control_kick_when_off(bt):
+    """In OFF mode no control cycle is queued after maintenance."""
+    bt.bt_hvac_mode = HVACMode.OFF
+    with (
+        patch(f"{_CLIMATE}.build_trv_snapshots", _snapshots()),
+        patch(f"{_CLIMATE}.run_valve_maintenance", AsyncMock()),
+        patch(f"{_CLIMATE}.compute_next_maintenance", MagicMock(return_value=_NEXT)),
+    ):
+        await BetterThermostat._run_valve_maintenance(bt, ["climate.trv"])
+    bt.control_queue_task.put_nowait.assert_not_called()

--- a/tests/unit/test_climate_set_hvac_mode.py
+++ b/tests/unit/test_climate_set_hvac_mode.py
@@ -1,0 +1,63 @@
+"""Branch coverage for BetterThermostat.async_set_hvac_mode.
+
+Pins the supported-mode handling, the rejection of unsupported modes, and the
+maintenance defer that must not enqueue a control action mid-exercise.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.climate.const import HVACMode
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+
+_CLIMATE = "custom_components.better_thermostat.climate"
+
+
+@pytest.fixture
+def bt():
+    """Minimal BetterThermostat mock for setting the HVAC mode."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.bt_hvac_mode = HVACMode.HEAT
+    mock.in_maintenance = False
+    mock._control_needed_after_maintenance = False
+    mock.async_write_ha_state = MagicMock()
+    mock.control_queue_task = AsyncMock()
+    return mock
+
+
+def _identity_mode():
+    """get_hvac_bt_mode stand-in: return the requested mode unchanged."""
+    return MagicMock(side_effect=lambda _self, mode: mode)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", [HVACMode.HEAT, HVACMode.HEAT_COOL, HVACMode.OFF])
+async def test_supported_mode_is_applied_and_queued(bt, mode):
+    """A supported mode is stored, state is written, and control is queued."""
+    with patch(f"{_CLIMATE}.get_hvac_bt_mode", _identity_mode()):
+        await BetterThermostat.async_set_hvac_mode(bt, mode)
+    assert bt.bt_hvac_mode == mode
+    bt.async_write_ha_state.assert_called_once()
+    bt.control_queue_task.put.assert_awaited_once_with(bt)
+
+
+@pytest.mark.asyncio
+async def test_unsupported_mode_is_rejected(bt):
+    """An unsupported mode leaves bt_hvac_mode untouched but still queues control."""
+    with patch(f"{_CLIMATE}.get_hvac_bt_mode", _identity_mode()) as mapper:
+        await BetterThermostat.async_set_hvac_mode(bt, HVACMode.COOL)
+    assert bt.bt_hvac_mode == HVACMode.HEAT  # unchanged
+    mapper.assert_not_called()
+    bt.control_queue_task.put.assert_awaited_once_with(bt)
+
+
+@pytest.mark.asyncio
+async def test_maintenance_defers_control(bt):
+    """During maintenance the control queue is not touched; a flag is set instead."""
+    bt.in_maintenance = True
+    with patch(f"{_CLIMATE}.get_hvac_bt_mode", _identity_mode()):
+        await BetterThermostat.async_set_hvac_mode(bt, HVACMode.HEAT)
+    assert bt._control_needed_after_maintenance is True
+    bt.control_queue_task.put.assert_not_awaited()

--- a/tests/unit/test_climate_temp_range.py
+++ b/tests/unit/test_climate_temp_range.py
@@ -1,0 +1,99 @@
+"""Branch coverage for BetterThermostat._resolve_temperature_range.
+
+Derives the working min/max/step from the child TRV states: the most
+restrictive bounds across TRVs, Fahrenheit conversion (with step treated as a
+delta), the non-overlapping-range warning, and the step-already-set guard.
+"""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.climate.const import (
+    ATTR_MAX_TEMP,
+    ATTR_MIN_TEMP,
+    ATTR_TARGET_TEMP_STEP,
+)
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+
+
+@pytest.fixture
+def bt():
+    """Minimal BetterThermostat mock for range resolution."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.bt_min_temp = None
+    mock.bt_max_temp = None
+    mock.bt_target_temp_step = None
+    return mock
+
+
+def _trv(min_t=None, max_t=None, step=None, unit=None, eid="climate.trv"):
+    attrs: dict = {}
+    if min_t is not None:
+        attrs[ATTR_MIN_TEMP] = min_t
+    if max_t is not None:
+        attrs[ATTR_MAX_TEMP] = max_t
+    if step is not None:
+        attrs[ATTR_TARGET_TEMP_STEP] = step
+    if unit is not None:
+        attrs["temperature_unit"] = unit
+    return State(eid, "heat", attributes=attrs)
+
+
+def test_intersection_of_bounds_across_trvs(bt):
+    """Min is the highest child min, max the lowest child max (intersection)."""
+    states = [
+        _trv(min_t=5.0, max_t=28.0, eid="climate.a"),
+        _trv(min_t=7.0, max_t=30.0, eid="climate.b"),
+    ]
+    BetterThermostat._resolve_temperature_range(bt, states)
+    assert bt.bt_min_temp == 7.0
+    assert bt.bt_max_temp == 28.0
+
+
+def test_fahrenheit_bounds_and_step_converted(bt):
+    """Fahrenheit bounds convert to Celsius; the step converts as a delta."""
+    states = [_trv(min_t=41.0, max_t=86.0, step=1.0, unit=UnitOfTemperature.FAHRENHEIT)]
+    BetterThermostat._resolve_temperature_range(bt, states)
+    assert bt.bt_min_temp == pytest.approx(5.0)
+    assert bt.bt_max_temp == pytest.approx(30.0)
+    # 1 °F delta -> 1 * 5/9 °C
+    assert bt.bt_target_temp_step == pytest.approx(round(1.0 * 5.0 / 9.0, 4))
+
+
+def test_step_picks_coarsest(bt):
+    """When several steps are present the coarsest is chosen."""
+    states = [_trv(step=0.1, eid="climate.a"), _trv(step=0.5, eid="climate.b")]
+    BetterThermostat._resolve_temperature_range(bt, states)
+    assert bt.bt_target_temp_step == 0.5
+
+
+def test_existing_step_not_overwritten(bt):
+    """A pre-configured step is kept."""
+    bt.bt_target_temp_step = 0.25
+    states = [_trv(step=1.0)]
+    BetterThermostat._resolve_temperature_range(bt, states)
+    assert bt.bt_target_temp_step == 0.25
+
+
+def test_empty_states_yield_none(bt):
+    """No states leave the bounds and step unset."""
+    BetterThermostat._resolve_temperature_range(bt, [])
+    assert bt.bt_min_temp is None
+    assert bt.bt_max_temp is None
+    assert bt.bt_target_temp_step is None
+
+
+def test_non_overlapping_ranges_still_assigned(bt):
+    """Non-overlapping child ranges (min > max) are assigned and warned about."""
+    states = [
+        _trv(min_t=25.0, max_t=30.0, eid="climate.a"),  # heater
+        _trv(min_t=16.0, max_t=22.0, eid="climate.b"),  # cooler
+    ]
+    BetterThermostat._resolve_temperature_range(bt, states)
+    assert bt.bt_min_temp == 25.0  # max of mins
+    assert bt.bt_max_temp == 22.0  # min of maxes
+    assert bt.bt_min_temp > bt.bt_max_temp


### PR DESCRIPTION
Raises unit-test coverage of `climate.py` from ~36% to ~49%, focusing on the
logic-bearing methods (scheduling, math, parsing, state mapping) where
regressions are most likely. **Test-only — no production changes.**

### Covered
- **`_maintenance_tick`** — every scheduling branch (unavailable entities,
  availability-check error, in-flight run, not-yet-due, window open, HVAC off,
  no enabled TRVs, dispatch).
- **`_async_update_ema_periodic`** — startup/no-data skips, EMA update + state
  write, slope computation, sub-threshold interval, error handling.
- **`reset_pid_learnings_service`** — reset count, save scheduling, bucket-key
  construction (current ±0.5 neighbours), default vs override gains, no-TRV /
  non-numeric-target paths.
- **`_run_valve_maintenance`** — re-entry guard, flag release on success **and**
  error (`in_maintenance` / `ignore_states` must always clear), reschedule, and
  the HVAC-gated control kick.
- **`async_set_hvac_mode`** — supported modes applied + queued, unsupported mode
  rejected, maintenance defer.
- **`hvac_mode` property** — None→OFF, enum passthrough, string coercion,
  garbage→OFF, HEAT-unavailable→cooler mode, unavailable-non-HEAT→OFF.
- **Temperature / feature properties** — `target_temperature` clamping,
  cooler-gated low/high, configured min/max, cooler-dependent
  `supported_features`.
- **`_resolve_temperature_range`** — bound intersection across TRVs, Fahrenheit
  conversion with delta-step, coarsest-step selection, step-already-set guard,
  empty states, non-overlapping ranges.
- **`_build_trv_snapshots`** — cached action, live-state fallback (`hvac_action`
  and legacy `action`) with write-back, no-state result, non-dict skip.

64 tests across nine focused files. Full suite green.

The remaining uncovered lines are mostly startup/lifecycle orchestration
(`__init__`, `async_added_to_hass`, `_finalize_startup`, `_initialize_trvs`) —
heavy HA-mocking with low bug-yield — which is intentionally left out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for internal thermostat functionality, including snapshot building, EMA updates, HVAC mode handling, maintenance operations, temperature range resolution, and PID controller resets. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->