### PR TITLE
refactor: StateManager is the only owner of learned controller state

### DIFF
--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -25,7 +25,6 @@ from custom_components.better_thermostat.utils.calibration.pid import (
     PIDParams,
     build_pid_key,
     compute_pid,
-    get_pid_state,
 )
 from custom_components.better_thermostat.utils.calibration.tpi import (
     TpiInput,
@@ -433,7 +432,7 @@ def _compute_pid_balance(self, entity_id: str):
 
     # Build PID params from config and learned values
     key = build_pid_key(self, entity_id)
-    pid_state = get_pid_state(key)
+    pid_state = self.state_mgr.get_pid(key)
 
     # Use learned gains if available, otherwise from config, otherwise defaults
     params = PIDParams(
@@ -466,7 +465,7 @@ def _compute_pid_balance(self, entity_id: str):
     )
 
     try:
-        percent, debug, _pid_state = compute_pid(
+        percent, debug, pid_state = compute_pid(
             params,
             self.bt_target_temp,
             self.cur_temp,
@@ -475,7 +474,9 @@ def _compute_pid_balance(self, entity_id: str):
             key,
             inp_current_temp_ema_C=self.cur_temp_filtered,
             max_opening_pct=_get_trv_max_opening(self, entity_id),
+            state=pid_state,
         )
+        self.state_mgr.set_pid(key, pid_state)
     except (ValueError, TypeError, ZeroDivisionError) as err:
         _LOGGER.debug(
             "better_thermostat %s: PID calibration compute failed for %s: %s",

--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -369,10 +369,13 @@ def _compute_tpi_balance(self, entity_id: str):
     # Use default TPI params
     params = TpiParams()
 
+    key = build_tpi_key(self, entity_id)
+    tpi_state = self.state_mgr.get_tpi(key)
+
     try:
-        tpi_output, _tpi_state = compute_tpi(
+        tpi_output, tpi_state = compute_tpi(
             TpiInput(
-                key=build_tpi_key(self, entity_id),
+                key=key,
                 current_temp_C=self.cur_temp,
                 target_temp_C=self.bt_target_temp,
                 outdoor_temp_C=_get_current_outdoor_temp(self),
@@ -382,7 +385,9 @@ def _compute_tpi_balance(self, entity_id: str):
                 entity_id=entity_id,
             ),
             params,
+            state=tpi_state,
         )
+        self.state_mgr.set_tpi(key, tpi_state)
     except (ValueError, TypeError, ZeroDivisionError) as err:
         _LOGGER.debug(
             "better_thermostat %s: TPI calibration compute failed for %s: %s",

--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -267,8 +267,10 @@ def _compute_mpc_balance(self, entity_id: str):
     else:
         mpc_key = build_mpc_key(self, entity_id)
 
+    mpc_state = self.state_mgr.get_mpc(mpc_key)
+
     try:
-        mpc_output, _mpc_state = compute_mpc(
+        mpc_output, mpc_state = compute_mpc(
             MpcInput(
                 key=mpc_key,
                 target_temp_C=self.bt_target_temp,
@@ -287,7 +289,10 @@ def _compute_mpc_balance(self, entity_id: str):
                 max_opening_pct=max_opening_pct,
             ),
             params,
+            state=mpc_state,
+            all_states=self.state_mgr.state.mpc,
         )
+        self.state_mgr.set_mpc(mpc_key, mpc_state)
     except (ValueError, TypeError, ZeroDivisionError) as err:
         _LOGGER.debug(
             "better_thermostat %s: MPC calibration compute failed for %s: %s",

--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -487,6 +487,8 @@ def _compute_pid_balance(self, entity_id: str):
             state=pid_state,
         )
         self.state_mgr.set_pid(key, pid_state)
+        if callable(getattr(self, "schedule_save_state", None)):
+            self.schedule_save_state()
     except (ValueError, TypeError, ZeroDivisionError) as err:
         _LOGGER.debug(
             "better_thermostat %s: PID calibration compute failed for %s: %s",

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -68,9 +68,8 @@ from .events.trv import trigger_trv_change
 from .events.window import trigger_window_change, window_queue
 from .model_fixes.model_quirks import inital_tweak, load_model_quirks
 from .utils.calibration.pid import (
-    export_pid_states as pid_export_states,
+    PIDParams,
     format_bucket,
-    reset_pid_state as pid_reset_state,
     resolve_unique_id,
     round_to_bucket,
 )
@@ -2804,20 +2803,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         - Schedules persistence saves for the map
         """
         try:
+            state_mgr = self.state_mgr
+            if state_mgr is None:
+                _LOGGER.debug(
+                    "better_thermostat %s: no state manager, nothing to reset",
+                    self.device_name,
+                )
+                return
             prefix = f"{self._unique_id}:"
-            # Collect keys to reset from balance module
-            current = pid_export_states(prefix=prefix) or {}
-            count = 0
-            for key in list(current.keys()):
-                try:
-                    pid_reset_state(key)
-                    count += 1
-                except Exception:
-                    _LOGGER.debug(
-                        "better_thermostat %s: could not reset PID state %s",
-                        self.device_name,
-                        key,
-                    )
+            count = state_mgr.reset_pid_states(prefix)
             _LOGGER.info(
                 "better_thermostat %s: reset %d PID learning state entries (prefix=%s)",
                 self.device_name,
@@ -2836,8 +2830,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             # Optionally seed PID defaults for the CURRENT target bucket(s)
             if apply_pid_defaults:
                 try:
-                    from .utils.calibration.pid import PIDParams, seed_pid_gains
-
                     # Use provided overrides or PIDParams defaults
                     _defs = PIDParams()
                     kp = float(defaults_kp) if defaults_kp is not None else _defs.kp
@@ -2873,8 +2865,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                         for b in buckets or []:
                             key = f"{uid}:{trv_id}:{b}"
                             try:
-                                if seed_pid_gains(key, kp=kp, ki=ki, kd=kd):
-                                    seeded += 1
+                                pid_state = state_mgr.get_pid(key)
+                                pid_state.pid_kp = kp
+                                pid_state.pid_ki = ki
+                                pid_state.pid_kd = kd
+                                state_mgr.set_pid(key, pid_state)
+                                seeded += 1
                             except Exception:
                                 _LOGGER.debug(
                                     "better_thermostat %s: could not seed PID gains for %s",

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -271,7 +271,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
     # Thermal tracker properties
     # Used by: extra_state_attributes, helpers.py, sensor.py,
     #          _restore_state, _hydrate_thermal_from_state,
-    #          _sync_controllers_to_state
+    #          _record_thermal_to_state
     # TODO: Eliminate most of these by accessing trackers directly.
     #   - heating_power_normalized, last_heating_power_stats, heating_cycles,
     #     last_heat_loss_stats, loss_cycles: only read by extra_state_attributes
@@ -692,7 +692,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 self._save_cancel = None
             if self.state_mgr is not None:
                 try:
-                    self._sync_controllers_to_state()
+                    self._record_thermal_to_state()
                     self.hass.async_create_background_task(
                         self.state_mgr.flush(),
                         name=f"bt_state_flush_{self.device_name}",
@@ -720,7 +720,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 entity_prefix=f"{self._unique_id}:",
                 config_entry_id=self._config_entry_id,
             )
-            self._hydrate_controllers_from_state()
             self._hydrate_thermal_from_state()
         except (FileNotFoundError, PermissionError, RuntimeError) as e:
             _LOGGER.debug(
@@ -2037,12 +2036,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
     # -- Unified state persistence helpers ------------------------------------
 
-    def _hydrate_controllers_from_state(self) -> None:
-        """Seed the module-level controller caches from persisted state."""
-        if self.state_mgr is None:
-            return
-        self.state_mgr.hydrate_controllers(f"{self._unique_id}:")
-
     def _hydrate_thermal_from_state(self) -> None:
         """Apply persisted, clamped thermal stats to entity attributes."""
         if self.state_mgr is None:
@@ -2053,14 +2046,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if heat_loss_rate is not None:
             self.heat_loss_rate = heat_loss_rate
 
-    def _sync_controllers_to_state(self) -> None:
-        """Push current controller caches and thermal stats into the StateManager."""
+    def _record_thermal_to_state(self) -> None:
+        """Push the entity-held thermal stats into the StateManager."""
         if self.state_mgr is None:
             return
-        self.state_mgr.sync_controllers(
-            f"{self._unique_id}:",
-            getattr(self, "heating_power", None),
-            getattr(self, "heat_loss_rate", None),
+        self.state_mgr.record_thermal(
+            getattr(self, "heating_power", None), getattr(self, "heat_loss_rate", None)
         )
 
     @callback
@@ -2084,7 +2075,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         async def _do_save(_now: object) -> None:
             self._save_cancel = None
             try:
-                self._sync_controllers_to_state()
+                self._record_thermal_to_state()
                 await state_mgr.save_if_dirty()
             except Exception:
                 _LOGGER.exception(

--- a/custom_components/better_thermostat/number.py
+++ b/custom_components/better_thermostat/number.py
@@ -12,11 +12,9 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .sensor import _ACTIVE_PID_NUMBERS, _ACTIVE_PRESET_NUMBERS
 from .utils.calibration.pid import (
-    _PID_STATES,
     DEFAULT_PID_KD,
     DEFAULT_PID_KI,
     DEFAULT_PID_KP,
-    PIDState,
     build_pid_key,
 )
 from .utils.const import (
@@ -244,13 +242,14 @@ class BetterThermostatPIDNumber(NumberEntity, RestoreEntity):
     def native_value(self) -> float | None:
         """Return the value of the number."""
         # Try to get the value from the current active PID state
-        key = build_pid_key(self._bt_climate, self._trv_entity_id)
-        pid_state = _PID_STATES.get(key)
-
-        if pid_state is not None:
-            val = getattr(pid_state, f"pid_{self._parameter}")
-            if val is not None:
-                return val
+        state_mgr = getattr(self._bt_climate, "state_mgr", None)
+        if state_mgr is not None:
+            key = build_pid_key(self._bt_climate, self._trv_entity_id)
+            pid_state = state_mgr.state.pid.get(key)
+            if pid_state is not None:
+                val = getattr(pid_state, f"pid_{self._parameter}")
+                if val is not None:
+                    return val
 
         # Defaults
         if self._parameter == "kp":
@@ -263,14 +262,18 @@ class BetterThermostatPIDNumber(NumberEntity, RestoreEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
+        state_mgr = getattr(self._bt_climate, "state_mgr", None)
+        if state_mgr is None:
+            _LOGGER.debug(
+                "Cannot set PID %s for %s: state manager not ready",
+                self._parameter,
+                self._trv_entity_id,
+            )
+            return
+
         # Update ONLY the current PID state to avoid overwriting learned values for other temperatures
         key = build_pid_key(self._bt_climate, self._trv_entity_id)
-
-        # Ensure state exists
-        if key not in _PID_STATES:
-            _PID_STATES[key] = PIDState()
-
-        pid_state = _PID_STATES[key]
+        pid_state = state_mgr.get_pid(key)
 
         _LOGGER.debug(
             "Updating PID state key %s: %s -> %s",
@@ -279,6 +282,7 @@ class BetterThermostatPIDNumber(NumberEntity, RestoreEntity):
             value,
         )
         setattr(pid_state, f"pid_{self._parameter}", value)
+        state_mgr.set_pid(key, pid_state)
 
         self._bt_climate.schedule_save_state()
         self.async_write_ha_state()

--- a/custom_components/better_thermostat/switch.py
+++ b/custom_components/better_thermostat/switch.py
@@ -145,6 +145,13 @@ class BetterThermostatPIDAutoTuneSwitch(SwitchEntity, RestoreEntity):
                 changed = True
         if changed:
             state_mgr.mark_dirty()
+        else:
+            # No bucket for this TRV yet (fresh start or after a PID
+            # reset): seed the active bucket so the toggle is not lost.
+            key = build_pid_key(self._bt_climate, self._trv_entity_id)
+            pid_state = state_mgr.get_pid(key)
+            pid_state.auto_tune = state
+            state_mgr.set_pid(key, pid_state)
 
         self._bt_climate.schedule_save_state()
         self.async_write_ha_state()

--- a/custom_components/better_thermostat/switch.py
+++ b/custom_components/better_thermostat/switch.py
@@ -13,7 +13,6 @@ from homeassistant.helpers.restore_state import RestoreEntity
 # Import tracking variables from sensor.py
 from .sensor import _ACTIVE_SWITCH_ENTITIES
 from .utils.calibration.pid import (
-    _PID_STATES,
     DEFAULT_PID_AUTO_TUNE,
     build_pid_key,
     resolve_unique_id,
@@ -108,11 +107,12 @@ class BetterThermostatPIDAutoTuneSwitch(SwitchEntity, RestoreEntity):
     def is_on(self) -> bool | None:
         """Return true if switch is on."""
         # Try to get the value from the current active PID state
-        key = build_pid_key(self._bt_climate, self._trv_entity_id)
-        pid_state = _PID_STATES.get(key)
-
-        if pid_state is not None and pid_state.auto_tune is not None:
-            return pid_state.auto_tune
+        state_mgr = getattr(self._bt_climate, "state_mgr", None)
+        if state_mgr is not None:
+            key = build_pid_key(self._bt_climate, self._trv_entity_id)
+            pid_state = state_mgr.state.pid.get(key)
+            if pid_state is not None and pid_state.auto_tune is not None:
+                return pid_state.auto_tune
 
         return DEFAULT_PID_AUTO_TUNE
 
@@ -126,13 +126,25 @@ class BetterThermostatPIDAutoTuneSwitch(SwitchEntity, RestoreEntity):
 
     def _update_state(self, state: bool):
         """Update the state."""
+        state_mgr = getattr(self._bt_climate, "state_mgr", None)
+        if state_mgr is None:
+            _LOGGER.debug(
+                "Cannot set PID auto-tune for %s: state manager not ready",
+                self._trv_entity_id,
+            )
+            return
+
         # Update persistent PID states (if any exist for this TRV)
         uid = resolve_unique_id(self._bt_climate)
         prefix = f"{uid}:{self._trv_entity_id}:"
 
-        for key, pid_state in _PID_STATES.items():
+        changed = False
+        for key, pid_state in state_mgr.state.pid.items():
             if key.startswith(prefix):
                 pid_state.auto_tune = state
+                changed = True
+        if changed:
+            state_mgr.mark_dirty()
 
         self._bt_climate.schedule_save_state()
         self.async_write_ha_state()

--- a/custom_components/better_thermostat/utils/calibration/mpc.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc.py
@@ -153,117 +153,6 @@ class _MpcState:
 # for backwards compatibility within this module.
 MpcState = _MpcState
 
-_MPC_STATES: dict[str, _MpcState] = {}
-
-_STATE_EXPORT_FIELDS = (
-    "last_percent",
-    "last_update_ts",
-    "last_target_C",
-    "ema_slope",
-    "gain_est",
-    "loss_est",
-    "ka_est",
-    "solar_gain_est",
-    "last_temp",
-    "last_time",
-    "last_trv_temp",
-    "last_trv_temp_ts",
-    "last_window_open_ts",
-    "min_effective_percent",
-    "dead_zone_hits",
-    "last_learn_time",
-    "last_learn_temp",
-    "last_residual_time",
-    "virtual_temp",
-    "virtual_temp_ts",
-    "last_room_temp_C",
-    "last_room_temp_ts",
-    "perf_curve",
-    "u_integral",
-    "time_integral",
-    "last_integration_ts",
-    "trv_profile",
-    "profile_confidence",
-    "profile_samples",
-    "created_ts",
-    "loss_learn_count",
-    "gain_learn_count",
-    "is_calibration_active",
-    "recent_errors",
-    "regime_boost_active",
-    "consecutive_insufficient_heat",
-    "kalman_P",
-    "tolerance_hold_active",
-)
-
-
-def _serialize_state(state: _MpcState) -> dict[str, Any]:
-    payload: dict[str, Any] = {}
-    for attr in _STATE_EXPORT_FIELDS:
-        value = getattr(state, attr, None)
-        if value is None:
-            continue
-        # Convert deque to list for JSON serialization
-        if isinstance(value, deque):
-            value = list(value)
-        payload[attr] = value
-    return payload
-
-
-def export_mpc_state_map(prefix: str | None = None) -> dict[str, dict[str, Any]]:
-    """Return a serializable mapping of MPC states, optionally filtered by key prefix."""
-
-    exported: dict[str, dict[str, Any]] = {}
-    for key, state in _MPC_STATES.items():
-        if prefix is not None and not key.startswith(prefix):
-            continue
-        payload = _serialize_state(state)
-        if payload:
-            exported[key] = payload
-    return exported
-
-
-def import_mpc_state_map(state_map: Mapping[str, Mapping[str, Any]]) -> None:
-    """Hydrate MPC states from a previously exported mapping."""
-
-    for key, payload in state_map.items():
-        if not isinstance(payload, Mapping):
-            continue
-        state = _MPC_STATES.setdefault(key, _MpcState())
-        for attr in _STATE_EXPORT_FIELDS:
-            if attr not in payload:
-                continue
-            value = payload[attr]
-            if value is None:
-                setattr(state, attr, None)
-                continue
-            if attr == "perf_curve" and isinstance(value, Mapping):
-                setattr(state, attr, dict(value))
-                continue
-            if attr == "recent_errors" and isinstance(value, (list, tuple)):
-                setattr(state, attr, deque(value, maxlen=20))
-                continue
-            try:
-                coerced: int | float | bool | str
-                match attr:
-                    case (
-                        "dead_zone_hits"
-                        | "loss_learn_count"
-                        | "gain_learn_count"
-                        | "profile_samples"
-                        | "consecutive_insufficient_heat"
-                    ):
-                        coerced = int(value)
-                    case "is_calibration_active" | "regime_boost_active":
-                        coerced = bool(value)
-                    case "trv_profile":
-                        coerced = str(value)
-                    case _:
-                        coerced = float(value)
-            except (TypeError, ValueError):
-                continue
-            setattr(state, attr, coerced)
-
 
 def _curve_bin_label(percent: float, bin_pct: float) -> str:
     bin_pct = max(1.0, float(bin_pct))
@@ -368,10 +257,7 @@ def _split_mpc_key(key: str) -> tuple[str | None, str | None, str | None]:
 
 
 def _seed_state_from_siblings(
-    key: str,
-    state: _MpcState,
-    params: MpcParams,
-    all_states: dict[str, _MpcState] | None = None,
+    key: str, state: _MpcState, params: MpcParams, all_states: Mapping[str, _MpcState]
 ) -> None:
     if not bool(getattr(params, "enable_min_effective_percent", True)):
         return
@@ -380,8 +266,7 @@ def _seed_state_from_siblings(
     uid, entity, _ = _split_mpc_key(key)
     if not uid or not entity:
         return
-    states = all_states if all_states is not None else _MPC_STATES
-    for other_key, other_state in states.items():
+    for other_key, other_state in all_states.items():
         if other_key == key:
             continue
         ouid, oentity, _ = _split_mpc_key(other_key)
@@ -558,9 +443,9 @@ def _round_for_debug(value: float | int | None, digits: int = 3) -> float | int 
 def compute_mpc(
     inp: MpcInput,
     params: MpcParams,
-    state: _MpcState | None = None,
     *,
-    all_states: dict[str, _MpcState] | None = None,
+    state: _MpcState,
+    all_states: Mapping[str, _MpcState],
 ) -> tuple[MpcOutput | None, _MpcState]:
     """Run the predictive controller and emit a valve recommendation.
 
@@ -571,12 +456,12 @@ def compute_mpc(
     params:
         Controller configuration (tuning knobs).
     state:
-        Mutable controller state for this key.  When ``None`` the function
-        falls back to the module-level ``_MPC_STATES`` dict for backwards
-        compatibility, but callers are encouraged to pass state explicitly.
+        Mutable controller state for this key, owned by the caller
+        (typically read from and written back to the ``StateManager``).
+        It is mutated in place and returned.
     all_states:
-        Mapping of *all* MPC states (used for sibling seeding).  When
-        ``None`` the module-level ``_MPC_STATES`` dict is used.
+        Mapping of *all* MPC states (used for sibling seeding across
+        target-temperature buckets), typically ``state_mgr.state.mpc``.
 
     Returns
     -------
@@ -586,15 +471,6 @@ def compute_mpc(
     """
 
     now = time()
-
-    # --- Resolve state ---
-    if state is None:
-        # Legacy path: use the module-level global dict.
-        state = _MPC_STATES.setdefault(inp.key, _MpcState())
-    else:
-        # Explicit state path: also store in global dict so that
-        # export_mpc_state_map() still works during the transition period.
-        _MPC_STATES[inp.key] = state
 
     if state.created_ts == 0.0:
         # For existing trained models, backdate the creation timestamp

--- a/custom_components/better_thermostat/utils/calibration/pid.py
+++ b/custom_components/better_thermostat/utils/calibration/pid.py
@@ -8,7 +8,8 @@ Goals:
 Notes
 -----
 - This module only computes recommendations; writing to the device stays in adapters/controlling.
-- Lightweight per-room state by a `key` (e.g., entity_id): EMA, hysteresis, rate limit.
+- Per-room state (EMA, hysteresis, rate limit) is owned by the caller and passed
+  in explicitly; the ``StateManager`` is the single source of truth.
 """
 
 from __future__ import annotations
@@ -16,7 +17,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import logging
 from time import monotonic
-from typing import Any, Protocol, TypedDict
+from typing import Protocol, TypedDict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -124,11 +125,6 @@ class PIDParams:
     big_change_threshold_pct: float = 33.0
 
 
-# --- Global State Storage -----------------------------------------------
-
-_PID_STATES: dict[str, PIDState] = {}
-
-
 # --- Helper Functions -----------------------------------------------
 
 
@@ -149,7 +145,8 @@ def compute_pid(
     key: str,
     inp_current_temp_ema_C: float | None = None,
     max_opening_pct: float | None = None,
-    state: PIDState | None = None,
+    *,
+    state: PIDState,
 ) -> tuple[float, PIDDebugInfo, PIDState]:
     """Compute PID-based valve opening percentage.
 
@@ -172,9 +169,9 @@ def compute_pid(
     max_opening_pct:
         Optional maximum valve opening percentage.
     state:
-        Mutable controller state.  When ``None`` the function falls back
-        to the module-level ``_PID_STATES`` dict for backwards
-        compatibility, but callers are encouraged to pass state explicitly.
+        Mutable controller state, owned by the caller (typically read from
+        and written back to the ``StateManager``).  It is mutated in place
+        and returned.
 
     Returns
     -------
@@ -183,12 +180,7 @@ def compute_pid(
     """
     now = monotonic()
 
-    # --- Resolve state ---
-    if state is None:
-        st = _PID_STATES.setdefault(key, PIDState())
-    else:
-        st = state
-        _PID_STATES[key] = st
+    st = state
 
     max_opening = 100.0
     if isinstance(max_opening_pct, (int, float)):
@@ -527,42 +519,6 @@ def _auto_tune_pid(
         return
 
 
-def reset_pid_state(key: str) -> None:
-    """Reset learned/smoothing values for a given room key."""
-    if key in _PID_STATES:
-        del _PID_STATES[key]
-
-
-def get_pid_state(key: str) -> PIDState | None:
-    """Return the PIDState for key or None if missing.
-
-    This is a small helper used externally to read persisted/learned gains.
-    """
-    return _PID_STATES.get(key)
-
-
-def seed_pid_gains(key: str, kp: float, ki: float, kd: float) -> bool:
-    """Seed PID gains for a given key, creating state if missing.
-
-    Args:
-        key: PID state key (format: {unique_id}:{entity_id}:{bucket})
-        kp: Proportional gain
-        ki: Integral gain
-        kd: Derivative gain
-
-    Returns
-    -------
-        True if gains were successfully seeded
-    """
-    if key not in _PID_STATES:
-        _PID_STATES[key] = PIDState()
-    state = _PID_STATES[key]
-    state.pid_kp = kp
-    state.pid_ki = ki
-    state.pid_kd = kd
-    return True
-
-
 # --- Key Builder Helper -----------------------------------------------
 
 
@@ -617,77 +573,3 @@ def build_pid_key(self, entity_id: str) -> str:
         bucket_tag = "tunknown"
 
     return f"{resolve_unique_id(self)}:{entity_id}:{bucket_tag}"
-
-
-# --- Persistence helpers --------------------------------------------
-
-
-def export_pid_states(prefix: str | None = None) -> dict[str, dict[str, Any]]:
-    """Export internal PID state to a JSON-serializable dict.
-
-    prefix: if provided, only include keys starting with this prefix.
-    """
-    out: dict[str, dict[str, Any]] = {}
-    for k, st in _PID_STATES.items():
-        if prefix is not None and not k.startswith(prefix):
-            continue
-        out[k] = {
-            "pid_integral": st.pid_integral,
-            "pid_last_meas": st.pid_last_meas,
-            "pid_last_time": st.pid_last_time,
-            "pid_kp": st.pid_kp,
-            "pid_ki": st.pid_ki,
-            "pid_kd": st.pid_kd,
-            "auto_tune": st.auto_tune,
-            "last_tune_ts": st.last_tune_ts,
-            "last_delta_sign": st.last_delta_sign,
-            "last_error_sign": st.last_error_sign,
-            "previous_abs_error": st.previous_abs_error,
-            "last_abs_error": st.last_abs_error,
-            "ema_slope": st.ema_slope,
-            "last_percent": st.last_percent,
-            "last_output_change_ts": st.last_output_change_ts,
-            "last_target_temp": st.last_target_temp,
-        }
-    return out
-
-
-def import_pid_states(
-    data: dict[str, dict[str, Any]], prefix_filter: str | None = None
-) -> int:
-    """Import previously saved PID states into the module-local cache.
-
-    Returns the number of imported entries. If prefix_filter is provided,
-    only keys starting with that prefix will be imported.
-    """
-    if not isinstance(data, dict):
-        return 0
-    count = 0
-    for k, v in data.items():
-        if prefix_filter is not None and not str(k).startswith(prefix_filter):
-            continue
-        try:
-            st = PIDState(
-                pid_integral=v.get("pid_integral", 0.0),
-                pid_last_meas=v.get("pid_last_meas"),
-                pid_last_time=v.get("pid_last_time", 0.0),
-                pid_kp=v.get("pid_kp"),
-                pid_ki=v.get("pid_ki"),
-                pid_kd=v.get("pid_kd"),
-                auto_tune=v.get("auto_tune"),
-                last_tune_ts=v.get("last_tune_ts", 0.0),
-                last_delta_sign=v.get("last_delta_sign"),
-                last_error_sign=v.get("last_error_sign"),
-                previous_abs_error=v.get("previous_abs_error"),
-                last_abs_error=v.get("last_abs_error"),
-                ema_slope=v.get("ema_slope"),
-                last_percent=v.get("last_percent", 0.0),
-                last_output_change_ts=v.get("last_output_change_ts", 0.0),
-                last_target_temp=v.get("last_target_temp"),
-            )
-            _PID_STATES[str(k)] = st
-            count += 1
-        except (KeyError, TypeError, ValueError):
-            # Ignore malformed entries
-            continue
-    return count

--- a/custom_components/better_thermostat/utils/calibration/tpi.py
+++ b/custom_components/better_thermostat/utils/calibration/tpi.py
@@ -7,7 +7,6 @@ cycle duration and exposes rich debug logs for diagnostics.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from dataclasses import dataclass, field
 import logging
 from time import monotonic
@@ -62,53 +61,6 @@ class _TpiState:
 # importing a private name.
 TpiState = _TpiState
 
-_TPI_STATES: dict[str, _TpiState] = {}
-
-_STATE_EXPORT_FIELDS = ("last_percent",)
-
-
-def export_tpi_state_map(prefix: str | None = None) -> dict[str, dict[str, Any]]:
-    """Return a serializable mapping of TPI states, optionally filtered by key prefix."""
-
-    exported: dict[str, dict[str, Any]] = {}
-    for key, state in _TPI_STATES.items():
-        if prefix is not None and not key.startswith(prefix):
-            continue
-        payload: dict[str, Any] = {}
-        for attr in _STATE_EXPORT_FIELDS:
-            value = getattr(state, attr, None)
-            if value is None:
-                continue
-            payload[attr] = value
-        if payload:
-            exported[key] = payload
-    return exported
-
-
-def import_tpi_state_map(state_map: Mapping[str, Mapping[str, Any]]) -> None:
-    """Hydrate TPI states from a previously exported mapping."""
-
-    for key, payload in state_map.items():
-        if not isinstance(payload, Mapping):
-            continue
-        state = _TPI_STATES.setdefault(key, _TpiState())
-        for attr in _STATE_EXPORT_FIELDS:
-            if attr not in payload:
-                continue
-            value = payload[attr]
-            if value is None:
-                setattr(state, attr, None)
-                continue
-            try:
-                coerced: int | float
-                if attr in ("dead_zone_hits",):
-                    coerced = int(value)
-                else:
-                    coerced = float(value)
-            except (TypeError, ValueError):
-                continue
-            setattr(state, attr, coerced)
-
 
 def _round_dbg(v: float | int | None, d: int = 3) -> float | int | None:
     if v is None:
@@ -120,7 +72,7 @@ def _round_dbg(v: float | int | None, d: int = 3) -> float | int | None:
 
 
 def compute_tpi(
-    inp: TpiInput, params: TpiParams, state: _TpiState | None = None
+    inp: TpiInput, params: TpiParams, *, state: _TpiState
 ) -> tuple[TpiOutput | None, _TpiState]:
     """Compute TPI duty cycle and on/off durations.
 
@@ -131,9 +83,9 @@ def compute_tpi(
     params:
         Controller configuration.
     state:
-        Mutable controller state.  When ``None`` the function falls back
-        to the module-level ``_TPI_STATES`` dict for backwards
-        compatibility, but callers are encouraged to pass state explicitly.
+        Mutable controller state, owned by the caller (typically read from
+        and written back to the ``StateManager``).  It is mutated in place
+        and returned.
 
     Returns
     -------
@@ -142,12 +94,6 @@ def compute_tpi(
         the updated state object.
     """
     now = monotonic()
-
-    # --- Resolve state ---
-    if state is None:
-        state = _TPI_STATES.setdefault(inp.key, _TpiState())
-    else:
-        _TPI_STATES[inp.key] = state
 
     name = inp.bt_name or "BT"
     entity = inp.entity_id or "unknown"

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -42,7 +42,7 @@ from homeassistant.helpers.storage import Store
 
 from .calibration.mpc import MpcState, export_mpc_state_map, import_mpc_state_map
 from .calibration.pid import PIDState
-from .calibration.tpi import TpiState, export_tpi_state_map, import_tpi_state_map
+from .calibration.tpi import TpiState
 from .const import MAX_HEAT_LOSS, MAX_HEATING_POWER, MIN_HEAT_LOSS, MIN_HEATING_POWER
 from .thermal_learning import clamp
 
@@ -397,10 +397,10 @@ class StateManager:
     def hydrate_controllers(self, prefix: str) -> None:
         """Seed the module-level controller caches from persisted state.
 
-        The MPC/TPI controllers keep their own global ``_*_STATES`` dicts.
-        This copies the persisted entries whose key starts with *prefix* into
-        those caches so ``compute_*()`` works immediately after startup.
-        PID state is read from and written to the StateManager directly and
+        The MPC controller keeps its own global ``_MPC_STATES`` dict.  This
+        copies the persisted entries whose key starts with *prefix* into that
+        cache so ``compute_mpc()`` works immediately after startup.  PID and
+        TPI state is read from and written to the StateManager directly and
         needs no bridging.
         """
         mpc_data = {
@@ -410,14 +410,6 @@ class StateManager:
         }
         if mpc_data:
             import_mpc_state_map(mpc_data)
-
-        tpi_data = {
-            key: asdict(tpi)
-            for key, tpi in self._state.tpi.items()
-            if key.startswith(prefix)
-        }
-        if tpi_data:
-            import_tpi_state_map(tpi_data)
 
     def clamped_thermal(self) -> tuple[float | None, float | None]:
         """Return persisted thermal stats clamped to their valid bounds.
@@ -452,18 +444,14 @@ class StateManager:
     ) -> None:
         """Export the module-level controller caches back into the store.
 
-        Pulls the latest MPC/TPI runtime state for *prefix* from the global
-        controller caches and records the supplied thermal stats, so a following
-        save reflects current runtime values.  PID state already lives in the
-        StateManager and needs no export step.
+        Pulls the latest MPC runtime state for *prefix* from the global
+        controller cache and records the supplied thermal stats, so a following
+        save reflects current runtime values.  PID and TPI state already live
+        in the StateManager and need no export step.
         """
         for key, state_dict in export_mpc_state_map(prefix).items():
             if isinstance(state_dict, dict):
                 self.set_mpc(key, deserialize_mpc(state_dict))
-
-        for key, state_dict in export_tpi_state_map(prefix).items():
-            if isinstance(state_dict, dict):
-                self.set_tpi(key, deserialize_tpi(state_dict))
 
         self.thermal = ThermalStats(
             heating_power=heating_power, heat_loss_rate=heat_loss_rate

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -40,7 +40,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
-from .calibration.mpc import MpcState, export_mpc_state_map, import_mpc_state_map
+from .calibration.mpc import MpcState
 from .calibration.pid import PIDState
 from .calibration.tpi import TpiState
 from .const import MAX_HEAT_LOSS, MAX_HEATING_POWER, MIN_HEAT_LOSS, MIN_HEATING_POWER
@@ -395,21 +395,11 @@ class StateManager:
     # -- Controller bridging -------------------------------------------------
 
     def hydrate_controllers(self, prefix: str) -> None:
-        """Seed the module-level controller caches from persisted state.
+        """No-op kept for the startup call path.
 
-        The MPC controller keeps its own global ``_MPC_STATES`` dict.  This
-        copies the persisted entries whose key starts with *prefix* into that
-        cache so ``compute_mpc()`` works immediately after startup.  PID and
-        TPI state is read from and written to the StateManager directly and
-        needs no bridging.
+        MPC/PID/TPI state is read from and written to the StateManager
+        directly; there are no module-level controller caches left to seed.
         """
-        mpc_data = {
-            key: asdict(mpc)
-            for key, mpc in self._state.mpc.items()
-            if key.startswith(prefix)
-        }
-        if mpc_data:
-            import_mpc_state_map(mpc_data)
 
     def clamped_thermal(self) -> tuple[float | None, float | None]:
         """Return persisted thermal stats clamped to their valid bounds.
@@ -442,17 +432,11 @@ class StateManager:
     def sync_controllers(
         self, prefix: str, heating_power: float | None, heat_loss_rate: float | None
     ) -> None:
-        """Export the module-level controller caches back into the store.
+        """Record the supplied thermal stats before a save.
 
-        Pulls the latest MPC runtime state for *prefix* from the global
-        controller cache and records the supplied thermal stats, so a following
-        save reflects current runtime values.  PID and TPI state already live
-        in the StateManager and need no export step.
+        MPC/PID/TPI state already lives in the StateManager and needs no
+        export step; only the entity-held thermal stats are pulled in here.
         """
-        for key, state_dict in export_mpc_state_map(prefix).items():
-            if isinstance(state_dict, dict):
-                self.set_mpc(key, deserialize_mpc(state_dict))
-
         self.thermal = ThermalStats(
             heating_power=heating_power, heat_loss_rate=heat_loss_rate
         )

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -392,14 +392,7 @@ class StateManager:
         """Manually mark state as needing persistence."""
         self._dirty = True
 
-    # -- Controller bridging -------------------------------------------------
-
-    def hydrate_controllers(self, prefix: str) -> None:
-        """No-op kept for the startup call path.
-
-        MPC/PID/TPI state is read from and written to the StateManager
-        directly; there are no module-level controller caches left to seed.
-        """
+    # -- Thermal stats ---------------------------------------------------------
 
     def clamped_thermal(self) -> tuple[float | None, float | None]:
         """Return persisted thermal stats clamped to their valid bounds.
@@ -429,14 +422,10 @@ class StateManager:
 
         return heating_power, heat_loss_rate
 
-    def sync_controllers(
-        self, prefix: str, heating_power: float | None, heat_loss_rate: float | None
+    def record_thermal(
+        self, heating_power: float | None, heat_loss_rate: float | None
     ) -> None:
-        """Record the supplied thermal stats before a save.
-
-        MPC/PID/TPI state already lives in the StateManager and needs no
-        export step; only the entity-held thermal stats are pulled in here.
-        """
+        """Record the entity-held thermal stats before a save."""
         self.thermal = ThermalStats(
             heating_power=heating_power, heat_loss_rate=heat_loss_rate
         )

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -41,7 +41,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
 from .calibration.mpc import MpcState, export_mpc_state_map, import_mpc_state_map
-from .calibration.pid import PIDState, export_pid_states, import_pid_states
+from .calibration.pid import PIDState
 from .calibration.tpi import TpiState, export_tpi_state_map, import_tpi_state_map
 from .const import MAX_HEAT_LOSS, MAX_HEATING_POWER, MIN_HEAT_LOSS, MIN_HEATING_POWER
 from .thermal_learning import clamp
@@ -341,6 +341,19 @@ class StateManager:
         self._state.pid[key] = pid
         self._dirty = True
 
+    def reset_pid_states(self, prefix: str) -> int:
+        """Drop all PID states whose key starts with *prefix*.
+
+        Returns the number of removed entries; marks the store dirty when
+        anything was removed.
+        """
+        keys = [key for key in self._state.pid if key.startswith(prefix)]
+        for key in keys:
+            del self._state.pid[key]
+        if keys:
+            self._dirty = True
+        return len(keys)
+
     def get_tpi(self, key: str) -> TpiState:
         """Get or create TPI state for a key."""
         if key not in self._state.tpi:
@@ -384,9 +397,11 @@ class StateManager:
     def hydrate_controllers(self, prefix: str) -> None:
         """Seed the module-level controller caches from persisted state.
 
-        The MPC/PID/TPI controllers keep their own global ``_*_STATES`` dicts.
+        The MPC/TPI controllers keep their own global ``_*_STATES`` dicts.
         This copies the persisted entries whose key starts with *prefix* into
         those caches so ``compute_*()`` works immediately after startup.
+        PID state is read from and written to the StateManager directly and
+        needs no bridging.
         """
         mpc_data = {
             key: asdict(mpc)
@@ -395,14 +410,6 @@ class StateManager:
         }
         if mpc_data:
             import_mpc_state_map(mpc_data)
-
-        pid_data = {
-            key: asdict(pid)
-            for key, pid in self._state.pid.items()
-            if key.startswith(prefix)
-        }
-        if pid_data:
-            import_pid_states(pid_data, prefix_filter=prefix)
 
         tpi_data = {
             key: asdict(tpi)
@@ -445,17 +452,14 @@ class StateManager:
     ) -> None:
         """Export the module-level controller caches back into the store.
 
-        Pulls the latest MPC/PID/TPI runtime state for *prefix* from the global
+        Pulls the latest MPC/TPI runtime state for *prefix* from the global
         controller caches and records the supplied thermal stats, so a following
-        save reflects current runtime values.
+        save reflects current runtime values.  PID state already lives in the
+        StateManager and needs no export step.
         """
         for key, state_dict in export_mpc_state_map(prefix).items():
             if isinstance(state_dict, dict):
                 self.set_mpc(key, deserialize_mpc(state_dict))
-
-        for key, state_dict in export_pid_states(prefix=prefix).items():
-            if isinstance(state_dict, dict):
-                self.set_pid(key, deserialize_pid(state_dict))
 
         for key, state_dict in export_tpi_state_map(prefix).items():
             if isinstance(state_dict, dict):

--- a/tests/test_controller_state_contract.py
+++ b/tests/test_controller_state_contract.py
@@ -2,11 +2,11 @@
 
 ``compute_pid``/``compute_tpi``/``compute_mpc`` accept an explicit ``state``
 argument, mutate it in place and return it as the updated state.
-``compute_pid`` requires the explicit state (the StateManager owns it);
-``compute_tpi``/``compute_mpc`` still fall back to a module-level dict
-(``_TPI_STATES``/``_MPC_STATES``) when no state is passed, and passing an
-explicit state additionally stores it in that dict. These tests pin the
-explicit-state path everywhere and the module-global path where it remains.
+``compute_pid``/``compute_tpi`` require the explicit state (the StateManager
+owns it); ``compute_mpc`` still falls back to a module-level dict
+(``_MPC_STATES``) when no state is passed, and passing an explicit state
+additionally stores it in that dict. These tests pin the explicit-state path
+everywhere and the module-global path where it remains.
 """
 
 from collections.abc import Iterator
@@ -25,7 +25,6 @@ from custom_components.better_thermostat.utils.calibration.pid import (
     PIDState,
     compute_pid,
 )
-import custom_components.better_thermostat.utils.calibration.tpi as tpi_module
 from custom_components.better_thermostat.utils.calibration.tpi import (
     TpiInput,
     TpiParams,
@@ -37,10 +36,8 @@ from custom_components.better_thermostat.utils.calibration.tpi import (
 @pytest.fixture(autouse=True)
 def _reset_globals() -> Iterator[None]:
     """Clear the remaining controller globals before and after each test."""
-    tpi_module._TPI_STATES.clear()
     mpc_module._MPC_STATES.clear()
     yield
-    tpi_module._TPI_STATES.clear()
     mpc_module._MPC_STATES.clear()
 
 
@@ -75,7 +72,7 @@ class TestPidStateContract:
 
 
 class TestTpiStateContract:
-    """State-threading contract of ``compute_tpi``."""
+    """State-threading contract of ``compute_tpi`` (explicit state only)."""
 
     @staticmethod
     def _inp(key: str) -> TpiInput:
@@ -83,26 +80,14 @@ class TestTpiStateContract:
         return TpiInput(key=key, current_temp_C=20.0, target_temp_C=22.0)
 
     def test_explicit_state_is_returned_and_accumulates(self) -> None:
-        """An explicit state is returned as the same object and keeps accumulating."""
+        """The explicit state is returned as the same object and keeps accumulating."""
         state = TpiState()
         _, st1 = compute_tpi(self._inp("k"), TpiParams(), state=state)
         assert st1 is state
         assert state.last_percent is not None
 
-        tpi_module._TPI_STATES.clear()
         _, st2 = compute_tpi(self._inp("k"), TpiParams(), state=st1)
         assert st2 is state
-
-    def test_missing_state_uses_module_global(self) -> None:
-        """Without an explicit state the call uses ``_TPI_STATES``."""
-        _, st = compute_tpi(self._inp("kg"), TpiParams())
-        assert tpi_module._TPI_STATES["kg"] is st
-
-    def test_explicit_state_is_also_stored_in_global(self) -> None:
-        """An explicit state is also written to ``_TPI_STATES``."""
-        state = TpiState()
-        compute_tpi(self._inp("kl"), TpiParams(), state=state)
-        assert tpi_module._TPI_STATES["kl"] is state
 
 
 class TestMpcStateContract:

--- a/tests/test_controller_state_contract.py
+++ b/tests/test_controller_state_contract.py
@@ -1,19 +1,11 @@
 """Tests for the controller state-threading contract.
 
-``compute_pid``/``compute_tpi``/``compute_mpc`` accept an explicit ``state``
-argument, mutate it in place and return it as the updated state.
-``compute_pid``/``compute_tpi`` require the explicit state (the StateManager
-owns it); ``compute_mpc`` still falls back to a module-level dict
-(``_MPC_STATES``) when no state is passed, and passing an explicit state
-additionally stores it in that dict. These tests pin the explicit-state path
-everywhere and the module-global path where it remains.
+``compute_pid``/``compute_tpi``/``compute_mpc`` require an explicit ``state``
+argument, mutate it in place and return it as the updated state; the
+StateManager owns all controller state and there are no module-level state
+dicts left. These tests pin the explicit-state contract.
 """
 
-from collections.abc import Iterator
-
-import pytest
-
-import custom_components.better_thermostat.utils.calibration.mpc as mpc_module
 from custom_components.better_thermostat.utils.calibration.mpc import (
     MpcInput,
     MpcParams,
@@ -31,14 +23,6 @@ from custom_components.better_thermostat.utils.calibration.tpi import (
     TpiState,
     compute_tpi,
 )
-
-
-@pytest.fixture(autouse=True)
-def _reset_globals() -> Iterator[None]:
-    """Clear the remaining controller globals before and after each test."""
-    mpc_module._MPC_STATES.clear()
-    yield
-    mpc_module._MPC_STATES.clear()
 
 
 def _pid_call(state: PIDState, key: str = "k") -> PIDState:
@@ -91,7 +75,7 @@ class TestTpiStateContract:
 
 
 class TestMpcStateContract:
-    """State-threading contract of ``compute_mpc``."""
+    """State-threading contract of ``compute_mpc`` (explicit state only)."""
 
     @staticmethod
     def _inp(key: str) -> MpcInput:
@@ -101,7 +85,7 @@ class TestMpcStateContract:
         )
 
     def test_explicit_state_is_returned_and_accumulates(self) -> None:
-        """An explicit state is returned as the same object and keeps accumulating."""
+        """The explicit state is returned as the same object and keeps accumulating."""
         params = MpcParams(mpc_adapt=True)
         state = MpcState()
         _, st1 = compute_mpc(
@@ -110,25 +94,23 @@ class TestMpcStateContract:
         assert st1 is state
         assert state.last_integration_ts > 0.0
 
-        mpc_module._MPC_STATES.clear()
         _, st2 = compute_mpc(self._inp("k"), params, state=st1, all_states={"k": st1})
         assert st2 is state
 
-    def test_missing_state_uses_module_global(self) -> None:
-        """Without an explicit state the call uses ``_MPC_STATES``."""
-        _, st = compute_mpc(self._inp("kg"), MpcParams())
-        assert mpc_module._MPC_STATES["kg"] is st
-
-    def test_explicit_state_is_also_stored_in_global(self) -> None:
-        """An explicit state is also written to ``_MPC_STATES``."""
+    def test_sibling_seeding_reads_from_all_states(self) -> None:
+        """Sibling seeding copies min_effective_percent from the all_states map."""
+        sibling = MpcState(min_effective_percent=18.0)
+        all_states = {"uid:climate.trv:t21.0": sibling}
         state = MpcState()
-        compute_mpc(self._inp("kl"), MpcParams(), state=state)
-        assert mpc_module._MPC_STATES["kl"] is state
-
-    def test_sibling_seeding_uses_global_when_all_states_missing(self) -> None:
-        """With ``all_states=None`` sibling seeding reads from ``_MPC_STATES``."""
-        _, st_a = compute_mpc(self._inp("bucket_a"), MpcParams())
-        assert mpc_module._MPC_STATES["bucket_a"] is st_a
-        _, st_b = compute_mpc(self._inp("bucket_b"), MpcParams())
-        assert mpc_module._MPC_STATES["bucket_b"] is st_b
-        assert set(mpc_module._MPC_STATES) >= {"bucket_a", "bucket_b"}
+        compute_mpc(
+            MpcInput(
+                key="uid:climate.trv:t22.0",
+                target_temp_C=22.0,
+                current_temp_C=21.5,
+                temp_slope_K_per_min=0.0,
+            ),
+            MpcParams(enable_min_effective_percent=True),
+            state=state,
+            all_states=all_states,
+        )
+        assert state.min_effective_percent == 18.0

--- a/tests/test_controller_state_contract.py
+++ b/tests/test_controller_state_contract.py
@@ -114,3 +114,15 @@ class TestMpcStateContract:
             all_states=all_states,
         )
         assert state.min_effective_percent == 18.0
+
+
+class TestNoModuleStateGlobals:
+    """The controller modules must not hold any module-level state dicts."""
+
+    def test_no_state_globals_left(self) -> None:
+        """No ``*_STATES`` module global exists in pid/tpi/mpc."""
+        from custom_components.better_thermostat.utils.calibration import mpc, pid, tpi
+
+        for module in (pid, tpi, mpc):
+            offenders = [name for name in vars(module) if name.endswith("_STATES")]
+            assert offenders == [], f"{module.__name__} still has {offenders}"

--- a/tests/test_controller_state_contract.py
+++ b/tests/test_controller_state_contract.py
@@ -1,10 +1,12 @@
 """Tests for the controller state-threading contract.
 
 ``compute_pid``/``compute_tpi``/``compute_mpc`` accept an explicit ``state``
-argument, mutate it in place and return it as the updated state. When no state
-is passed they fall back to a module-level dict (``_PID_STATES``/``_TPI_STATES``/
-``_MPC_STATES``); passing an explicit state additionally stores it in that dict.
-These tests pin both the explicit-state path and the module-global path.
+argument, mutate it in place and return it as the updated state.
+``compute_pid`` requires the explicit state (the StateManager owns it);
+``compute_tpi``/``compute_mpc`` still fall back to a module-level dict
+(``_TPI_STATES``/``_MPC_STATES``) when no state is passed, and passing an
+explicit state additionally stores it in that dict. These tests pin the
+explicit-state path everywhere and the module-global path where it remains.
 """
 
 from collections.abc import Iterator
@@ -18,7 +20,6 @@ from custom_components.better_thermostat.utils.calibration.mpc import (
     MpcState,
     compute_mpc,
 )
-import custom_components.better_thermostat.utils.calibration.pid as pid_module
 from custom_components.better_thermostat.utils.calibration.pid import (
     PIDParams,
     PIDState,
@@ -35,17 +36,15 @@ from custom_components.better_thermostat.utils.calibration.tpi import (
 
 @pytest.fixture(autouse=True)
 def _reset_globals() -> Iterator[None]:
-    """Clear the controller globals before and after each test."""
-    pid_module._PID_STATES.clear()
+    """Clear the remaining controller globals before and after each test."""
     tpi_module._TPI_STATES.clear()
     mpc_module._MPC_STATES.clear()
     yield
-    pid_module._PID_STATES.clear()
     tpi_module._TPI_STATES.clear()
     mpc_module._MPC_STATES.clear()
 
 
-def _pid_call(state: PIDState | None, key: str = "k") -> PIDState:
+def _pid_call(state: PIDState, key: str = "k") -> PIDState:
     """Call ``compute_pid`` with fixed inputs (error = 2.0 K)."""
     params = PIDParams(auto_tune=False, min_hold_time_s=0.0)
     _, _, out = compute_pid(
@@ -61,32 +60,18 @@ def _pid_call(state: PIDState | None, key: str = "k") -> PIDState:
 
 
 class TestPidStateContract:
-    """State-threading contract of ``compute_pid``."""
+    """State-threading contract of ``compute_pid`` (explicit state only)."""
 
     def test_explicit_state_is_returned_and_accumulates(self) -> None:
-        """An explicit state is returned as the same object and keeps accumulating."""
+        """The explicit state is returned as the same object and keeps accumulating."""
         state = PIDState()
         out1 = _pid_call(state)
         assert out1 is state
         assert state.last_abs_error == 2.0
 
-        # The explicit path does not depend on the module global.
-        pid_module._PID_STATES.clear()
         out2 = _pid_call(out1)
         assert out2 is state
         assert state.previous_abs_error == 2.0
-
-    def test_missing_state_uses_module_global(self) -> None:
-        """Without an explicit state the call uses ``_PID_STATES``."""
-        out = _pid_call(None, key="kg")
-        assert "kg" in pid_module._PID_STATES
-        assert pid_module._PID_STATES["kg"] is out
-
-    def test_explicit_state_is_also_stored_in_global(self) -> None:
-        """An explicit state is also written to ``_PID_STATES``."""
-        state = PIDState()
-        _pid_call(state, key="kl")
-        assert pid_module._PID_STATES["kl"] is state
 
 
 class TestTpiStateContract:

--- a/tests/test_mpc.py
+++ b/tests/test_mpc.py
@@ -1,10 +1,25 @@
-"""Tests for the MPC (Model Predictive Control) controller."""
+"""Tests for the MPC (Model Predictive Control) controller.
+
+State is threaded explicitly through a test-local state dict, mirroring how
+the StateManager owns controller state in production.
+"""
 
 from custom_components.better_thermostat.utils.calibration.mpc import (
     MpcInput,
     MpcParams,
-    compute_mpc,
+    MpcState,
+    compute_mpc as _compute_mpc,
 )
+
+_STATES: dict[str, MpcState] = {}
+
+
+def compute_mpc(inp, params):
+    """Run ``_compute_mpc`` threading state for ``inp.key`` via ``_STATES``."""
+    state = _STATES.setdefault(inp.key, MpcState())
+    output, new_state = _compute_mpc(inp, params, state=state, all_states=_STATES)
+    _STATES[inp.key] = new_state
+    return output, new_state
 
 
 class TestMPCController:
@@ -12,10 +27,7 @@ class TestMPCController:
 
     def setup_method(self):
         """Reset MPC states before each test."""
-        # Reset all states to ensure clean tests
-        import custom_components.better_thermostat.utils.calibration.mpc as mpc_module
-
-        mpc_module._MPC_STATES.clear()
+        _STATES.clear()
 
     def test_no_temperatures(self):
         """Test behavior when temperatures are missing."""
@@ -136,10 +148,6 @@ class TestMPCController:
 
     def test_adaptive_parameter_estimation(self):
         """Test adaptive estimation of thermal gain and loss coefficients."""
-        from custom_components.better_thermostat.utils.calibration.mpc import (
-            _MPC_STATES,
-        )
-
         params = MpcParams(
             mpc_adapt=True,
             mpc_adapt_alpha=0.5,
@@ -168,7 +176,7 @@ class TestMPCController:
         result1, _ = compute_mpc(inp1, params)
         assert result1 is not None
         # Should set initial gain_est and loss_est
-        state = _MPC_STATES[key]
+        state = _STATES[key]
         print(
             f"After inp1 (error={target - current}): gain_est={state.gain_est}, loss_est={state.loss_est}, valve_percent={result1.valve_percent}"
         )
@@ -241,10 +249,6 @@ class TestMPCController:
 
         from time import time
 
-        from custom_components.better_thermostat.utils.calibration.mpc import (
-            _MPC_STATES,
-        )
-
         params = MpcParams(
             mpc_adapt=True,
             mpc_adapt_alpha=0.5,
@@ -259,7 +263,7 @@ class TestMPCController:
         )
         _ = compute_mpc(inp1, params)
 
-        st = _MPC_STATES[key]
+        st = _STATES[key]
         st.last_percent = 100.0
         st.last_learn_temp = inp1.current_temp_C
         st.last_learn_time = time() - 300.0  # >=180s, but <600s (no steady-state gain)
@@ -271,7 +275,7 @@ class TestMPCController:
             key=key, target_temp_C=22.0, current_temp_C=21.5, temp_slope_K_per_min=0.08
         )
         _ = compute_mpc(inp2, params)
-        st = _MPC_STATES[key]
+        st = _STATES[key]
 
         assert st.gain_est is not None
         assert float(st.gain_est) <= gain_before
@@ -280,10 +284,6 @@ class TestMPCController:
         """If valve is high, temperature is flat, and still below target, gain should decrease."""
 
         from time import time
-
-        from custom_components.better_thermostat.utils.calibration.mpc import (
-            _MPC_STATES,
-        )
 
         params = MpcParams(
             mpc_adapt=True,
@@ -298,7 +298,7 @@ class TestMPCController:
             MpcInput(key=key, target_temp_C=22.0, current_temp_C=21.5), params
         )
 
-        st = _MPC_STATES[key]
+        st = _STATES[key]
         st.gain_est = 0.1
         st.loss_est = 0.01
         st.last_percent = 90.0
@@ -324,10 +324,6 @@ class TestMPCController:
 
         from time import time
 
-        from custom_components.better_thermostat.utils.calibration.mpc import (
-            _MPC_STATES,
-        )
-
         params = MpcParams(
             mpc_adapt=True,
             mpc_adapt_alpha=0.5,
@@ -341,7 +337,7 @@ class TestMPCController:
             MpcInput(key=key, target_temp_C=22.0, current_temp_C=21.8), params
         )
 
-        st = _MPC_STATES[key]
+        st = _STATES[key]
         st.gain_est = 0.12
         st.loss_est = 0.01
         st.last_percent = 36.0
@@ -462,8 +458,6 @@ class TestMPCController:
     def test_tolerance_hold_keeps_virtual_temp_fresh(self):
         """Virtual temperature/Kalman state should keep updating while tolerance hold is active."""
 
-        import custom_components.better_thermostat.utils.calibration.mpc as mpc_module
-
         params = MpcParams(
             mpc_adapt=False,
             min_update_interval_s=0.0,
@@ -482,7 +476,7 @@ class TestMPCController:
         assert first is not None
         assert first.valve_percent == 0
 
-        state = mpc_module._MPC_STATES[key]
+        state = _STATES[key]
         v1 = state.virtual_temp
         assert v1 is not None
 
@@ -499,10 +493,6 @@ class TestMPCController:
 
     def test_heating_sequence_simulation(self):
         """Simulate a heating sequence to test controller behavior over time."""
-        from custom_components.better_thermostat.utils.calibration.mpc import (
-            export_mpc_state_map,
-        )
-
         params = MpcParams(
             # mpc_adapt=True,
             mpc_thermal_gain=0.06,
@@ -538,10 +528,7 @@ class TestMPCController:
             valve_pct = result.valve_percent
             dbg = result.debug or {}
 
-            state_map = export_mpc_state_map(prefix=key)
-            vtemp = None
-            if key in state_map:
-                vtemp = state_map[key].get("virtual_temp")
+            vtemp = _STATES[key].virtual_temp if key in _STATES else None
 
             error = target - current
             results.append((current, valve_pct))

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -1,28 +1,42 @@
 """Tests for the PID controller."""
 
 from custom_components.better_thermostat.utils.calibration.pid import (
+    PIDDebugInfo,
     PIDParams,
+    PIDState,
     build_pid_key,
     compute_pid,
-    get_pid_state,
-    seed_pid_gains,
 )
 
 
 class TestPIDController:
-    """Test cases for PID controller."""
+    """Test cases for PID controller.
+
+    State is threaded explicitly: each test keeps its own per-key state
+    dict, mirroring how the StateManager owns controller state in
+    production.
+    """
 
     def setup_method(self):
-        """Reset PID states before each test."""
-        # Reset all states to ensure clean tests
-        import custom_components.better_thermostat.utils.calibration.pid as pid_module
+        """Start each test with a fresh per-key state dict."""
+        self._states: dict[str, PIDState] = {}
 
-        pid_module._PID_STATES.clear()
+    def _compute(self, **kwargs) -> tuple[float, PIDDebugInfo, PIDState]:
+        """Call ``compute_pid`` threading state for ``kwargs['key']``."""
+        key = kwargs["key"]
+        state = self._states.setdefault(key, PIDState())
+        percent, debug, new_state = compute_pid(state=state, **kwargs)
+        self._states[key] = new_state
+        return percent, debug, new_state
+
+    def _state(self, key: str) -> PIDState | None:
+        """Return the threaded state for ``key`` (None if never computed)."""
+        return self._states.get(key)
 
     def test_no_temperatures(self):
         """Test behavior when temperatures are missing."""
         params = PIDParams()
-        percent, debug, _ = compute_pid(
+        percent, debug, _ = self._compute(
             params=params,
             inp_target_temp_C=None,
             inp_current_temp_C=20.0,
@@ -41,7 +55,7 @@ class TestPIDController:
             auto_tune=False, kp=10.0, ki=1.0, kd=5.0, min_hold_time_s=0.0
         )
         # First call to initialize
-        percent1, _, _ = compute_pid(
+        percent1, _, _ = self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,
@@ -53,7 +67,7 @@ class TestPIDController:
         assert percent1 > 0
 
         # Second call with same error; integer rounding may mask tiny increments
-        percent2, _, _ = compute_pid(
+        percent2, _, _ = self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,
@@ -66,7 +80,7 @@ class TestPIDController:
         # After a few iterations the integral term should raise the output
         percent_last = percent2
         for _ in range(6):
-            percent_last, _, _ = compute_pid(
+            percent_last, _, _ = self._compute(
                 params=params,
                 inp_target_temp_C=22.0,
                 inp_current_temp_C=20.0,
@@ -80,7 +94,7 @@ class TestPIDController:
         """Test anti-windup clamping."""
         params = PIDParams(auto_tune=False, kp=100.0, ki=10.0, i_min=-10.0, i_max=10.0)
         # Large error to cause windup
-        percent, _, _ = compute_pid(
+        percent, _, _ = self._compute(
             params=params,
             inp_target_temp_C=30.0,
             inp_current_temp_C=20.0,
@@ -91,7 +105,7 @@ class TestPIDController:
         # Should be clamped to 100%
         assert percent == 100.0
         # Check that integral is clamped
-        state = get_pid_state("test_windup")
+        state = self._state("test_windup")
         assert state.pid_integral <= params.i_max
 
     def test_auto_tune_overshoot(self):
@@ -106,7 +120,7 @@ class TestPIDController:
         key = "test_overshoot"
 
         # First call: positive error > band
-        compute_pid(
+        self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,
@@ -116,7 +130,7 @@ class TestPIDController:
         )
 
         # Second call: overshoot (negative error < band)
-        compute_pid(
+        self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=22.05,  # error = -0.05 < band
@@ -125,7 +139,7 @@ class TestPIDController:
             key=key,
         )
 
-        state = get_pid_state(key)
+        state = self._state(key)
         # kp should be reduced, kd increased
         assert state.pid_kp < params.kp
         assert state.pid_kd > params.kd
@@ -142,7 +156,7 @@ class TestPIDController:
         key = "test_sluggish"
 
         # Large error < 1.0, small slope -> sluggish
-        compute_pid(
+        self._compute(
             params=params,
             inp_target_temp_C=20.8,  # error = 0.8 < 1.0
             inp_current_temp_C=20.0,  # error = 0.8 > band
@@ -151,7 +165,7 @@ class TestPIDController:
             key=key,
         )
 
-        state = get_pid_state(key)
+        state = self._state(key)
         # ki should be increased
         assert state.pid_ki > params.ki
 
@@ -166,7 +180,7 @@ class TestPIDController:
         key = "test_steady"
 
         # Small error, low percent -> steady state
-        compute_pid(
+        self._compute(
             params=params,
             inp_target_temp_C=20.1,
             inp_current_temp_C=20.0,  # error = 0.1 < band
@@ -175,7 +189,7 @@ class TestPIDController:
             key=key,
         )
 
-        state = get_pid_state(key)
+        state = self._state(key)
         # ki should be decreased
         assert state.pid_ki < params.ki
 
@@ -191,7 +205,7 @@ class TestPIDController:
         key = "test_interval"
 
         # First call: sluggish -> tune
-        compute_pid(
+        self._compute(
             params=params,
             inp_target_temp_C=20.8,  # error = 0.8 < 1.0
             inp_current_temp_C=20.0,
@@ -200,7 +214,7 @@ class TestPIDController:
             key=key,
         )
 
-        state_after_first = get_pid_state(key)
+        state_after_first = self._state(key)
         assert state_after_first is not None
         kp_after_first = state_after_first.pid_kp
         ki_after_first = state_after_first.pid_ki
@@ -209,7 +223,7 @@ class TestPIDController:
         assert ki_after_first > params.ki  # Should have increased due to sluggish
 
         # Immediate second call with sluggish again - should not tune due to interval
-        compute_pid(
+        self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,  # same error
@@ -218,7 +232,7 @@ class TestPIDController:
             key=key,
         )
 
-        state_after_second = get_pid_state(key)
+        state_after_second = self._state(key)
         assert state_after_second is not None
         # Gains should remain the same as after first tune
         assert state_after_second.pid_kp == kp_after_first
@@ -249,7 +263,7 @@ class TestPIDController:
         # Trigger overshoot multiple times to push gains to limits
         for _ in range(5):
             # Positive error
-            compute_pid(
+            self._compute(
                 params=params,
                 inp_target_temp_C=22.0,
                 inp_current_temp_C=20.0,
@@ -258,7 +272,7 @@ class TestPIDController:
                 key=key,
             )
             # Overshoot
-            compute_pid(
+            self._compute(
                 params=params,
                 inp_target_temp_C=22.0,
                 inp_current_temp_C=22.2,  # error = -0.2 > threshold
@@ -267,7 +281,7 @@ class TestPIDController:
                 key=key,
             )
 
-        state = get_pid_state(key)
+        state = self._state(key)
         # kp should be clamped to min, kd to max
         assert state is not None
         assert state.pid_kp >= params.kp_min
@@ -289,7 +303,7 @@ class TestPIDController:
         key = "test_combined"
 
         # First: sluggish (error <1.0, small slope)
-        compute_pid(
+        self._compute(
             params=params,
             inp_target_temp_C=20.8,  # error = 0.8
             inp_current_temp_C=20.0,
@@ -298,14 +312,14 @@ class TestPIDController:
             key=key,
         )
 
-        state_after_sluggish = get_pid_state(key)
+        state_after_sluggish = self._state(key)
         assert state_after_sluggish is not None
         ki_after_sluggish = state_after_sluggish.pid_ki
         assert ki_after_sluggish is not None
         assert ki_after_sluggish > params.ki  # Increased
 
         # Second: overshoot (previous abs > band, current abs < band)
-        compute_pid(
+        self._compute(
             params=params,
             inp_target_temp_C=20.8,  # error = 0.8 > band
             inp_current_temp_C=20.0,
@@ -313,7 +327,7 @@ class TestPIDController:
             inp_temp_slope_K_per_min=0.02,  # > threshold, no sluggish
             key=key,
         )
-        compute_pid(
+        self._compute(
             params=params,
             inp_target_temp_C=20.8,
             inp_current_temp_C=20.83,  # error = -0.03 < band
@@ -322,7 +336,7 @@ class TestPIDController:
             key=key,
         )
 
-        state_after_combined = get_pid_state(key)
+        state_after_combined = self._state(key)
         assert state_after_combined is not None
         assert state_after_combined.pid_ki is not None
         assert state_after_combined.pid_kp is not None
@@ -351,7 +365,7 @@ class TestPIDController:
         for i in range(10):
             error = 2.0 if i % 2 == 0 else -0.5  # Alternate positive and overshoot
             current_temp = 20.0 + (2.0 - error)  # Adjust to create error
-            compute_pid(
+            self._compute(
                 params=params,
                 inp_target_temp_C=22.0,
                 inp_current_temp_C=current_temp,
@@ -359,7 +373,7 @@ class TestPIDController:
                 inp_temp_slope_K_per_min=0.0,
                 key=key,
             )
-            state = get_pid_state(key)
+            state = self._state(key)
             assert state is not None
             assert state.pid_kp is not None
             assert state.pid_ki is not None
@@ -382,7 +396,7 @@ class TestPIDController:
             auto_tune=False, d_on_measurement=True, d_smoothing_alpha=0.5
         )
         # First call to initialize
-        compute_pid(
+        self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,
@@ -391,7 +405,7 @@ class TestPIDController:
             key="test_deriv",
         )
         # Second call to have dt > 0
-        _, debug, _ = compute_pid(
+        _, debug, _ = self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,
@@ -418,7 +432,7 @@ class TestPIDController:
         key = "test_hold_block"
 
         # First call establishes baseline
-        percent1, _, _ = compute_pid(
+        percent1, _, _ = self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,  # Error = 2.0, P = 20%
@@ -429,7 +443,7 @@ class TestPIDController:
         assert percent1 == 20.0  # P-term only: 10 * 2.0 = 20
 
         # Second call with slightly different error (small change < 33%)
-        percent2, _, _ = compute_pid(
+        percent2, _, _ = self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.5,  # Error = 1.5, P = 15%
@@ -453,7 +467,7 @@ class TestPIDController:
         key = "test_hold_big"
 
         # First call establishes baseline
-        percent1, _, _ = compute_pid(
+        percent1, _, _ = self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,  # Error = 2.0, P = 20%
@@ -464,7 +478,7 @@ class TestPIDController:
         assert percent1 == 20.0
 
         # Second call with large error change (big change >= 33%)
-        percent2, _, _ = compute_pid(
+        percent2, _, _ = self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=15.0,  # Error = 7.0, P = 70%
@@ -488,7 +502,7 @@ class TestPIDController:
         key = "test_hold_target"
 
         # First call establishes baseline
-        percent1, _, _ = compute_pid(
+        percent1, _, _ = self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,  # Error = 2.0, P = 20%
@@ -499,7 +513,7 @@ class TestPIDController:
         assert percent1 == 20.0
 
         # Second call with changed target temperature
-        percent2, _, _ = compute_pid(
+        percent2, _, _ = self._compute(
             params=params,
             inp_target_temp_C=23.0,  # Target changed by 1.0°C (> 0.05)
             inp_current_temp_C=20.0,  # Error = 3.0, P = 30%
@@ -523,7 +537,7 @@ class TestPIDController:
         key = "test_hold_disabled"
 
         # First call
-        percent1, _, _ = compute_pid(
+        percent1, _, _ = self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.0,
@@ -534,7 +548,7 @@ class TestPIDController:
         assert percent1 == 20.0
 
         # Second call with small change - should NOT be blocked
-        percent2, _, _ = compute_pid(
+        percent2, _, _ = self._compute(
             params=params,
             inp_target_temp_C=22.0,
             inp_current_temp_C=20.5,  # Small change
@@ -560,67 +574,3 @@ class TestPIDController:
         bt.bt_target_temp = None
         key = build_pid_key(bt, "climate.test")
         assert key == "test_bt:climate.test:tunknown"
-
-    def test_seed_pid_gains_creates_new_state(self):
-        """Test that seed_pid_gains creates a new state if key doesn't exist."""
-        key = "test_seed_new"
-
-        # Ensure state doesn't exist
-        assert get_pid_state(key) is None
-
-        # Seed gains
-        result = seed_pid_gains(key, kp=15.0, ki=0.05, kd=300.0)
-
-        assert result is True
-        state = get_pid_state(key)
-        assert state is not None
-        assert state.pid_kp == 15.0
-        assert state.pid_ki == 0.05
-        assert state.pid_kd == 300.0
-
-    def test_seed_pid_gains_updates_existing_state(self):
-        """Test that seed_pid_gains updates an existing state."""
-        key = "test_seed_update"
-
-        # Create initial state with different values
-        seed_pid_gains(key, kp=10.0, ki=0.01, kd=100.0)
-        state_before = get_pid_state(key)
-        assert state_before.pid_kp == 10.0
-
-        # Update with new values
-        result = seed_pid_gains(key, kp=20.0, ki=0.02, kd=200.0)
-
-        assert result is True
-        state_after = get_pid_state(key)
-        assert state_after.pid_kp == 20.0
-        assert state_after.pid_ki == 0.02
-        assert state_after.pid_kd == 200.0
-
-    def test_seed_pid_gains_preserves_other_state_fields(self):
-        """Test that seed_pid_gains only updates gains, not other fields."""
-        key = "test_seed_preserve"
-        params = PIDParams(auto_tune=False, kp=10.0, ki=0.1, kd=50.0)
-
-        # Run PID to create state with integral value
-        compute_pid(
-            params=params,
-            inp_target_temp_C=22.0,
-            inp_current_temp_C=20.0,
-            inp_trv_temp_C=21.0,
-            inp_temp_slope_K_per_min=0.0,
-            key=key,
-        )
-
-        state_before = get_pid_state(key)
-        integral_before = state_before.pid_integral
-
-        # Seed new gains
-        seed_pid_gains(key, kp=25.0, ki=0.08, kd=400.0)
-
-        state_after = get_pid_state(key)
-        # Gains should be updated
-        assert state_after.pid_kp == 25.0
-        assert state_after.pid_ki == 0.08
-        assert state_after.pid_kd == 400.0
-        # Integral should be preserved
-        assert state_after.pid_integral == integral_before

--- a/tests/test_tpi.py
+++ b/tests/test_tpi.py
@@ -3,17 +3,23 @@
 from custom_components.better_thermostat.utils.calibration.tpi import (
     TpiInput,
     TpiParams,
+    TpiState,
     build_tpi_key,
     compute_tpi,
 )
 
 
 class TestTpiController:
-    """Test cases for TPI controller."""
+    """Test cases for TPI controller.
+
+    State is threaded explicitly per test, mirroring how the StateManager
+    owns controller state in production.
+    """
 
     def test_blocked_by_window_or_heating_not_allowed(self):
         """Test that duty cycle is 0 when heating is blocked."""
         params = TpiParams()
+        state = TpiState()
         inp = TpiInput(
             key="test",
             current_temp_C=20.0,
@@ -21,37 +27,39 @@ class TestTpiController:
             window_open=True,
             heating_allowed=True,
         )
-        result, _ = compute_tpi(inp, params)
+        result, state = compute_tpi(inp, params, state=state)
         assert result.duty_cycle_pct == 0.0
         assert result.debug["reason"] == "blocked"
 
         inp.heating_allowed = False
         inp.window_open = False
-        result, _ = compute_tpi(inp, params)
+        result, state = compute_tpi(inp, params, state=state)
         assert result.duty_cycle_pct == 0.0
         assert result.debug["reason"] == "blocked"
 
     def test_missing_temperatures(self):
         """Test behavior when temperatures are missing."""
         params = TpiParams()
+        state = TpiState()
         inp = TpiInput(key="test", current_temp_C=None, target_temp_C=22.0)
-        result, _ = compute_tpi(inp, params)
+        result, state = compute_tpi(inp, params, state=state)
         assert result.duty_cycle_pct == 0.0  # No last_percent, so 0
         assert result.debug["reason"] == "missing_temps"
 
         # Now with last_percent
         inp.current_temp_C = 20.0
-        result, _ = compute_tpi(inp, params)
+        result, state = compute_tpi(inp, params, state=state)
         # Should calculate normally, clamped to 100
         assert result.duty_cycle_pct == 100.0
 
     def test_normal_calculation(self):
         """Test normal TPI calculation."""
         params = TpiParams(coef_int=0.5, coef_ext=0.02)
+        state = TpiState()
         inp = TpiInput(
             key="test", current_temp_C=20.0, target_temp_C=22.0, outdoor_temp_C=15.0
         )
-        result, _ = compute_tpi(inp, params)
+        result, state = compute_tpi(inp, params, state=state)
         assert result.duty_cycle_pct == 100.0  # clamped
         assert result.debug["error_K"] == 2.0
         assert result.debug["raw_pct"] == 114.0
@@ -59,28 +67,30 @@ class TestTpiController:
     def test_overshoot_threshold(self):
         """Test that heating is disabled on overshoot."""
         params = TpiParams(threshold_high=0.5)
+        state = TpiState()
         inp = TpiInput(
             key="test",
             current_temp_C=22.6,
             target_temp_C=22.0,  # error = -0.6
         )
-        result, _ = compute_tpi(inp, params)
+        result, state = compute_tpi(inp, params, state=state)
         assert result.duty_cycle_pct == 0.0
         assert result.debug["reason"] == "threshold_high"
 
     def test_clamping(self):
         """Test min/max clamping."""
         params = TpiParams(clamp_min_pct=10.0, clamp_max_pct=90.0, coef_int=1.0)
+        state = TpiState()
         inp = TpiInput(
             key="test",
             current_temp_C=20.0,
             target_temp_C=25.0,  # error=5, duty=500, clamped to 90
         )
-        result, _ = compute_tpi(inp, params)
+        result, state = compute_tpi(inp, params, state=state)
         assert result.duty_cycle_pct == 90.0
 
         inp.target_temp_C = 19.0  # error=-1, duty=-100, clamped to 10
-        result, _ = compute_tpi(inp, params)
+        result, state = compute_tpi(inp, params, state=state)
         assert result.duty_cycle_pct == 10.0
 
     def test_build_tpi_key(self):

--- a/tests/unit/test_calibration_mpc_state_manager.py
+++ b/tests/unit/test_calibration_mpc_state_manager.py
@@ -1,0 +1,80 @@
+"""Tests that MPC calibration reads and writes state through the state manager."""
+
+from unittest.mock import MagicMock
+
+from custom_components.better_thermostat.calibration import _compute_mpc_balance
+from custom_components.better_thermostat.utils.calibration.mpc import (
+    MpcState,
+    build_mpc_key,
+)
+
+
+class _MpcStateStub:
+    """Minimal stand-in for the state manager's MPC accessors."""
+
+    def __init__(self) -> None:
+        self.mpc: dict[str, MpcState] = {}
+
+    @property
+    def state(self):
+        return self
+
+    def get_mpc(self, key: str) -> MpcState:
+        """Return the stored state for ``key``, creating it on first access."""
+        return self.mpc.setdefault(key, MpcState())
+
+    def set_mpc(self, key: str, mpc: MpcState) -> None:
+        """Store ``mpc`` under ``key``."""
+        self.mpc[key] = mpc
+
+
+def _make_bt(state_mgr: _MpcStateStub) -> MagicMock:
+    """Return a BetterThermostat mock wired for a single heating TRV."""
+    bt = MagicMock()
+    bt.device_name = "Test BT"
+    bt.unique_id = "uid"
+    bt.bt_target_temp = 22.0
+    bt.cur_temp = 20.0
+    bt.cur_temp_filtered = None
+    bt.temp_slope = 0.0
+    bt.tolerance = 0.0
+    bt.window_open = False
+    bt.bt_hvac_mode = "heat"
+    bt.outdoor_sensor = None
+    bt.weather_entity = None
+    bt.hass.states.get.return_value = None
+    bt.real_trvs = {
+        "climate.trv": {
+            "advanced": {},
+            "current_temperature": 21.0,
+            "min_temp": 5.0,
+            "max_temp": 30.0,
+        }
+    }
+    bt.state_mgr = state_mgr
+    return bt
+
+
+def test_mpc_balance_persists_state_in_state_manager() -> None:
+    """The computed MPC state lands in the state manager under the MPC key."""
+    state_mgr = _MpcStateStub()
+    bt = _make_bt(state_mgr)
+
+    _compute_mpc_balance(bt, "climate.trv")
+
+    key = build_mpc_key(bt, "climate.trv")
+    assert key in state_mgr.mpc
+    assert state_mgr.mpc[key].last_integration_ts > 0.0
+
+
+def test_mpc_balance_threads_the_same_state_across_calls() -> None:
+    """Repeated calls keep accumulating on the state manager's state object."""
+    state_mgr = _MpcStateStub()
+    bt = _make_bt(state_mgr)
+    key = build_mpc_key(bt, "climate.trv")
+
+    _compute_mpc_balance(bt, "climate.trv")
+    first = state_mgr.mpc[key]
+
+    _compute_mpc_balance(bt, "climate.trv")
+    assert state_mgr.mpc[key] is first

--- a/tests/unit/test_calibration_pid_state_manager.py
+++ b/tests/unit/test_calibration_pid_state_manager.py
@@ -60,6 +60,16 @@ def test_pid_balance_persists_learned_state_in_state_manager() -> None:
     assert state_mgr.pid[key].last_abs_error == 2.0
 
 
+def test_pid_balance_schedules_state_persistence() -> None:
+    """A successful PID cycle schedules a save of the learned state."""
+    state_mgr = _PidStateStub()
+    bt = _make_bt(state_mgr)
+
+    _compute_pid_balance(bt, "climate.trv")
+
+    bt.schedule_save_state.assert_called()
+
+
 def test_pid_balance_threads_the_same_state_across_calls() -> None:
     """Repeated calls keep accumulating on the state manager's state object."""
     state_mgr = _PidStateStub()

--- a/tests/unit/test_calibration_pid_state_manager.py
+++ b/tests/unit/test_calibration_pid_state_manager.py
@@ -1,0 +1,74 @@
+"""Tests that PID calibration reads and writes state through the state manager."""
+
+from unittest.mock import MagicMock
+
+from custom_components.better_thermostat.calibration import _compute_pid_balance
+from custom_components.better_thermostat.utils.calibration.pid import (
+    PIDState,
+    build_pid_key,
+)
+
+
+class _PidStateStub:
+    """Minimal stand-in for the state manager's PID accessors."""
+
+    def __init__(self) -> None:
+        self.pid: dict[str, PIDState] = {}
+
+    def get_pid(self, key: str) -> PIDState:
+        """Return the stored state for ``key``, creating it on first access."""
+        return self.pid.setdefault(key, PIDState())
+
+    def set_pid(self, key: str, pid: PIDState) -> None:
+        """Store ``pid`` under ``key``."""
+        self.pid[key] = pid
+
+
+def _make_bt(state_mgr: _PidStateStub) -> MagicMock:
+    """Return a BetterThermostat mock wired for a single heating TRV."""
+    bt = MagicMock()
+    bt.device_name = "Test BT"
+    bt.unique_id = "uid"
+    bt.bt_target_temp = 22.0
+    bt.cur_temp = 20.0
+    bt.cur_temp_filtered = None
+    bt.temp_slope = 0.0
+    bt.window_open = False
+    bt.bt_hvac_mode = "heat"
+    bt.real_trvs = {
+        "climate.trv": {
+            "advanced": {},
+            "current_temperature": 21.0,
+            "min_temp": 5.0,
+            "max_temp": 30.0,
+        }
+    }
+    bt.state_mgr = state_mgr
+    return bt
+
+
+def test_pid_balance_persists_learned_state_in_state_manager() -> None:
+    """The computed PID state lands in the state manager under the PID key."""
+    state_mgr = _PidStateStub()
+    bt = _make_bt(state_mgr)
+
+    _compute_pid_balance(bt, "climate.trv")
+
+    key = build_pid_key(bt, "climate.trv")
+    assert key in state_mgr.pid
+    # error = |target - current| = |22.0 - 20.0|
+    assert state_mgr.pid[key].last_abs_error == 2.0
+
+
+def test_pid_balance_threads_the_same_state_across_calls() -> None:
+    """Repeated calls keep accumulating on the state manager's state object."""
+    state_mgr = _PidStateStub()
+    bt = _make_bt(state_mgr)
+    key = build_pid_key(bt, "climate.trv")
+
+    _compute_pid_balance(bt, "climate.trv")
+    first = state_mgr.pid[key]
+
+    _compute_pid_balance(bt, "climate.trv")
+    assert state_mgr.pid[key] is first
+    assert first.previous_abs_error == 2.0

--- a/tests/unit/test_calibration_tpi_state_manager.py
+++ b/tests/unit/test_calibration_tpi_state_manager.py
@@ -1,0 +1,73 @@
+"""Tests that TPI calibration reads and writes state through the state manager."""
+
+from unittest.mock import MagicMock
+
+from custom_components.better_thermostat.calibration import _compute_tpi_balance
+from custom_components.better_thermostat.utils.calibration.tpi import (
+    TpiState,
+    build_tpi_key,
+)
+
+
+class _TpiStateStub:
+    """Minimal stand-in for the state manager's TPI accessors."""
+
+    def __init__(self) -> None:
+        self.tpi: dict[str, TpiState] = {}
+
+    def get_tpi(self, key: str) -> TpiState:
+        """Return the stored state for ``key``, creating it on first access."""
+        return self.tpi.setdefault(key, TpiState())
+
+    def set_tpi(self, key: str, tpi: TpiState) -> None:
+        """Store ``tpi`` under ``key``."""
+        self.tpi[key] = tpi
+
+
+def _make_bt(state_mgr: _TpiStateStub) -> MagicMock:
+    """Return a BetterThermostat mock wired for a single heating TRV."""
+    bt = MagicMock()
+    bt.device_name = "Test BT"
+    bt.unique_id = "uid"
+    bt.bt_target_temp = 22.0
+    bt.cur_temp = 20.0
+    bt.window_open = False
+    bt.bt_hvac_mode = "heat"
+    bt.outdoor_sensor = None
+    bt.weather_entity = None
+    bt.real_trvs = {
+        "climate.trv": {
+            "advanced": {},
+            "current_temperature": 21.0,
+            "min_temp": 5.0,
+            "max_temp": 30.0,
+        }
+    }
+    bt.state_mgr = state_mgr
+    return bt
+
+
+def test_tpi_balance_persists_state_in_state_manager() -> None:
+    """The computed TPI state lands in the state manager under the TPI key."""
+    state_mgr = _TpiStateStub()
+    bt = _make_bt(state_mgr)
+
+    _compute_tpi_balance(bt, "climate.trv")
+
+    key = build_tpi_key(bt, "climate.trv")
+    assert key in state_mgr.tpi
+    # error = 2.0 K, duty = coef_int * 2.0 * 100 = 120 -> clamped to 100
+    assert state_mgr.tpi[key].last_percent == 100.0
+
+
+def test_tpi_balance_threads_the_same_state_across_calls() -> None:
+    """Repeated calls keep accumulating on the state manager's state object."""
+    state_mgr = _TpiStateStub()
+    bt = _make_bt(state_mgr)
+    key = build_tpi_key(bt, "climate.trv")
+
+    _compute_tpi_balance(bt, "climate.trv")
+    first = state_mgr.tpi[key]
+
+    _compute_tpi_balance(bt, "climate.trv")
+    assert state_mgr.tpi[key] is first

--- a/tests/unit/test_climate_reset_pid.py
+++ b/tests/unit/test_climate_reset_pid.py
@@ -1,19 +1,50 @@
 """Branch coverage for BetterThermostat.reset_pid_learnings_service.
 
-The service clears cached PID state for the entity and can optionally seed PID
-defaults into the current target bucket and its ±0.5 °C neighbours.  These tests
-pin the reset count, the bucket key construction, and the seed conditions.
+The service clears the entity's PID state in the StateManager and can
+optionally seed PID defaults into the current target bucket and its ±0.5 °C
+neighbours.  These tests pin the reset scope, the bucket key construction,
+and the seed conditions.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from custom_components.better_thermostat.climate import BetterThermostat
-from custom_components.better_thermostat.utils.calibration.pid import PIDParams
+from custom_components.better_thermostat.utils.calibration.pid import (
+    PIDParams,
+    PIDState,
+)
 
-_CLIMATE = "custom_components.better_thermostat.climate"
-_PID = "custom_components.better_thermostat.utils.calibration.pid"
+
+class _StateMgrStub:
+    """Minimal stand-in for the StateManager's PID surface."""
+
+    def __init__(self) -> None:
+        self.pid: dict[str, PIDState] = {}
+        self.dirty = False
+
+    @property
+    def state(self):
+        return self
+
+    def get_pid(self, key: str) -> PIDState:
+        return self.pid.setdefault(key, PIDState())
+
+    def set_pid(self, key: str, pid: PIDState) -> None:
+        self.pid[key] = pid
+        self.dirty = True
+
+    def reset_pid_states(self, prefix: str) -> int:
+        keys = [key for key in self.pid if key.startswith(prefix)]
+        for key in keys:
+            del self.pid[key]
+        if keys:
+            self.dirty = True
+        return len(keys)
+
+    def mark_dirty(self) -> None:
+        self.dirty = True
 
 
 @pytest.fixture
@@ -27,57 +58,51 @@ def bt():
     mock.real_trvs = {"climate.trv": {}}
     mock.schedule_save_state = MagicMock()
     mock.control_queue_task = AsyncMock()
+    mock.state_mgr = _StateMgrStub()
     return mock
 
 
 @pytest.mark.asyncio
 async def test_resets_each_cached_key(bt):
-    """Every exported PID key for this entity is reset and persistence scheduled."""
-    keys = {"uid:climate.trv:t21.0": {}, "uid:climate.trv:t20.0": {}}
-    with (
-        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value=keys)),
-        patch(f"{_CLIMATE}.pid_reset_state") as reset,
-    ):
-        await BetterThermostat.reset_pid_learnings_service(bt)
-    assert reset.call_count == 2
+    """Every PID key for this entity is removed and persistence scheduled."""
+    bt.state_mgr.pid = {
+        "uid:climate.trv:t21.0": PIDState(),
+        "uid:climate.trv:t20.0": PIDState(),
+        "other:climate.x:t21.0": PIDState(),
+    }
+    await BetterThermostat.reset_pid_learnings_service(bt)
+    assert set(bt.state_mgr.pid) == {"other:climate.x:t21.0"}
     bt.schedule_save_state.assert_called()
 
 
 @pytest.mark.asyncio
 async def test_no_keys_still_schedules_save(bt):
-    """With nothing cached, no reset happens but a save is still scheduled."""
-    with (
-        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
-        patch(f"{_CLIMATE}.pid_reset_state") as reset,
-    ):
-        await BetterThermostat.reset_pid_learnings_service(bt)
-    reset.assert_not_called()
+    """With nothing cached, no removal happens but a save is still scheduled."""
+    await BetterThermostat.reset_pid_learnings_service(bt)
+    assert bt.state_mgr.pid == {}
     bt.schedule_save_state.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_no_state_manager_is_a_noop(bt):
+    """Without a StateManager the service returns without scheduling a save."""
+    bt.state_mgr = None
+    await BetterThermostat.reset_pid_learnings_service(bt)
+    bt.schedule_save_state.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_no_defaults_does_not_seed(bt):
     """Without apply_pid_defaults, no gains are seeded."""
-    with (
-        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
-        patch(f"{_CLIMATE}.pid_reset_state"),
-        patch(f"{_PID}.seed_pid_gains") as seed,
-    ):
-        await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=False)
-    seed.assert_not_called()
+    await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=False)
+    assert bt.state_mgr.pid == {}
 
 
 @pytest.mark.asyncio
 async def test_seeds_current_and_neighbour_buckets(bt):
     """Defaults seed the current bucket and its ±0.5 °C neighbours per TRV."""
-    with (
-        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
-        patch(f"{_CLIMATE}.pid_reset_state"),
-        patch(f"{_PID}.seed_pid_gains", MagicMock(return_value=True)) as seed,
-    ):
-        await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=True)
-    seeded_keys = {call.args[0] for call in seed.call_args_list}
-    assert seeded_keys == {
+    await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=True)
+    assert set(bt.state_mgr.pid) == {
         "uid:climate.trv:t21.0",
         "uid:climate.trv:t21.5",
         "uid:climate.trv:t20.5",
@@ -90,46 +115,43 @@ async def test_seeds_current_and_neighbour_buckets(bt):
 async def test_defaults_use_pidparams_values(bt):
     """Without overrides, the PIDParams defaults are seeded."""
     defaults = PIDParams()
-    with (
-        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
-        patch(f"{_CLIMATE}.pid_reset_state"),
-        patch(f"{_PID}.seed_pid_gains", MagicMock(return_value=True)) as seed,
-    ):
-        await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=True)
-    kwargs = seed.call_args_list[0].kwargs
-    assert kwargs == {"kp": defaults.kp, "ki": defaults.ki, "kd": defaults.kd}
+    await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=True)
+    seeded = bt.state_mgr.pid["uid:climate.trv:t21.0"]
+    assert seeded.pid_kp == defaults.kp
+    assert seeded.pid_ki == defaults.ki
+    assert seeded.pid_kd == defaults.kd
 
 
 @pytest.mark.asyncio
 async def test_overrides_are_passed_through(bt):
     """Explicit kp/ki/kd overrides are forwarded to seeding."""
-    with (
-        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
-        patch(f"{_CLIMATE}.pid_reset_state"),
-        patch(f"{_PID}.seed_pid_gains", MagicMock(return_value=True)) as seed,
-    ):
-        await BetterThermostat.reset_pid_learnings_service(
-            bt,
-            apply_pid_defaults=True,
-            defaults_kp=1.5,
-            defaults_ki=0.2,
-            defaults_kd=0.05,
-        )
-    kwargs = seed.call_args_list[0].kwargs
-    assert kwargs == {"kp": 1.5, "ki": 0.2, "kd": 0.05}
+    await BetterThermostat.reset_pid_learnings_service(
+        bt, apply_pid_defaults=True, defaults_kp=1.5, defaults_ki=0.2, defaults_kd=0.05
+    )
+    seeded = bt.state_mgr.pid["uid:climate.trv:t21.0"]
+    assert seeded.pid_kp == 1.5
+    assert seeded.pid_ki == 0.2
+    assert seeded.pid_kd == 0.05
+
+
+@pytest.mark.asyncio
+async def test_seeding_preserves_other_state_fields(bt):
+    """Seeding only updates gains; learned fields like the integral survive."""
+    bt.state_mgr.pid["uid:climate.trv:t21.0"] = PIDState(pid_integral=7.5)
+    # Reset clears the entry, so seed into a pre-populated *fresh* manager:
+    bt.state_mgr.reset_pid_states = lambda prefix: 0
+    await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=True)
+    seeded = bt.state_mgr.pid["uid:climate.trv:t21.0"]
+    assert seeded.pid_integral == 7.5
+    assert seeded.pid_kp == PIDParams().kp
 
 
 @pytest.mark.asyncio
 async def test_no_trvs_seeds_nothing(bt):
     """With no TRVs, nothing is seeded and the control loop is not kicked."""
     bt.real_trvs = {}
-    with (
-        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
-        patch(f"{_CLIMATE}.pid_reset_state"),
-        patch(f"{_PID}.seed_pid_gains", MagicMock(return_value=True)) as seed,
-    ):
-        await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=True)
-    seed.assert_not_called()
+    await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=True)
+    assert bt.state_mgr.pid == {}
     bt.control_queue_task.put.assert_not_awaited()
 
 
@@ -137,11 +159,6 @@ async def test_no_trvs_seeds_nothing(bt):
 async def test_non_numeric_target_seeds_nothing(bt):
     """A non-numeric target yields no buckets, so nothing is seeded."""
     bt.bt_target_temp = None
-    with (
-        patch(f"{_CLIMATE}.pid_export_states", MagicMock(return_value={})),
-        patch(f"{_CLIMATE}.pid_reset_state"),
-        patch(f"{_PID}.seed_pid_gains", MagicMock(return_value=True)) as seed,
-    ):
-        await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=True)
-    seed.assert_not_called()
+    await BetterThermostat.reset_pid_learnings_service(bt, apply_pid_defaults=True)
+    assert bt.state_mgr.pid == {}
     bt.control_queue_task.put.assert_not_awaited()

--- a/tests/unit/test_mpc_comprehensive.py
+++ b/tests/unit/test_mpc_comprehensive.py
@@ -10,7 +10,6 @@ from time import time
 
 import pytest
 
-from custom_components.better_thermostat.utils.calibration import mpc as mpc_mod
 from custom_components.better_thermostat.utils.calibration.mpc import (
     DISTRIBUTE_COMPENSATION_PCT_PER_K,
     MpcInput,
@@ -25,11 +24,24 @@ from custom_components.better_thermostat.utils.calibration.mpc import (
     _update_perf_curve,
     build_mpc_group_key,
     build_mpc_key,
-    compute_mpc,
+    compute_mpc as _compute_mpc_raw,
     distribute_valve_percent,
-    export_mpc_state_map,
-    import_mpc_state_map,
 )
+from custom_components.better_thermostat.utils.state_manager import deserialize_mpc
+
+_STATES: dict[str, _MpcState] = {}
+
+
+def compute_mpc(inp, params):
+    """Run ``compute_mpc`` threading state for ``inp.key`` via ``_STATES``.
+
+    Mirrors how production owns controller state in the StateManager.
+    """
+    state = _STATES.setdefault(inp.key, _MpcState())
+    output, new_state = _compute_mpc_raw(inp, params, state=state, all_states=_STATES)
+    _STATES[inp.key] = new_state
+    return output, new_state
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -38,10 +50,10 @@ from custom_components.better_thermostat.utils.calibration.mpc import (
 
 @pytest.fixture(autouse=True)
 def _clean_mpc_states():
-    """Reset global MPC state before every test."""
-    mpc_mod._MPC_STATES.clear()
+    """Reset the test-local MPC state dict before every test."""
+    _STATES.clear()
     yield
-    mpc_mod._MPC_STATES.clear()
+    _STATES.clear()
 
 
 _UNSET: object = object()
@@ -289,19 +301,17 @@ class TestBuildMpcKey:
 
 
 # ===================================================================
-# 2. STATE PERSISTENCE (export / import)
+# 2. STATE PERSISTENCE (StateManager serialization)
 # ===================================================================
 
 
 class TestStatePersistence:
-    """Tests for export_mpc_state_map and import_mpc_state_map."""
-
-    def test_export_empty(self):
-        """Test that exporting with no states returns empty dict."""
-        assert export_mpc_state_map() == {}
+    """Persistence of MpcState via the StateManager's deserializer."""
 
     def test_round_trip(self):
-        """Test that all MPC state fields survive an export/import round-trip."""
+        """All MPC state fields survive an asdict/deserialize round-trip."""
+        from dataclasses import asdict
+
         state = _MpcState()
         state.gain_est = 0.08
         state.loss_est = 0.015
@@ -311,70 +321,37 @@ class TestStatePersistence:
         state.is_calibration_active = True
         state.trv_profile = "threshold"
         state.profile_confidence = 0.85
-        mpc_mod._MPC_STATES["k1"] = state
 
-        exported = export_mpc_state_map()
-        assert "k1" in exported
-        payload = exported["k1"]
-        assert payload["gain_est"] == 0.08
-        assert payload["dead_zone_hits"] == 3
-        assert payload["trv_profile"] == "threshold"
-
-        # Clear and re-import
-        mpc_mod._MPC_STATES.clear()
-        import_mpc_state_map(exported)
-        restored = mpc_mod._MPC_STATES["k1"]
+        restored = deserialize_mpc(asdict(state))
         assert restored.gain_est == pytest.approx(0.08)
         assert restored.loss_est == pytest.approx(0.015)
         assert restored.dead_zone_hits == 3
         assert restored.is_calibration_active is True
         assert restored.trv_profile == "threshold"
+        assert restored.last_percent == 42.0
+        assert restored.min_effective_percent == 12.0
 
-    def test_export_with_prefix_filter(self):
-        """Test that export with prefix only returns matching keys."""
-        mpc_mod._MPC_STATES["bt1:trv:t22.0"] = _MpcState(gain_est=0.05)
-        mpc_mod._MPC_STATES["bt2:trv:t22.0"] = _MpcState(gain_est=0.06)
+    def test_deserialize_ignores_unknown_fields(self):
+        """Unknown fields in the payload are ignored without error."""
+        restored = deserialize_mpc({"gain_est": 0.05, "unknown_field": 999})
+        assert restored.gain_est == pytest.approx(0.05)
 
-        filtered = export_mpc_state_map(prefix="bt1")
-        assert "bt1:trv:t22.0" in filtered
-        assert "bt2:trv:t22.0" not in filtered
+    def test_deserialize_coerces_types(self):
+        """String values are coerced to proper numeric types."""
+        restored = deserialize_mpc({"gain_est": "0.07", "dead_zone_hits": "5"})
+        assert restored.gain_est == pytest.approx(0.07)
+        assert restored.dead_zone_hits == 5
 
-    def test_import_ignores_invalid_payload(self):
-        """Test that non-dict payloads are silently skipped."""
-        import_mpc_state_map({"k": "not_a_dict"})
-        assert "k" not in mpc_mod._MPC_STATES
+    def test_deserialize_handles_none_values(self):
+        """None values in the payload are preserved."""
+        restored = deserialize_mpc({"gain_est": None})
+        assert restored.gain_est is None
 
-    def test_import_ignores_unknown_fields(self):
-        """Test that unknown fields in payload are ignored without error."""
-        import_mpc_state_map({"k": {"gain_est": 0.05, "unknown_field": 999}})
-        assert mpc_mod._MPC_STATES["k"].gain_est == pytest.approx(0.05)
-
-    def test_import_coerces_types(self):
-        """Test that string values are coerced to proper numeric types."""
-        import_mpc_state_map({"k": {"gain_est": "0.07", "dead_zone_hits": "5"}})
-        s = mpc_mod._MPC_STATES["k"]
-        assert s.gain_est == pytest.approx(0.07)
-        assert s.dead_zone_hits == 5
-
-    def test_import_handles_none_values(self):
-        """Test that None values in payload are preserved."""
-        import_mpc_state_map({"k": {"gain_est": None}})
-        assert mpc_mod._MPC_STATES["k"].gain_est is None
-
-    def test_import_handles_perf_curve(self):
-        """Test that perf_curve dicts are restored correctly."""
+    def test_deserialize_handles_perf_curve(self):
+        """perf_curve dicts are restored correctly."""
         curve = {"p00_05": {"count": 3, "avg_room_rate": 0.01}}
-        import_mpc_state_map({"k": {"perf_curve": curve}})
-        assert mpc_mod._MPC_STATES["k"].perf_curve == curve
-
-    def test_export_skips_none_fields(self):
-        """Serialization should skip None values to keep payload compact."""
-        mpc_mod._MPC_STATES["k"] = _MpcState()  # All defaults (mostly None)
-        exported = export_mpc_state_map()
-        # A default state has very few non-None values
-        if "k" in exported:
-            for v in exported["k"].values():
-                assert v is not None
+        restored = deserialize_mpc({"perf_curve": curve})
+        assert restored.perf_curve == curve
 
 
 # ===================================================================
@@ -473,13 +450,13 @@ class TestComputeMpcBasic:
         """Test that window_open resets integrals and control state."""
         params = _default_params(mpc_adapt=True)
         _compute(_inp(key="win"), params)
-        state = mpc_mod._MPC_STATES["win"]
+        state = _STATES["win"]
         state.last_percent = 50.0
         state.u_integral = 1000.0
         state.time_integral = 100.0
 
         _compute(_inp(key="win", window_open=True), params)
-        state = mpc_mod._MPC_STATES["win"]
+        state = _STATES["win"]
         assert state.last_percent == 0.0
         assert state.u_integral == 0.0
         assert state.time_integral == 0.0
@@ -490,16 +467,16 @@ class TestComputeMpcBasic:
         """Active calibration should be aborted when window opens."""
         params = _default_params()
         _compute(_inp(key="cal_abort"), params)
-        mpc_mod._MPC_STATES["cal_abort"].is_calibration_active = True
+        _STATES["cal_abort"].is_calibration_active = True
 
         _compute(_inp(key="cal_abort", window_open=True), params)
-        assert mpc_mod._MPC_STATES["cal_abort"].is_calibration_active is False
+        assert _STATES["cal_abort"].is_calibration_active is False
 
     def test_valve_integration_accumulates(self):
         """u_integral should accumulate valve position over time."""
         params = _default_params()
         _compute(_inp(key="integ"), params)
-        state = mpc_mod._MPC_STATES["integ"]
+        state = _STATES["integ"]
         state.last_percent = 50.0
         old_integral = state.u_integral
 
@@ -520,7 +497,7 @@ class TestAdaptiveLearning:
     def _setup_learning_state(self, key: str, params: MpcParams, **state_overrides):
         """Initialize MPC state and set up for learning."""
         _compute(_inp(key=key), params)
-        state = mpc_mod._MPC_STATES[key]
+        state = _STATES[key]
         for k, v in state_overrides.items():
             setattr(state, k, v)
         return state
@@ -529,21 +506,21 @@ class TestAdaptiveLearning:
         """Test that gain_est is seeded from mpc_thermal_gain on first call."""
         params = _default_params(mpc_adapt=True, mpc_thermal_gain=0.08)
         _compute(_inp(key="ginit"), params)
-        state = mpc_mod._MPC_STATES["ginit"]
+        state = _STATES["ginit"]
         assert state.gain_est == pytest.approx(0.08)
 
     def test_loss_initialized_on_first_call(self):
         """Test that loss_est is seeded from mpc_loss_coeff on first call."""
         params = _default_params(mpc_adapt=True, mpc_loss_coeff=0.012)
         _compute(_inp(key="linit"), params)
-        state = mpc_mod._MPC_STATES["linit"]
+        state = _STATES["linit"]
         assert state.loss_est == pytest.approx(0.012)
 
     def test_no_adaptation_when_disabled(self):
         """Test that gain_est and loss_est stay None when mpc_adapt=False."""
         params = _default_params(mpc_adapt=False)
         _compute(_inp(key="noadapt"), params)
-        state = mpc_mod._MPC_STATES["noadapt"]
+        state = _STATES["noadapt"]
         assert state.gain_est is None
         assert state.loss_est is None
 
@@ -744,7 +721,7 @@ class TestAdaptiveLearning:
         """ka_est should be calculated when outdoor_temp is provided."""
         params = _default_params(mpc_adapt=True, mpc_loss_coeff=0.01)
         _compute(_inp(key="ka", current_temp_C=20.0, outdoor_temp_C=5.0), params)
-        state = mpc_mod._MPC_STATES["ka"]
+        state = _STATES["ka"]
         assert state.ka_est is not None
         # ka = loss / (indoor - outdoor) = 0.01 / 15 ≈ 0.000667
         assert state.ka_est == pytest.approx(0.01 / 15.0, rel=0.01)
@@ -791,14 +768,14 @@ class TestVirtualTemperature:
         """Test that virtual_temp starts at the sensor reading."""
         params = _default_params(use_virtual_temp=True)
         _compute(_inp(key="vinit", current_temp_C=20.5), params)
-        state = mpc_mod._MPC_STATES["vinit"]
+        state = _STATES["vinit"]
         assert state.virtual_temp == pytest.approx(20.5)
 
     def test_virtual_temp_corrects_large_drift(self):
         """Kalman filter should correct virtual_temp when it drifts far from sensor."""
         params = _default_params(use_virtual_temp=True)
         _compute(_inp(key="vreset", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["vreset"]
+        state = _STATES["vreset"]
         # Artificially drift virtual temp far from sensor
         state.virtual_temp = 21.0  # 1K off from sensor at 20.0
         state.last_sensor_temp_C = 19.5  # different from current so update triggers
@@ -813,7 +790,7 @@ class TestVirtualTemperature:
         """Kalman update should keep virtual_temp close to sensor value."""
         params = _default_params(use_virtual_temp=True)
         _compute(_inp(key="vclamp", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["vclamp"]
+        state = _STATES["vclamp"]
         state.virtual_temp = 20.3  # slightly drifted
         state.last_sensor_temp_C = 19.9  # different so update fires
         state.last_percent = 50.0
@@ -826,7 +803,7 @@ class TestVirtualTemperature:
         """Sync should be skipped when sensor value hasn't changed."""
         params = _default_params(use_virtual_temp=True)
         _compute(_inp(key="vsame", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["vsame"]
+        state = _STATES["vsame"]
         state.last_sensor_temp_C = 20.0  # same as current
         state.last_percent = 50.0
 
@@ -837,7 +814,7 @@ class TestVirtualTemperature:
         """When virtual temp is enabled, delta_t should use virtual temp, not sensor."""
         params = _default_params(use_virtual_temp=True)
         _compute(_inp(key="vdelta", current_temp_C=20.0, target_temp_C=22.0), params)
-        state = mpc_mod._MPC_STATES["vdelta"]
+        state = _STATES["vdelta"]
         # Virtual temp should be close to sensor on first call
         assert state.virtual_temp is not None
 
@@ -845,10 +822,10 @@ class TestVirtualTemperature:
         """Test that window_open resets virtual_temp to None."""
         params = _default_params(use_virtual_temp=True)
         _compute(_inp(key="vwin", current_temp_C=20.0), params)
-        assert mpc_mod._MPC_STATES["vwin"].virtual_temp is not None
+        assert _STATES["vwin"].virtual_temp is not None
 
         _compute(_inp(key="vwin", window_open=True), params)
-        assert mpc_mod._MPC_STATES["vwin"].virtual_temp is None
+        assert _STATES["vwin"].virtual_temp is None
 
 
 # ===================================================================
@@ -912,7 +889,7 @@ class TestRegimeBoostIntegration:
         """Test that regime boost triggers when recent_errors show sustained bias."""
         params = _default_params(mpc_adapt=True, mpc_adapt_alpha=0.1)
         _compute(_inp(key="rboost"), params)
-        state = mpc_mod._MPC_STATES["rboost"]
+        state = _STATES["rboost"]
         # Inject biased errors to trigger regime change
         state.recent_errors = [0.05] * 15
         # But _detect_regime_change returns False when std==0
@@ -1050,7 +1027,7 @@ class TestPostProcessing:
 
         # First call: cold room -> high valve
         _compute(_inp(key="dumax", current_temp_C=18.0), params)
-        state = mpc_mod._MPC_STATES["dumax"]
+        state = _STATES["dumax"]
         state.last_percent = 50.0  # Force a known starting point
         state.last_update_ts = time()
 
@@ -1064,7 +1041,7 @@ class TestPostProcessing:
         params = _default_params(mpc_du_max_pct=5.0)
 
         _compute(_inp(key="dumax_over", current_temp_C=18.0), params)
-        state = mpc_mod._MPC_STATES["dumax_over"]
+        state = _STATES["dumax_over"]
         state.last_percent = 50.0
         state.last_update_ts = time()
 
@@ -1093,7 +1070,7 @@ class TestPostProcessing:
         """If min_effective_percent is set, low nonzero outputs should be clamped up."""
         params = _default_params(enable_min_effective_percent=True)
         _compute(_inp(key="mineff"), params)
-        state = mpc_mod._MPC_STATES["mineff"]
+        state = _STATES["mineff"]
         state.min_effective_percent = 15.0
 
         # Request a small valve opening
@@ -1177,7 +1154,7 @@ class TestForcedCalibration:
         """Active calibration should end when temp < target - hysteresis."""
         params = _default_params()
         _compute(_inp(key="calend", current_temp_C=22.5, target_temp_C=22.0), params)
-        state = mpc_mod._MPC_STATES["calend"]
+        state = _STATES["calend"]
         state.is_calibration_active = True
 
         # Temp drops to 21.7 (< 22.0 - 0.2 = 21.8)
@@ -1188,7 +1165,7 @@ class TestForcedCalibration:
         """During active calibration, valve should be forced to 0."""
         params = _default_params()
         _compute(_inp(key="cal0", current_temp_C=22.1, target_temp_C=22.0), params)
-        state = mpc_mod._MPC_STATES["cal0"]
+        state = _STATES["cal0"]
         state.is_calibration_active = True
 
         result = _compute(
@@ -1203,7 +1180,7 @@ class TestForcedCalibration:
         for i in range(50):
             key = f"cal_stoch_{i}"
             _compute(_inp(key=key, current_temp_C=22.5, target_temp_C=22.0), params)
-            state = mpc_mod._MPC_STATES[key]
+            state = _STATES[key]
             if state.is_calibration_active:
                 triggered = True
                 break
@@ -1214,7 +1191,7 @@ class TestForcedCalibration:
         """Calibration chance should decay as loss_learn_count increases."""
         params = _default_params()
         _compute(_inp(key="cal_decay"), params)
-        state = mpc_mod._MPC_STATES["cal_decay"]
+        state = _STATES["cal_decay"]
         state.loss_learn_count = 100
         # chance = max(0.05, 1/(100+1)) ≈ 0.01 -> clamped to 0.05
         # Very unlikely to trigger in a single attempt
@@ -1234,7 +1211,7 @@ class TestStaleStateDetection:
         """Test that stale state (>15min) resets learning anchors."""
         params = _default_params(mpc_adapt=True)
         _compute(_inp(key="stale"), params)
-        state = mpc_mod._MPC_STATES["stale"]
+        state = _STATES["stale"]
         state.last_time = time() - 1000  # 16+ min ago
         state.last_learn_temp = 19.0
         state.u_integral = 5000.0
@@ -1257,31 +1234,31 @@ class TestSeedFromSiblings:
         params = _default_params(enable_min_effective_percent=True)
         # Create a sibling with known min_effective_percent
         sibling_state = _MpcState(min_effective_percent=15.0)
-        mpc_mod._MPC_STATES["uid1:climate.trv:t21.0"] = sibling_state
+        _STATES["uid1:climate.trv:t21.0"] = sibling_state
 
         # New key same uid+entity, different bucket
         _compute(_inp(key="uid1:climate.trv:t22.0", current_temp_C=20.0), params)
-        new_state = mpc_mod._MPC_STATES["uid1:climate.trv:t22.0"]
+        new_state = _STATES["uid1:climate.trv:t22.0"]
         assert new_state.min_effective_percent == 15.0
 
     def test_no_seeding_when_disabled(self):
         """Test that seeding is skipped when enable_min_effective_percent=False."""
         params = _default_params(enable_min_effective_percent=False)
         sibling_state = _MpcState(min_effective_percent=15.0)
-        mpc_mod._MPC_STATES["uid2:climate.trv:t21.0"] = sibling_state
+        _STATES["uid2:climate.trv:t21.0"] = sibling_state
 
         _compute(_inp(key="uid2:climate.trv:t22.0", current_temp_C=20.0), params)
-        new_state = mpc_mod._MPC_STATES["uid2:climate.trv:t22.0"]
+        new_state = _STATES["uid2:climate.trv:t22.0"]
         assert new_state.min_effective_percent is None
 
     def test_no_seeding_from_different_entity(self):
         """Test that seeding only happens from same uid+entity siblings."""
         params = _default_params(enable_min_effective_percent=True)
         sibling_state = _MpcState(min_effective_percent=15.0)
-        mpc_mod._MPC_STATES["uid3:climate.trv_A:t21.0"] = sibling_state
+        _STATES["uid3:climate.trv_A:t21.0"] = sibling_state
 
         _compute(_inp(key="uid3:climate.trv_B:t22.0", current_temp_C=20.0), params)
-        new_state = mpc_mod._MPC_STATES["uid3:climate.trv_B:t22.0"]
+        new_state = _STATES["uid3:climate.trv_B:t22.0"]
         assert new_state.min_effective_percent is None
 
 
@@ -1378,7 +1355,7 @@ class TestEdgeCases:
         """When temp_slope_K_per_min is provided, EMA slope should be tracked."""
         params = _default_params()
         _compute(_inp(key="slope_ema", temp_slope_K_per_min=0.05), params)
-        state = mpc_mod._MPC_STATES["slope_ema"]
+        state = _STATES["slope_ema"]
         assert state.ema_slope is not None
         assert state.ema_slope == pytest.approx(0.05)
 
@@ -1525,7 +1502,7 @@ class TestKalmanFilter:
         """
         params = _default_params(use_virtual_temp=True, kalman_R=0.04)
         _compute(_inp(key="kp_init", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["kp_init"]
+        state = _STATES["kp_init"]
         # Init sets P=R=0.04, then sensor_changed triggers update:
         # K = P/(P+R) = 0.04/(0.04+0.04) = 0.5
         # P_new = (1-0.5)*0.04 = 0.02
@@ -1535,7 +1512,7 @@ class TestKalmanFilter:
         """P should increase after predict step (uncertainty grows with time)."""
         params = _default_params(use_virtual_temp=True, kalman_Q=0.001)
         _compute(_inp(key="kp_grow", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["kp_grow"]
+        state = _STATES["kp_grow"]
         state.last_percent = 50.0
         P_after_init = state.kalman_P
 
@@ -1550,7 +1527,7 @@ class TestKalmanFilter:
         """P should decrease after update step (measurement reduces uncertainty)."""
         params = _default_params(use_virtual_temp=True, kalman_Q=0.001, kalman_R=0.04)
         _compute(_inp(key="kp_shrink", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["kp_shrink"]
+        state = _STATES["kp_shrink"]
         state.last_percent = 50.0
         state.kalman_P = 1.0  # High uncertainty
         state.last_sensor_temp_C = 19.5  # Different from current → triggers update
@@ -1563,7 +1540,7 @@ class TestKalmanFilter:
         """With high P (relative to R), Kalman gain K → 1, trusting sensor more."""
         params = _default_params(use_virtual_temp=True, kalman_R=0.04)
         _compute(_inp(key="kg_high", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["kg_high"]
+        state = _STATES["kg_high"]
         state.kalman_P = 100.0  # Very high uncertainty
         state.last_sensor_temp_C = 19.0  # Force update
         state.virtual_temp = 21.0  # Far from sensor
@@ -1577,7 +1554,7 @@ class TestKalmanFilter:
         """With low P (relative to R), Kalman gain K → 0, trusting model more."""
         params = _default_params(use_virtual_temp=True, kalman_R=0.04)
         _compute(_inp(key="kg_low", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["kg_low"]
+        state = _STATES["kg_low"]
         state.kalman_P = 0.0001  # Very low uncertainty
         state.last_sensor_temp_C = 19.0  # Force update
         state.virtual_temp = 21.0  # Far from sensor
@@ -1596,7 +1573,7 @@ class TestKalmanFilter:
             mpc_adapt=True,
         )
         _compute(_inp(key="kpred", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["kpred"]
+        state = _STATES["kpred"]
         state.last_percent = 100.0  # Full open
         state.gain_est = 0.06
         state.loss_est = 0.01
@@ -1737,7 +1714,7 @@ class TestGainLearnCountGuard:
             enable_min_effective_percent=False,
         )
         _compute(_inp(key=key, current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES[key]
+        state = _STATES[key]
         state.gain_est = 0.06
         state.loss_est = 0.02
         state.gain_learn_count = gain_learn_count
@@ -1787,7 +1764,7 @@ class TestGainRecovery:
             mpc_adapt=True, mpc_adapt_alpha=0.1, enable_min_effective_percent=False
         )
         _compute(_inp(key="grecov", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["grecov"]
+        state = _STATES["grecov"]
         state.gain_est = 0.02  # Artificially low gain
         state.loss_est = 0.005
         state.last_percent = 50.0  # u=0.5
@@ -1809,7 +1786,7 @@ class TestGainRecovery:
             mpc_adapt=True, mpc_adapt_alpha=0.1, enable_min_effective_percent=False
         )
         _compute(_inp(key="gnorec", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["gnorec"]
+        state = _STATES["gnorec"]
         state.gain_est = 0.10
         state.loss_est = 0.01
         state.last_percent = 50.0  # u=0.5
@@ -1845,7 +1822,7 @@ class TestHighUSteadyStateGain:
             mpc_adapt=True, mpc_adapt_alpha=0.1, enable_min_effective_percent=False
         )
         _compute(_inp(key="huss", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["huss"]
+        state = _STATES["huss"]
         state.gain_est = 0.10
         state.loss_est = 0.01
         state.last_percent = 30.0  # u=0.3 > 0.15
@@ -1881,13 +1858,13 @@ class TestKaEstDynamicLoss:
         params = _default_params(mpc_adapt=True, mpc_loss_coeff=0.01)
         # Cold outside: delta = 20 - (-10) = 30
         _compute(_inp(key="ka_cold", current_temp_C=20.0, outdoor_temp_C=-10.0), params)
-        state_cold = mpc_mod._MPC_STATES["ka_cold"]
+        state_cold = _STATES["ka_cold"]
         assert state_cold.ka_est is not None
         assert state_cold.ka_est == pytest.approx(0.01 / 30.0, rel=0.01)
 
         # Warm outside: delta = max(5.0, 20 - 15) = 5
         _compute(_inp(key="ka_warm", current_temp_C=20.0, outdoor_temp_C=15.0), params)
-        state_warm = mpc_mod._MPC_STATES["ka_warm"]
+        state_warm = _STATES["ka_warm"]
         assert state_warm.ka_est is not None
         assert state_warm.ka_est == pytest.approx(0.01 / 5.0, rel=0.01)
 
@@ -1903,7 +1880,7 @@ class TestKaEstDynamicLoss:
             enable_min_effective_percent=False,
         )
         _compute(_inp(key="ka_upd", current_temp_C=21.0, outdoor_temp_C=5.0), params)
-        state = mpc_mod._MPC_STATES["ka_upd"]
+        state = _STATES["ka_upd"]
         state.last_percent = 0.0
         state.last_learn_temp = 21.0
         state.last_learn_time = time() - 300
@@ -1935,7 +1912,7 @@ class TestResidualRateLimiting:
         )
         now = time()
         _compute(_inp(key=key, current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES[key]
+        state = _STATES[key]
         state.gain_est = 0.06
         state.loss_est = 0.01
         state.last_percent = 17.0  # close to u0 = 0.01/0.06 ≈ 0.167 → 16.7%
@@ -1982,7 +1959,7 @@ class TestBigChangeHoldBypass:
         )
         # First call: set low valve
         _compute(_inp(key="bigopen", current_temp_C=22.0, target_temp_C=22.0), params)
-        state = mpc_mod._MPC_STATES["bigopen"]
+        state = _STATES["bigopen"]
         state.last_percent = 10.0
         state.last_update_ts = time()  # just updated
 
@@ -2001,7 +1978,7 @@ class TestBigChangeHoldBypass:
             big_change_force_close_pct=10.0,
         )
         _compute(_inp(key="bigclose", current_temp_C=18.0, target_temp_C=22.0), params)
-        state = mpc_mod._MPC_STATES["bigclose"]
+        state = _STATES["bigclose"]
         state.last_percent = 80.0
         state.last_update_ts = time()  # just updated
 
@@ -2022,7 +1999,7 @@ class TestBigChangeHoldBypass:
         _compute(
             _inp(key="smallclose", current_temp_C=18.0, target_temp_C=22.0), params
         )
-        state = mpc_mod._MPC_STATES["smallclose"]
+        state = _STATES["smallclose"]
         state.last_percent = 25.0
         state.last_update_ts = time()
 
@@ -2068,7 +2045,7 @@ class TestStaleStateAnchorReset:
         """Stale detection should reset learn_time and learn_temp, not just u_integral."""
         params = _default_params(mpc_adapt=True)
         _compute(_inp(key="stale_full", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["stale_full"]
+        state = _STATES["stale_full"]
         state.last_time = time() - 1000  # 16+ min ago
         state.last_learn_temp = 18.0
         state.last_learn_time = time() - 1000
@@ -2095,7 +2072,7 @@ class TestTargetChangeBoundary:
         """A target change of exactly 0.05K should be detected."""
         params = _default_params(mpc_adapt=True, mpc_adapt_alpha=0.5)
         _compute(_inp(key="tgt_exact", current_temp_C=20.0, target_temp_C=22.0), params)
-        state = mpc_mod._MPC_STATES["tgt_exact"]
+        state = _STATES["tgt_exact"]
         state.last_target_C = 22.0
         state.last_learn_temp = 20.0
         state.last_learn_time = time() - 300
@@ -2117,7 +2094,7 @@ class TestTargetChangeBoundary:
         """A target change of less than 0.05K should NOT be detected."""
         params = _default_params(mpc_adapt=True, mpc_adapt_alpha=0.5)
         _compute(_inp(key="tgt_sub", current_temp_C=20.0, target_temp_C=22.0), params)
-        state = mpc_mod._MPC_STATES["tgt_sub"]
+        state = _STATES["tgt_sub"]
         state.last_target_C = 22.0
         state.last_learn_temp = 20.0
         state.last_learn_time = time() - 300
@@ -2165,7 +2142,7 @@ class TestSolarGainInit:
         """solar_gain_est should be initialized when mpc_adapt=True."""
         params = _default_params(mpc_adapt=True)
         _compute(_inp(key="solar_init", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["solar_init"]
+        state = _STATES["solar_init"]
         assert state.solar_gain_est is not None
         assert state.solar_gain_est == pytest.approx(
             0.01
@@ -2175,7 +2152,7 @@ class TestSolarGainInit:
         """solar_gain_est should stay None when mpc_adapt=False."""
         params = _default_params(mpc_adapt=False)
         _compute(_inp(key="solar_noinit", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["solar_noinit"]
+        state = _STATES["solar_noinit"]
         assert state.solar_gain_est is None
 
 
@@ -2191,7 +2168,7 @@ class TestIntegrationAccumulation:
         """u_integral and time_integral should track valve usage over time."""
         params = _default_params()
         _compute(_inp(key="integ_prec", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["integ_prec"]
+        state = _STATES["integ_prec"]
         state.last_percent = 50.0
         state.last_integration_ts = time() - 60  # 60s ago
 
@@ -2204,7 +2181,7 @@ class TestIntegrationAccumulation:
         """Window open should reset u_integral and time_integral."""
         params = _default_params()
         _compute(_inp(key="integ_win", current_temp_C=20.0), params)
-        state = mpc_mod._MPC_STATES["integ_win"]
+        state = _STATES["integ_win"]
         state.u_integral = 5000.0
         state.time_integral = 300.0
 

--- a/tests/unit/test_mpc_import_string_fields.py
+++ b/tests/unit/test_mpc_import_string_fields.py
@@ -1,149 +1,118 @@
-"""Tests for import_mpc_state_map handling of string and int fields."""
+"""Tests for deserialize_mpc handling of string, int, and bool fields.
+
+MPC state is persisted through the StateManager; ``deserialize_mpc`` is the
+deserializer applied on load and must coerce JSON-typed payloads back into
+the proper field types.
+"""
 
 from __future__ import annotations
 
+from dataclasses import asdict
+
 import pytest
 
-from custom_components.better_thermostat.utils.calibration import mpc as mpc_mod
-from custom_components.better_thermostat.utils.calibration.mpc import (
-    _MpcState,
-    export_mpc_state_map,
-    import_mpc_state_map,
-)
+from custom_components.better_thermostat.utils.calibration.mpc import _MpcState
+from custom_components.better_thermostat.utils.state_manager import deserialize_mpc
 
 
-@pytest.fixture(autouse=True)
-def _clean_mpc_states():
-    """Reset global MPC state before every test."""
-    mpc_mod._MPC_STATES.clear()
-    yield
-    mpc_mod._MPC_STATES.clear()
+def _round_trip(state: _MpcState) -> _MpcState:
+    """Serialize a state like the StateManager does and deserialize it again."""
+    return deserialize_mpc(asdict(state))
 
 
 class TestImportStringFields:
-    """Tests for correct type coercion in import_mpc_state_map."""
+    """Tests for correct type coercion in deserialize_mpc."""
 
     def test_trv_profile_survives_round_trip(self):
-        """trv_profile should be preserved as a string after export/import."""
+        """trv_profile should be preserved as a string after a round-trip."""
         state = _MpcState()
         state.trv_profile = "threshold"
         state.gain_est = 0.08
-        mpc_mod._MPC_STATES["k1"] = state
 
-        exported = export_mpc_state_map()
-        mpc_mod._MPC_STATES.clear()
-        import_mpc_state_map(exported)
-
-        restored = mpc_mod._MPC_STATES["k1"]
+        restored = _round_trip(state)
         assert restored.trv_profile == "threshold"
         assert restored.gain_est == pytest.approx(0.08)
 
     def test_trv_profile_unknown_survives_round_trip(self):
-        """Default trv_profile 'unknown' should also survive round-trip."""
+        """Default trv_profile 'unknown' should also survive a round-trip."""
         state = _MpcState()
         state.trv_profile = "unknown"
-        mpc_mod._MPC_STATES["k2"] = state
 
-        exported = export_mpc_state_map()
-        mpc_mod._MPC_STATES.clear()
-        import_mpc_state_map(exported)
-
-        assert mpc_mod._MPC_STATES["k2"].trv_profile == "unknown"
+        assert _round_trip(state).trv_profile == "unknown"
 
     def test_trv_profile_all_known_values(self):
-        """All known trv_profile values should survive round-trip."""
+        """All known trv_profile values should survive a round-trip."""
         for profile in ("unknown", "linear", "threshold", "exponential"):
-            mpc_mod._MPC_STATES.clear()
             state = _MpcState()
             state.trv_profile = profile
-            mpc_mod._MPC_STATES["k"] = state
 
-            exported = export_mpc_state_map()
-            mpc_mod._MPC_STATES.clear()
-            import_mpc_state_map(exported)
-
-            assert mpc_mod._MPC_STATES["k"].trv_profile == profile
+            assert _round_trip(state).trv_profile == profile
 
     def test_profile_samples_survives_round_trip(self):
-        """profile_samples (int) should survive export/import."""
+        """profile_samples (int) should survive a round-trip."""
         state = _MpcState()
         state.profile_samples = 42
-        mpc_mod._MPC_STATES["k3"] = state
 
-        exported = export_mpc_state_map()
-        mpc_mod._MPC_STATES.clear()
-        import_mpc_state_map(exported)
-
-        assert mpc_mod._MPC_STATES["k3"].profile_samples == 42
+        assert _round_trip(state).profile_samples == 42
 
     def test_is_calibration_active_survives_round_trip(self):
-        """is_calibration_active (bool) should survive export/import."""
+        """is_calibration_active (bool) should survive a round-trip."""
         state = _MpcState()
         state.is_calibration_active = True
-        mpc_mod._MPC_STATES["k4"] = state
 
-        exported = export_mpc_state_map()
-        mpc_mod._MPC_STATES.clear()
-        import_mpc_state_map(exported)
-
-        assert mpc_mod._MPC_STATES["k4"].is_calibration_active is True
+        assert _round_trip(state).is_calibration_active is True
 
     def test_loss_learn_count_survives_round_trip(self):
-        """loss_learn_count (int) should survive export/import."""
+        """loss_learn_count (int) should survive a round-trip."""
         state = _MpcState()
         state.loss_learn_count = 15
-        mpc_mod._MPC_STATES["k5"] = state
 
-        exported = export_mpc_state_map()
-        mpc_mod._MPC_STATES.clear()
-        import_mpc_state_map(exported)
-
-        assert mpc_mod._MPC_STATES["k5"].loss_learn_count == 15
+        assert _round_trip(state).loss_learn_count == 15
 
     def test_regime_boost_active_survives_round_trip(self):
-        """regime_boost_active (bool) should survive export/import."""
+        """regime_boost_active (bool) should survive a round-trip."""
         state = _MpcState()
         state.regime_boost_active = True
-        mpc_mod._MPC_STATES["k_rb"] = state
 
-        exported = export_mpc_state_map()
-        mpc_mod._MPC_STATES.clear()
-        import_mpc_state_map(exported)
-
-        assert mpc_mod._MPC_STATES["k_rb"].regime_boost_active is True
+        assert _round_trip(state).regime_boost_active is True
 
     def test_consecutive_insufficient_heat_survives_round_trip(self):
-        """consecutive_insufficient_heat (int) should survive export/import."""
+        """consecutive_insufficient_heat (int) should survive a round-trip."""
         state = _MpcState()
         state.consecutive_insufficient_heat = 5
-        mpc_mod._MPC_STATES["k_cih"] = state
 
-        exported = export_mpc_state_map()
-        mpc_mod._MPC_STATES.clear()
-        import_mpc_state_map(exported)
-
-        restored = mpc_mod._MPC_STATES["k_cih"]
+        restored = _round_trip(state)
         assert restored.consecutive_insufficient_heat == 5
         assert isinstance(restored.consecutive_insufficient_heat, int)
 
+    def test_string_payload_values_are_coerced(self):
+        """JSON payloads with string-typed numbers are coerced on load."""
+        restored = deserialize_mpc(
+            {
+                "gain_est": "0.07",
+                "profile_samples": "42",
+                "loss_learn_count": "7",
+                "trv_profile": "linear",
+            }
+        )
+        assert restored.gain_est == pytest.approx(0.07)
+        assert restored.profile_samples == 42
+        assert restored.loss_learn_count == 7
+        assert restored.trv_profile == "linear"
+
     def test_perf_curve_survives_round_trip(self):
-        """perf_curve (dict) should survive export/import."""
+        """perf_curve (dict) should survive a round-trip."""
         state = _MpcState()
         state.perf_curve = {"p00_10": {"rate": 0.05, "count": 3}}
-        mpc_mod._MPC_STATES["k_pc"] = state
 
-        exported = export_mpc_state_map()
-        mpc_mod._MPC_STATES.clear()
-        import_mpc_state_map(exported)
-
-        restored = mpc_mod._MPC_STATES["k_pc"]
+        restored = _round_trip(state)
         assert isinstance(restored.perf_curve, dict)
         assert "p00_10" in restored.perf_curve
         assert restored.perf_curve["p00_10"]["rate"] == pytest.approx(0.05)
         assert restored.perf_curve["p00_10"]["count"] == 3
 
     def test_full_state_round_trip(self):
-        """All field types should survive a full export/import round-trip."""
+        """All field types should survive a full round-trip."""
         state = _MpcState()
         state.gain_est = 0.08
         state.loss_est = 0.015
@@ -158,13 +127,8 @@ class TestImportStringFields:
         state.regime_boost_active = True
         state.consecutive_insufficient_heat = 3
         state.perf_curve = {"p50_60": {"rate": 0.1, "count": 5}}
-        mpc_mod._MPC_STATES["k6"] = state
 
-        exported = export_mpc_state_map()
-        mpc_mod._MPC_STATES.clear()
-        import_mpc_state_map(exported)
-
-        restored = mpc_mod._MPC_STATES["k6"]
+        restored = _round_trip(state)
         assert restored.gain_est == pytest.approx(0.08)
         assert restored.loss_est == pytest.approx(0.015)
         assert restored.last_percent == pytest.approx(42.0)

--- a/tests/unit/test_pid_entity_state_access.py
+++ b/tests/unit/test_pid_entity_state_access.py
@@ -1,0 +1,156 @@
+"""PID number and auto-tune switch read/write state through the StateManager.
+
+The entities resolve the active PID state via ``build_pid_key`` and the
+climate's ``state_mgr``; without a manager (startup failure) they fall back
+to defaults and refuse writes instead of crashing.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.better_thermostat.number import BetterThermostatPIDNumber
+from custom_components.better_thermostat.switch import BetterThermostatPIDAutoTuneSwitch
+from custom_components.better_thermostat.utils.calibration.pid import (
+    DEFAULT_PID_AUTO_TUNE,
+    DEFAULT_PID_KP,
+    PIDState,
+)
+
+_KEY = "uid:climate.trv:t21.0"
+
+
+class _StateMgrStub:
+    """Minimal stand-in for the StateManager's PID surface."""
+
+    def __init__(self) -> None:
+        self.pid: dict[str, PIDState] = {}
+        self.dirty = False
+
+    @property
+    def state(self):
+        return self
+
+    def get_pid(self, key: str) -> PIDState:
+        return self.pid.setdefault(key, PIDState())
+
+    def set_pid(self, key: str, pid: PIDState) -> None:
+        self.pid[key] = pid
+        self.dirty = True
+
+    def mark_dirty(self) -> None:
+        self.dirty = True
+
+
+def _make_bt() -> MagicMock:
+    bt = MagicMock()
+    bt.unique_id = "uid"
+    bt.bt_target_temp = 21.0
+    bt.schedule_save_state = MagicMock()
+    bt.state_mgr = _StateMgrStub()
+    return bt
+
+
+class TestPidNumber:
+    """BetterThermostatPIDNumber reads and writes via the StateManager."""
+
+    def _make(self, bt) -> BetterThermostatPIDNumber:
+        number = BetterThermostatPIDNumber(bt, "climate.trv", "kp", False)
+        number.async_write_ha_state = MagicMock()
+        return number
+
+    def test_reads_learned_gain_from_state_manager(self):
+        """A learned gain in the manager is exposed as the number value."""
+        bt = _make_bt()
+        bt.state_mgr.pid[_KEY] = PIDState(pid_kp=123.0)
+        assert self._make(bt).native_value == 123.0
+
+    def test_missing_state_falls_back_to_default(self):
+        """Without a stored state the default value is exposed."""
+        bt = _make_bt()
+        assert self._make(bt).native_value == DEFAULT_PID_KP
+
+    def test_no_state_manager_falls_back_to_default(self):
+        """Without a state manager the default value is exposed."""
+        bt = _make_bt()
+        bt.state_mgr = None
+        assert self._make(bt).native_value == DEFAULT_PID_KP
+
+    @pytest.mark.asyncio
+    async def test_set_writes_only_current_bucket(self):
+        """Setting a gain writes only the current bucket and marks dirty."""
+        bt = _make_bt()
+        bt.state_mgr.pid["uid:climate.trv:t20.0"] = PIDState(pid_kp=1.0)
+        number = self._make(bt)
+
+        await number.async_set_native_value(55.0)
+
+        assert bt.state_mgr.pid[_KEY].pid_kp == 55.0
+        assert bt.state_mgr.pid["uid:climate.trv:t20.0"].pid_kp == 1.0
+        assert bt.state_mgr.dirty is True
+        bt.schedule_save_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_set_without_state_manager_is_a_noop(self):
+        """Setting without a state manager neither writes nor schedules a save."""
+        bt = _make_bt()
+        bt.state_mgr = None
+        number = self._make(bt)
+
+        await number.async_set_native_value(55.0)
+
+        bt.schedule_save_state.assert_not_called()
+
+
+class TestAutoTuneSwitch:
+    """BetterThermostatPIDAutoTuneSwitch reads/writes auto_tune via the manager."""
+
+    def _make(self, bt) -> BetterThermostatPIDAutoTuneSwitch:
+        switch = BetterThermostatPIDAutoTuneSwitch(bt, "climate.trv", False)
+        switch.async_write_ha_state = MagicMock()
+        return switch
+
+    def test_reads_auto_tune_flag(self):
+        """A stored auto_tune flag is exposed as the switch state."""
+        bt = _make_bt()
+        bt.state_mgr.pid[_KEY] = PIDState(auto_tune=False)
+        assert self._make(bt).is_on is False
+
+    def test_missing_state_falls_back_to_default(self):
+        """Without a stored state the default value is exposed."""
+        bt = _make_bt()
+        assert self._make(bt).is_on is DEFAULT_PID_AUTO_TUNE
+
+    def test_no_state_manager_falls_back_to_default(self):
+        """Without a state manager the default value is exposed."""
+        bt = _make_bt()
+        bt.state_mgr = None
+        assert self._make(bt).is_on is DEFAULT_PID_AUTO_TUNE
+
+    def test_update_sets_flag_on_all_buckets_of_this_trv(self):
+        """Toggling updates every bucket of this TRV, not other TRVs."""
+        bt = _make_bt()
+        bt.state_mgr.pid = {
+            "uid:climate.trv:t21.0": PIDState(),
+            "uid:climate.trv:t20.0": PIDState(),
+            "uid:climate.other:t21.0": PIDState(),
+        }
+        switch = self._make(bt)
+
+        switch._update_state(False)
+
+        assert bt.state_mgr.pid["uid:climate.trv:t21.0"].auto_tune is False
+        assert bt.state_mgr.pid["uid:climate.trv:t20.0"].auto_tune is False
+        assert bt.state_mgr.pid["uid:climate.other:t21.0"].auto_tune is None
+        assert bt.state_mgr.dirty is True
+        bt.schedule_save_state.assert_called_once()
+
+    def test_update_without_state_manager_is_a_noop(self):
+        """Toggling without a state manager neither writes nor schedules a save."""
+        bt = _make_bt()
+        bt.state_mgr = None
+        switch = self._make(bt)
+
+        switch._update_state(True)
+
+        bt.schedule_save_state.assert_not_called()

--- a/tests/unit/test_pid_entity_state_access.py
+++ b/tests/unit/test_pid_entity_state_access.py
@@ -145,6 +145,22 @@ class TestAutoTuneSwitch:
         assert bt.state_mgr.dirty is True
         bt.schedule_save_state.assert_called_once()
 
+    def test_update_seeds_active_bucket_when_none_exists(self):
+        """Toggling with no stored bucket seeds the active one.
+
+        After a PID reset (or before the first PID cycle) the map is
+        empty; the toggle must still survive and be readable.
+        """
+        bt = _make_bt()
+        switch = self._make(bt)
+
+        switch._update_state(False)
+
+        assert bt.state_mgr.pid[_KEY].auto_tune is False
+        assert bt.state_mgr.dirty is True
+        assert switch.is_on is False
+        bt.schedule_save_state.assert_called_once()
+
     def test_update_without_state_manager_is_a_noop(self):
         """Toggling without a state manager neither writes nor schedules a save."""
         bt = _make_bt()

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -709,53 +709,45 @@ class TestHydrateControllers:
     """hydrate_controllers() seeds module caches with the prefix-filtered state."""
 
     def test_imports_only_prefixed_keys(self):
-        """Only keys starting with the prefix are pushed into the caches."""
+        """Only keys starting with the prefix are pushed into the cache."""
         mgr = _make_manager()
         mgr.set_mpc("p:trv1", MpcState(gain_est=0.5))
         mgr.set_mpc("other:trvX", MpcState(gain_est=9.9))
-        mgr.set_tpi("p:trv1", TpiState())
 
-        with (
-            patch(f"{_SM}.import_mpc_state_map") as imp_mpc,
-            patch(f"{_SM}.import_tpi_state_map") as imp_tpi,
-        ):
+        with patch(f"{_SM}.import_mpc_state_map") as imp_mpc:
             mgr.hydrate_controllers("p:")
 
         imp_mpc.assert_called_once()
         assert set(imp_mpc.call_args[0][0]) == {"p:trv1"}
-        imp_tpi.assert_called_once()
-        assert set(imp_tpi.call_args[0][0]) == {"p:trv1"}
 
     def test_no_matching_keys_skips_import(self):
-        """When nothing matches the prefix, the import functions are not called."""
+        """When nothing matches the prefix, the import function is not called."""
         mgr = _make_manager()
         mgr.set_mpc("other:trvX", MpcState())
 
-        with (
-            patch(f"{_SM}.import_mpc_state_map") as imp_mpc,
-            patch(f"{_SM}.import_tpi_state_map") as imp_tpi,
-        ):
+        with patch(f"{_SM}.import_mpc_state_map") as imp_mpc:
             mgr.hydrate_controllers("p:")
 
         imp_mpc.assert_not_called()
-        imp_tpi.assert_not_called()
 
     def test_hydrate_does_not_mark_dirty(self):
         """Seeding caches from persisted state must not dirty the store."""
         mgr = _make_manager()
         mgr.set_mpc("p:trv1", MpcState())
         mgr._dirty = False
-        with patch(f"{_SM}.import_mpc_state_map"), patch(f"{_SM}.import_tpi_state_map"):
+        with patch(f"{_SM}.import_mpc_state_map"):
             mgr.hydrate_controllers("p:")
         assert mgr.dirty is False
 
-    def test_hydrate_leaves_pid_untouched(self):
-        """PID state needs no bridging; hydrate ignores it entirely."""
+    def test_hydrate_leaves_pid_and_tpi_untouched(self):
+        """PID/TPI state needs no bridging; hydrate ignores it entirely."""
         mgr = _make_manager()
         mgr.set_pid("p:trv1", PIDState(pid_kp=42.0))
-        with patch(f"{_SM}.import_mpc_state_map"), patch(f"{_SM}.import_tpi_state_map"):
+        mgr.set_tpi("p:trv1", TpiState(last_percent=33.0))
+        with patch(f"{_SM}.import_mpc_state_map"):
             mgr.hydrate_controllers("p:")
         assert mgr.state.pid["p:trv1"].pid_kp == 42.0
+        assert mgr.state.tpi["p:trv1"].last_percent == 33.0
 
 
 # ---------------------------------------------------------------------------
@@ -769,10 +761,7 @@ class TestSyncControllers:
     def test_records_thermal_and_dirties(self):
         """Supplied thermal stats are stored and the store is marked dirty."""
         mgr = _make_manager()
-        with (
-            patch(f"{_SM}.export_mpc_state_map", return_value={}),
-            patch(f"{_SM}.export_tpi_state_map", return_value={}),
-        ):
+        with patch(f"{_SM}.export_mpc_state_map", return_value={}):
             mgr.sync_controllers("p:", 0.07, 0.02)
         assert mgr.thermal.heating_power == 0.07
         assert mgr.thermal.heat_loss_rate == 0.02
@@ -781,12 +770,9 @@ class TestSyncControllers:
     def test_exports_controller_caches_into_store(self):
         """Exported controller dicts are deserialized back into the store."""
         mgr = _make_manager()
-        with (
-            patch(
-                f"{_SM}.export_mpc_state_map",
-                return_value={"p:trv1": asdict(MpcState(gain_est=1.23))},
-            ),
-            patch(f"{_SM}.export_tpi_state_map", return_value={}),
+        with patch(
+            f"{_SM}.export_mpc_state_map",
+            return_value={"p:trv1": asdict(MpcState(gain_est=1.23))},
         ):
             mgr.sync_controllers("p:", None, None)
         assert mgr.state.mpc["p:trv1"].gain_est == 1.23
@@ -794,23 +780,19 @@ class TestSyncControllers:
     def test_non_dict_export_entry_is_skipped(self):
         """A malformed (non-dict) export entry is ignored, not stored."""
         mgr = _make_manager()
-        with (
-            patch(f"{_SM}.export_mpc_state_map", return_value={"p:bad": "notadict"}),
-            patch(f"{_SM}.export_tpi_state_map", return_value={}),
-        ):
+        with patch(f"{_SM}.export_mpc_state_map", return_value={"p:bad": "notadict"}):
             mgr.sync_controllers("p:", None, None)
         assert "p:bad" not in mgr.state.mpc
 
-    def test_sync_does_not_overwrite_pid_state(self):
-        """PID state in the store stays untouched by sync_controllers."""
+    def test_sync_does_not_overwrite_pid_or_tpi_state(self):
+        """PID/TPI state in the store stays untouched by sync_controllers."""
         mgr = _make_manager()
         mgr.set_pid("p:trv1", PIDState(pid_kp=42.0))
-        with (
-            patch(f"{_SM}.export_mpc_state_map", return_value={}),
-            patch(f"{_SM}.export_tpi_state_map", return_value={}),
-        ):
+        mgr.set_tpi("p:trv1", TpiState(last_percent=33.0))
+        with patch(f"{_SM}.export_mpc_state_map", return_value={}):
             mgr.sync_controllers("p:", None, None)
         assert mgr.state.pid["p:trv1"].pid_kp == 42.0
+        assert mgr.state.tpi["p:trv1"].last_percent == 33.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -701,59 +701,29 @@ class TestClampedThermal:
 
 
 # ---------------------------------------------------------------------------
-# Controller bridging: hydrate_controllers
+# Thermal stats recording
 # ---------------------------------------------------------------------------
 
 
-class TestHydrateControllers:
-    """hydrate_controllers() is a no-op: state lives in the manager itself."""
-
-    def test_hydrate_leaves_state_untouched(self):
-        """Controller state in the store is not modified by hydrate."""
-        mgr = _make_manager()
-        mgr.set_mpc("p:trv1", MpcState(gain_est=0.5))
-        mgr.set_pid("p:trv1", PIDState(pid_kp=42.0))
-        mgr.set_tpi("p:trv1", TpiState(last_percent=33.0))
-
-        mgr.hydrate_controllers("p:")
-
-        assert mgr.state.mpc["p:trv1"].gain_est == 0.5
-        assert mgr.state.pid["p:trv1"].pid_kp == 42.0
-        assert mgr.state.tpi["p:trv1"].last_percent == 33.0
-
-    def test_hydrate_does_not_mark_dirty(self):
-        """Hydrating must not dirty the store."""
-        mgr = _make_manager()
-        mgr.set_mpc("p:trv1", MpcState())
-        mgr._dirty = False
-        mgr.hydrate_controllers("p:")
-        assert mgr.dirty is False
-
-
-# ---------------------------------------------------------------------------
-# Controller bridging: sync_controllers
-# ---------------------------------------------------------------------------
-
-
-class TestSyncControllers:
-    """sync_controllers() records thermal stats; controller state stays put."""
+class TestRecordThermal:
+    """record_thermal() stores the supplied stats; controller state stays put."""
 
     def test_records_thermal_and_dirties(self):
         """Supplied thermal stats are stored and the store is marked dirty."""
         mgr = _make_manager()
-        mgr.sync_controllers("p:", 0.07, 0.02)
+        mgr.record_thermal(0.07, 0.02)
         assert mgr.thermal.heating_power == 0.07
         assert mgr.thermal.heat_loss_rate == 0.02
         assert mgr.dirty is True
 
-    def test_sync_does_not_touch_controller_state(self):
-        """MPC/PID/TPI state in the store stays untouched by sync_controllers."""
+    def test_does_not_touch_controller_state(self):
+        """MPC/PID/TPI state in the store stays untouched by record_thermal."""
         mgr = _make_manager()
         mgr.set_mpc("p:trv1", MpcState(gain_est=1.23))
         mgr.set_pid("p:trv1", PIDState(pid_kp=42.0))
         mgr.set_tpi("p:trv1", TpiState(last_percent=33.0))
 
-        mgr.sync_controllers("p:", None, None)
+        mgr.record_thermal(None, None)
 
         assert mgr.state.mpc["p:trv1"].gain_est == 1.23
         assert mgr.state.pid["p:trv1"].pid_kp == 42.0

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -713,21 +713,16 @@ class TestHydrateControllers:
         mgr = _make_manager()
         mgr.set_mpc("p:trv1", MpcState(gain_est=0.5))
         mgr.set_mpc("other:trvX", MpcState(gain_est=9.9))
-        mgr.set_pid("p:trv1", PIDState())
         mgr.set_tpi("p:trv1", TpiState())
 
         with (
             patch(f"{_SM}.import_mpc_state_map") as imp_mpc,
-            patch(f"{_SM}.import_pid_states") as imp_pid,
             patch(f"{_SM}.import_tpi_state_map") as imp_tpi,
         ):
             mgr.hydrate_controllers("p:")
 
         imp_mpc.assert_called_once()
         assert set(imp_mpc.call_args[0][0]) == {"p:trv1"}
-        imp_pid.assert_called_once()
-        assert imp_pid.call_args.kwargs["prefix_filter"] == "p:"
-        assert set(imp_pid.call_args[0][0]) == {"p:trv1"}
         imp_tpi.assert_called_once()
         assert set(imp_tpi.call_args[0][0]) == {"p:trv1"}
 
@@ -738,13 +733,11 @@ class TestHydrateControllers:
 
         with (
             patch(f"{_SM}.import_mpc_state_map") as imp_mpc,
-            patch(f"{_SM}.import_pid_states") as imp_pid,
             patch(f"{_SM}.import_tpi_state_map") as imp_tpi,
         ):
             mgr.hydrate_controllers("p:")
 
         imp_mpc.assert_not_called()
-        imp_pid.assert_not_called()
         imp_tpi.assert_not_called()
 
     def test_hydrate_does_not_mark_dirty(self):
@@ -752,13 +745,17 @@ class TestHydrateControllers:
         mgr = _make_manager()
         mgr.set_mpc("p:trv1", MpcState())
         mgr._dirty = False
-        with (
-            patch(f"{_SM}.import_mpc_state_map"),
-            patch(f"{_SM}.import_pid_states"),
-            patch(f"{_SM}.import_tpi_state_map"),
-        ):
+        with patch(f"{_SM}.import_mpc_state_map"), patch(f"{_SM}.import_tpi_state_map"):
             mgr.hydrate_controllers("p:")
         assert mgr.dirty is False
+
+    def test_hydrate_leaves_pid_untouched(self):
+        """PID state needs no bridging; hydrate ignores it entirely."""
+        mgr = _make_manager()
+        mgr.set_pid("p:trv1", PIDState(pid_kp=42.0))
+        with patch(f"{_SM}.import_mpc_state_map"), patch(f"{_SM}.import_tpi_state_map"):
+            mgr.hydrate_controllers("p:")
+        assert mgr.state.pid["p:trv1"].pid_kp == 42.0
 
 
 # ---------------------------------------------------------------------------
@@ -774,7 +771,6 @@ class TestSyncControllers:
         mgr = _make_manager()
         with (
             patch(f"{_SM}.export_mpc_state_map", return_value={}),
-            patch(f"{_SM}.export_pid_states", return_value={}),
             patch(f"{_SM}.export_tpi_state_map", return_value={}),
         ):
             mgr.sync_controllers("p:", 0.07, 0.02)
@@ -790,7 +786,6 @@ class TestSyncControllers:
                 f"{_SM}.export_mpc_state_map",
                 return_value={"p:trv1": asdict(MpcState(gain_est=1.23))},
             ),
-            patch(f"{_SM}.export_pid_states", return_value={}),
             patch(f"{_SM}.export_tpi_state_map", return_value={}),
         ):
             mgr.sync_controllers("p:", None, None)
@@ -801,8 +796,60 @@ class TestSyncControllers:
         mgr = _make_manager()
         with (
             patch(f"{_SM}.export_mpc_state_map", return_value={"p:bad": "notadict"}),
-            patch(f"{_SM}.export_pid_states", return_value={}),
             patch(f"{_SM}.export_tpi_state_map", return_value={}),
         ):
             mgr.sync_controllers("p:", None, None)
         assert "p:bad" not in mgr.state.mpc
+
+    def test_sync_does_not_overwrite_pid_state(self):
+        """PID state in the store stays untouched by sync_controllers."""
+        mgr = _make_manager()
+        mgr.set_pid("p:trv1", PIDState(pid_kp=42.0))
+        with (
+            patch(f"{_SM}.export_mpc_state_map", return_value={}),
+            patch(f"{_SM}.export_tpi_state_map", return_value={}),
+        ):
+            mgr.sync_controllers("p:", None, None)
+        assert mgr.state.pid["p:trv1"].pid_kp == 42.0
+
+
+# ---------------------------------------------------------------------------
+# PID state reset
+# ---------------------------------------------------------------------------
+
+
+class TestResetPidStates:
+    """reset_pid_states() drops prefixed keys and reports the count."""
+
+    def test_removes_only_prefixed_keys(self):
+        """Keys with the prefix are removed; others stay."""
+        mgr = _make_manager()
+        mgr.set_pid("p:trv1:t21.0", PIDState())
+        mgr.set_pid("p:trv1:t21.5", PIDState())
+        mgr.set_pid("other:trvX:t20.0", PIDState())
+
+        removed = mgr.reset_pid_states("p:")
+
+        assert removed == 2
+        assert set(mgr.state.pid) == {"other:trvX:t20.0"}
+
+    def test_removal_marks_dirty(self):
+        """Removing entries marks the store dirty."""
+        mgr = _make_manager()
+        mgr.set_pid("p:trv1:t21.0", PIDState())
+        mgr._dirty = False
+
+        mgr.reset_pid_states("p:")
+
+        assert mgr.dirty is True
+
+    def test_no_match_returns_zero_and_stays_clean(self):
+        """Without matching keys nothing is removed and dirty stays False."""
+        mgr = _make_manager()
+        mgr.set_pid("other:trvX:t20.0", PIDState())
+        mgr._dirty = False
+
+        removed = mgr.reset_pid_states("p:")
+
+        assert removed == 0
+        assert mgr.dirty is False

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -706,48 +706,28 @@ class TestClampedThermal:
 
 
 class TestHydrateControllers:
-    """hydrate_controllers() seeds module caches with the prefix-filtered state."""
+    """hydrate_controllers() is a no-op: state lives in the manager itself."""
 
-    def test_imports_only_prefixed_keys(self):
-        """Only keys starting with the prefix are pushed into the cache."""
+    def test_hydrate_leaves_state_untouched(self):
+        """Controller state in the store is not modified by hydrate."""
         mgr = _make_manager()
         mgr.set_mpc("p:trv1", MpcState(gain_est=0.5))
-        mgr.set_mpc("other:trvX", MpcState(gain_est=9.9))
+        mgr.set_pid("p:trv1", PIDState(pid_kp=42.0))
+        mgr.set_tpi("p:trv1", TpiState(last_percent=33.0))
 
-        with patch(f"{_SM}.import_mpc_state_map") as imp_mpc:
-            mgr.hydrate_controllers("p:")
+        mgr.hydrate_controllers("p:")
 
-        imp_mpc.assert_called_once()
-        assert set(imp_mpc.call_args[0][0]) == {"p:trv1"}
-
-    def test_no_matching_keys_skips_import(self):
-        """When nothing matches the prefix, the import function is not called."""
-        mgr = _make_manager()
-        mgr.set_mpc("other:trvX", MpcState())
-
-        with patch(f"{_SM}.import_mpc_state_map") as imp_mpc:
-            mgr.hydrate_controllers("p:")
-
-        imp_mpc.assert_not_called()
+        assert mgr.state.mpc["p:trv1"].gain_est == 0.5
+        assert mgr.state.pid["p:trv1"].pid_kp == 42.0
+        assert mgr.state.tpi["p:trv1"].last_percent == 33.0
 
     def test_hydrate_does_not_mark_dirty(self):
-        """Seeding caches from persisted state must not dirty the store."""
+        """Hydrating must not dirty the store."""
         mgr = _make_manager()
         mgr.set_mpc("p:trv1", MpcState())
         mgr._dirty = False
-        with patch(f"{_SM}.import_mpc_state_map"):
-            mgr.hydrate_controllers("p:")
+        mgr.hydrate_controllers("p:")
         assert mgr.dirty is False
-
-    def test_hydrate_leaves_pid_and_tpi_untouched(self):
-        """PID/TPI state needs no bridging; hydrate ignores it entirely."""
-        mgr = _make_manager()
-        mgr.set_pid("p:trv1", PIDState(pid_kp=42.0))
-        mgr.set_tpi("p:trv1", TpiState(last_percent=33.0))
-        with patch(f"{_SM}.import_mpc_state_map"):
-            mgr.hydrate_controllers("p:")
-        assert mgr.state.pid["p:trv1"].pid_kp == 42.0
-        assert mgr.state.tpi["p:trv1"].last_percent == 33.0
 
 
 # ---------------------------------------------------------------------------
@@ -756,41 +736,26 @@ class TestHydrateControllers:
 
 
 class TestSyncControllers:
-    """sync_controllers() exports module caches and records thermal stats."""
+    """sync_controllers() records thermal stats; controller state stays put."""
 
     def test_records_thermal_and_dirties(self):
         """Supplied thermal stats are stored and the store is marked dirty."""
         mgr = _make_manager()
-        with patch(f"{_SM}.export_mpc_state_map", return_value={}):
-            mgr.sync_controllers("p:", 0.07, 0.02)
+        mgr.sync_controllers("p:", 0.07, 0.02)
         assert mgr.thermal.heating_power == 0.07
         assert mgr.thermal.heat_loss_rate == 0.02
         assert mgr.dirty is True
 
-    def test_exports_controller_caches_into_store(self):
-        """Exported controller dicts are deserialized back into the store."""
+    def test_sync_does_not_touch_controller_state(self):
+        """MPC/PID/TPI state in the store stays untouched by sync_controllers."""
         mgr = _make_manager()
-        with patch(
-            f"{_SM}.export_mpc_state_map",
-            return_value={"p:trv1": asdict(MpcState(gain_est=1.23))},
-        ):
-            mgr.sync_controllers("p:", None, None)
-        assert mgr.state.mpc["p:trv1"].gain_est == 1.23
-
-    def test_non_dict_export_entry_is_skipped(self):
-        """A malformed (non-dict) export entry is ignored, not stored."""
-        mgr = _make_manager()
-        with patch(f"{_SM}.export_mpc_state_map", return_value={"p:bad": "notadict"}):
-            mgr.sync_controllers("p:", None, None)
-        assert "p:bad" not in mgr.state.mpc
-
-    def test_sync_does_not_overwrite_pid_or_tpi_state(self):
-        """PID/TPI state in the store stays untouched by sync_controllers."""
-        mgr = _make_manager()
+        mgr.set_mpc("p:trv1", MpcState(gain_est=1.23))
         mgr.set_pid("p:trv1", PIDState(pid_kp=42.0))
         mgr.set_tpi("p:trv1", TpiState(last_percent=33.0))
-        with patch(f"{_SM}.export_mpc_state_map", return_value={}):
-            mgr.sync_controllers("p:", None, None)
+
+        mgr.sync_controllers("p:", None, None)
+
+        assert mgr.state.mpc["p:trv1"].gain_est == 1.23
         assert mgr.state.pid["p:trv1"].pid_kp == 42.0
         assert mgr.state.tpi["p:trv1"].last_percent == 33.0
 


### PR DESCRIPTION
## What

Makes the `StateManager` the only owner of learned controller state (PID, MPC, TPI). The module-level dicts `_PID_STATES` / `_MPC_STATES` / `_TPI_STATES` are gone; state is threaded explicitly: `calibration.py` passes the entry's state into `compute_*` and stores the returned successor back into the per-entry store.

## Why

The compute functions already accepted and returned explicit state — but `calibration.py` discarded the returned successor, so the real state lived in module globals. Module globals have three concrete failure modes:

- **Cross-entry leakage:** two Better Thermostat instances share one process-wide dict; key collisions silently share learned models.
- **Reload staleness:** a config-entry reload rebuilds the entity but the globals survive, so the "fresh" entry resumes from state the user tried to reset.
- **Unbounded growth:** keys accumulate for the lifetime of the process; nothing evicts entries for removed TRVs.

A contract test pins the new invariant: computing with explicit state must not read or write any module-level registry.

## How to review

Six commits, each green on its own (full suite verified per commit):

1. **contract test** — pins the state-threading contract (this is #2050, absorbed here).
2. **source PID state from the state manager** — the read side.
3. **PID ownership** — write side; the global becomes a bridge.
4. **TPI ownership** — same pattern.
5. **MPC ownership** — same pattern (incl. sibling seeding via the passed `all_states` map instead of the global).
6. **drop the bridging layer** — the globals and their export/import shims are deleted.

## Relation to other PRs

- Supersedes **#2050** (its contract test is commit 1 here — #2050 can be closed in favor of this).
- Touches the same state-resolve block in `compute_*` as **#2057** (poison resistance). Whichever lands second has a three-line conflict with an obvious resolution (keep the sanitize call, drop the global write); happy to rebase.
- Second self-contained slice of the architecture PoC **#2053**, independent of the first (#2056).

## Testing

Full suite green on every commit of the series; ruff check + format clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured internal state management architecture to enhance consistency and reliability of calibration controller operations and thermal state persistence

* **Tests**
  * Added comprehensive test coverage validating state persistence behavior, state threading across system operations, and controller integration patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->