### PR TITLE
refactor: clamp restored thermal values via the shared clamp helper

### DIFF
--- a/custom_components/better_thermostat/utils/restore.py
+++ b/custom_components/better_thermostat/utils/restore.py
@@ -17,6 +17,7 @@ from homeassistant.core import State
 
 from .const import MAX_HEAT_LOSS, MAX_HEATING_POWER, MIN_HEAT_LOSS, MIN_HEATING_POWER
 from .helpers import convert_to_float_celsius
+from .thermal_learning import clamp
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -104,7 +105,7 @@ def clamp_heating_power(raw: str | int | float | None, device_name: str) -> floa
         value = 0.01 if raw is None else float(raw)
     except (TypeError, ValueError):
         value = 0.01
-    bounded = max(MIN_HEATING_POWER, min(MAX_HEATING_POWER, value))
+    bounded = clamp(value, MIN_HEATING_POWER, MAX_HEATING_POWER)
     if bounded != value:
         _LOGGER.info(
             "better_thermostat %s: Restored heating_power %.3f is outside allowed "
@@ -126,4 +127,4 @@ def clamp_heat_loss(raw: str | int | float | None) -> float | None:
         value = float(raw)
     except (TypeError, ValueError):
         return None
-    return max(MIN_HEAT_LOSS, min(MAX_HEAT_LOSS, value))
+    return clamp(value, MIN_HEAT_LOSS, MAX_HEAT_LOSS)

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -44,6 +44,7 @@ from .calibration.mpc import MpcState, export_mpc_state_map, import_mpc_state_ma
 from .calibration.pid import PIDState, export_pid_states, import_pid_states
 from .calibration.tpi import TpiState, export_tpi_state_map, import_tpi_state_map
 from .const import MAX_HEAT_LOSS, MAX_HEATING_POWER, MIN_HEAT_LOSS, MIN_HEATING_POWER
+from .thermal_learning import clamp
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -422,9 +423,8 @@ class StateManager:
         heating_power: float | None = None
         if thermal.heating_power is not None:
             try:
-                heating_power = max(
-                    MIN_HEATING_POWER,
-                    min(MAX_HEATING_POWER, float(thermal.heating_power)),
+                heating_power = clamp(
+                    float(thermal.heating_power), MIN_HEATING_POWER, MAX_HEATING_POWER
                 )
             except (TypeError, ValueError):
                 heating_power = None
@@ -432,8 +432,8 @@ class StateManager:
         heat_loss_rate: float | None = None
         if thermal.heat_loss_rate is not None:
             try:
-                heat_loss_rate = max(
-                    MIN_HEAT_LOSS, min(MAX_HEAT_LOSS, float(thermal.heat_loss_rate))
+                heat_loss_rate = clamp(
+                    float(thermal.heat_loss_rate), MIN_HEAT_LOSS, MAX_HEAT_LOSS
                 )
             except (TypeError, ValueError):
                 heat_loss_rate = None


### PR DESCRIPTION
`restore.py` and `StateManager.clamped_thermal` both bounded the restored heating
power and heat loss with an inline `max(MIN, min(MAX, x))`. Both now use the
existing `thermal_learning.clamp(x, lo, hi)`, so the bound enforcement reads the
same way and lives in one place.

No functional change — `clamp(x, lo, hi)` returns exactly `max(lo, min(hi, x))`.
Covered by the existing `test_restore.py` and `test_state_manager.py` suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code consistency by consolidating numeric value constraints across thermal management utilities using a shared helper function. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->