### PR TITLE
docs: keep README version info from going stale

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.14"]
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Requirements
 
 - Minimum required Home Assistant version: `2025.12`
-  (_continuously tested against the Home Assistant version pinned in [`requirements.dev.txt`](requirements.dev.txt)_)
+  (_continuously tested against Home Assistant_ [![Tested Home Assistant version](https://img.shields.io/badge/dynamic/regex?url=https%3A%2F%2Fraw.githubusercontent.com%2FKartoffelToby%2Fbetter_thermostat%2Fdevelop%2Frequirements.dev.txt&search=homeassistant%3D%3D%28%5B0-9.%5D%2B%29&replace=%241&label=&color=009688)](requirements.dev.txt))
 
 ### Companion UI
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Requirements
 
 - Minimum required Home Assistant version: `2025.12`
-  (_continuously tested against the latest Home Assistant release_)
+  (_continuously tested against the Home Assistant version pinned in [`requirements.dev.txt`](requirements.dev.txt)_)
 
 ### Companion UI
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Active installations](https://badge.t-haber.de/badge/better_thermostat?kill_cache=1)](https://github.com/KartoffelToby/better_thermostat/)
 [![GitHub issues](https://img.shields.io/github/issues/KartoffelToby/better_thermostat?style=for-the-badge)](https://github.com/KartoffelToby/better_thermostat/issues)
-[![Version - 1.8.1](https://img.shields.io/badge/Version-1.8.1-009688?style=for-the-badge)](https://github.com/KartoffelToby/better_thermostat/releases)
+[![Version](https://img.shields.io/github/v/release/KartoffelToby/better_thermostat?style=for-the-badge&label=Version&color=009688)](https://github.com/KartoffelToby/better_thermostat/releases)
 [![Discord](https://img.shields.io/discord/925725316540923914.svg?style=for-the-badge)](https://discord.gg/9BUegWTG3K)
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
 
@@ -10,8 +10,8 @@
 
 ## Requirements
 
-- Minimum required Home Assistant version: `2024.12`
-  (_Latest tested version: `2026.6.0`_)
+- Minimum required Home Assistant version: `2025.12`
+  (_continuously tested against the latest Home Assistant release_)
 
 ### Companion UI
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
-homeassistant==2026.2.3
-pytest-homeassistant-custom-component==0.13.316
+homeassistant==2026.6.2
+pytest-homeassistant-custom-component==0.13.338
 pre-commit==4.6.0
 codespell==2.4.2
 ruff==0.15.15


### PR DESCRIPTION
## What

Three README values were hard-coded and had drifted (or keep drifting) out of date:

- **Version badge**: was pinned per release and already lagged behind on `master` (showed 1.8.0 while 1.8.1 was released). Now uses the dynamic shields.io release badge, so it always shows the latest GitHub release — no manual bump needed.
- **Minimum Home Assistant version**: README still said `2024.12`, but `hacs.json` was bumped to `2025.12.0` with the 1.8.0 RC. Aligned to `2025.12`.
- **"Latest tested version"**: a hard-coded HA version that needs a manual bump every month. Replaced with a shields.io dynamic-regex badge that reads the `homeassistant==` pin straight from `requirements.dev.txt` on `develop` — the exact version CI tests against, rendered live, never stale.

Additionally, the dev pins are bumped to the current Home Assistant release so "tested against" means the latest one again:

- `homeassistant` 2026.2.3 → **2026.6.2**
- `pytest-homeassistant-custom-component` 0.13.316 → **0.13.338** (each phcc release requires one exact `homeassistant` version, so the pair moves together)

Full test suite passes against the new pins (1486 passed).

## Why

Stale version numbers on the repo front page make the project look unmaintained even when it isn't. All three spots are now either self-updating or tied to a single source of truth: bumping the pin in `requirements.dev.txt` is the only step, and the README follows automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced static version badge with a GitHub releases badge in the README.
  * Updated minimum required Home Assistant version to 2025.12.
  * Clarified testing note to indicate continuous testing against the latest Home Assistant release.

* **Chores**
  * Bumped development dependency and test tooling versions.
  * Updated CI test matrix to run on Python 3.14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->