### PR TITLE
test: integration harness — real config entry against a simulated TRV

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,5 @@
 homeassistant==2026.2.3
+pytest-homeassistant-custom-component==0.13.316
 pre-commit==4.6.0
 codespell==2.4.2
 ruff==0.15.15

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -92,6 +92,7 @@ class FakeTrvEntity(ClimateEntity):
     _attr_target_temperature_step = 0.5
 
     def __init__(self):
+        """Initialize device state and the recorded-write assertion surface."""
         self._attr_hvac_mode = HVACMode.HEAT
         self._attr_current_temperature = 19.5
         self._attr_target_temperature = 20.0
@@ -102,7 +103,12 @@ class FakeTrvEntity(ClimateEntity):
         self.drop_next_setpoint_write = False
 
     async def async_set_temperature(self, **kwargs) -> None:
-        """Apply and confirm a setpoint write."""
+        """Apply and confirm a setpoint write.
+
+        The write is always recorded; with ``drop_next_setpoint_write``
+        set it is then swallowed instead of applied, simulating a device
+        that lost the command over the radio.
+        """
         temperature = kwargs[ATTR_TEMPERATURE]
         self.set_temperature_calls.append(temperature)
         if self.drop_next_setpoint_write:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,194 @@
+"""Harness for tests against a real Home Assistant instance.
+
+The unit suite mocks the entity; everything here sets up a real config
+entry against a real (simulated) climate entity so the wiring across
+the layers — entity lifecycle, queues, adapters, services — is
+exercised end to end.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    setup_test_component_platform,
+)
+
+# Pin the repository's custom_components namespace package before the
+# hass fixture mounts the plugin's testing config dir: that dir carries
+# a regular custom_components package which would otherwise shadow the
+# repository and make the loader report "Integration not found".
+import custom_components.better_thermostat  # noqa: F401  isort: skip
+
+from homeassistant.components.climate import (
+    DOMAIN as CLIMATE_DOMAIN,
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACMode,
+)
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.setup import async_setup_component
+
+DOMAIN = "better_thermostat"
+TRV_ID = "climate.fake_trv"
+SENSOR_ID = "sensor.room_temperature"
+WINDOW_ID = "binary_sensor.window"
+
+
+@pytest.fixture(autouse=True)
+async def _recorder(recorder_mock):
+    """Provide the recorder the integration's manifest depends on.
+
+    Must be instantiated before anything pulls up the hass fixture.
+    """
+    return
+
+
+@pytest.fixture(autouse=True)
+def _enable_custom_integrations(_recorder, enable_custom_integrations):
+    """Let Home Assistant load custom_components from the repository."""
+    return
+
+
+@pytest.fixture(autouse=True)
+def _compressed_sleeps():
+    """Compress asyncio sleeps so the entity runs in test time.
+
+    The integration sleeps real intervals (startup settle, write
+    propagation, poll loops). The replacement keeps the scheduling
+    semantics — it always yields to the event loop — without the wall
+    time.
+    """
+    real_sleep = asyncio.sleep
+
+    async def fast(delay, result=None, **kwargs):
+        await real_sleep(0.005 if delay and delay > 0 else 0)
+        return result
+
+    with patch("asyncio.sleep", new=fast):
+        yield
+
+
+class FakeTrvEntity(ClimateEntity):
+    """A well-behaved simulated TRV as a real climate entity.
+
+    Commands arrive through the real climate services and are confirmed
+    into the entity state, like a device that applies every write. The
+    recorded calls are the assertion surface.
+    """
+
+    _attr_name = "fake trv"
+    _attr_should_poll = False
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+    )
+    _attr_min_temp = 5.0
+    _attr_max_temp = 30.0
+    _attr_target_temperature_step = 0.5
+
+    def __init__(self):
+        self._attr_hvac_mode = HVACMode.HEAT
+        self._attr_current_temperature = 19.5
+        self._attr_target_temperature = 20.0
+        self.set_temperature_calls: list[float] = []
+        self.set_hvac_mode_calls: list[str] = []
+        # Radio loss simulation: the next setpoint write is recorded but
+        # neither applied nor confirmed.
+        self.drop_next_setpoint_write = False
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        """Apply and confirm a setpoint write."""
+        temperature = kwargs[ATTR_TEMPERATURE]
+        self.set_temperature_calls.append(temperature)
+        if self.drop_next_setpoint_write:
+            self.drop_next_setpoint_write = False
+            return
+        self._attr_target_temperature = temperature
+        self.async_write_ha_state()
+
+    async def async_set_hvac_mode(self, hvac_mode) -> None:
+        """Apply and confirm a mode write."""
+        self.set_hvac_mode_calls.append(str(hvac_mode))
+        self._attr_hvac_mode = hvac_mode
+        self.async_write_ha_state()
+
+
+@pytest.fixture
+async def fake_trv(hass):
+    """Register a fake TRV with the real climate component."""
+    entity = FakeTrvEntity()
+    setup_test_component_platform(hass, CLIMATE_DOMAIN, [entity])
+    assert await async_setup_component(
+        hass, CLIMATE_DOMAIN, {CLIMATE_DOMAIN: {"platform": "test"}}
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(TRV_ID) is not None
+    return entity
+
+
+def make_entry(*, with_window=False) -> MockConfigEntry:
+    """Build a config entry matching the current entry schema."""
+    data = {
+        "name": "BT Test",
+        "thermostat": [
+            {
+                "trv": TRV_ID,
+                "integration": "generic_thermostat",
+                "model": "Generic",
+                "advanced": {
+                    "calibration": "target_temp_based",
+                    "calibration_mode": "default",
+                    "no_off_system_mode": False,
+                },
+            }
+        ],
+        "temperature_sensor": SENSOR_ID,
+        "model": "Generic",
+        "target_temp_step": "0.5",
+        "tolerance": 0.3,
+        "off_temperature": 5,
+    }
+    if with_window:
+        data["window_sensors"] = WINDOW_ID
+        data["window_off_delay"] = 0
+        data["window_off_delay_after"] = 0
+    return MockConfigEntry(domain=DOMAIN, version=18, data=data, title="BT Test")
+
+
+async def setup_entry(hass, entry) -> None:
+    """Set the entry up and let the startup sequence settle."""
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def wait_for(hass, predicate, timeout_s=10.0) -> bool:
+    """Yield to the loop until ``predicate()`` is true or time runs out."""
+    deadline = hass.loop.time() + timeout_s
+    while hass.loop.time() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(0)
+        await hass.async_block_till_done()
+    return predicate()
+
+
+async def wait_for_startup(hass, entry):
+    """Return the BT entity once its startup task has fully finished.
+
+    The startup background task keeps running after the entry setup
+    returns; events fired before it registers its state listeners would
+    be lost. ``_async_unsub_state_changed`` is assigned in the listener
+    registration block at the end of the sequence.
+    """
+    bt = hass.data[DOMAIN][entry.entry_id]["climate"]
+    assert await wait_for(
+        hass,
+        lambda: not bt.startup_running and bt._async_unsub_state_changed is not None,
+    )
+    return bt

--- a/tests/integration/test_entry_lifecycle.py
+++ b/tests/integration/test_entry_lifecycle.py
@@ -1,0 +1,113 @@
+"""End-to-end tests: config entry to real device writes.
+
+These tests exist because the unit suite mocks the entity: a control
+path that silently writes nothing keeps every unit test green. Here a
+real entry is set up against a simulated TRV and the assertions are the
+service calls that arrive at the device.
+"""
+
+from homeassistant.components.climate.const import ATTR_HVAC_ACTION
+from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.core import State
+from pytest_homeassistant_custom_component.common import mock_restore_cache
+
+from .conftest import (
+    SENSOR_ID,
+    WINDOW_ID,
+    make_entry,
+    setup_entry,
+    wait_for,
+    wait_for_startup,
+)
+
+BT_ENTITY = "climate.bt_test"
+
+
+def _room_sensor(hass, value="18.0"):
+    hass.states.async_set(SENSOR_ID, value, {"unit_of_measurement": "°C"})
+
+
+async def test_setup_creates_the_entity_and_syncs_the_trv(hass, fake_trv):
+    """Startup ends with a real setpoint write at the device."""
+    _room_sensor(hass)
+    entry = make_entry()
+    await setup_entry(hass, entry)
+    await wait_for_startup(hass, entry)
+
+    state = hass.states.get(BT_ENTITY)
+    assert state is not None
+    assert state.state == "heat"
+
+    # The initial sync wrote a setpoint through the climate service.
+    assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
+    written = fake_trv.set_temperature_calls[-1]
+    assert 5.0 <= written <= 30.0
+
+
+async def test_window_open_turns_the_trv_off(hass, fake_trv):
+    """A window-open event reaches the device as an OFF command."""
+    _room_sensor(hass)
+    hass.states.async_set(WINDOW_ID, "off")
+    entry = make_entry(with_window=True)
+    await setup_entry(hass, entry)
+    await wait_for_startup(hass, entry)
+    assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
+
+    hass.states.async_set(WINDOW_ID, "on")
+    assert await wait_for(hass, lambda: "off" in fake_trv.set_hvac_mode_calls)
+
+    bt_state = hass.states.get(BT_ENTITY)
+    assert bt_state.attributes.get("window_open") is True
+
+
+async def test_restored_target_temperature_survives_a_restart(hass, fake_trv):
+    """The restored target temperature drives the first sync."""
+    mock_restore_cache(
+        hass,
+        [State(BT_ENTITY, "heat", {ATTR_TEMPERATURE: 23.5, ATTR_HVAC_ACTION: "idle"})],
+    )
+    _room_sensor(hass)
+    entry = make_entry()
+    await setup_entry(hass, entry)
+    await wait_for_startup(hass, entry)
+
+    assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
+    state = hass.states.get(BT_ENTITY)
+    assert state.attributes.get(ATTR_TEMPERATURE) == 23.5
+
+
+async def test_unload_and_reload_the_entry(hass, fake_trv):
+    """Unloading stops the entry cleanly; reloading controls again.
+
+    The entity runs several background tasks (control queue, window
+    queue, keepalive) and many listeners — the classic leak class for
+    custom components lives exactly here.
+    """
+    from homeassistant.config_entries import ConfigEntryState
+
+    _room_sensor(hass)
+    entry = make_entry()
+    await setup_entry(hass, entry)
+    await wait_for_startup(hass, entry)
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    bt_state = hass.states.get(BT_ENTITY)
+    assert bt_state is None or bt_state.state == "unavailable"
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    await wait_for_startup(hass, entry)
+    assert hass.states.get(BT_ENTITY).state == "heat"
+
+    # The device is already converged, so the restart sync rightly writes
+    # nothing; a target change proves the reloaded entry controls again.
+    fake_trv.set_temperature_calls.clear()
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": BT_ENTITY, "temperature": 23.5},
+        blocking=True,
+    )
+    assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)

--- a/tests/integration/test_entry_lifecycle.py
+++ b/tests/integration/test_entry_lifecycle.py
@@ -24,6 +24,7 @@ BT_ENTITY = "climate.bt_test"
 
 
 def _room_sensor(hass, value="18.0"):
+    """Set the external room temperature sensor to ``value`` (°C)."""
     hass.states.async_set(SENSOR_ID, value, {"unit_of_measurement": "°C"})
 
 


### PR DESCRIPTION
## What

A test-only PR: an integration test layer (`tests/integration/`) that runs Better Thermostat as a real config entry against a real (simulated) climate entity inside a real Home Assistant test instance.

## Why

The unit suite mocks the entity — which means a control path that silently writes *nothing* keeps every unit test green. The failure class this catches is invisible any other way: wiring across entity lifecycle, queues, adapters, and the climate services. Here the assertion surface is the service calls that actually arrive at the device.

Covered end to end:

- **Startup sync** — entry setup ends with a real setpoint write at the device.
- **Window → OFF** — a window-open event reaches the device as an OFF command.
- **Restore** — a restored target temperature drives the first sync after restart.
- **Unload/reload** — the entry unloads cleanly (background tasks, listeners) and provably controls again after reload (asserted via a target change, since an already-converged device rightly gets no write).

## Harness notes (the non-obvious parts)

- The repository's `custom_components` namespace package is pinned **before** the `pytest-homeassistant-custom-component` testing config dir mounts, which would otherwise shadow it ("Integration not found").
- The recorder fixture is ordered ahead of `hass` (the manifest depends on it).
- `asyncio.sleep` is compressed but keeps its yield semantics, so the entity's startup settle and write propagation run in test time without changing scheduling behavior.
- The fake TRV is a real `ClimateEntity` registered with the real climate component — commands arrive through real services and are confirmed into entity state like a device that applies every write.

## Testing

4 new tests; full suite green alongside them; ruff clean. No production code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end integration tests and a simulated thermostat harness to validate entity setup, initial device sync, window-open behavior, restored target temperature across restarts, and unload/reload lifecycle.

* **Chores**
  * Pinned an additional development testing dependency for the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->