### PR TITLE
build: strict pyrefly on the HA-free model fixes (+ TS0601 None-deref fix)

### DIFF
--- a/custom_components/better_thermostat/model_fixes/BHT-002-GCLZB.py
+++ b/custom_components/better_thermostat/model_fixes/BHT-002-GCLZB.py
@@ -7,8 +7,10 @@ helper functions below normalize values to sensible integer offsets.
 
 import math
 
+from custom_components.better_thermostat.model_fixes.types import ModelFixHost
 
-def fix_local_calibration(self, entity_id, offset):
+
+def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> float:
     """Sanitize and normalize a reported calibration offset.
 
     Rounds to the nearest integer (towards ceiling if the room is heating)
@@ -23,16 +25,22 @@ def fix_local_calibration(self, entity_id, offset):
     return offset
 
 
-def fix_target_temperature_calibration(self, entity_id, temperature):
+def fix_target_temperature_calibration(
+    self: ModelFixHost, entity_id: str, temperature: float
+) -> float:
     """No-op target-temperature calibration fix for this model."""
     return temperature
 
 
-async def override_set_hvac_mode(self, entity_id, hvac_mode):
+async def override_set_hvac_mode(
+    self: ModelFixHost, entity_id: str, hvac_mode: str
+) -> bool:
     """No override on system mode for this model."""
     return False
 
 
-async def override_set_temperature(self, entity_id, temperature):
+async def override_set_temperature(
+    self: ModelFixHost, entity_id: str, temperature: float
+) -> bool:
     """No temperature override for this model."""
     return False

--- a/custom_components/better_thermostat/model_fixes/COZB0001.py
+++ b/custom_components/better_thermostat/model_fixes/COZB0001.py
@@ -6,10 +6,12 @@ COZB0001 based devices.
 
 import logging
 
+from custom_components.better_thermostat.model_fixes.types import ModelFixHost
+
 _LOGGER = logging.getLogger(__name__)
 
 
-def fix_local_calibration(self, entity_id, offset):
+def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> float:
     """Adjust the local calibration offset for COZB0001 devices.
 
     Just invert the given offset for this model, as they seem to report it in reverse compared to other devices.
@@ -17,12 +19,16 @@ def fix_local_calibration(self, entity_id, offset):
     return -offset
 
 
-def fix_target_temperature_calibration(self, entity_id, temperature):
+def fix_target_temperature_calibration(
+    self: ModelFixHost, entity_id: str, temperature: float
+) -> float:
     """Return the given target temperature unchanged."""
     return temperature
 
 
-async def override_set_hvac_mode(self, entity_id, hvac_mode):
+async def override_set_hvac_mode(
+    self: ModelFixHost, entity_id: str, hvac_mode: str
+) -> bool:
     """No HVAC mode override for COZB0001 devices.
 
     Return False to indicate no custom handling and let the adapter handle
@@ -31,7 +37,9 @@ async def override_set_hvac_mode(self, entity_id, hvac_mode):
     return False
 
 
-async def override_set_temperature(self, entity_id, temperature):
+async def override_set_temperature(
+    self: ModelFixHost, entity_id: str, temperature: float
+) -> bool:
     """No set_temperature override for COZB0001 devices.
 
     Return False to indicate the adapter should use the default set_temperature

--- a/custom_components/better_thermostat/model_fixes/ME167.py
+++ b/custom_components/better_thermostat/model_fixes/ME167.py
@@ -6,10 +6,12 @@ ME167 based devices.
 
 import logging
 
+from custom_components.better_thermostat.model_fixes.types import ModelFixHost
+
 _LOGGER = logging.getLogger(__name__)
 
 
