### PR TITLE
chore: add .coderabbit.yaml to enable reviews on develop PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,69 @@
+# CodeRabbit configuration.
+# Schema + docs: https://docs.coderabbit.ai/getting-started/configure-coderabbit
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: en-US
+
+reviews:
+  # "assertive" surfaces nitpicks and refactor hints in addition to the
+  # high-confidence findings. Switch to "chill" if the team finds it noisy.
+  profile: assertive
+
+  # Post findings as review comments instead of GitHub "Request changes", so a
+  # review never blocks merging on its own.
+  request_changes_workflow: false
+
+  high_level_summary: true
+  poem: false
+  review_status: true
+
+  auto_review:
+    enabled: true
+
+    # The repo's default branch is `master`, but development PRs target
+    # `develop`. Without this, CodeRabbit skips every develop PR
+    # ("auto reviews disabled on non-default branch").
+    base_branches:
+      - "develop"
+
+    # PRs are opened as draft by default and marked ready later, so review them
+    # while still draft — except genuine work-in-progress (see keywords below).
+    drafts: true
+
+    ignore_title_keywords:
+      - "WIP"
+      - "work in progress"
+      - "DO NOT MERGE"
+
+  # Don't spend review effort on generated, vendored or lock files.
+  path_filters:
+    - "!custom_components/better_thermostat/translations/**"
+    - "!node_modules/**"
+    - "!website/**"
+    - "!**/*.lock"
+
+  # Project-specific review guidance.
+  path_instructions:
+    - path: "tests/**"
+      instructions: >-
+        Tests run with `uv run pytest -p no:homeassistant`. Every test function
+        and class needs a docstring (ruff pydocstyle "D" rules are enforced).
+        Follow the existing patterns: MagicMock + real dicts for `real_trvs`,
+        `State()` for HA states, `@pytest.mark.asyncio` / `AsyncMock` for async.
+    - path: "custom_components/better_thermostat/**"
+      instructions: >-
+        Home Assistant custom integration. Comments must describe the current
+        (IS) state only — no change history or PR references. Public functions,
+        classes and methods need docstrings.
+
+  tools:
+    # ruff is the linter and formatter of record for this repo.
+    ruff:
+      enabled: true
+    # Disabled: pylint crashed in CodeRabbit's sandbox on a prior review and
+    # would only duplicate ruff.
+    pylint:
+      enabled: false
+
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -65,5 +65,16 @@ reviews:
     pylint:
       enabled: false
 
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    # CodeRabbit reads these to learn the project's standards and apply them
+    # during reviews. CONTRIBUTING.md is in the repo today; AGENTS.md / CLAUDE.md
+    # are only honored if/once they are committed.
+    filePatterns:
+      - "CONTRIBUTING.md"
+      - "AGENTS.md"
+      - "CLAUDE.md"
+
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -68,13 +68,11 @@ reviews:
 knowledge_base:
   code_guidelines:
     enabled: true
-    # CodeRabbit reads these to learn the project's standards and apply them
-    # during reviews. CONTRIBUTING.md is in the repo today; AGENTS.md / CLAUDE.md
-    # are only honored if/once they are committed.
+    # CONTRIBUTING.md is the only guideline doc currently in the repo.
+    # (CodeRabbit's built-in defaults already pick up CLAUDE.md, .cursorrules,
+    # .github/copilot-instructions.md, etc. should any of those be added later.)
     filePatterns:
       - "CONTRIBUTING.md"
-      - "AGENTS.md"
-      - "CLAUDE.md"
 
 chat:
   auto_reply: true


### PR DESCRIPTION
## Why

CodeRabbit currently **skips every PR targeting `develop`** with *"auto reviews disabled on base/target branches other than the default branch"* — because the repo's default branch is `master`. Manual `@coderabbitai review` is unreliable on these PRs (the incremental engine treats the already-"skipped" commits as reviewed). This adds a repo-level `.coderabbit.yaml` that opts `develop` into auto review, plus a few project-aligned defaults.

> ⚠️ This is a repo-wide policy change for CodeRabbit — opening as **draft** for discussion with the maintainers before merging.

## What the config sets (each is easy to flip)

| Setting | Value | Rationale |
|---------|-------|-----------|
| `auto_review.base_branches` | `["develop"]` | **The actual fix** — review PRs targeting develop. |
| `auto_review.drafts` | `true` | PRs are opened as draft by default and marked ready later. |
| `auto_review.ignore_title_keywords` | `WIP`, `work in progress`, `DO NOT MERGE` | Don't review genuine work-in-progress. |
| `profile` | `assertive` | Surface nitpicks/refactor hints, not just high-confidence findings. Switch to `chill` for fewer comments. |
| `request_changes_workflow` | `false` | Findings as comments; a review never blocks merge on its own. |
| `poem` | `false` | Reduce noise. |
| `path_filters` | exclude `translations/**`, `node_modules/**`, `website/**`, `*.lock` | No review effort on generated/vendored files. |
| `path_instructions` | tests/ + custom_components/ | Encodes repo conventions (pytest `-p no:homeassistant`, docstrings, IS-state comments). |
| `tools.ruff` / `tools.pylint` | on / off | ruff is the linter of record; pylint crashed in CodeRabbit's sandbox on a prior review and would only duplicate ruff. |

## Open questions for the team
- **Profile**: `assertive` (more, incl. nitpicks) vs `chill` (fewer)?
- **Drafts**: review all drafts, or only on ready-for-review?
- Anything else worth pinning (labels, linked-issue enforcement, additional path rules)?

YAML validated locally. Keys follow the CodeRabbit v2 schema (referenced at the top of the file for editor validation) — worth a final check against the live schema / CodeRabbit UI.

| `knowledge_base.code_guidelines` | CONTRIBUTING.md (+ AGENTS.md/CLAUDE.md once committed) | CodeRabbit learns project standards from these docs. |
