### PR TITLE
chore: add diagnostic logging for TRV setpoint sync edge cases

### DIFF
--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -326,7 +326,7 @@ async def trigger_trv_change(self, event):
             v is not None and abs(_new_heating_setpoint - v) < _step
             for v in _bt_known_values
         )
-        if (
+        _accept_user_setpoint = (
             not _is_echo
             and not child_lock
             and self.real_trvs[entity_id]["target_temp_received"] is True
@@ -334,7 +334,8 @@ async def trigger_trv_change(self, event):
             and self.real_trvs[entity_id]["hvac_mode"] != HVACMode.OFF
             and self.window_open is False
             and not self.real_trvs[entity_id].get("ignore_trv_states", False)
-        ):
+        )
+        if _accept_user_setpoint:
             _LOGGER.debug(
                 "better_thermostat %s: TRV %s decoded TRV target temp changed from %s to %s",
                 self.device_name,
@@ -350,12 +351,45 @@ async def trigger_trv_change(self, event):
                     )
 
             _main_change = True
+        elif _new_heating_setpoint != _old_heating_setpoint:
+            # A setpoint change arrived from the TRV but was not adopted as user
+            # intent. Record which guard suppressed it so intermittent "change
+            # ignored" / "device not syncing" reports can be diagnosed from a
+            # debug log instead of guesswork.
+            _LOGGER.debug(
+                "better_thermostat %s: TRV %s setpoint change %s -> %s NOT adopted "
+                "(echo=%s child_lock=%s target_temp_received=%s system_mode_received=%s "
+                "hvac_mode=%s window_open=%s ignore_trv_states=%s bt_target_temp=%s "
+                "last_temperature=%s step=%s)",
+                self.device_name,
+                entity_id,
+                _old_heating_setpoint,
+                _new_heating_setpoint,
+                _is_echo,
+                child_lock,
+                self.real_trvs[entity_id]["target_temp_received"],
+                self.real_trvs[entity_id]["system_mode_received"],
+                self.real_trvs[entity_id]["hvac_mode"],
+                self.window_open,
+                self.real_trvs[entity_id].get("ignore_trv_states", False),
+                self.bt_target_temp,
+                self.real_trvs[entity_id]["last_temperature"],
+                _step,
+            )
 
         if self.real_trvs[entity_id]["advanced"].get("no_off_system_mode", False):
             if _new_heating_setpoint == self.real_trvs[entity_id]["min_temp"]:
                 # Only set OFF if window is NOT open - min_temp during window
                 # open was set by BT, not by user turning off heating
                 if not self.window_open:
+                    if self.bt_hvac_mode != HVACMode.OFF:
+                        _LOGGER.debug(
+                            "better_thermostat %s: TRV %s reported min_temp %s on a "
+                            "no_off_system_mode device -> interpreting as heating OFF",
+                            self.device_name,
+                            entity_id,
+                            _new_heating_setpoint,
+                        )
                     self.bt_hvac_mode = HVACMode.OFF
             else:
                 self.bt_hvac_mode = HVACMode.HEAT

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -673,10 +673,13 @@ async def check_system_mode(self, heater_entity_id=None):
     _real_trv = self.real_trvs[heater_entity_id]
     while _real_trv["hvac_mode"] != _real_trv["last_hvac_mode"]:
         if _timeout > 360:
-            _LOGGER.debug(
-                "better_thermostat %s: %s the real TRV did not respond to the system mode change",
+            _LOGGER.warning(
+                "better_thermostat %s: TRV %s did not confirm the system mode change "
+                "after 360s (wrote=%s, last reported=%s); giving up and assuming applied",
                 self.device_name,
                 heater_entity_id,
+                _real_trv["last_hvac_mode"],
+                _real_trv["hvac_mode"],
             )
             _timeout = 0
             break
@@ -736,10 +739,13 @@ async def check_target_temperature(self, heater_entity_id=None):
             _timeout = 0
             break
         if _timeout > 360:
-            _LOGGER.debug(
-                "better_thermostat %s: %s the real TRV did not respond to the target temperature change",
+            _LOGGER.warning(
+                "better_thermostat %s: TRV %s did not confirm the target temperature "
+                "after 360s (wrote=%s, last reported=%s); giving up and assuming applied",
                 self.device_name,
                 heater_entity_id,
+                _real_trv["last_temperature"],
+                _current_set_temperature,
             )
             _timeout = 0
             break


### PR DESCRIPTION
## Why

Some users report intermittent group-sync issues — control loops, target changes being ignored, or a single TRV in a group not synchronising — that do **not** reproduce in a typical setup. The handling is correct in the common case, but the relevant logic is spread across echo suppression, a pending-confirmation window and a 6-minute confirmation poll. When a legitimate change is dropped today, there is no way to tell *which* guard fired, so these reports can only be guessed at.

This PR adds **targeted, behaviour-neutral logging** at the decision points so an affected user's debug log pinpoints the cause. **No behaviour change — logging only.**

## What

- **`events/trv.py`** — when a TRV-reported setpoint change is *not* adopted as user intent, log which guard suppressed it (`echo`, `target_temp_received`, `system_mode_received`, `hvac_mode`, `window_open`, `ignore_trv_states`) including `bt_target_temp`, `last_temperature` and the device `step`. The acceptance condition is unchanged, only extracted into a named variable.
- **`events/trv.py`** — log when a reported `min_temp` flips a `no_off_system_mode` device to `OFF` (the one path where an echo can start a loop).
- **`controlling.py`** — raise the 6-minute confirmation timeout in `check_target_temperature()` and `check_system_mode()` from `debug` to `warning`, including the written vs. last-reported value, so a device that never confirms a write becomes visible.

## How to use

Enable debug logging for the integration. The `... setpoint change X -> Y NOT adopted (...)` line names the guard that dropped a change; the new `warning`s surface TRVs that never confirm a write. That turns the next, actual fix into a data-driven one-liner instead of guesswork.

## Notes

- Behaviour-neutral; existing unit tests pass (`tests/unit/controlling/`, `test_trv_events.py`, `test_trv_ignore_states.py`).
- No fix is included here on purpose — this is to gather diagnosis for the intermittent reports first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced TRV setpoint change handling with improved debug logging for better troubleshooting.
  * Upgraded confirmation timeout warnings from debug to warning level when TRV fails to confirm system mode or temperature changes after 360 seconds, providing clearer diagnostics for connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->