### PR TITLE
test: drop xfail for integer off_temperature (not a real case)

### DIFF
--- a/tests/unit/test_weather.py
+++ b/tests/unit/test_weather.py
@@ -704,18 +704,3 @@ class TestSuspectedBugs:
         bt.call_for_heat = True
         await check_weather(bt)
         assert bt.call_for_heat is True
-
-    @pytest.mark.xfail(
-        strict=True,
-        reason="check_weather_prediction rejects an integer off_temperature "
-        "via the isinstance(..., float) guard.",
-    )
-    async def test_integer_off_temperature_should_be_honoured(self):
-        """An integer off_temperature is honoured like a float."""
-        states = {WEATHER_ID: weather_state(temperature=2.0)}
-        hass = make_hass(states=states)
-        hass.services.async_call = AsyncMock(
-            return_value=forecast_resp(WEATHER_ID, [1.0, 1.0])
-        )
-        bt = make_bt(hass, weather_entity=WEATHER_ID, off_temperature=10)  # int!
-        assert await check_weather_prediction(bt) is True


### PR DESCRIPTION
## Why

Follow-up to closing #2017. The strict-xfail test `test_integer_off_temperature_should_be_honoured` (merged in #2015) documents a non-issue.

`self.off_temperature` is assigned only in the `BetterThermostat` constructor (climate.py:373-379), where the value is forced through `float()`:

```python
self.off_temperature = None
if off_temperature not in (None, "", "None"):
    try:
        parsed_off = float(off_temperature)
        if -100.0 < parsed_off < 150.0:
            self.off_temperature = parsed_off
```

So `off_temperature` is always `float` or `None` and can never reach `check_weather_prediction` / `check_ambient_air_temperature` as an `int`. The `isinstance(..., float)` guard is therefore correct, and the xfail test constructs `off_temperature=10` directly on a mock — a state the integration cannot produce.

## Change

Remove that one xfail test. The other xfail in `TestSuspectedBugs` (transient weather-service failure → heating disabled) is a real bug and is kept; it is fixed by #2016.

`uv run pytest tests/unit/test_weather.py -p no:homeassistant` → `48 passed, 1 xfailed`.