-def fix_local_calibration(self, entity_id, offset):
+def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> float:
     """Adjust the local calibration offset for ME167 devices.
 
     Just invert the given offset for this model, as they seem to report it in reverse compared to other devices.
@@ -17,12 +19,16 @@ def fix_local_calibration(self, entity_id, offset):
     return -offset
 
 
-def fix_target_temperature_calibration(self, entity_id, temperature):
+def fix_target_temperature_calibration(
+    self: ModelFixHost, entity_id: str, temperature: float
+) -> float:
     """Return the given target temperature unchanged."""
     return temperature
 
 
-async def override_set_hvac_mode(self, entity_id, hvac_mode):
+async def override_set_hvac_mode(
+    self: ModelFixHost, entity_id: str, hvac_mode: str
+) -> bool:
     """No HVAC mode override for ME167 devices.
 
     Return False to indicate no custom handling and let the adapter handle
@@ -31,7 +37,9 @@ async def override_set_hvac_mode(self, entity_id, hvac_mode):
     return False
 
 
-async def override_set_temperature(self, entity_id, temperature):
+async def override_set_temperature(
+    self: ModelFixHost, entity_id: str, temperature: float
+) -> bool:
     """No set_temperature override for ME167 devices.
 
     Return False to indicate the adapter should use the default set_temperature

--- a/custom_components/better_thermostat/model_fixes/SEA801-Zigbee_SEA802-Zigbee.py
+++ b/custom_components/better_thermostat/model_fixes/SEA801-Zigbee_SEA802-Zigbee.py
@@ -6,6 +6,7 @@ SEA801/SEA802 based devices.
 
 import logging
 
+from custom_components.better_thermostat.model_fixes.types import ModelFixHost
 from custom_components.better_thermostat.utils.helpers import (
     entity_uses_mpc_calibration,
 )
@@ -13,7 +14,7 @@ from custom_components.better_thermostat.utils.helpers import (
 _LOGGER = logging.getLogger(__name__)
 
 
-def fix_local_calibration(self, entity_id, offset):
+def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> float:
     """Adjust the local calibration offset for SEA801/SEA802 devices.
 
     The function applies small adjustments based on the external and target
@@ -32,7 +33,9 @@ def fix_local_calibration(self, entity_id, offset):
     return offset
 
 
-def fix_target_temperature_calibration(self, entity_id, temperature):
+def fix_target_temperature_calibration(
+    self: ModelFixHost, entity_id: str, temperature: float
+) -> float:
     """Adjust the setpoint temperature for SEA801/SEA802 devices.
 
     Ensures a minimum distance between the current TRV temperature and the
@@ -61,7 +64,9 @@ def fix_target_temperature_calibration(self, entity_id, temperature):
     return temperature
 
 
-async def override_set_hvac_mode(self, entity_id, hvac_mode):
+async def override_set_hvac_mode(
+    self: ModelFixHost, entity_id: str, hvac_mode: str
+) -> bool:
     """No HVAC mode override for SEA801/SEA802 devices.
 
     Return False to indicate no custom handling and let the adapter handle
@@ -70,7 +75,9 @@ async def override_set_hvac_mode(self, entity_id, hvac_mode):
     return False
 
 
-async def override_set_temperature(self, entity_id, temperature):
+async def override_set_temperature(
+    self: ModelFixHost, entity_id: str, temperature: float
+) -> bool:
     """No set_temperature override for SEA801/SEA802 devices.
 
     Return False to indicate the adapter should use the default set_temperature

--- a/custom_components/better_thermostat/model_fixes/TS0601.py
+++ b/custom_components/better_thermostat/model_fixes/TS0601.py
@@ -3,8 +3,10 @@
 Contains model-specific handling for known quirks in TS0601-based devices.
 """
 
+from custom_components.better_thermostat.model_fixes.types import ModelFixHost
 
