### PR TITLE
fix: keep outdoor threshold working when recorder history is empty (#2038)

### DIFF
--- a/custom_components/better_thermostat/utils/weather.py
+++ b/custom_components/better_thermostat/utils/weather.py
@@ -305,6 +305,12 @@ async def check_ambient_air_temperature(self):
                     )
 
         avg_temp = _temp_history.min
+        if avg_temp is None:
+            # No usable recorder history (e.g. a freshly created helper or a
+            # sensor the recorder does not retain). Fall back to the current
+            # reading so the outdoor threshold still applies instead of
+            # defaulting to "heat".
+            avg_temp = self.last_avg_outdoor_temp
 
         _LOGGER.debug("Initializing from database completed")
     else:

--- a/tests/unit/test_weather.py
+++ b/tests/unit/test_weather.py
@@ -532,7 +532,8 @@ class TestCheckAmbientAirTemperature:
         assert bt.call_for_heat is True
 
     async def test_recorder_malformed_history_is_tolerated(self):
-        """A non-dict history payload must not raise; it yields no data."""
+        """A non-dict history payload must not raise; it falls back to the
+        current reading instead of disabling the threshold (issue #2038)."""
         states = {
             OUTDOOR_ID: make_state(state="5.0", attrs={"unit_of_measurement": "°C"})
         }
@@ -543,11 +544,12 @@ class TestCheckAmbientAirTemperature:
                 return_value=["not", "a", "dict"]
             )
             await check_ambient_air_temperature(bt)
-        assert bt.last_avg_outdoor_temp is None
+        assert bt.last_avg_outdoor_temp == pytest.approx(5.0)
         assert bt.call_for_heat is True
 
-    async def test_recorder_empty_history_yields_none_and_forces_heat(self):
-        """An empty recorder history leaves no average and forces heat."""
+    async def test_recorder_empty_history_falls_back_to_current_reading(self):
+        """An empty recorder history must fall back to the current reading
+        rather than wiping it and forcing heat (issue #2038)."""
         states = {
             OUTDOOR_ID: make_state(state="5.0", attrs={"unit_of_measurement": "°C"})
         }
@@ -558,8 +560,24 @@ class TestCheckAmbientAirTemperature:
                 return_value={OUTDOOR_ID: []}
             )
             await check_ambient_air_temperature(bt)
-        assert bt.last_avg_outdoor_temp is None
+        assert bt.last_avg_outdoor_temp == pytest.approx(5.0)
         assert bt.call_for_heat is True
+
+    async def test_recorder_empty_history_above_threshold_disables_heat(self):
+        """The #2038 symptom: outdoor above the threshold with no usable
+        history must still disable heating, not default to heat."""
+        states = {
+            OUTDOOR_ID: make_state(state="21.0", attrs={"unit_of_measurement": "°C"})
+        }
+        hass = make_hass(states=states, components={"recorder"})
+        bt = make_bt(hass, outdoor_sensor=OUTDOOR_ID, off_temperature=14.0)
+        with patch(f"{WEATHER_MOD}.get_instance") as gi:
+            gi.return_value.async_add_executor_job = AsyncMock(
+                return_value={OUTDOOR_ID: []}
+            )
+            await check_ambient_air_temperature(bt)
+        assert bt.last_avg_outdoor_temp == pytest.approx(21.0)
+        assert bt.call_for_heat is False
 
 
 # ===========================================================================

--- a/tests/unit/test_weather.py
+++ b/tests/unit/test_weather.py
@@ -532,8 +532,11 @@ class TestCheckAmbientAirTemperature:
         assert bt.call_for_heat is True
 
     async def test_recorder_malformed_history_is_tolerated(self):
-        """A non-dict history payload must not raise; it falls back to the
-        current reading instead of disabling the threshold (issue #2038)."""
+        """A non-dict history payload must not raise.
+
+        It falls back to the current reading instead of disabling the threshold
+        (issue #2038).
+        """
         states = {
             OUTDOOR_ID: make_state(state="5.0", attrs={"unit_of_measurement": "°C"})
         }
@@ -548,8 +551,10 @@ class TestCheckAmbientAirTemperature:
         assert bt.call_for_heat is True
 
     async def test_recorder_empty_history_falls_back_to_current_reading(self):
-        """An empty recorder history must fall back to the current reading
-        rather than wiping it and forcing heat (issue #2038)."""
+        """An empty recorder history must fall back to the current reading.
+
+        It must not wipe the reading and force heat (issue #2038).
+        """
         states = {
             OUTDOOR_ID: make_state(state="5.0", attrs={"unit_of_measurement": "°C"})
         }
@@ -564,8 +569,10 @@ class TestCheckAmbientAirTemperature:
         assert bt.call_for_heat is True
 
     async def test_recorder_empty_history_above_threshold_disables_heat(self):
-        """The #2038 symptom: outdoor above the threshold with no usable
-        history must still disable heating, not default to heat."""
+        """Outdoor above the threshold with no usable history disables heating.
+
+        The #2038 symptom: it must still disable heating, not default to heat.
+        """
         states = {
             OUTDOOR_ID: make_state(state="21.0", attrs={"unit_of_measurement": "°C"})
         }


### PR DESCRIPTION
## Problem

Fixes #2038.

With an `outdoor_sensor` configured (and no `weather` entity), the heating-off threshold is evaluated in `check_ambient_air_temperature()` via the recorder history. When the recorder has **no usable history** for that sensor — a freshly created helper, or a sensor the recorder does not retain — `_temp_history.min` is `None`, and the code:

1. forced `call_for_heat = True` (heat on), and
2. **overwrote** the valid current reading in `last_avg_outdoor_temp` with `None`.

After that, the hourly `check_weather()` also sees `last_avg_outdoor_temp is None` and forces heat again, so the outdoor threshold is effectively dead — heating runs even when it is 21 °C outside with a 14 °C threshold (the reporter's setup uses helper entities).

The threshold comparison itself (`avg < off_temperature`) was correct; it just never ran with a real value because the `None` fallback defaulted to "heat" and discarded the current reading.

## Fix

When no history-derived average is available, fall back to the **current sensor reading** (already fetched a few lines above) instead of `None`. The threshold then keeps applying, and `last_avg_outdoor_temp` retains a usable value.

```python
avg_temp = _temp_history.min
if avg_temp is None:
    # No usable recorder history (e.g. a freshly created helper or a
    # sensor the recorder does not retain). Fall back to the current
    # reading so the outdoor threshold still applies instead of
    # defaulting to "heat".
    avg_temp = self.last_avg_outdoor_temp
```

## Tests (TDD)

`tests/unit/test_weather.py`:
- Updated the two tests that previously codified the buggy behavior (`empty`/`malformed` history → `None` + force heat) to assert the corrected fallback.
- Added `test_recorder_empty_history_above_threshold_disables_heat` reproducing the #2038 symptom: outdoor 21 °C, threshold 14 °C, empty history → `call_for_heat is False`.

Full unit suite: 1219 passed.

## Follow-up (separate PR)

The `outdoor_sensor` has no state-change listener; it is only re-evaluated at startup, daily at 05:00, and in the conditional 5-min tick. A responsive re-evaluation on outdoor-temperature changes will be addressed separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Thermostat now falls back to the last known outdoor temperature when recorded weather history is missing or malformed, preventing unintended default-to-heat behavior.

* **Tests**
  * Unit tests updated to assert correct fallback behavior for empty or corrupted weather history scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->