### PR TITLE
build: type-check the component, strict on the calibration modules

### DIFF
--- a/custom_components/better_thermostat/utils/calibration/mpc.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc.py
@@ -11,6 +11,8 @@ import random
 from time import time
 from typing import Any
 
+from .types import CalibrationHost
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -141,7 +143,7 @@ class _MpcState:
     loss_learn_count: int = 0
     gain_learn_count: int = 0
     is_calibration_active: bool = False
-    recent_errors: deque = field(default_factory=lambda: deque(maxlen=20))
+    recent_errors: deque[float] = field(default_factory=lambda: deque(maxlen=20))
     regime_boost_active: bool = False
     consecutive_insufficient_heat: int = 0
     kalman_P: float = 1.0  # Kalman filter error covariance
@@ -276,7 +278,7 @@ def _seed_state_from_siblings(
                 return
 
 
-def build_mpc_key(bt, entity_id: str) -> str:
+def build_mpc_key(bt: CalibrationHost, entity_id: str) -> str:
     """Return a stable key for MPC state tracking.
 
     For a single-TRV BT instance this key is entity-specific.
@@ -298,7 +300,7 @@ def build_mpc_key(bt, entity_id: str) -> str:
     return f"{uid}:{entity_id}:{bucket}"
 
 
-def build_mpc_group_key(bt) -> str:
+def build_mpc_group_key(bt: CalibrationHost) -> str:
     """Return a BT-level (group) key for MPC state tracking.
 
     All TRVs under the same BT instance share this key so that a single
@@ -397,7 +399,7 @@ def distribute_valve_percent(
     return result
 
 
-def _detect_regime_change(recent_errors: deque | list) -> bool:
+def _detect_regime_change(recent_errors: deque[float] | list[float]) -> bool:
     """Detect systematic bias in prediction errors using Student's t-test.
 
     If the mean error deviates significantly from 0 relative to standard deviation,

--- a/custom_components/better_thermostat/utils/calibration/pid.py
+++ b/custom_components/better_thermostat/utils/calibration/pid.py
@@ -19,6 +19,8 @@ import logging
 from time import monotonic
 from typing import Protocol, TypedDict
 
+from .types import CalibrationHost
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -548,7 +550,7 @@ def format_bucket(bucket: float) -> str:
     return f"t{bucket:.1f}"
 
 
-def build_pid_key(self, entity_id: str) -> str:
+def build_pid_key(self: CalibrationHost, entity_id: str) -> str:
     """Build consistent PID state key across all modules.
 
     Format: {unique_id}:{entity_id}:t{target_temp:.1f}

--- a/custom_components/better_thermostat/utils/calibration/tpi.py
+++ b/custom_components/better_thermostat/utils/calibration/tpi.py
@@ -12,6 +12,8 @@ import logging
 from time import monotonic
 from typing import Any
 
+from .types import CalibrationHost
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -186,7 +188,7 @@ def _finalize_output(
     return TpiOutput(duty_cycle_pct=duty_pct, debug=debug), state
 
 
-def build_tpi_key(bt, entity_id: str) -> str:
+def build_tpi_key(bt: CalibrationHost, entity_id: str) -> str:
     """Return a stable key for TPI state tracking (similar to MPC)."""
 
     try:

--- a/custom_components/better_thermostat/utils/calibration/types.py
+++ b/custom_components/better_thermostat/utils/calibration/types.py
@@ -1,0 +1,21 @@
+"""Shared structural types for the calibration helpers.
+
+These Protocols describe the minimal BetterThermostat surface that the
+Home-Assistant-free calibration code reads, so the helpers can be typed
+without importing Home Assistant.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class CalibrationHost(Protocol):
+    """Minimal BetterThermostat surface used to build calibration state keys."""
+
+    bt_target_temp: float | None
+
+    @property
+    def unique_id(self) -> str | None:
+        """Home Assistant entity unique id, if one is assigned."""
+        ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,16 @@ exclude = [
 reportMissingImports = true
 reportMissingTypeStubs = false
 pythonVersion = "3.14"
+
+[tool.pyrefly]
+python-version = "3.14"
+project-includes = ["custom_components/better_thermostat"]
+min-severity = "error"
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/number.py"
+errors = { bad-override-mutable-attribute = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/utils/calibration/*.py"
+errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }


### PR DESCRIPTION
## Summary

Introduces a committed `[tool.pyrefly]` configuration. The whole `custom_components/better_thermostat` package is type-checked at the **default (non-strict)** level, and the Home-Assistant-free **calibration package is elevated to strict**.

Rationale for the split:
- The default level catches genuine type errors everywhere without fighting Home Assistant's incomplete type stubs. The strict `implicit-any` family (untyped parameters/attributes/containers) stays a *warning* outside the allowlist, so HA-coupled code does not drown the report.
- A per-file sub-config makes individual modules **strict** by elevating the untyped-definition codes to errors. This strict allowlist is meant to grow file by file as more Home-Assistant-free code is made strict-clean.

## Config shape

```toml
[tool.pyrefly]
python-version = "3.14"
project-includes = ["custom_components/better_thermostat"]
min-severity = "error"

[[tool.pyrefly.sub-config]]
matches = "custom_components/better_thermostat/number.py"
errors = { bad-override-mutable-attribute = false }

[[tool.pyrefly.sub-config]]
matches = "custom_components/better_thermostat/utils/calibration/*.py"
errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
```

- `python-version = "3.14"` is required so pyrefly parses the project's 3.14-only syntax (unparenthesized multi-exception `except`) instead of reporting it as invalid.
- The `number.py` sub-config exempts Home Assistant's `_attr_device_class` attribute-narrowing pattern (`NumberDeviceClass` vs the `str | None` inherited from `RestoreEntity`) — a stub invariance artifact, not a defect.

## Code changes (calibration strict-clean)

- **New `CalibrationHost` Protocol** (`utils/calibration/types.py`) describing the minimal BetterThermostat surface the key builders read (`bt_target_temp`, `unique_id`) — lets the helpers be typed without importing Home Assistant.
- Annotated the `bt`/`self` host parameters of the MPC/PID/TPI key builders.
- Gave `recent_errors` and the regime-change helper concrete element types (`deque[float]` / `list[float]`).

## Verification

- `pyrefly check` → **0 errors** over the whole component (3 pre-existing `# type: ignore` suppressions untouched).
- Strict enforcement on the allowlist and lenient default elsewhere both confirmed by negative tests.
- `ruff check` / `ruff format --check` clean; calibration unit tests pass. All edits are annotations + config — no behavioural change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced type safety across calibration utilities for improved code reliability.
  * Added type definitions for calibration system components to support better code analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->