-def fix_local_calibration(self, entity_id, offset):
+
+def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> float:
     """Normalize local calibration offset for TS0601 devices.
 
     This function performs model-specific rounding/adjustment to avoid
@@ -21,17 +23,21 @@ def fix_local_calibration(self, entity_id, offset):
     return offset
 
 
-def fix_target_temperature_calibration(self, entity_id, temperature):
+def fix_target_temperature_calibration(
+    self: ModelFixHost, entity_id: str, temperature: float
+) -> float:
     """Adjust target temperature calibration for TS0601 devices.
 
     Ensures a minimum distance between the current TRV internal temperature
     and the requested setpoint to avoid oscillation.
     """
-    _cur_trv_temp = float(
-        self.hass.states.get(entity_id).attributes["current_temperature"]
-    )
+    _state = self.hass.states.get(entity_id)
+    _cur_trv_temp = None
+    if _state is not None:
+        _cur_trv_temp = _state.attributes.get("current_temperature")
     if _cur_trv_temp is None:
         return temperature
+    _cur_trv_temp = float(_cur_trv_temp)
     if (
         round(temperature, 1) > round(_cur_trv_temp, 1)
         and temperature - _cur_trv_temp < 1.5
@@ -41,11 +47,15 @@ def fix_target_temperature_calibration(self, entity_id, temperature):
     return temperature
 
 
-async def override_set_hvac_mode(self, entity_id, hvac_mode):
+async def override_set_hvac_mode(
+    self: ModelFixHost, entity_id: str, hvac_mode: str
+) -> bool:
     """No special HVAC mode override for TS0601 devices."""
     return False
 
 
-async def override_set_temperature(self, entity_id, temperature):
+async def override_set_temperature(
+    self: ModelFixHost, entity_id: str, temperature: float
+) -> bool:
     """No special set_temperature override for TS0601 devices."""
     return False

--- a/custom_components/better_thermostat/model_fixes/TS0601_thermostat.py
+++ b/custom_components/better_thermostat/model_fixes/TS0601_thermostat.py
@@ -4,8 +4,10 @@ These helpers fix or adapt device-reported values for TS0601 thermostat
 devices used by the Better Thermostat integration.
 """
 
+from custom_components.better_thermostat.model_fixes.types import ModelFixHost
 
-def fix_local_calibration(self, entity_id, offset):
+
+def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> float:
     """Normalize a local calibration offset for TS0601 thermostat devices."""
     _cur_external_temp = self.cur_temp
     _target_temp = self.bt_target_temp
@@ -18,13 +20,17 @@ def fix_local_calibration(self, entity_id, offset):
     return offset
 
 
-def fix_target_temperature_calibration(self, entity_id, temperature):
+def fix_target_temperature_calibration(
+    self: ModelFixHost, entity_id: str, temperature: float
+) -> float:
     """Adjust the target temperature for TS0601 thermostat devices."""
-    _cur_trv_temp = float(
-        self.hass.states.get(entity_id).attributes["current_temperature"]
-    )
+    _state = self.hass.states.get(entity_id)
+    _cur_trv_temp = None
+    if _state is not None:
+        _cur_trv_temp = _state.attributes.get("current_temperature")
     if _cur_trv_temp is None:
         return temperature
