### PR TITLE
docs: serve the documentation pages under their declared URLs

### DIFF
--- a/docs/Configuration/algorithms.md
+++ b/docs/Configuration/algorithms.md
@@ -1,9 +1,7 @@
 ---
-layout: default
 title: Calibration Algorithms
-nav_order: 2
-has_children: true
-permalink: calibration_algorithms
+description: The Better Thermostat calibration algorithms and how to choose one.
+slug: calibration_algorithms
 ---
 
 Better Thermostat offers several calibration algorithms (also called "Calibration Modes") that control how your TRV (Thermostatic Radiator Valve) is adjusted to maintain your desired temperature. Each algorithm has different characteristics and is suited for different situations.

--- a/docs/Configuration/configuration.md
+++ b/docs/Configuration/configuration.md
@@ -1,9 +1,7 @@
 ---
-layout: default
 title: Configuration
-nav_order: 2
-has_children: true
-permalink: configuration
+description: Create and configure a Better Thermostat device.
+slug: configuration
 ---
 
 ## Create a new Better Thermostat device

--- a/docs/Q&A/debugging.md
+++ b/docs/Q&A/debugging.md
@@ -1,10 +1,7 @@
 ---
-layout: default
 title: How do I activate the debug mode?
-nav_order: 3
-description: "BT."
-permalink: qanda/debugging
-parent: Q&A
+description: Enable Better Thermostat debug logging with or without a restart.
+slug: qanda/debugging
 ---
 
 # How do I activate the debug mode?

--- a/docs/Q&A/modes.md
+++ b/docs/Q&A/modes.md
@@ -1,10 +1,7 @@
 ---
-layout: default
 title: What is the difference between "local calibration" and "temperature-based calibration"?
-nav_order: 3
-description: "BT."
-permalink: qanda/modes
-parent: Q&A
+description: Local (offset-based) versus target-temperature-based calibration.
+slug: qanda/modes
 ---
 
 # What is the difference between "local calibration" and "temperature-based calibration"?

--- a/docs/Q&A/qanda.md
+++ b/docs/Q&A/qanda.md
@@ -1,7 +1,13 @@
 ---
-layout: default
 title: Q&A
-nav_order: 4
-has_children: true
-permalink: qanda
+description: Questions and answers around Better Thermostat.
+slug: qanda
 ---
+
+# Q&A
+
+- [Which devices are currently supported?](/qanda/supported)
+- [What is the difference between "local calibration" and "temperature-based calibration"?](/qanda/modes)
+- [How do I activate the debug mode?](/qanda/debugging)
+
+More questions are answered in the [FAQ](/faq/common-questions).

--- a/docs/Q&A/supported.md
+++ b/docs/Q&A/supported.md
@@ -1,10 +1,7 @@
 ---
-layout: default
 title: Which devices are currently supported?
-nav_order: 3
-description: "BT."
-permalink: qanda/supported
-parent: Q&A
+description: Which TRVs and integrations Better Thermostat supports.
+slug: qanda/supported
 ---
 
 # Which devices are currently supported?

--- a/docs/faq/missing-entity.md
+++ b/docs/faq/missing-entity.md
@@ -1,0 +1,27 @@
+---
+title: Missing entity
+description: What the "related entity is missing" repair issue means and how to fix it.
+slug: qanda/missing_entity
+---
+
+Better Thermostat raises a **missing entity** repair issue when one of
+the entities it was configured with — a TRV, the room temperature
+sensor, a window sensor, or another configured device — is not available
+in Home Assistant.
+
+## Common causes
+
+- The device's battery is empty or the device lost its radio connection.
+- The integration providing the entity is not loaded or failed to start.
+- The entity was renamed or removed, so the entity id Better Thermostat
+  was configured with no longer exists.
+
+## How to fix it
+
+1. Open **Settings → Devices & services** and find the entity named in
+   the issue. Check the device's battery and reconnect it if necessary.
+2. If the entity id changed, either rename it back or update the Better
+   Thermostat configuration to the new entity id (open the Better
+   Thermostat entry and reconfigure it).
+3. Once the entity is back, confirm the repair issue — it also clears on
+   its own when the entity becomes available again.

--- a/docs/hydraulic_balance_design.md
+++ b/docs/hydraulic_balance_design.md
@@ -1,9 +1,7 @@
 ---
-layout: default
 title: Hydraulic
-nav_order: 6
-description: "BT."
-permalink: hydraulic
+description: Decentralized hydraulic balance in Better Thermostat.
+slug: hydraulic
 ---
 
 # Decentralized Hydraulic Balance in Better Thermostat


### PR DESCRIPTION
## Problem

The published site (Astro Starlight, built from `docs/` via `website/`) routes pages by file path and ignores the Jekyll `permalink:` frontmatter the older pages still carry. Every URL declared that way returns 404 on better-thermostat.org — including URLs the integration itself links to:

| URL | Linked from | Before |
|---|---|---|
| `qanda/missing_entity` | `utils/watcher.py` repair issue (2×) | 404, no page existed at all |
| `configuration` | config flow | 404 (page built at `configuration/configuration`) |
| `calibration_algorithms` | declared permalink | 404 (built at `configuration/algorithms`) |
| `qanda`, `qanda/debugging`, `qanda/modes`, `qanda/supported` | declared permalinks, historical deep links | 404 (built at `qa/*`) |
| `hydraulic` | declared permalink | 404 (built at `hydraulic_balance_design`) |

Same class of issue as the calibration-link 404 fixed earlier.

## Change

- Each affected page carries an explicit Starlight `slug:` matching its declared URL; the dead Jekyll fields (`layout`, `nav_order`, `parent`, `permalink`) are removed and the placeholder descriptions ("BT.") replaced.
- New page `docs/faq/missing-entity.md` (slug `qanda/missing_entity`) explains the repair issue that links to it: causes and how to fix, matching the integration's behavior.
- The `qanda` landing page links its children instead of rendering empty.

## Verification

`bun run build` in `website/`; the built routes now include `calibration_algorithms`, `configuration`, `hydraulic`, `qanda`, `qanda/debugging`, `qanda/missing_entity`, `qanda/modes`, `qanda/supported`.

## Out of scope

`qanda/degraded_mode` and `qanda/window_sensor` (also linked from repair issues) get their pages in the pending core-architecture branch, which introduces the behavior they document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **New FAQ page** added explaining the "missing entity" repair issue, including common causes and resolution steps.
* **Updated documentation structure** across configuration and Q&A sections with improved metadata and descriptions for better organization.
* **Enhanced documentation content** in Q&A pages with clearer descriptions of calibration modes and supported features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->