### PR TITLE
refactor: tighten exception handling in the valve-maintenance path

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1877,6 +1877,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 return
             await check_and_update_degraded_mode(self)
         except Exception:
+            _LOGGER.debug(
+                "better_thermostat %s: maintenance availability check failed; "
+                "skipping this tick",
+                self.device_name,
+            )
             return
 
         # Skip if already running or not due
@@ -1886,7 +1891,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         try:
             if self.next_valve_maintenance and now < self.next_valve_maintenance:
                 return
-        except Exception:
+        except TypeError:
+            # next_valve_maintenance is not comparable to now; fall through and
+            # let this tick re-evaluate the schedule.
             pass
 
         # Skip when device is OFF or window open
@@ -1910,6 +1917,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         try:
             trvs_to_service = collect_maintenance_trvs(self.real_trvs)
         except Exception:
+            _LOGGER.debug(
+                "better_thermostat %s: could not collect maintenance TRVs",
+                self.device_name,
+            )
             trvs_to_service = []
 
         if not trvs_to_service:
@@ -1941,7 +1952,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             for trv_id in trvs:
                 try:
                     self.real_trvs[trv_id]["ignore_trv_states"] = True
-                except Exception:
+                except (KeyError, TypeError):
                     pass
 
             # Build snapshots (skips TRVs with state=None)
@@ -1955,7 +1966,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 if trv_id not in serviced_ids:
                     try:
                         self.real_trvs[trv_id]["ignore_trv_states"] = False
-                    except Exception:
+                    except (KeyError, TypeError):
                         pass
 
             # Bind adapter callbacks to self
@@ -1966,6 +1977,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     ok = await _delegate_set_valve(self, entity_id, int(pct))
                     return bool(ok)
                 except Exception:
+                    _LOGGER.debug(
+                        "better_thermostat %s: maintenance valve set failed for %s",
+                        self.device_name,
+                        entity_id,
+                    )
                     return False
 
             async def _set_temp(entity_id: str, temp: float) -> None:
@@ -1987,7 +2003,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             for trv_id in serviced_ids:
                 try:
                     self.real_trvs[trv_id]["ignore_trv_states"] = False
-                except Exception:
+                except (KeyError, TypeError):
                     pass
 
             # Schedule next run


### PR DESCRIPTION
The valve-maintenance tick and run used bare `except Exception: pass`, hiding any
failure. This makes the handling intentional without removing the safety nets.

### Narrowed (clear failure type)
- The `ignore_trv_states` guard writes (`real_trvs[trv_id][...] = ...`) now catch
  `(KeyError, TypeError)`.
- The not-yet-due check (`now < next_valve_maintenance`) catches `TypeError`.

### Kept broad, now visible
The catches around external/HA calls stay broad — an unexpected type there must
not crash a background maintenance run — but log at `debug` instead of silently
passing: the availability check, the maintenance-TRV collection, and the adapter
valve set.

No functional change; every safety net remains.

> Scoped to `_maintenance_tick` / `_run_valve_maintenance`. The same cleanup in
> `reset_pid_learnings_service` is deferred to avoid colliding with #2022, which
> already touches that method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in thermostat maintenance operations with more specific exception catching, reducing unintended error suppression.
  * Enhanced logging during maintenance procedures to better assist in troubleshooting issues.
  * Increased robustness of maintenance scheduling by properly handling edge cases during comparison operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->