### PR TITLE
feat: re-evaluate outdoor threshold on outdoor sensor changes

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -780,6 +780,28 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if event is not None:
             await self.control_queue_task.put(self)
 
+    async def _trigger_outdoor_change(self, event=None):
+        """Re-evaluate the outdoor-temperature threshold on sensor changes.
+
+        The threshold is otherwise only refreshed at startup and the daily
+        tick. Re-running the ambient check when the outdoor sensor changes
+        lets heating react promptly. Control is only re-queued when
+        ``call_for_heat`` actually flips, so frequent outdoor readings that
+        stay on the same side of the threshold do not spam the queue.
+        """
+        _check = await check_critical_entities(self)
+        if _check is False:
+            return
+        await check_and_update_degraded_mode(self)
+        if getattr(self, "in_maintenance", False):
+            return
+        await check_ambient_air_temperature(self)
+        if self._last_call_for_heat != self.call_for_heat:
+            self._last_call_for_heat = self.call_for_heat
+            self.async_write_ha_state()
+            if event is not None:
+                await self.control_queue_task.put(self)
+
     async def _trigger_temperature_change(self, event):
         _check = await check_critical_entities(self)
         if _check is False:
@@ -1844,6 +1866,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             self.async_on_remove(
                 async_track_state_change_event(
                     self.hass, [self.cooler_entity_id], self._trigger_cooler_change
+                )
+            )
+        if self.outdoor_sensor is not None:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass, [self.outdoor_sensor], self._trigger_outdoor_change
                 )
             )
         # Sende initial sofort einen Keepalive, damit TRVs nicht bis zum ersten 30min-Tick warten müssen

--- a/tests/unit/test_outdoor_sensor_listener.py
+++ b/tests/unit/test_outdoor_sensor_listener.py
@@ -1,0 +1,104 @@
+"""Tests for the outdoor-sensor state-change handler in climate.py.
+
+The outdoor temperature threshold used to be re-evaluated only at startup,
+once per day at 05:00, and in the conditional 5-minute tick. ``_trigger_outdoor_change``
+re-evaluates the threshold whenever the outdoor sensor changes, so heating
+reacts promptly instead of waiting for the daily tick. Control is only
+re-queued when ``call_for_heat`` actually flips, to avoid spamming the queue
+on every outdoor reading.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+
+CLIMATE_MOD = "custom_components.better_thermostat.climate"
+
+
+def _make_self(*, call_for_heat_after, last_call_for_heat, in_maintenance=False):
+    """Build a BetterThermostat stand-in for the outdoor-change handler."""
+    bt = SimpleNamespace(
+        device_name="Test BT",
+        in_maintenance=in_maintenance,
+        call_for_heat=last_call_for_heat,
+        _last_call_for_heat=last_call_for_heat,
+        async_write_ha_state=MagicMock(),
+        control_queue_task=MagicMock(put=AsyncMock()),
+    )
+    # The new outdoor reading drives call_for_heat to this value.
+    bt._call_for_heat_after = call_for_heat_after
+    return bt
+
+
+def _patch_checks(bt, *, critical=True):
+    """Patch the watcher/weather helpers used by the handler.
+
+    The ambient-check mock is stored on ``bt._ambient_mock`` so tests can
+    assert whether the threshold was (re-)evaluated.
+    """
+
+    async def _set_call_for_heat(_self):
+        _self.call_for_heat = _self._call_for_heat_after
+
+    bt._ambient_mock = AsyncMock(side_effect=_set_call_for_heat)
+    return patch.multiple(
+        CLIMATE_MOD,
+        check_critical_entities=AsyncMock(return_value=critical),
+        check_and_update_degraded_mode=AsyncMock(),
+        check_ambient_air_temperature=bt._ambient_mock,
+    )
+
+
+@pytest.mark.asyncio
+async def test_outdoor_change_flips_call_for_heat_enqueues_control():
+    """Threshold crossing (heat -> no heat) writes state and queues control."""
+    bt = _make_self(call_for_heat_after=False, last_call_for_heat=True)
+
+    with _patch_checks(bt):
+        await BetterThermostat._trigger_outdoor_change(bt, event=MagicMock())
+
+    assert bt.call_for_heat is False
+    assert bt._last_call_for_heat is False
+    bt.async_write_ha_state.assert_called_once()
+    bt.control_queue_task.put.assert_awaited_once_with(bt)
+
+
+@pytest.mark.asyncio
+async def test_outdoor_change_no_flip_does_not_enqueue():
+    """An outdoor reading that does not cross the threshold queues nothing."""
+    bt = _make_self(call_for_heat_after=True, last_call_for_heat=True)
+
+    with _patch_checks(bt):
+        await BetterThermostat._trigger_outdoor_change(bt, event=MagicMock())
+
+    bt.async_write_ha_state.assert_not_called()
+    bt.control_queue_task.put.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_outdoor_change_skips_when_critical_unavailable():
+    """If a critical entity is unavailable, the threshold is not evaluated."""
+    bt = _make_self(call_for_heat_after=False, last_call_for_heat=True)
+
+    with _patch_checks(bt, critical=False):
+        await BetterThermostat._trigger_outdoor_change(bt, event=MagicMock())
+
+    bt._ambient_mock.assert_not_awaited()
+    bt.control_queue_task.put.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_outdoor_change_skips_during_maintenance():
+    """Valve maintenance suppresses the outdoor re-evaluation."""
+    bt = _make_self(
+        call_for_heat_after=False, last_call_for_heat=True, in_maintenance=True
+    )
+
+    with _patch_checks(bt):
+        await BetterThermostat._trigger_outdoor_change(bt, event=MagicMock())
+
+    bt._ambient_mock.assert_not_awaited()
+    bt.control_queue_task.put.assert_not_awaited()


### PR DESCRIPTION
## Motivation

Follow-up to #2044 (issue #2038).

The outdoor-temperature heating-off threshold is currently only re-evaluated:

- at startup,
- once per day at **05:00** (`async_track_time_change(..., 5, 0, 0)`),
- in the conditional 5-minute tick — which is only registered when a balance/calibration mode is active.

So for a plain `outdoor_sensor` setup (no balance/calibration mode), an outdoor temperature crossing the threshold is only acted on at the next daily tick — up to ~24 h of delay. There is no state-change listener on the outdoor sensor (the daily tick has been the only refresh since 2022).

## Change

Register an `async_track_state_change_event` listener on the outdoor sensor that calls a new handler `_trigger_outdoor_change`. It mirrors the existing trigger handlers:

- skips when a critical entity (TRV) is unavailable,
- runs `check_and_update_degraded_mode`,
- skips during valve maintenance,
- re-runs `check_ambient_air_temperature` to refresh the rolling average,
- writes state and re-queues control **only when `call_for_heat` actually flips**, so frequent outdoor readings that stay on the same side of the threshold don't spam the control queue.

The valve-maintenance / balance / calibration tick wiring is left untouched.

## Tests (TDD)

`tests/unit/test_outdoor_sensor_listener.py`:
- flip (heat → no heat) writes state and enqueues control,
- no flip enqueues nothing,
- critical entity unavailable → threshold not evaluated,
- valve maintenance suppresses evaluation.

Full unit suite: 1222 passed.

> Note: depends conceptually on #2044 (the empty-history fix). Recommend merging #2044 first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The thermostat now continuously monitors outdoor temperature sensor changes and automatically re-evaluates heating requirements when outdoor conditions change, improving system responsiveness.

* **Tests**
  * Added comprehensive unit tests for outdoor sensor monitoring, including scenarios for heating decision changes, unchanged states, unavailable sensors, and maintenance mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->