### PR TITLE
fix: read TRV temperatures in the Home Assistant system unit

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -118,6 +118,7 @@ from .utils.helpers import (
     get_hvac_bt_mode,
     is_reasonable_temperature,
     normalize_hvac_mode,
+    state_temperature_unit,
 )
 from .utils.hvac_action import (
     ToleranceHysteresis,
@@ -1027,8 +1028,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         max_temps: list[float] = []
         steps: list[float] = []
         for s in states:
-            _unit = s.attributes.get(
-                "temperature_unit", s.attributes.get("unit_of_measurement")
+            _unit = state_temperature_unit(
+                s.attributes, self.hass.config.units.temperature_unit
             )
             _raw_min = s.attributes.get(ATTR_MIN_TEMP)
             if _raw_min is not None:
@@ -1133,9 +1134,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     str(trv_temp),
                     self.device_name,
                     "startup() TRV fallback",
-                    unit_of_measurement=trv_state.attributes.get(
-                        "temperature_unit",
-                        trv_state.attributes.get("unit_of_measurement"),
+                    unit_of_measurement=state_temperature_unit(
+                        trv_state.attributes,
+                        self.hass.config.units.temperature_unit,
                     ),
                 )
                 if not is_reasonable_temperature(candidate):
@@ -1209,9 +1210,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     str(_cooler_state.attributes.get("temperature")),
                     self.device_name,
                     "startup()",
-                    unit_of_measurement=_cooler_state.attributes.get(
-                        "temperature_unit",
-                        _cooler_state.attributes.get("unit_of_measurement"),
+                    unit_of_measurement=state_temperature_unit(
+                        _cooler_state.attributes,
+                        self.hass.config.units.temperature_unit,
                     ),
                 )
             # else: already logged warning above
@@ -1422,7 +1423,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     "better_thermostat %s: No previously saved temperature found on startup, get it from the TRV",
                     self.device_name,
                 )
-                _restored_target = mean_trv_target(states, self.device_name)
+                _restored_target = mean_trv_target(
+                    states,
+                    self.device_name,
+                    system_unit=self.hass.config.units.temperature_unit,
+                )
                 if _restored_target is not None:
                     self.bt_target_temp = _restored_target
             _LOGGER.debug("better_thermostat %s: defaults restored", self.device_name)
@@ -1585,16 +1590,16 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 str(_attrs.get("max_temp", 30)),
                 self.device_name,
                 "startup",
-                unit_of_measurement=_attrs.get(
-                    "temperature_unit", _attrs.get("unit_of_measurement")
+                unit_of_measurement=state_temperature_unit(
+                    _attrs, self.hass.config.units.temperature_unit
                 ),
             )
             trv_data["min_temp"] = convert_to_float_celsius(
                 str(_attrs.get("min_temp", 5)),
                 self.device_name,
                 "startup",
-                unit_of_measurement=_attrs.get(
-                    "temperature_unit", _attrs.get("unit_of_measurement")
+                unit_of_measurement=state_temperature_unit(
+                    _attrs, self.hass.config.units.temperature_unit
                 ),
             )
             # Prefer configured step over device-reported step
@@ -1615,8 +1620,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 str(_attrs.get("temperature", 5)),
                 self.device_name,
                 "startup",
-                unit_of_measurement=_attrs.get(
-                    "temperature_unit", _attrs.get("unit_of_measurement")
+                unit_of_measurement=state_temperature_unit(
+                    _attrs, self.hass.config.units.temperature_unit
                 ),
             )
             trv_data["hvac_modes"] = _attrs.get("hvac_modes", None)
@@ -1626,16 +1631,16 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 str(_attrs.get("temperature")),
                 self.device_name,
                 "startup()",
-                unit_of_measurement=_attrs.get(
-                    "temperature_unit", _attrs.get("unit_of_measurement")
+                unit_of_measurement=state_temperature_unit(
+                    _attrs, self.hass.config.units.temperature_unit
                 ),
             )
             trv_data["current_temperature"] = convert_to_float_celsius(
                 str(_attrs.get("current_temperature") or 5),
                 self.device_name,
                 "startup()",
-                unit_of_measurement=_attrs.get(
-                    "temperature_unit", _attrs.get("unit_of_measurement")
+                unit_of_measurement=state_temperature_unit(
+                    _attrs, self.hass.config.units.temperature_unit
                 ),
             )
             _LOGGER.debug(

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1133,7 +1133,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     continue
                 candidate = attr_to_celsius(
                     self,
-                    trv_state.attributes,
+                    trv_state,
                     "current_temperature",
                     None,
                     "startup() TRV fallback",
@@ -1206,7 +1206,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 None,
             ):
                 self.bt_target_cooltemp = attr_to_celsius(
-                    self, _cooler_state.attributes, "temperature", None, "startup()"
+                    self, _cooler_state, "temperature", None, "startup()"
                 )
             # else: already logged warning above
 
@@ -1579,12 +1579,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             trv_data["valve_position"] = convert_to_float(
                 str(_attrs.get("valve_position", None)), self.device_name, "startup"
             )
-            trv_data["max_temp"] = attr_to_celsius(
-                self, _attrs, "max_temp", 30, "startup"
-            )
-            trv_data["min_temp"] = attr_to_celsius(
-                self, _attrs, "min_temp", 5, "startup"
-            )
+            trv_data["max_temp"] = attr_to_celsius(self, _s, "max_temp", 30, "startup")
+            trv_data["min_temp"] = attr_to_celsius(self, _s, "min_temp", 5, "startup")
             # Prefer configured step over device-reported step
             cfg_step = (
                 self.bt_target_temp_step
@@ -1600,13 +1596,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     "startup",
                 )
             trv_data["temperature"] = attr_to_celsius(
-                self, _attrs, "temperature", 5, "startup"
+                self, _s, "temperature", 5, "startup"
             )
             trv_data["hvac_modes"] = _attrs.get("hvac_modes", None)
             trv_data["hvac_mode"] = _s.state if _s else None
             trv_data["last_hvac_mode"] = _s.state if _s else None
             trv_data["last_temperature"] = attr_to_celsius(
-                self, _attrs, "temperature", None, "startup()"
+                self, _s, "temperature", None, "startup()"
             )
             trv_data["current_temperature"] = convert_to_float_celsius(
                 str(_attrs.get("current_temperature") or 5),

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -111,6 +111,7 @@ from .utils.const import (
 )
 from .utils.controlling import control_queue, control_trv
 from .utils.helpers import (
+    attr_to_celsius,
     convert_to_float,
     convert_to_float_celsius,
     find_battery_entity,
@@ -1130,14 +1131,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 trv_temp = trv_state.attributes.get("current_temperature")
                 if trv_temp is None:
                     continue
-                candidate = convert_to_float_celsius(
-                    str(trv_temp),
-                    self.device_name,
+                candidate = attr_to_celsius(
+                    self,
+                    trv_state.attributes,
+                    "current_temperature",
+                    None,
                     "startup() TRV fallback",
-                    unit_of_measurement=state_temperature_unit(
-                        trv_state.attributes,
-                        self.hass.config.units.temperature_unit,
-                    ),
                 )
                 if not is_reasonable_temperature(candidate):
                     _LOGGER.warning(
@@ -1206,14 +1205,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 STATE_UNKNOWN,
                 None,
             ):
-                self.bt_target_cooltemp = convert_to_float_celsius(
-                    str(_cooler_state.attributes.get("temperature")),
-                    self.device_name,
-                    "startup()",
-                    unit_of_measurement=state_temperature_unit(
-                        _cooler_state.attributes,
-                        self.hass.config.units.temperature_unit,
-                    ),
+                self.bt_target_cooltemp = attr_to_celsius(
+                    self, _cooler_state.attributes, "temperature", None, "startup()"
                 )
             # else: already logged warning above
 
@@ -1586,21 +1579,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             trv_data["valve_position"] = convert_to_float(
                 str(_attrs.get("valve_position", None)), self.device_name, "startup"
             )
-            trv_data["max_temp"] = convert_to_float_celsius(
-                str(_attrs.get("max_temp", 30)),
-                self.device_name,
-                "startup",
-                unit_of_measurement=state_temperature_unit(
-                    _attrs, self.hass.config.units.temperature_unit
-                ),
+            trv_data["max_temp"] = attr_to_celsius(
+                self, _attrs, "max_temp", 30, "startup"
             )
-            trv_data["min_temp"] = convert_to_float_celsius(
-                str(_attrs.get("min_temp", 5)),
-                self.device_name,
-                "startup",
-                unit_of_measurement=state_temperature_unit(
-                    _attrs, self.hass.config.units.temperature_unit
-                ),
+            trv_data["min_temp"] = attr_to_celsius(
+                self, _attrs, "min_temp", 5, "startup"
             )
             # Prefer configured step over device-reported step
             cfg_step = (
@@ -1616,24 +1599,14 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     self.device_name,
                     "startup",
                 )
-            trv_data["temperature"] = convert_to_float_celsius(
-                str(_attrs.get("temperature", 5)),
-                self.device_name,
-                "startup",
-                unit_of_measurement=state_temperature_unit(
-                    _attrs, self.hass.config.units.temperature_unit
-                ),
+            trv_data["temperature"] = attr_to_celsius(
+                self, _attrs, "temperature", 5, "startup"
             )
             trv_data["hvac_modes"] = _attrs.get("hvac_modes", None)
             trv_data["hvac_mode"] = _s.state if _s else None
             trv_data["last_hvac_mode"] = _s.state if _s else None
-            trv_data["last_temperature"] = convert_to_float_celsius(
-                str(_attrs.get("temperature")),
-                self.device_name,
-                "startup()",
-                unit_of_measurement=state_temperature_unit(
-                    _attrs, self.hass.config.units.temperature_unit
-                ),
+            trv_data["last_temperature"] = attr_to_celsius(
+                self, _attrs, "temperature", None, "startup()"
             )
             trv_data["current_temperature"] = convert_to_float_celsius(
                 str(_attrs.get("current_temperature") or 5),

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -30,6 +30,7 @@ from custom_components.better_thermostat.utils.helpers import (
     get_device_model,
     is_reasonable_temperature,
     mode_remap,
+    state_temperature_unit,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -122,8 +123,8 @@ async def trigger_trv_change(self, event):
         str(_org_trv_state.attributes.get("current_temperature", None)),
         self.device_name,
         "TRV_current_temp",
-        unit_of_measurement=_org_trv_state.attributes.get(
-            "temperature_unit", _org_trv_state.attributes.get("unit_of_measurement")
+        unit_of_measurement=state_temperature_unit(
+            _org_trv_state.attributes, self.hass.config.units.temperature_unit
         ),
     )
     if _new_current_temp is not None and not is_reasonable_temperature(
@@ -258,16 +259,16 @@ async def trigger_trv_change(self, event):
         str(old_state.attributes.get(_main_key, None)),
         self.device_name,
         "trigger_trv_change()",
-        unit_of_measurement=old_state.attributes.get(
-            "temperature_unit", old_state.attributes.get("unit_of_measurement")
+        unit_of_measurement=state_temperature_unit(
+            old_state.attributes, self.hass.config.units.temperature_unit
         ),
     )
     _new_heating_setpoint = convert_to_float_celsius(
         str(new_state.attributes.get(_main_key, None)),
         self.device_name,
         "trigger_trv_change()",
-        unit_of_measurement=new_state.attributes.get(
-            "temperature_unit", new_state.attributes.get("unit_of_measurement")
+        unit_of_measurement=state_temperature_unit(
+            new_state.attributes, self.hass.config.units.temperature_unit
         ),
     )
     _is_no_off_device = self.real_trvs[entity_id]["advanced"].get(

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -119,7 +119,7 @@ async def trigger_trv_change(self, event):
         )
 
     _new_current_temp = attr_to_celsius(
-        self, _org_trv_state.attributes, "current_temperature", None, "TRV_current_temp"
+        self, _org_trv_state, "current_temperature", None, "TRV_current_temp"
     )
     if _new_current_temp is not None and not is_reasonable_temperature(
         _new_current_temp
@@ -250,10 +250,10 @@ async def trigger_trv_change(self, event):
         _main_key = "target_temp_low"
 
     _old_heating_setpoint = attr_to_celsius(
-        self, old_state.attributes, _main_key, None, "trigger_trv_change()"
+        self, old_state, _main_key, None, "trigger_trv_change()"
     )
     _new_heating_setpoint = attr_to_celsius(
-        self, new_state.attributes, _main_key, None, "trigger_trv_change()"
+        self, new_state, _main_key, None, "trigger_trv_change()"
     )
     _is_no_off_device = self.real_trvs[entity_id]["advanced"].get(
         "no_off_system_mode", False

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -25,12 +25,11 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.helpers import (
+    attr_to_celsius,
     convert_to_float,
-    convert_to_float_celsius,
     get_device_model,
     is_reasonable_temperature,
     mode_remap,
-    state_temperature_unit,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -119,13 +118,8 @@ async def trigger_trv_change(self, event):
             e,
         )
 
-    _new_current_temp = convert_to_float_celsius(
-        str(_org_trv_state.attributes.get("current_temperature", None)),
-        self.device_name,
-        "TRV_current_temp",
-        unit_of_measurement=state_temperature_unit(
-            _org_trv_state.attributes, self.hass.config.units.temperature_unit
-        ),
+    _new_current_temp = attr_to_celsius(
+        self, _org_trv_state.attributes, "current_temperature", None, "TRV_current_temp"
     )
     if _new_current_temp is not None and not is_reasonable_temperature(
         _new_current_temp
@@ -255,21 +249,11 @@ async def trigger_trv_change(self, event):
     if "temperature" not in old_state.attributes:
         _main_key = "target_temp_low"
 
-    _old_heating_setpoint = convert_to_float_celsius(
-        str(old_state.attributes.get(_main_key, None)),
-        self.device_name,
-        "trigger_trv_change()",
-        unit_of_measurement=state_temperature_unit(
-            old_state.attributes, self.hass.config.units.temperature_unit
-        ),
+    _old_heating_setpoint = attr_to_celsius(
+        self, old_state.attributes, _main_key, None, "trigger_trv_change()"
     )
-    _new_heating_setpoint = convert_to_float_celsius(
-        str(new_state.attributes.get(_main_key, None)),
-        self.device_name,
-        "trigger_trv_change()",
-        unit_of_measurement=state_temperature_unit(
-            new_state.attributes, self.hass.config.units.temperature_unit
-        ),
+    _new_heating_setpoint = attr_to_celsius(
+        self, new_state.attributes, _main_key, None, "trigger_trv_change()"
     )
     _is_no_off_device = self.real_trvs[entity_id]["advanced"].get(
         "no_off_system_mode", False

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -718,7 +718,11 @@ async def check_target_temperature(self, heater_entity_id=None):
             )
             break
         _current_set_temperature = attr_to_celsius(
-            self, _trv_state.attributes, "temperature", None, "check_target_temperature()"
+            self,
+            _trv_state.attributes,
+            "temperature",
+            None,
+            "check_target_temperature()",
         )
         if _timeout == 0:
             _LOGGER.debug(

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -414,7 +414,7 @@ async def control_trv(self, heater_entity_id=None):
             return True
 
         _current_set_temperature = attr_to_celsius(
-            self, _trv.attributes, "temperature", None, "controlling()"
+            self, _trv, "temperature", None, "controlling()"
         )
 
         _remapped_states = convert_outbound_states(
@@ -718,11 +718,7 @@ async def check_target_temperature(self, heater_entity_id=None):
             )
             break
         _current_set_temperature = attr_to_celsius(
-            self,
-            _trv_state.attributes,
-            "temperature",
-            None,
-            "check_target_temperature()",
+            self, _trv_state, "temperature", None, "check_target_temperature()"
         )
         if _timeout == 0:
             _LOGGER.debug(

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -23,9 +23,8 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.helpers import (
+    attr_to_celsius,
     convert_to_float,
-    convert_to_float_celsius,
-    state_temperature_unit,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -414,13 +413,8 @@ async def control_trv(self, heater_entity_id=None):
             self.real_trvs[heater_entity_id]["ignore_trv_states"] = False
             return True
 
-        _current_set_temperature = convert_to_float_celsius(
-            str(_trv.attributes.get("temperature", None)),
-            self.device_name,
-            "controlling()",
-            unit_of_measurement=state_temperature_unit(
-                _trv.attributes, self.hass.config.units.temperature_unit
-            ),
+        _current_set_temperature = attr_to_celsius(
+            self, _trv.attributes, "temperature", None, "controlling()"
         )
 
         _remapped_states = convert_outbound_states(
@@ -723,13 +717,8 @@ async def check_target_temperature(self, heater_entity_id=None):
                 heater_entity_id,
             )
             break
-        _current_set_temperature = convert_to_float_celsius(
-            str(_trv_state.attributes.get("temperature", None)),
-            self.device_name,
-            "check_target_temperature()",
-            unit_of_measurement=state_temperature_unit(
-                _trv_state.attributes, self.hass.config.units.temperature_unit
-            ),
+        _current_set_temperature = attr_to_celsius(
+            self, _trv_state.attributes, "temperature", None, "check_target_temperature()"
         )
         if _timeout == 0:
             _LOGGER.debug(

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -22,7 +22,11 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationMode,
     CalibrationType,
 )
-from custom_components.better_thermostat.utils.helpers import convert_to_float
+from custom_components.better_thermostat.utils.helpers import (
+    convert_to_float,
+    convert_to_float_celsius,
+    state_temperature_unit,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -410,10 +414,13 @@ async def control_trv(self, heater_entity_id=None):
             self.real_trvs[heater_entity_id]["ignore_trv_states"] = False
             return True
 
-        _current_set_temperature = convert_to_float(
+        _current_set_temperature = convert_to_float_celsius(
             str(_trv.attributes.get("temperature", None)),
             self.device_name,
             "controlling()",
+            unit_of_measurement=state_temperature_unit(
+                _trv.attributes, self.hass.config.units.temperature_unit
+            ),
         )
 
         _remapped_states = convert_outbound_states(
@@ -716,10 +723,13 @@ async def check_target_temperature(self, heater_entity_id=None):
                 heater_entity_id,
             )
             break
-        _current_set_temperature = convert_to_float(
+        _current_set_temperature = convert_to_float_celsius(
             str(_trv_state.attributes.get("temperature", None)),
             self.device_name,
             "check_target_temperature()",
+            unit_of_measurement=state_temperature_unit(
+                _trv_state.attributes, self.hass.config.units.temperature_unit
+            ),
         )
         if _timeout == 0:
             _LOGGER.debug(

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -365,6 +365,25 @@ def convert_to_float_celsius(
     return result
 
 
+def state_temperature_unit(
+    attributes: dict[str, Any] | None, system_unit: str | None
+) -> str | None:
+    """Resolve the temperature unit of a state's attributes.
+
+    ``climate`` entities report their temperatures in the Home Assistant system
+    unit and do not expose a ``temperature_unit`` / ``unit_of_measurement``
+    attribute. ``system_unit`` (``hass.config.units.temperature_unit``) is used
+    as the fallback so the values are interpreted in the right unit. Sensors
+    that carry an explicit ``unit_of_measurement`` keep it.
+    """
+    if not attributes:
+        return system_unit
+    return attributes.get(
+        "temperature_unit",
+        attributes.get("unit_of_measurement", system_unit),
+    )
+
+
 class rounding:
     """Rounding helpers for stable step-based rounding.
 

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -376,6 +376,19 @@ def state_temperature_unit(
     attribute. ``system_unit`` (``hass.config.units.temperature_unit``) is used
     as the fallback so the values are interpreted in the right unit. Sensors
     that carry an explicit ``unit_of_measurement`` keep it.
+
+    Parameters
+    ----------
+    attributes : Mapping[str, object] | None
+            the state attributes to inspect, or None when the state is missing
+    system_unit : str | None
+            the configured system temperature unit, used as fallback
+
+    Returns
+    -------
+    str | None
+            the resolved temperature unit, or ``system_unit`` when no explicit
+            unit attribute is present
     """
     if not attributes:
         return system_unit
@@ -398,8 +411,30 @@ def attr_to_celsius(
     The single inbound boundary for foreign temperatures: it resolves the source
     unit via :func:`state_temperature_unit` (system-unit fallback, since
     ``climate`` entities expose no unit attribute) and converts to the Celsius
-    Better Thermostat works in internally. ``self`` supplies ``hass`` and
-    ``device_name``.
+    Better Thermostat works in internally.
+
+    Parameters
+    ----------
+    self :
+            the Better Thermostat instance, supplying ``hass`` and ``device_name``
+    state : State | None
+            the source state to read from, or None when it is unavailable
+    key : str
+            the attribute name holding the temperature (e.g. ``"temperature"``)
+    default : str | int | float | None
+            value used when the attribute is missing
+    context : str
+            calling context, forwarded for logging
+
+    Returns
+    -------
+    float | None
+            the temperature in Celsius, or None if conversion failed
+
+    See Also
+    --------
+    convert_to_float_celsius : performs the unit conversion
+    state_temperature_unit : resolves the source unit
     """
     attributes = state.attributes if state is not None else {}
     return convert_to_float_celsius(

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.const import UnitOfTemperature
+from homeassistant.core import State
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry
 from homeassistant.util import dt as dt_util
@@ -366,7 +367,7 @@ def convert_to_float_celsius(
 
 
 def state_temperature_unit(
-    attributes: Mapping[str, Any] | None, system_unit: str | None
+    attributes: Mapping[str, object] | None, system_unit: str | None
 ) -> str | None:
     """Resolve the temperature unit of a state's attributes.
 
@@ -378,14 +379,16 @@ def state_temperature_unit(
     """
     if not attributes:
         return system_unit
-    return attributes.get(
-        "temperature_unit", attributes.get("unit_of_measurement", system_unit)
-    )
+    for attr in ("temperature_unit", "unit_of_measurement"):
+        unit = attributes.get(attr)
+        if isinstance(unit, str):
+            return unit
+    return system_unit
 
 
 def attr_to_celsius(
     self,
-    attributes: Mapping[str, Any] | None,
+    state: State | None,
     key: str,
     default: str | int | float | None = None,
     context: str = "",
@@ -398,7 +401,7 @@ def attr_to_celsius(
     Better Thermostat works in internally. ``self`` supplies ``hass`` and
     ``device_name``.
     """
-    attributes = attributes or {}
+    attributes = state.attributes if state is not None else {}
     return convert_to_float_celsius(
         str(attributes.get(key, default)),
         self.device_name,

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -379,8 +379,7 @@ def state_temperature_unit(
     if not attributes:
         return system_unit
     return attributes.get(
-        "temperature_unit",
-        attributes.get("unit_of_measurement", system_unit),
+        "temperature_unit", attributes.get("unit_of_measurement", system_unit)
     )
 
 

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -1,6 +1,6 @@
 """Helper functions for the Better Thermostat component."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from datetime import datetime
 import logging
 import math
@@ -366,7 +366,7 @@ def convert_to_float_celsius(
 
 
 def state_temperature_unit(
-    attributes: dict[str, Any] | None, system_unit: str | None
+    attributes: Mapping[str, Any] | None, system_unit: str | None
 ) -> str | None:
     """Resolve the temperature unit of a state's attributes.
 
@@ -385,7 +385,7 @@ def state_temperature_unit(
 
 def attr_to_celsius(
     self,
-    attributes: dict[str, Any] | None,
+    attributes: Mapping[str, Any] | None,
     key: str,
     default: str | int | float | None = None,
     context: str = "",

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -384,6 +384,32 @@ def state_temperature_unit(
     )
 
 
+def attr_to_celsius(
+    self,
+    attributes: dict[str, Any] | None,
+    key: str,
+    default: str | int | float | None = None,
+    context: str = "",
+) -> float | None:
+    """Read a temperature attribute from a foreign state and return it in °C.
+
+    The single inbound boundary for foreign temperatures: it resolves the source
+    unit via :func:`state_temperature_unit` (system-unit fallback, since
+    ``climate`` entities expose no unit attribute) and converts to the Celsius
+    Better Thermostat works in internally. ``self`` supplies ``hass`` and
+    ``device_name``.
+    """
+    attributes = attributes or {}
+    return convert_to_float_celsius(
+        str(attributes.get(key, default)),
+        self.device_name,
+        context,
+        unit_of_measurement=state_temperature_unit(
+            attributes, self.hass.config.units.temperature_unit
+        ),
+    )
+
+
 class rounding:
     """Rounding helpers for stable step-based rounding.
 

--- a/custom_components/better_thermostat/utils/restore.py
+++ b/custom_components/better_thermostat/utils/restore.py
@@ -16,14 +16,17 @@ from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import State
 
 from .const import MAX_HEAT_LOSS, MAX_HEATING_POWER, MIN_HEAT_LOSS, MIN_HEATING_POWER
-from .helpers import convert_to_float_celsius
+from .helpers import convert_to_float_celsius, state_temperature_unit
 from .thermal_learning import clamp
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def mean_trv_target(
-    states: list[State], device_name: str, context: str = "restore(target)"
+    states: list[State],
+    device_name: str,
+    context: str = "restore(target)",
+    system_unit: str | None = None,
 ) -> float | None:
     """Mean of the valid TRV target temperatures, each converted to Celsius.
 
@@ -34,9 +37,7 @@ def mean_trv_target(
         raw = state.attributes.get(ATTR_TEMPERATURE)
         if raw is None:
             continue
-        unit = state.attributes.get(
-            "temperature_unit", state.attributes.get("unit_of_measurement")
-        )
+        unit = state_temperature_unit(state.attributes, system_unit)
         celsius = convert_to_float_celsius(
             str(raw), device_name, context, unit_of_measurement=unit
         )
@@ -61,7 +62,7 @@ def restore_target_temperature(
     yields a value.
     """
     if saved is None:
-        return mean_trv_target(states, device_name)
+        return mean_trv_target(states, device_name, system_unit=system_unit)
 
     value = convert_to_float_celsius(
         saved, device_name, "restore_target_temperature", system_unit
@@ -73,7 +74,7 @@ def restore_target_temperature(
             device_name,
             saved,
         )
-        return mean_trv_target(states, device_name)
+        return mean_trv_target(states, device_name, system_unit=system_unit)
 
     low = min_temp if min_temp is not None else 5.0
     high = max_temp if max_temp is not None else 30.0

--- a/tests/unit/test_climate_temp_range.py
+++ b/tests/unit/test_climate_temp_range.py
@@ -64,6 +64,33 @@ def test_fahrenheit_bounds_and_step_converted(bt):
     assert bt.bt_target_temp_step == pytest.approx(round(1.0 * 5.0 / 9.0, 4))
 
 
+def test_fahrenheit_bounds_without_unit_attr_use_system_unit(bt):
+    """A climate child reports no unit attribute; the system unit decides.
+
+    HA climate entities never expose ``temperature_unit`` /
+    ``unit_of_measurement`` in their state attributes and always report in the
+    configured system unit. With a Fahrenheit system the raw 41/86 bounds must
+    therefore be read as °F and converted to 5/30 °C — otherwise BT would treat
+    41 °F as 41 °C and clamp every setpoint far too high.
+    """
+    bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+    states = [_trv(min_t=41.0, max_t=86.0, step=1.0)]
+    BetterThermostat._resolve_temperature_range(bt, states)
+    assert bt.bt_min_temp == pytest.approx(5.0)
+    assert bt.bt_max_temp == pytest.approx(30.0)
+    assert bt.bt_target_temp_step == pytest.approx(round(1.0 * 5.0 / 9.0, 4))
+
+
+def test_celsius_bounds_without_unit_attr_unchanged(bt):
+    """With a Celsius system the raw bounds stay as-is (no spurious conversion)."""
+    bt.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+    states = [_trv(min_t=5.0, max_t=30.0, step=0.5)]
+    BetterThermostat._resolve_temperature_range(bt, states)
+    assert bt.bt_min_temp == pytest.approx(5.0)
+    assert bt.bt_max_temp == pytest.approx(30.0)
+    assert bt.bt_target_temp_step == pytest.approx(0.5)
+
+
 def test_step_picks_coarsest(bt):
     """When several steps are present the coarsest is chosen."""
     states = [_trv(step=0.1, eid="climate.a"), _trv(step=0.5, eid="climate.b")]

--- a/tests/unit/test_helpers_attr_to_celsius.py
+++ b/tests/unit/test_helpers_attr_to_celsius.py
@@ -22,9 +22,7 @@ def _bt(system_unit):
     return SimpleNamespace(
         device_name="Test BT",
         hass=SimpleNamespace(
-            config=SimpleNamespace(
-                units=SimpleNamespace(temperature_unit=system_unit)
-            )
+            config=SimpleNamespace(units=SimpleNamespace(temperature_unit=system_unit))
         ),
     )
 

--- a/tests/unit/test_helpers_attr_to_celsius.py
+++ b/tests/unit/test_helpers_attr_to_celsius.py
@@ -9,6 +9,7 @@ Celsius conversion into the single inbound boundary used across the codebase.
 from types import SimpleNamespace
 
 from homeassistant.const import UnitOfTemperature
+from homeassistant.core import State
 import pytest
 
 from custom_components.better_thermostat.utils.helpers import (
@@ -25,6 +26,11 @@ def _bt(system_unit):
             config=SimpleNamespace(units=SimpleNamespace(temperature_unit=system_unit))
         ),
     )
+
+
+def _state(attributes):
+    """Build a minimal climate State carrying the given attributes."""
+    return State("climate.trv", "heat", attributes=attributes)
 
 
 class TestStateTemperatureUnit:
@@ -67,26 +73,33 @@ class TestAttrToCelsius:
     def test_fahrenheit_system_without_unit_attr(self):
         """A unit-less climate attribute is read via the Fahrenheit system unit."""
         bt = _bt(UnitOfTemperature.FAHRENHEIT)
-        result = attr_to_celsius(bt, {"temperature": 64.0}, "temperature")
+        result = attr_to_celsius(bt, _state({"temperature": 64.0}), "temperature")
         assert result == pytest.approx(17.78, abs=0.05)
 
     def test_celsius_system_without_unit_attr(self):
         """A Celsius system leaves the value unchanged."""
         bt = _bt(UnitOfTemperature.CELSIUS)
-        assert attr_to_celsius(bt, {"temperature": 20.0}, "temperature") == 20.0
+        assert attr_to_celsius(bt, _state({"temperature": 20.0}), "temperature") == 20.0
 
     def test_explicit_unit_attribute_overrides_system(self):
         """An explicit Fahrenheit unit converts even on a Celsius system."""
         bt = _bt(UnitOfTemperature.CELSIUS)
-        attrs = {"temperature": 68.0, "temperature_unit": UnitOfTemperature.FAHRENHEIT}
-        assert attr_to_celsius(bt, attrs, "temperature") == pytest.approx(20.0)
+        state = _state(
+            {"temperature": 68.0, "temperature_unit": UnitOfTemperature.FAHRENHEIT}
+        )
+        assert attr_to_celsius(bt, state, "temperature") == pytest.approx(20.0)
 
     def test_missing_key_returns_default_converted(self):
         """A missing key uses the default, still unit-resolved."""
         bt = _bt(UnitOfTemperature.FAHRENHEIT)
-        assert attr_to_celsius(bt, {}, "temperature", 50) == pytest.approx(10.0)
+        assert attr_to_celsius(bt, _state({}), "temperature", 50) == pytest.approx(10.0)
 
     def test_missing_key_no_default_returns_none(self):
         """A missing key with no default yields None."""
         bt = _bt(UnitOfTemperature.CELSIUS)
-        assert attr_to_celsius(bt, {}, "temperature") is None
+        assert attr_to_celsius(bt, _state({}), "temperature") is None
+
+    def test_none_state_returns_default_converted(self):
+        """A missing state falls back to the default, resolved via system unit."""
+        bt = _bt(UnitOfTemperature.FAHRENHEIT)
+        assert attr_to_celsius(bt, None, "temperature", 50) == pytest.approx(10.0)

--- a/tests/unit/test_helpers_attr_to_celsius.py
+++ b/tests/unit/test_helpers_attr_to_celsius.py
@@ -1,0 +1,94 @@
+"""Tests for the foreign-temperature inbound boundary helpers.
+
+``state_temperature_unit`` resolves the source unit of a state, falling back to
+the Home Assistant system unit because ``climate`` entities report in that unit
+and expose no unit attribute. ``attr_to_celsius`` wraps that resolution and the
+Celsius conversion into the single inbound boundary used across the codebase.
+"""
+
+from types import SimpleNamespace
+
+from homeassistant.const import UnitOfTemperature
+import pytest
+
+from custom_components.better_thermostat.utils.helpers import (
+    attr_to_celsius,
+    state_temperature_unit,
+)
+
+
+def _bt(system_unit):
+    """Minimal stand-in exposing the ``hass`` and ``device_name`` attr_to_celsius reads."""
+    return SimpleNamespace(
+        device_name="Test BT",
+        hass=SimpleNamespace(
+            config=SimpleNamespace(
+                units=SimpleNamespace(temperature_unit=system_unit)
+            )
+        ),
+    )
+
+
+class TestStateTemperatureUnit:
+    """Unit resolution with the system-unit fallback."""
+
+    def test_explicit_temperature_unit_wins(self):
+        """An explicit temperature_unit attribute takes precedence."""
+        attrs = {"temperature_unit": UnitOfTemperature.CELSIUS}
+        assert (
+            state_temperature_unit(attrs, UnitOfTemperature.FAHRENHEIT)
+            == UnitOfTemperature.CELSIUS
+        )
+
+    def test_unit_of_measurement_fallback(self):
+        """unit_of_measurement is used when temperature_unit is absent."""
+        attrs = {"unit_of_measurement": UnitOfTemperature.FAHRENHEIT}
+        assert (
+            state_temperature_unit(attrs, UnitOfTemperature.CELSIUS)
+            == UnitOfTemperature.FAHRENHEIT
+        )
+
+    def test_no_attribute_uses_system_unit(self):
+        """Without any unit attribute the system unit is the fallback."""
+        assert (
+            state_temperature_unit({}, UnitOfTemperature.FAHRENHEIT)
+            == UnitOfTemperature.FAHRENHEIT
+        )
+
+    def test_none_attributes_uses_system_unit(self):
+        """``None`` attributes fall back to the system unit."""
+        assert (
+            state_temperature_unit(None, UnitOfTemperature.CELSIUS)
+            == UnitOfTemperature.CELSIUS
+        )
+
+
+class TestAttrToCelsius:
+    """The combined read + convert boundary."""
+
+    def test_fahrenheit_system_without_unit_attr(self):
+        """A unit-less climate attribute is read via the Fahrenheit system unit."""
+        bt = _bt(UnitOfTemperature.FAHRENHEIT)
+        result = attr_to_celsius(bt, {"temperature": 64.0}, "temperature")
+        assert result == pytest.approx(17.78, abs=0.05)
+
+    def test_celsius_system_without_unit_attr(self):
+        """A Celsius system leaves the value unchanged."""
+        bt = _bt(UnitOfTemperature.CELSIUS)
+        assert attr_to_celsius(bt, {"temperature": 20.0}, "temperature") == 20.0
+
+    def test_explicit_unit_attribute_overrides_system(self):
+        """An explicit Fahrenheit unit converts even on a Celsius system."""
+        bt = _bt(UnitOfTemperature.CELSIUS)
+        attrs = {"temperature": 68.0, "temperature_unit": UnitOfTemperature.FAHRENHEIT}
+        assert attr_to_celsius(bt, attrs, "temperature") == pytest.approx(20.0)
+
+    def test_missing_key_returns_default_converted(self):
+        """A missing key uses the default, still unit-resolved."""
+        bt = _bt(UnitOfTemperature.FAHRENHEIT)
+        assert attr_to_celsius(bt, {}, "temperature", 50) == pytest.approx(10.0)
+
+    def test_missing_key_no_default_returns_none(self):
+        """A missing key with no default yields None."""
+        bt = _bt(UnitOfTemperature.CELSIUS)
+        assert attr_to_celsius(bt, {}, "temperature") is None

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -79,6 +79,20 @@ class TestMeanTrvTarget:
         )
         assert mean_trv_target([s], DEV) == pytest.approx(20.0)
 
+    def test_no_unit_attr_uses_system_unit(self):
+        """Without a unit attribute the passed system unit decides the reading."""
+        result = mean_trv_target(
+            [_trv(68.0)], DEV, system_unit=UnitOfTemperature.FAHRENHEIT
+        )
+        assert result == pytest.approx(20.0)
+
+    def test_no_unit_attr_celsius_system_unchanged(self):
+        """A Celsius system leaves a unit-less reading as-is."""
+        result = mean_trv_target(
+            [_trv(20.0)], DEV, system_unit=UnitOfTemperature.CELSIUS
+        )
+        assert result == pytest.approx(20.0)
+
 
 # ---------------------------------------------------------------------------
 # restore_target_temperature

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -233,6 +233,37 @@ class TestInternalTemperatureChange:
         assert mock_bt.real_trvs[ENTITY_ID]["current_temperature"] == new_temp
 
     @pytest.mark.asyncio
+    async def test_fahrenheit_current_temp_without_unit_attr(self, mock_bt):
+        """A Fahrenheit TRV with no unit attribute is read via the system unit.
+
+        HA climate entities report in the system unit and expose no
+        ``temperature_unit`` attribute. With a Fahrenheit system, a raw
+        64 reading is 64 °F (≈17.8 °C) — a plausible indoor value. Without the
+        system-unit fallback it is mistaken for 64 °C, rejected as implausible
+        and dropped.
+        """
+        from homeassistant.const import UnitOfTemperature
+
+        mock_bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        trv_state = _make_state(attributes={"current_temperature": 64.0})
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID]["current_temperature"] = 18.0
+        mock_bt.real_trvs[ENTITY_ID]["calibration_received"] = True
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        # 64 °F -> ~17.78 °C, accepted and cached (not dropped as implausible).
+        assert mock_bt.real_trvs[ENTITY_ID]["current_temperature"] == pytest.approx(
+            17.78, abs=0.05
+        )
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("marker_temp", [126.5, 127.0])
     async def test_implausible_trv_temp_ignored(self, mock_bt, marker_temp):
         """AVM marker values (126.5 °C OFF, 127.0 °C ON) must not overwrite the cache."""


### PR DESCRIPTION
## Problem

Fixes #2029 (and the still-broken root cause behind #1858).

On a Home Assistant setup configured for **Fahrenheit**, all TRV temperatures were double/mis-converted after upgrading to 1.8:

- TRV `current_temperature` was rejected as implausible (`reports implausible current_temperature 64.0; ignoring`).
- The control/setpoint temperature jumped to a value that is not an obvious conversion of the previous one.

## Root cause

HA `climate` entities report **all** temperatures in the configured system unit and do **not** expose a `temperature_unit` / `unit_of_measurement` attribute in their state (verified in `homeassistant/components/climate/__init__.py` — `state_attributes` / `capability_attributes` emit values via `show_temp(...)` without any unit attribute).

BT resolved the source unit exclusively from those (absent) attributes:

```python
state.attributes.get("temperature_unit", state.attributes.get("unit_of_measurement"))
```

On a Fahrenheit system this returns `None`, so every TRV reading was treated as Celsius:

- `current_temperature` 64 °F was read as 64 °C → rejected by the plausibility guard → dropped.
- `min_temp`/`max_temp` (41/86 °F) were stored as 41/86 °C. A 17 °C setpoint was then clamped **up** to 41 in `delegate.set_temperature` and sent to the TRV as 41 → 105.8 °F → the "setpoint jumped" symptom.

The outbound `climate.set_temperature` call already converts Celsius → system unit correctly (`adapters/generic.py`, and the cooler path), so this is purely an **inbound** unit-detection problem.

## Fix

Two commits:

1. **fix** — Add `state_temperature_unit(attributes, system_unit)`, which falls back to `hass.config.units.temperature_unit` when no explicit unit attribute is present, and apply it at every TRV/cooler read boundary:
   - `events/trv.py`: current temperature + old/new setpoint
   - `climate.py`: `_resolve_temperature_range`, TRV temperature fallback, cooler target, `_initialize_trvs` (min/max/temperature/last/current), restore mean
   - `utils/controlling.py`: setpoint read-back in `control_trv` and `check_target_temperature` (now compared in Celsius)
   - `utils/restore.py`: `mean_trv_target` threads the system unit through

2. **refactor** — Funnel the repeated "resolve unit + convert to Celsius" blocks through a single `attr_to_celsius(self, attributes, key, default, context)` boundary helper, so new read sites can't forget the system-unit fallback (the exact omission that caused this bug).

Sensors and weather entities are untouched — they carry an explicit `unit_of_measurement`/`temperature_unit`, so the fallback never triggers. On a Celsius system the behaviour is unchanged.

## Tests

Added failing-first regression tests (they reproduce the bug before the fix):

- `test_climate_temp_range.py`: Fahrenheit min/max without a unit attribute now convert to 5/30 °C; Celsius unchanged.
- `test_trv_events.py`: a 64 °F unit-less `current_temperature` is accepted (~17.78 °C) instead of being dropped as implausible.
- `test_restore.py`: `mean_trv_target` honours the passed system unit.
- `test_helpers_attr_to_celsius.py`: direct coverage of the unit-resolution + conversion boundary.

Full suite: 1407 passed. `ruff check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent temperature-unit resolution across startup, state restore, TRV events, and runtime so readings, bounds, setpoints, and step values convert correctly when devices omit unit info.
  * Improved TRV and cooler temperature handling to prevent misinterpreted values and incorrect control decisions.

* **Tests**
  * Added unit tests verifying unit-less attribute handling and conversion behavior across system-unit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->