### PR TITLE
fix: remove dead calibration documentation links from config flow (#2040)

### DIFF
--- a/custom_components/better_thermostat/translations/da.json
+++ b/custom_components/better_thermostat/translations/da.json
@@ -3,7 +3,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Konfigurer din Better Thermostat til at integrere med Home Assistant\n**Hvis du har brug for mere info: https://better-thermostat.org/configuration#first-step**",
+        "description": "Konfigurer din Better Thermostat til at integrere med Home Assistant",
         "data": {
           "name": "Navn",
           "thermostat": "Den rigtige termostat",
@@ -20,7 +20,7 @@
         }
       },
       "advanced": {
-        "description": "Avanceret konfiguration {trv}\n***Info om kalibreringstyper: https://better-thermostat.org/configuration#second-step*** ",
+        "description": "Avanceret konfiguration {trv}",
         "data": {
           "protect_overheating": "Overophedningsbeskyttelse?",
           "heat_auto_swapped": "Hvis auto betyder varme for din TRV og du vil bytte det",
@@ -69,7 +69,7 @@
           "window_off_delay_after": "Forsinkelse, før termostaten tænder, når vinduet er lukket",
           "outdoor_sensor": "Har du en udendørsføler, kan du bruge den til at få udetemperaturen",
           "valve_maintenance": "Hvis din termostat ikke har nogen egen vedligeholdelsestilstand, kan du bruge denne",
-          "calibration": "Den slags kalibrering https://better-thermostat.org/configuration#second-step",
+          "calibration": "Den slags kalibrering",
           "weather": "Din vejrentitet for at få udendørstemperaturen",
           "heat_auto_swapped": "Hvis auto betyder varme til din TRV, og du ønsker at bytte den",
           "child_lock": "Ignorer alle input på TRV som en børnesikring",
@@ -77,7 +77,7 @@
         }
       },
       "advanced": {
-        "description": "Avanceret konfiguration {trv}\n***Info om kalibreringstyper: https://better-thermostat.org/configuration#second-step*** ",
+        "description": "Avanceret konfiguration {trv}",
         "data": {
           "protect_overheating": "Overophedningsbeskyttelse?",
           "heat_auto_swapped": "Hvis auto betyder varme for din TRV og du vil bytte det",

--- a/custom_components/better_thermostat/translations/de.json
+++ b/custom_components/better_thermostat/translations/de.json
@@ -3,7 +3,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Einrichtung von Better Thermostat mit Home Assistant\n**Für mehr Informationen: https://better-thermostat.org/configuration#first-step**",
+        "description": "Einrichtung von Better Thermostat mit Home Assistant",
         "data": {
           "name": "Name",
           "thermostat": "Das reale Thermostat",
@@ -25,7 +25,7 @@
         }
       },
       "advanced": {
-        "description": "Einstellungen für {trv}\n\n***Infos über die Kalibrierungstypen: https://better-thermostat.org/configuration#second-step*** ",
+        "description": "Einstellungen für {trv}",
         "data": {
           "protect_overheating": "Überhitzung verhindern?",
           "heat_auto_swapped": "Tauscht die Modi auto und heat, falls diese bei dem realen Thermostat vertauscht sind.",
@@ -80,14 +80,14 @@
           "child_lock": "Ignorieren Sie alle Eingaben am TRV wie eine Kindersicherung.",
           "homematicip": "Wenn Sie HomematicIP verwenden, sollten Sie dies aktivieren, um die Anfragen zu verlangsamen und den Duty Cycle zu verhindern.",
           "heat_auto_swapped": "Wenn das Auto Wärme für Ihr TRV bedeutet und Sie es austauschen möchten.",
-          "calibration": "Die Art der Kalibrierung https://better-thermostat.org/configuration#second-step"
+          "calibration": "Die Art der Kalibrierung"
         },
         "data_description": {
           "presets": "Wähle die Presets aus, die für dieses Thermostat verfügbar sein sollen."
         }
       },
       "advanced": {
-        "description": "Aktualisiere die Einstellungen für {trv}\n\n***Infos über die Kalibrierungstypen: https://better-thermostat.org/configuration#second-step*** ",
+        "description": "Aktualisiere die Einstellungen für {trv}",
         "data": {
           "trend_mix_trv": "Glättung (EMA‑Mix, 0–1)",
           "percent_hysteresis_pts": "Hysterese (Prozentpunkte)",

--- a/custom_components/better_thermostat/translations/el.json
+++ b/custom_components/better_thermostat/translations/el.json
@@ -3,7 +3,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Ρυθμίστε το Better Thermostat για να ενσωματωθεί στο Home Assistant\n**Εάν χρειάζεστε περισσότερες πληροφορίες: https://better-thermostat.org/configuration#first-step**",
+        "description": "Ρυθμίστε το Better Thermostat για να ενσωματωθεί στο Home Assistant",
         "data": {
           "name": "Όνομα",
           "thermostat": "Ο πραγματικός θερμοστάτης",
@@ -20,7 +20,7 @@
         }
       },
       "advanced": {
-        "description": "Προηγμένη ρύθμιση {trv}\n***Πληροφορίες για τους τύπους βαθμονόμησης: https://better-thermostat.org/configuration#second-step***",
+        "description": "Προηγμένη ρύθμιση {trv}",
         "data": {
           "protect_overheating": "Προστασία από υπερθέρμανση;",
           "heat_auto_swapped": "Αν το αυτόματο σημαίνει θέρμανση για το TRV σας και θέλετε να το ανταλλάξετε",
@@ -69,7 +69,7 @@
           "window_off_delay_after": "Καθυστέρηση πριν ενεργοποιηθεί ο θερμοστάτης όταν κλείνει το παράθυρο",
           "outdoor_sensor": "Εάν έχετε αισθητήρα εξωτερικής θερμοκρασίας, μπορείτε να τον χρησιμοποιήσετε για να λάβετε την εξωτερική θερμοκρασία",
           "valve_maintenance": "Εάν ο θερμοστάτης σας δεν διαθέτει δικό του τρόπο συντήρησης, μπορείτε να χρησιμοποιήσετε αυτήν την επιλογή",
-          "calibration": "Ο τύπος βαθμονόμησης https://better-thermostat.org/configuration#second-step",
+          "calibration": "Ο τύπος βαθμονόμησης",
           "weather": "Η οντότητά σας για τον καιρό για να λαμβάνετε την εξωτερική θερμοκρασία",
           "heat_auto_swapped": "Αν το αυτόματο σημαίνει θέρμανση για το TRV σας και θέλετε να το ανταλλάξετε",
           "child_lock": "Αγνοήστε όλες τις εισόδους στο TRV όπως λειτουργία κλειδώματος παιδιών",
@@ -77,7 +77,7 @@
         }
       },
       "advanced": {
-        "description": "Προηγμένη ρύθμιση {trv}\n***Πληροφορίες για τους τύπους βαθμονόμησης: https://better-thermostat.org/configuration#second-step***",
+        "description": "Προηγμένη ρύθμιση {trv}",
         "data": {
           "protect_overheating": "Προστασία από υπερθέρμανση;",
           "heat_auto_swapped": "Αν το αυτόματο σημαίνει θέρμανση για το TRV σας και θέλετε να το ανταλλάξετε",

--- a/custom_components/better_thermostat/translations/fr.json
+++ b/custom_components/better_thermostat/translations/fr.json
@@ -3,7 +3,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Configurez Better Thermostat pour l'intégrer à Home Assistant\n**Si vous avez besoin de plus d'informations : https://better-thermostat.org/configuration#first-step**",
+        "description": "Configurez Better Thermostat pour l'intégrer à Home Assistant",
         "data": {
           "name": "Nom",
           "thermostat": "Le vrai thermostat",
@@ -20,7 +20,7 @@
         }
       },
       "advanced": {
-        "description": "Configuration avancée {trv}\n***Informations sur les types de calibrage : https://better-thermostat.org/configuration#second-step***",
+        "description": "Configuration avancée {trv}",
         "data": {
           "protect_overheating": "Protection contre la surchauffe ?",
           "heat_auto_swapped": "Si le mode automatique signifie chauffage pour votre TRV et que vous voulez le permuter",
@@ -69,7 +69,7 @@
           "window_off_delay_after": "Délai avant que le thermostat ne s'allume lorsque la fenêtre est fermée",
           "outdoor_sensor": "Si vous avez un capteur extérieur, vous pouvez l'utiliser pour obtenir la température extérieure",
           "valve_maintenance": "Si votre thermostat n'a pas de mode maintenance propre, vous pouvez utiliser celui-ci",
-          "calibration": "Le type de calibrage https://better-thermostat.org/configuration#second-step",
+          "calibration": "Le type de calibrage",
           "weather": "Votre entité météo pour obtenir la température extérieure",
           "heat_auto_swapped": "Si le mode automatique signifie chauffage pour votre TRV et que vous voulez le permuter",
           "child_lock": "Ignorer toutes les entrées sur le TRV comme une sécurité enfant",
@@ -77,7 +77,7 @@
         }
       },
       "advanced": {
-        "description": "Configuration avancée {trv}\n***Informations sur les types de calibrage : https://better-thermostat.org/configuration#second-step***",
+        "description": "Configuration avancée {trv}",
         "data": {
           "protect_overheating": "Protection contre la surchauffe ?",
           "heat_auto_swapped": "Si le mode automatique signifie chauffage pour votre TRV et que vous voulez le permuter",

--- a/custom_components/better_thermostat/translations/it.json
+++ b/custom_components/better_thermostat/translations/it.json
@@ -3,7 +3,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Configura il tuo Better Thermostat per integrarlo con Home Assistant\n**Per maggiori informazioni: https://better-thermostat.org/configuration#first-step**",
+        "description": "Configura il tuo Better Thermostat per integrarlo con Home Assistant",
         "data": {
           "name": "Nome",
           "thermostat": "Il termostato reale",
@@ -20,7 +20,7 @@
         }
       },
       "advanced": {
-        "description": "Configurazione avanzata {trv}\n***Informazioni sui tipi di calibrazione: https://better-thermostat.org/configuration#second-step***",
+        "description": "Configurazione avanzata {trv}",
         "data": {
           "protect_overheating": "Protezione dal surriscaldamento?",
           "heat_auto_swapped": "Se 'auto' indica riscaldamento per il tuo TRV e vuoi invertirlo",
@@ -69,7 +69,7 @@
           "window_off_delay_after": "Ritardo prima che il termostato si riaccenda quando la finestra viene chiusa",
           "outdoor_sensor": "Se hai un sensore esterno, puoi usarlo per ottenere la temperatura esterna",
           "valve_maintenance": "Se il tuo termostato non ha una modalità di manutenzione propria, puoi usare questa",
-          "calibration": "Tipo di calibrazione https://better-thermostat.org/configuration#second-step",
+          "calibration": "Tipo di calibrazione",
           "weather": "La tua entità meteo per ottenere la temperatura esterna",
           "heat_auto_swapped": "Se 'auto' indica riscaldamento per il tuo TRV e vuoi invertirlo",
           "child_lock": "Ignora tutti gli input sul TRV come un blocco bambini",
@@ -77,7 +77,7 @@
         }
       },
       "advanced": {
-        "description": "Configurazione avanzata {trv}\n***Informazioni sui tipi di calibrazione: https://better-thermostat.org/configuration#second-step***",
+        "description": "Configurazione avanzata {trv}",
         "data": {
           "protect_overheating": "Protezione dal surriscaldamento?",
           "heat_auto_swapped": "Se 'auto' indica riscaldamento per il tuo TRV e vuoi invertirlo",

--- a/custom_components/better_thermostat/translations/pl.json
+++ b/custom_components/better_thermostat/translations/pl.json
@@ -3,7 +3,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Skonfiguruj swój Better Thermostat do integracji z Home Assistant\n**Więcej informacji znajdziesz na: https://better-thermostat.org/configuration#first-step**",
+        "description": "Skonfiguruj swój Better Thermostat do integracji z Home Assistant",
         "data": {
           "name": "Nazwa",
           "thermostat": "Twój termostat",
@@ -17,7 +17,7 @@
         }
       },
       "advanced": {
-        "description": "Zaawansowana konfiguracja {trv}\n***Informacja o typach kalibracji: https://better-thermostat.org/configuration#second-step***",
+        "description": "Zaawansowana konfiguracja {trv}",
         "data": {
           "heat_auto_swapped": "Jeżeli tryb auto oznacza grzanie dla Twojego TRV i chcesz to zmienić",
           "child_lock": "Ignoruj wszystkie wejścia w TRV jak np. Blokada dziecięca",
@@ -62,7 +62,7 @@
           "window_off_delay": "Opóźnienie wyłączenia termostatu, kiedy otworzysz okno lub je zamkniesz (w sekundach)",
           "outdoor_sensor": "Jeśli masz czujnik zewnętrzny, możesz go użyć, aby uzyskać temperaturę zewnętrzną",
           "valve_maintenance": "Jeżeli Twój termostat nie ma własnego trybu konserwacji, możesz użyć tej opcji.",
-          "calibration": "Rodzaje kalibracji https://better-thermostat.org/configuration#second-step",
+          "calibration": "Rodzaje kalibracji",
           "weather": "Twoja jednostka pogodowa, aby uzyskać temperaturę zewnętrzną",
           "heat_auto_swapped": "Jeżeli tryb auto oznacza grzanie dla Twojego TRV i chcesz to zmienić",
           "child_lock": "Ignoruj wszystkie wejścia w TRV jak np. Blokada dziecięca",
@@ -72,7 +72,7 @@
         }
       },
       "advanced": {
-        "description": "Zaawansowana konfiguracja {trv}\n***Informacja o typach kalibracji: https://better-thermostat.org/configuration#second-step***",
+        "description": "Zaawansowana konfiguracja {trv}",
         "data": {
           "heat_auto_swapped": "Jeżeli tryb auto oznacza grzanie dla Twojego TRV i chcesz to zmienić",
           "child_lock": "Ignoruj wszystkie wejścia w TRV jak np. Blokada dziecięca",

--- a/custom_components/better_thermostat/translations/ru.json
+++ b/custom_components/better_thermostat/translations/ru.json
@@ -3,7 +3,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Настройте термостат Better Thermostat для интеграции с Home Assistant\n**Если вам нужна дополнительная информация: https://better-thermostat.org/configuration#first-step**",
+        "description": "Настройте термостат Better Thermostat для интеграции с Home Assistant",
         "data": {
           "name": "Имя",
           "thermostat": "Реальный термостат",
@@ -20,7 +20,7 @@
         }
       },
       "advanced": {
-        "description": "Расширенная конфигурация {trv}\n***Информация о типах калибровки:https://better-thermostat.org/configuration#second-step***",
+        "description": "Расширенная конфигурация {trv}",
         "data": {
           "protect_overheating": "Защита от перегрева?",
           "heat_auto_swapped": "Если автомат означает обогрев вашего термостата, и вы хотите его поменять",
@@ -69,7 +69,7 @@
           "window_off_delay_after": "Задержка перед включением термостата при закрытии окна",
           "outdoor_sensor": "Если у вас есть датчик наружной температуры, вы можете использовать его для определения температуры наружного воздуха.",
           "valve_maintenance": "Если у вашего термостата нет собственного режима обслуживания, вы можете использовать этот.",
-          "calibration": "Тип калибровки https://better-thermostat.org/configuration#second-step",
+          "calibration": "Тип калибровки",
           "weather": "Датчик температуры наружного воздуха",
           "heat_auto_swapped": "Если автомат означает обогрев вашего термостата, и вы хотите его поменять",
           "child_lock": "Игнорировать все входы на термостате, как блокировку от детей.",
@@ -77,7 +77,7 @@
         }
       },
       "advanced": {
-        "description": "Расширенная конфигурация {trv}\n***Информация о типах калибровки: https://better-thermostat.org/configuration# Second-step***",
+        "description": "Расширенная конфигурация {trv}",
         "data": {
           "protect_overheating": "Защита от перегрева?",
           "heat_auto_swapped": "Если стоит функция auto, это означает нагрев вашего термостата и вы хотите его заменить",

--- a/custom_components/better_thermostat/translations/sk.json
+++ b/custom_components/better_thermostat/translations/sk.json
@@ -3,7 +3,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Nastavenie lepšieho termostatu na integráciu s aplikáciou Home Assistant\n**Ak potrebujete viac informácií: https://better-thermostat.org/configuration#first-step**",
+        "description": "Nastavenie lepšieho termostatu na integráciu s aplikáciou Home Assistant",
         "data": {
           "name": "Názov",
           "thermostat": "Skutočný termostat",
@@ -25,7 +25,7 @@
         }
       },
       "advanced": {
-        "description": "Rozšírená konfigurácia {trv}\n***Informácie o druhoch kalibrácie: https://better-thermostat.org/configuration#second-step***",
+        "description": "Rozšírená konfigurácia {trv}",
         "data": {
           "protect_overheating": "Ochrana proti prehriatiu?",
           "heat_auto_swapped": "Ak auto znamená teplo pre váš TRV a chcete ho vymeniť",
@@ -74,7 +74,7 @@
           "window_off_delay_after": "Oneskorenie pred zapnutím termostatu pri zatvorenom okne",
           "outdoor_sensor": "Ak máte vonkajší snímač, môžete pomocou neho zistiť vonkajšiu teplotu",
           "valve_maintenance": "Ak váš termostat nemá vlastný režim údržby, môžete použiť tento režim",
-          "calibration": "Druh kalibrácie https://better-thermostat.org/configuration#second-step",
+          "calibration": "Druh kalibrácie",
           "weather": "Váš meteorologický subjekt na zistenie vonkajšej teploty",
           "presets": "Enabled Predvoľby",
           "target_temp_step": "Krok cieľovej teploty",
@@ -87,7 +87,7 @@
         }
       },
       "advanced": {
-        "description": "Rozšírená konfigurácia {trv}\n***Informácie o druhoch kalibrácie: https://better-thermostat.org/configuration#second-step***",
+        "description": "Rozšírená konfigurácia {trv}",
         "data": {
           "trend_mix_trv": "Dočasná zmes (externá hmotnosť, 0–1)",
           "percent_hysteresis_pts": "Hysterézia (percentuálne body)",

--- a/custom_components/better_thermostat/translations/tr.json
+++ b/custom_components/better_thermostat/translations/tr.json
@@ -3,7 +3,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Better Thermostat'ınızı Home Assistant ile entegre etmek için yapılandırın\n**Daha fazla bilgi için: https://better-thermostat.org/configuration#first-step**",
+        "description": "Better Thermostat'ınızı Home Assistant ile entegre etmek için yapılandırın",
         "data": {
           "name": "Ad",
           "thermostat": "Gerçek termostat",
@@ -21,7 +21,7 @@
         }
       },
       "advanced": {
-        "description": "Gelişmiş yapılandırma {trv}\n***Kalibrasyon türleri hakkında bilgi: https://better-thermostat.org/configuration#second-step***",
+        "description": "Gelişmiş yapılandırma {trv}",
         "data": {
           "balance_mode": "Hidrolik denge modu (Deneysel)",
           "mpc_thermal_gain": "MPC termal kazanç",
@@ -88,7 +88,7 @@
           "window_off_delay_after": "Pencere kapandığında termostatın açılması için gecikme süresi",
           "outdoor_sensor": "Dış ortam sensörünüz varsa, dış ortam sıcaklığını almak için kullanabilirsiniz",
           "valve_maintenance": "Termostatınızın kendi bakım modu yoksa, bunu kullanabilirsiniz",
-          "calibration": "Kalibrasyon türü https://better-thermostat.org/configuration#second-step",
+          "calibration": "Kalibrasyon türü",
           "weather": "Dış ortam sıcaklığını almak için hava durumu varlığı",
           "target_temp_step": "Hedef sıcaklık adımı",
           "heat_auto_swapped": "TRV'nizde otomatik mod ısıtma anlamına geliyorsa ve değiştirmek istiyorsanız",
@@ -97,7 +97,7 @@
         }
       },
       "advanced": {
-        "description": "Gelişmiş yapılandırma {trv}\n***Kalibrasyon türleri hakkında bilgi: https://better-thermostat.org/configuration#second-step***",
+        "description": "Gelişmiş yapılandırma {trv}",
         "data": {
           "balance_mode": "Hidrolik denge modu (Deneysel)",
           "mpc_thermal_gain": "MPC termal kazanç",


### PR DESCRIPTION
## Problem

Fixes #2040.

In the config flow, the step descriptions and the *Calibration type* field linked to `https://better-thermostat.org/configuration#first-step` / `#second-step`. The docs site was restructured and `/configuration` now returns **404** — clicking the "information about calibration types" link lands on an error page.

## Root cause

The English base strings (`strings.json` / `translations/en.json`) already **dropped** these external links and instead explain the calibration types/modes **inline** in the field descriptions. The nine non-English translations (`da, de, el, fr, it, pl, ru, sk, tr`) were never updated and still carry the dead links — in the user step, the advanced step descriptions, and the calibration field label.

## Fix

Remove the dead link constructs from the nine translation files so no step points at a 404, matching the English base (no external link). Surrounding text is preserved; only the `…: <url>` / markdown-wrapped link fragments are stripped. This also cleans up a `#/Second-step` typo in `ru`.

No new URL is introduced on purpose: the site has no dedicated calibration page anymore, and the English base intentionally relies on inline explanations — adding a link would risk going stale again.

## Verification

- No `configuration#` occurrences remain in any translation.
- No dangling markdown remnants (e.g. empty `***…:***`).
- All translation JSON files validate.