### PR TITLE
refactor: parse bt_hvac_mode to HVACMode instead of storing raw strings

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -443,7 +443,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.bt_target_temp = 5.0
         self.bt_target_cooltemp = None
         self._support_flags = SUPPORT_FLAGS | ClimateEntityFeature.PRESET_MODE
-        self.bt_hvac_mode = None
+        self.bt_hvac_mode: HVACMode | None = None
         # Track min/max encountered target temps (initialize to default span)
         self.min_target_temp = 18.0
         self.max_target_temp = 21.0
@@ -1334,7 +1334,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 "better_thermostat %s: restoring other attributes...", self.device_name
             )
             if old_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
-                self.bt_hvac_mode = old_state.state
+                try:
+                    self.bt_hvac_mode = HVACMode(old_state.state)
+                except ValueError:
+                    _LOGGER.warning(
+                        "better_thermostat %s: restored an unrecognised hvac mode %s; "
+                        "leaving it for validation",
+                        self.device_name,
+                        old_state.state,
+                    )
             if old_state.attributes.get(ATTR_STATE_CALL_FOR_HEAT, None) is not None:
                 self.call_for_heat = bool(
                     old_state.attributes.get(ATTR_STATE_CALL_FOR_HEAT)
@@ -2442,7 +2450,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         hvac_mode_norm = normalize_hvac_mode(hvac_mode)
         if hvac_mode_norm in (HVACMode.HEAT, HVACMode.HEAT_COOL, HVACMode.OFF):
-            self.bt_hvac_mode = get_hvac_bt_mode(self, hvac_mode_norm)
+            self.bt_hvac_mode = HVACMode(get_hvac_bt_mode(self, hvac_mode_norm))
         else:
             _LOGGER.error(
                 "better_thermostat %s: Unsupported hvac_mode %s",

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -513,6 +513,34 @@ class TestRestoreState:
 
         assert bt.bt_target_temp == 22.0
 
+    @pytest.mark.asyncio
+    async def test_restored_mode_is_parsed_to_enum(self, bt):
+        """A valid restored state string becomes an HVACMode enum."""
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {ATTR_TEMPERATURE: 21.0}
+        bt.async_get_last_state = AsyncMock(return_value=old)
+        bt.bt_hvac_mode = None
+        bt.preset_mgr.temperatures = {}
+
+        await BetterThermostat._restore_state(bt, [_make_trv_state()])
+
+        assert bt.bt_hvac_mode is HVACMode.HEAT
+
+    @pytest.mark.asyncio
+    async def test_unrecognised_mode_left_unset(self, bt):
+        """An unrecognised restored state is not stored (stays None for validation)."""
+        old = MagicMock()
+        old.state = "not_a_mode"
+        old.attributes = {ATTR_TEMPERATURE: 21.0}
+        bt.async_get_last_state = AsyncMock(return_value=old)
+        bt.bt_hvac_mode = None
+        bt.preset_mgr.temperatures = {}
+
+        await BetterThermostat._restore_state(bt, [_make_trv_state()])
+
+        assert bt.bt_hvac_mode is None
+
 
 # ---------------------------------------------------------------------------
 # 6. _validate_hvac_mode


### PR DESCRIPTION
`bt_hvac_mode` could hold a raw string: `_restore_state` assigned the
`RestoreEntity` state string directly, and `get_hvac_bt_mode` returns `str`. That
left the attribute typed `str | HVACMode | None`, which the `compute_hvac_action`
call (expecting `HVACMode | None`) flagged.

### Changes
- `_restore_state` parses the restored state with `HVACMode(...)`; an
  unrecognised value is logged and left unset, so `_validate_hvac_mode` (which
  already runs next) resolves it instead of a junk string being stored.
- The `get_hvac_bt_mode` result is normalized to `HVACMode` at the assignment.
- `bt_hvac_mode` is annotated `HVACMode | None`.

### Behaviour
Restoring a valid mode (`heat`/`off`/`heat_cool`) is unchanged — `HVACMode("heat")`
is `HVACMode.HEAT`, equal to the previous string. Only an *unrecognised* restored
mode changes: it now stays `None` (and is fixed by validation) rather than being
stored verbatim.

### Tests
Added `_restore_state` cases for a valid mode parsing to the enum and an
unrecognised mode being left unset. Full suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Thermostat state restoration no longer crashes on unrecognized HVAC mode strings.
  * Improved HVAC mode value normalization and validation during state restoration.

* **Tests**
  * Added unit tests for HVAC mode restoration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->