### PR TITLE
fix: sensor handling, store loading, and window-state hardening

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1252,7 +1252,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     "Open" if self.window_open else "Closed",
                 )
             else:
-                # Window sensor unavailable - assume closed (safer default)
+                # At startup, unavailable/unknown usually means the sensor
+                # has not joined HA yet, so heating continues normally
+                # (assume closed). At runtime the same states mean a live
+                # sensor was lost and count as open (see events/window.py).
                 self.window_open = False
                 _LOGGER.debug(
                     "better_thermostat %s: window sensor unavailable, assuming closed",
@@ -1630,7 +1633,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             # unit conversion (a literal "5" read as °F becomes about
             # -15 °C), and a real reading of 0.0 is a reading.
             _raw_current_temp = _attrs.get("current_temperature")
-            trv_data["current_temperature"] = (
+            _current_temp = (
                 convert_to_float_celsius(
                     str(_raw_current_temp),
                     self.device_name,
@@ -1642,6 +1645,20 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 if _raw_current_temp is not None
                 else 5.0
             )
+            # Marker / garbage readings (for example AVM's 126.5 / 127 °C)
+            # must not seed the cache and feed the first control cycle.
+            if _current_temp is not None and not is_reasonable_temperature(
+                _current_temp
+            ):
+                _LOGGER.warning(
+                    "better_thermostat %s: TRV %s reports implausible "
+                    "current_temperature %s at startup; ignoring",
+                    self.device_name,
+                    trv,
+                    _current_temp,
+                )
+                _current_temp = None
+            trv_data["current_temperature"] = _current_temp
             _LOGGER.debug(
                 "better_thermostat %s: controlling TRV %s...", self.device_name, trv
             )

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1626,13 +1626,21 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             trv_data["last_temperature"] = attr_to_celsius(
                 self, _s, "temperature", None, "startup()"
             )
-            trv_data["current_temperature"] = convert_to_float_celsius(
-                str(_attrs.get("current_temperature") or 5),
-                self.device_name,
-                "startup()",
-                unit_of_measurement=state_temperature_unit(
-                    _attrs, self.hass.config.units.temperature_unit
-                ),
+            # The 5.0 °C fallback for a missing reading must not pass the
+            # unit conversion (a literal "5" read as °F becomes about
+            # -15 °C), and a real reading of 0.0 is a reading.
+            _raw_current_temp = _attrs.get("current_temperature")
+            trv_data["current_temperature"] = (
+                convert_to_float_celsius(
+                    str(_raw_current_temp),
+                    self.device_name,
+                    "startup()",
+                    unit_of_measurement=state_temperature_unit(
+                        _attrs, self.hass.config.units.temperature_unit
+                    ),
+                )
+                if _raw_current_temp is not None
+                else 5.0
             )
             _LOGGER.debug(
                 "better_thermostat %s: controlling TRV %s...", self.device_name, trv
@@ -2337,10 +2345,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
     @property
     def hvac_action(self):
-        """Return the current HVAC action."""
-        if self.attr_hvac_action is not None:
-            return self.attr_hvac_action
-        return self._compute_hvac_action_pure().action
+        """Return the current HVAC action.
+
+        Every control cycle commits a fresh action; the one computation
+        here bridges the gap until the first commit and is cached so
+        repeated state reads do not rebuild it.
+        """
+        if self.attr_hvac_action is None:
+            self.attr_hvac_action = self._compute_hvac_action_pure().action
+        return self.attr_hvac_action
 
     def _should_heat_with_tolerance(
         self, previous_action: HVACAction | None, tol: float

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -96,6 +96,9 @@ async def trigger_trv_change(self, event):
                 _org_trv_state.state,
             )
             self.real_trvs[entity_id]["current_temperature"] = None
+            # The next valid reading is the first live data after the
+            # outage and must not be dropped by the debounce below.
+            self.real_trvs[entity_id]["accept_next_internal_temp"] = True
         return
 
     child_lock = self.real_trvs[entity_id]["advanced"].get("child_lock")
@@ -158,7 +161,8 @@ async def trigger_trv_change(self, event):
         _new_current_temp is not None
         and self.real_trvs[entity_id]["current_temperature"] != _new_current_temp
         and (
-            (dt_util.now() - self.last_internal_sensor_change).total_seconds()
+            self.real_trvs[entity_id].pop("accept_next_internal_temp", False)
+            or (dt_util.now() - self.last_internal_sensor_change).total_seconds()
             > _time_diff
             or (
                 self.real_trvs[entity_id]["calibration_received"] is False

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -8,6 +8,7 @@ convert thermostat states and prepare outbound payloads.
 import logging
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import State, callback
 from homeassistant.util import dt as dt_util
 
@@ -83,6 +84,20 @@ async def trigger_trv_change(self, event):
         )
         return
 
+    if _org_trv_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+        # The device is gone; its last internal temperature must not
+        # keep feeding the calibration as if it were live.
+        if self.real_trvs[entity_id].get("current_temperature") is not None:
+            _LOGGER.debug(
+                "better_thermostat %s: TRV %s became %s; invalidating its "
+                "internal temperature",
+                self.device_name,
+                entity_id,
+                _org_trv_state.state,
+            )
+            self.real_trvs[entity_id]["current_temperature"] = None
+        return
+
     child_lock = self.real_trvs[entity_id]["advanced"].get("child_lock")
 
     # Dynamische Modell-Erkennung: nur einmalig (z. B. beim Start) – nicht bei jedem Event
@@ -99,17 +114,16 @@ async def trigger_trv_change(self, event):
                 ):
                     detected = await get_device_model(self, entity_id)
                     if isinstance(detected, str) and detected:
-                        if prev_model != detected:
-                            _LOGGER.info(
-                                "better_thermostat %s: TRV %s model changed: %s -> %s; reloading quirks",
-                                self.device_name,
-                                entity_id,
-                                prev_model,
-                                detected,
-                            )
-                            quirks = await load_model_quirks(self, detected, entity_id)
-                            self.real_trvs[entity_id]["model"] = detected
-                            self.real_trvs[entity_id]["model_quirks"] = quirks
+                        _LOGGER.info(
+                            "better_thermostat %s: TRV %s model detected: %s; "
+                            "loading quirks",
+                            self.device_name,
+                            entity_id,
+                            detected,
+                        )
+                        quirks = await load_model_quirks(self, detected, entity_id)
+                        self.real_trvs[entity_id]["model"] = detected
+                        self.real_trvs[entity_id]["model_quirks"] = quirks
     except Exception as e:
         _LOGGER.debug(
             "better_thermostat %s: dynamic model detection failed for %s: %s",

--- a/custom_components/better_thermostat/events/window.py
+++ b/custom_components/better_thermostat/events/window.py
@@ -113,13 +113,18 @@ async def window_queue(self):
                             self.window_delay_after,
                         )
                         await asyncio.sleep(self.window_delay_after)
+                    window_state = self.hass.states.get(self.window_id)
+                    if window_state is None:
+                        _LOGGER.debug(
+                            "better_thermostat %s: Window sensor %s vanished "
+                            "during the debounce delay; skipping event",
+                            self.device_name,
+                            self.window_id,
+                        )
+                        continue
                     # remap off on to true false
                     current_window_state = True
-                    if self.hass.states.get(self.window_id).state in (
-                        "off",
-                        "false",
-                        "closed",
-                    ):
+                    if window_state.state in ("off", "false", "closed"):
                         current_window_state = False
                     # make sure the current state is the suggested change state to prevent a false positive:
                     if current_window_state == window_event_to_process:

--- a/custom_components/better_thermostat/events/window.py
+++ b/custom_components/better_thermostat/events/window.py
@@ -7,7 +7,6 @@ delayed handling so that HVAC behavior uses window-open information reliably.
 import asyncio
 import logging
 
-from homeassistant.const import STATE_OFF
 from homeassistant.core import callback
 from homeassistant.helpers import issue_registry as ir
 
@@ -41,7 +40,7 @@ async def trigger_window_change(self, event) -> None:
 
     old_window_open = self.window_open
 
-    if new_state in ("on", "unknown", "unavailable"):
+    if new_state in ("on", "true", "open", "unknown", "unavailable"):
         new_window_open = True
         if new_state == "unknown":
             _LOGGER.warning(
@@ -52,7 +51,7 @@ async def trigger_window_change(self, event) -> None:
         # window was opened, disable heating power calculation for this period
         self._heating_tracker.start_temp = None
         self.async_write_ha_state()
-    elif new_state == "off":
+    elif new_state in ("off", "false", "closed"):
         new_window_open = False
     else:
         _LOGGER.error(
@@ -116,7 +115,11 @@ async def window_queue(self):
                         await asyncio.sleep(self.window_delay_after)
                     # remap off on to true false
                     current_window_state = True
-                    if self.hass.states.get(self.window_id).state == STATE_OFF:
+                    if self.hass.states.get(self.window_id).state in (
+                        "off",
+                        "false",
+                        "closed",
+                    ):
                         current_window_state = False
                     # make sure the current state is the suggested change state to prevent a false positive:
                     if current_window_state == window_event_to_process:

--- a/custom_components/better_thermostat/events/window.py
+++ b/custom_components/better_thermostat/events/window.py
@@ -47,6 +47,11 @@ async def trigger_window_change(self, event) -> None:
                 "better_thermostat %s: Window sensor state is unknown, assuming window is open",
                 self.device_name,
             )
+        elif new_state == "unavailable":
+            _LOGGER.info(
+                "better_thermostat %s: Window sensor is unavailable, assuming window is open",
+                self.device_name,
+            )
 
         # window was opened, disable heating power calculation for this period
         self._heating_tracker.start_temp = None

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -487,9 +487,9 @@ class StateManager:
             self._state = _deserialize(raw)
         except Exception:
             _LOGGER.warning(
-                "better_thermostat [%s]: persisted state is unreadable, "
-                "starting fresh",
+                "better_thermostat [%s]: persisted state is unreadable, starting fresh",
                 self._entry_id,
+                exc_info=True,
             )
             self._state = RuntimeState()
             self._dirty = False

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -477,11 +477,23 @@ class StateManager:
             )
             return
 
-        version = raw.get("version", 0)
-        if version < 1:
-            raw = _migrate_v0_to_v1(raw)
-
-        self._state = _deserialize(raw)
+        # A store that breaks deserialization yields defaults, not a
+        # crash: load() runs inside the entity's startup task, and
+        # relearning replaces anything a poisoned store could offer.
+        try:
+            version = raw.get("version", 0)
+            if version < 1:
+                raw = _migrate_v0_to_v1(raw)
+            self._state = _deserialize(raw)
+        except Exception:
+            _LOGGER.warning(
+                "better_thermostat [%s]: persisted state is unreadable, "
+                "starting fresh",
+                self._entry_id,
+            )
+            self._state = RuntimeState()
+            self._dirty = False
+            return
         self._dirty = False
         _LOGGER.debug(
             "better_thermostat [%s]: Loaded state v%d (%d mpc, %d pid, %d tpi keys)",

--- a/tests/unit/test_climate_hvac_action_cache.py
+++ b/tests/unit/test_climate_hvac_action_cache.py
@@ -1,0 +1,44 @@
+"""The hvac_action property computes at most once between commits.
+
+Every control cycle commits a fresh action; the property only has to
+bridge the gap until the first commit. Recomputing on every state read
+rebuilds the TRV snapshot list each time for a result that is thrown
+away.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock
+
+from homeassistant.components.climate.const import HVACAction
+
+from custom_components.better_thermostat.climate import BetterThermostat
+
+
+def _bt():
+    bt = MagicMock()
+    bt.attr_hvac_action = None
+    bt._compute_hvac_action_pure = Mock(
+        return_value=SimpleNamespace(action=HVACAction.IDLE)
+    )
+    return bt
+
+
+def test_first_read_computes_once_and_caches():
+    """Repeated reads before the first commit compute only once."""
+    bt = _bt()
+    first = BetterThermostat.hvac_action.fget(bt)
+    second = BetterThermostat.hvac_action.fget(bt)
+
+    assert first is HVACAction.IDLE
+    assert second is HVACAction.IDLE
+    bt._compute_hvac_action_pure.assert_called_once()
+
+
+def test_committed_action_wins_over_the_cache():
+    """A committed action replaces whatever the property cached."""
+    bt = _bt()
+    BetterThermostat.hvac_action.fget(bt)
+    bt.attr_hvac_action = HVACAction.HEATING
+
+    assert BetterThermostat.hvac_action.fget(bt) is HVACAction.HEATING
+    bt._compute_hvac_action_pure.assert_called_once()

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -418,6 +418,14 @@ class TestInitializeTrvCurrentTemperature:
         await self._run(bt)
         assert bt.real_trvs[TRV_ID]["current_temperature"] == 0.0
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("marker_temp", [126.5, 127.0])
+    async def test_implausible_startup_reading_is_dropped(self, bt, marker_temp):
+        """AVM marker values must not seed the cache for the first control cycle."""
+        bt = self._trv_only_bt(bt, {"current_temperature": marker_temp})
+        await self._run(bt)
+        assert bt.real_trvs[TRV_ID]["current_temperature"] is None
+
 
 class TestRestoreState:
     """Tests for _restore_state."""

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -370,6 +370,55 @@ class TestInitializeSensors:
 # ---------------------------------------------------------------------------
 
 
+class TestInitializeTrvCurrentTemperature:
+    """The startup fallback for a missing TRV reading is 5.0 °C, literally.
+
+    Passing the literal through the unit conversion turned it into about
+    -15 °C on Fahrenheit systems, and the falsy-or fallback swallowed a
+    real reading of 0.0.
+    """
+
+    def _trv_only_bt(self, bt, attrs, unit="°C"):
+        bt.real_trvs = {TRV_ID: {"calibration": 1, "advanced": {}}}
+        bt.hass.config.units.temperature_unit = unit
+        bt.hass.states.get.return_value = _make_trv_state(attrs=attrs)
+        return bt
+
+    async def _run(self, bt):
+        with (
+            patch("custom_components.better_thermostat.climate.init", AsyncMock()),
+            patch(
+                "custom_components.better_thermostat.climate.inital_tweak", AsyncMock()
+            ),
+            patch(
+                "custom_components.better_thermostat.climate.control_trv",
+                AsyncMock(return_value=True),
+            ),
+        ):
+            await BetterThermostat._initialize_trvs(bt)
+
+    @pytest.mark.asyncio
+    async def test_missing_reading_falls_back_to_five_celsius(self, bt):
+        """No reading: the fallback is 5.0 °C on a Celsius system."""
+        bt = self._trv_only_bt(bt, {"current_temperature": None})
+        await self._run(bt)
+        assert bt.real_trvs[TRV_ID]["current_temperature"] == 5.0
+
+    @pytest.mark.asyncio
+    async def test_fallback_is_not_unit_converted(self, bt):
+        """On a Fahrenheit system the fallback stays 5.0 °C, not -15 °C."""
+        bt = self._trv_only_bt(bt, {"current_temperature": None}, unit="°F")
+        await self._run(bt)
+        assert bt.real_trvs[TRV_ID]["current_temperature"] == 5.0
+
+    @pytest.mark.asyncio
+    async def test_zero_reading_is_kept(self, bt):
+        """A legitimate 0.0° reading is a reading, not a missing value."""
+        bt = self._trv_only_bt(bt, {"current_temperature": 0.0})
+        await self._run(bt)
+        assert bt.real_trvs[TRV_ID]["current_temperature"] == 0.0
+
+
 class TestRestoreState:
     """Tests for _restore_state."""
 

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -516,6 +516,24 @@ class TestStateManagerLoadSave:
         assert mgr.dirty is False
 
     @pytest.mark.asyncio
+    async def test_load_survives_a_poisoned_store(self):
+        """A store that breaks deserialization yields defaults, not a crash.
+
+        load() runs inside the entity's startup task; an exception here
+        would kill startup over data that relearning replaces anyway.
+        """
+        mgr, mock_store = self._make_manager_with_store()
+        mock_store.async_load.return_value = {"version": 1, "mpc": {"k": {}}}
+        with patch(
+            "custom_components.better_thermostat.utils.state_manager._deserialize",
+            side_effect=TypeError("poisoned"),
+        ):
+            await mgr.load()
+
+        assert mgr.state.mpc == {}
+        assert mgr.dirty is False
+
+    @pytest.mark.asyncio
     async def test_load_valid_state(self):
         """Loading valid v1 data populates all sections."""
         mgr, mock_store = self._make_manager_with_store()

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import asdict
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -516,22 +517,28 @@ class TestStateManagerLoadSave:
         assert mgr.dirty is False
 
     @pytest.mark.asyncio
-    async def test_load_survives_a_poisoned_store(self):
+    async def test_load_survives_a_poisoned_store(self, caplog):
         """A store that breaks deserialization yields defaults, not a crash.
 
         load() runs inside the entity's startup task; an exception here
         would kill startup over data that relearning replaces anyway.
+        The recovery is announced by a warning that carries the exception.
         """
         mgr, mock_store = self._make_manager_with_store()
         mock_store.async_load.return_value = {"version": 1, "mpc": {"k": {}}}
-        with patch(
-            "custom_components.better_thermostat.utils.state_manager._deserialize",
-            side_effect=TypeError("poisoned"),
+        with (
+            caplog.at_level(logging.WARNING),
+            patch(
+                "custom_components.better_thermostat.utils.state_manager._deserialize",
+                side_effect=TypeError("poisoned"),
+            ),
         ):
             await mgr.load()
 
         assert mgr.state.mpc == {}
         assert mgr.dirty is False
+        assert "persisted state is unreadable, starting fresh" in caplog.text
+        assert "poisoned" in caplog.text
 
     @pytest.mark.asyncio
     async def test_load_valid_state(self):

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -134,6 +134,28 @@ class TestUnavailableInvalidation:
 
         assert mock_bt.real_trvs[ENTITY_ID]["current_temperature"] is None
 
+    @pytest.mark.asyncio
+    async def test_first_reading_after_recovery_bypasses_debounce(self, mock_bt):
+        """The first valid reading after an outage repopulates the cache at once."""
+        unavailable = State(ENTITY_ID, "unavailable")
+        mock_bt.hass.states.get.return_value = unavailable
+        await trigger_trv_change(mock_bt, _make_event(mock_bt, new_state=unavailable))
+        assert mock_bt.real_trvs[ENTITY_ID]["current_temperature"] is None
+
+        # The TRV recovers well inside the 5 s debounce window.
+        mock_bt.last_internal_sensor_change = dt_util.now()
+        trv_state = _make_state(attributes={"current_temperature": 18.0})
+        mock_bt.hass.states.get.return_value = trv_state
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID]["current_temperature"] == 18.0
+
 
 class TestTriggerTrvChangeGuards:
     """Guard-clause tests for trigger_trv_change()."""

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -120,6 +120,21 @@ def _make_event(bt, new_state=None, old_state=None, entity_id=ENTITY_ID):
 # ---------------------------------------------------------------------------
 
 
+class TestUnavailableInvalidation:
+    """An unavailable TRV must not keep feeding a stale internal temperature."""
+
+    @pytest.mark.asyncio
+    async def test_unavailable_trv_invalidates_internal_temperature(self, mock_bt):
+        """The stored reading is cleared so calibration stops using it."""
+        unavailable = State(ENTITY_ID, "unavailable")
+        mock_bt.hass.states.get.return_value = unavailable
+
+        event = _make_event(mock_bt, new_state=unavailable)
+        await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID]["current_temperature"] is None
+
+
 class TestTriggerTrvChangeGuards:
     """Guard-clause tests for trigger_trv_change()."""
 

--- a/tests/unit/test_window_events.py
+++ b/tests/unit/test_window_events.py
@@ -10,7 +10,10 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from custom_components.better_thermostat.events.window import trigger_window_change
+from custom_components.better_thermostat.events.window import (
+    trigger_window_change,
+    window_queue,
+)
 
 _WINDOW = "custom_components.better_thermostat.events.window"
 
@@ -63,3 +66,23 @@ async def test_unrecognized_state_raises_an_issue():
         await trigger_window_change(bt, _event("banana"))
     issue.assert_called_once()
     assert bt.window_queue_task.empty()
+
+
+@pytest.mark.asyncio
+async def test_queue_survives_a_sensor_that_vanished_during_debounce():
+    """A sensor removed during the debounce delay drops the event, not the task."""
+    bt = _make_bt(sensor_state="on")
+    bt.window_delay = 0
+    bt.window_delay_after = 0
+    bt.hass.states.get.return_value = None
+
+    task = asyncio.create_task(window_queue(bt))
+    await bt.window_queue_task.put(True)
+    await asyncio.wait_for(bt.window_queue_task.join(), timeout=1)
+
+    assert not task.done()
+    bt.async_write_ha_state.assert_not_called()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task

--- a/tests/unit/test_window_events.py
+++ b/tests/unit/test_window_events.py
@@ -69,6 +69,29 @@ async def test_unrecognized_state_raises_an_issue():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("final_state", ["unknown", "unavailable"])
+async def test_queue_treats_unknown_and_unavailable_as_open(final_state):
+    """A sensor that turns unknown/unavailable during debounce confirms an open event."""
+    bt = _make_bt(sensor_state=final_state)
+    bt.window_delay = 0
+    bt.window_delay_after = 0
+    bt.in_maintenance = False
+    bt.control_queue_task = asyncio.Queue()
+
+    task = asyncio.create_task(window_queue(bt))
+    await bt.window_queue_task.put(True)
+    await asyncio.wait_for(bt.window_queue_task.join(), timeout=1)
+
+    assert bt.window_open is True
+    bt.async_write_ha_state.assert_called_once()
+    assert bt.control_queue_task.qsize() == 1
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
 async def test_queue_survives_a_sensor_that_vanished_during_debounce():
     """A sensor removed during the debounce delay drops the event, not the task."""
     bt = _make_bt(sensor_state="on")

--- a/tests/unit/test_window_events.py
+++ b/tests/unit/test_window_events.py
@@ -1,0 +1,65 @@
+"""Tests for the window sensor event handler.
+
+The accepted state vocabulary matches what the invalid_window_state
+repair issue promises: on/true/open count as open, off/false/closed as
+closed, unknown/unavailable as open (the safe direction).
+"""
+
+import asyncio
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from custom_components.better_thermostat.events.window import trigger_window_change
+
+_WINDOW = "custom_components.better_thermostat.events.window"
+
+
+def _make_bt(*, sensor_state="off", window_open=False):
+    bt = MagicMock()
+    bt.device_name = "Test BT"
+    bt.window_id = "binary_sensor.window"
+    bt.window_open = window_open
+    bt.async_write_ha_state = Mock()
+    bt.window_queue_task = asyncio.Queue()
+
+    state = Mock()
+    state.state = sensor_state
+    bt.hass.states.get.return_value = state
+    return bt
+
+
+def _event(state_value):
+    new_state = Mock()
+    new_state.state = state_value
+    event = Mock()
+    event.data = {"new_state": new_state}
+    return event
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reading", ["on", "true", "open", "unknown", "unavailable"])
+async def test_open_readings_queue_an_open_event(reading):
+    """Every documented open synonym is accepted as open."""
+    bt = _make_bt(sensor_state=reading)
+    await trigger_window_change(bt, _event(reading))
+    assert bt.window_queue_task.get_nowait() is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reading", ["off", "false", "closed"])
+async def test_closed_readings_queue_a_close_event(reading):
+    """Every documented closed synonym is accepted as closed."""
+    bt = _make_bt(sensor_state=reading, window_open=True)
+    await trigger_window_change(bt, _event(reading))
+    assert bt.window_queue_task.get_nowait() is False
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_state_raises_an_issue():
+    """Anything outside the documented vocabulary raises a repair issue."""
+    bt = _make_bt(sensor_state="banana")
+    with patch(f"{_WINDOW}.ir.async_create_issue") as issue:
+        await trigger_window_change(bt, _event("banana"))
+    issue.assert_called_once()
+    assert bt.window_queue_task.empty()


### PR DESCRIPTION
Six small, independent fixes extracted from the architecture review in #2053 — each verified to exist on `develop` and fixed here without any dependency on the rework, so they can land in the 1.8 line.

## Fixes

1. **Fahrenheit startup seed** — the fallback for a missing TRV internal temperature passed the literal `5` through the unit conversion: on °F systems the seeded reading became **about −15 °C** and skewed the local calibration until the first real reading. The falsy `or 5` also swallowed a legitimate `0.0` reading. The fallback is now 5.0 °C literally, and a real reading is kept.
2. **Stale TRV temperature after an outage** — a TRV that becomes `unavailable` now invalidates its stored internal temperature, so calibration stops computing against a frozen value from before the outage.
3. **Window sensor vocabulary** — the `invalid_window_state` repair issue lists `true`/`false`/`open`/`closed` as expected states, but the handler accepted only `on`/`off`: a template or group sensor reporting `open` got an error whose own text claimed `open` is valid. The handler now accepts the documented vocabulary (open synonyms → open, closed synonyms → closed; `unknown`/`unavailable` keep counting as open — the safe direction).
4. **Unreadable persisted state** — an unexpected store shape that broke deserialization propagated out of `StateManager.load()` into the entity's startup task. It now starts fresh with a warning; relearning replaces anything a poisoned store could offer. (Field-level corruption was already absorbed per field.)
5. **`hvac_action` recompute on every state read** — until the first control cycle commits an action, every `async_write_ha_state` rebuilt the TRV snapshot list and re-ran the hysteresis just to throw the result away. The property caches its one bridging computation.
6. **Model-detection log** — the message claimed "model changed: None -> X" although the branch only runs when no model was known yet; it reads "model detected" now.

## Tests

Each behavioral fix comes with regression tests (15 new tests, including the °F-fallback case and a poisoned-store load); the full suite passes (1437).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve genuine 0°C readings; use a safe 5.0 fallback when TRV temp is missing and drop implausible readings.
  * Invalidate stored TRV internal temps on unavailable/unknown states so fresh readings are accepted.
  * Broaden window sensor vocabulary for open/closed and make debounce logic resilient to disappearing sensors.
  * Survive corrupted persisted state at startup by resetting state and logging a warning.

* **Performance**
  * Cache HVAC action results to avoid repeated recomputation.

* **Tests**
  * Added unit tests for TRV startup, TRV/window events, state-store recovery, and HVAC-action caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->