+    _cur_trv_temp = float(_cur_trv_temp)
     if (
         round(temperature, 1) > round(_cur_trv_temp, 1)
         and temperature - _cur_trv_temp < 1.5
@@ -34,11 +40,15 @@ def fix_target_temperature_calibration(self, entity_id, temperature):
     return temperature
 
 
-async def override_set_hvac_mode(self, entity_id, hvac_mode):
+async def override_set_hvac_mode(
+    self: ModelFixHost, entity_id: str, hvac_mode: str
+) -> bool:
     """No special override for HVAC mode on TS0601 thermostats."""
     return False
 
 
-async def override_set_temperature(self, entity_id, temperature):
+async def override_set_temperature(
+    self: ModelFixHost, entity_id: str, temperature: float
+) -> bool:
     """No special override for target temperature on TS0601 thermostats."""
     return False

--- a/custom_components/better_thermostat/model_fixes/types.py
+++ b/custom_components/better_thermostat/model_fixes/types.py
@@ -1,0 +1,49 @@
+"""Shared structural types for the model-fix quirk modules.
+
+These Protocols describe the minimal BetterThermostat and Home Assistant
+surface the quirk helpers read, so the helpers can be typed without importing
+Home Assistant.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Protocol
+
+
+class _StateLike(Protocol):
+    """Minimal Home Assistant state surface read by the model fixes."""
+
+    @property
+    def attributes(self) -> Mapping[str, float | int | str | None]:
+        """State attributes, keyed by name."""
+        ...
+
+
+class _StatesLike(Protocol):
+    """Minimal ``hass.states`` registry surface read by the model fixes."""
+
+    def get(self, entity_id: str) -> _StateLike | None:
+        """Return the state for an entity id, or None if it is unknown."""
+        ...
+
+
+class _HassLike(Protocol):
+    """Minimal Home Assistant core surface read by the model fixes."""
+
+    @property
+    def states(self) -> _StatesLike:
+        """State registry exposing per-entity state lookups."""
+        ...
+
+
+class ModelFixHost(Protocol):
+    """Minimal BetterThermostat surface the model-fix quirks read."""
+
+    cur_temp: float
+    bt_target_temp: float
+
+    @property
+    def hass(self) -> _HassLike:
+        """Home Assistant core the BetterThermostat instance is attached to."""
+        ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,3 +116,31 @@ errors = { bad-override-mutable-attribute = false }
 [[tool.pyrefly.sub-config]]
 matches = "custom_components/better_thermostat/utils/calibration/*.py"
 errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/types.py"
+errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/TS0601.py"
+errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/TS0601_thermostat.py"
+errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/ME167.py"
+errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/COZB0001.py"
+errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/BHT-002-GCLZB.py"
+errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/SEA801-Zigbee_SEA802-Zigbee.py"
+errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }


### PR DESCRIPTION
## Summary

Second step of the ratcheted strict-typing effort. Adds the six import-free model-fix quirk modules to the strict pyrefly allowlist and makes them strict-clean.

> **Depends on #2073** (stacked). This branch is based on #2073, so its diff currently includes that PR's commit. Once #2073 merges, this will be rebased onto `develop` and the diff narrows to the model-fix changes.

## Changes

- **New `ModelFixHost` Protocol** (`model_fixes/types.py`) describing the minimal BetterThermostat + Home Assistant surface the quirk helpers read (`cur_temp`, `bt_target_temp`, `hass.states.get(...).attributes`) — lets the quirks be typed without importing Home Assistant.
- Annotated parameters and return types of the four quirk contract functions (`fix_local_calibration`, `fix_target_temperature_calibration`, `override_set_hvac_mode`, `override_set_temperature`) across all six modules.
- **Bug fix:** TS0601 and TS0601_thermostat dereferenced `hass.states.get(entity_id).attributes` without a `None` guard in `fix_target_temperature_calibration`. An unavailable TRV state raised an `AttributeError` instead of leaving the setpoint unchanged (and the subsequent `if … is None` check was dead code after `float()`). Aligned them with the guard SEA801/SEA802 already uses. The setpoint adjustment itself is unchanged.
- Used absolute imports for the shared Protocol — the hyphenated module filenames (`BHT-002-GCLZB.py`, `SEA801-Zigbee_SEA802-Zigbee.py`) are not importable via a relative `from .types`.

## Config

Each module is its own strict sub-config entry in `[tool.pyrefly]`. The HA-coupled model fixes (`default`, `model_quirks`, `SPZB0001`, `TRVZB`) stay at the default (non-strict) level.

## Verification

- `pyrefly check` → **0 errors** over the whole component; strict enforcement on the model fixes confirmed by a negative test.
- `ruff check` / `ruff format --check` clean.
- Model-fix / calibration / model-detection tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when reading thermostat `current_temperature` for certain TS0601 models, avoiding crashes when entity state or attributes are missing.
* **Refactor**
  * Enhanced type safety across model-fix helpers by adding explicit type annotations for calibration and override hooks, while keeping existing behavior the same.
* **Chores**
  * Updated lint/type-check configuration to apply consistent rule suppressions to the affected model-fix modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->