### PR TITLE
docs: numpy-style docstrings for the model-fix quirk hooks

### DIFF
--- a/custom_components/better_thermostat/model_fixes/BHT-002-GCLZB.py
+++ b/custom_components/better_thermostat/model_fixes/BHT-002-GCLZB.py
@@ -16,6 +16,18 @@ def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> 
     Rounds to the nearest integer (towards ceiling if the room is heating)
     to recover from the erroneous float values produced by some Zigbee
     integrations.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV the offset belongs to.
+    offset : float
+        Local calibration offset reported by the device.
+
+    Returns
+    -------
+    float
+        The normalized integer-valued calibration offset.
     """
     if self.cur_temp < self.bt_target_temp:
         offset = math.ceil(offset)
@@ -28,19 +40,58 @@ def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> 
 def fix_target_temperature_calibration(
     self: ModelFixHost, entity_id: str, temperature: float
 ) -> float:
-    """No-op target-temperature calibration fix for this model."""
+    """No-op target-temperature calibration fix for this model.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV whose setpoint is calibrated.
+    temperature : float
+        Requested setpoint temperature.
+
+    Returns
+    -------
+    float
+        The unchanged setpoint temperature.
+    """
     return temperature
 
 
 async def override_set_hvac_mode(
     self: ModelFixHost, entity_id: str, hvac_mode: str
 ) -> bool:
-    """No override on system mode for this model."""
+    """No override on system mode for this model.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV.
+    hvac_mode : str
+        Requested HVAC mode.
+
+    Returns
+    -------
+    bool
+        True if the model handled the change, otherwise False.
+    """
     return False
 
 
 async def override_set_temperature(
     self: ModelFixHost, entity_id: str, temperature: float
 ) -> bool:
-    """No temperature override for this model."""
+    """No temperature override for this model.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV.
+    temperature : float
+        Requested setpoint temperature.
+
+    Returns
+    -------
+    bool
+        True if the model handled the change, otherwise False.
+    """
     return False

--- a/custom_components/better_thermostat/model_fixes/COZB0001.py
+++ b/custom_components/better_thermostat/model_fixes/COZB0001.py
@@ -14,7 +14,20 @@ _LOGGER = logging.getLogger(__name__)
 def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> float:
     """Adjust the local calibration offset for COZB0001 devices.
 
-    Just invert the given offset for this model, as they seem to report it in reverse compared to other devices.
+    Just invert the given offset for this model, as they seem to report it in
+    reverse compared to other devices.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV the offset belongs to.
+    offset : float
+        Local calibration offset reported by the device.
+
+    Returns
+    -------
+    float
+        The inverted local calibration offset.
     """
     return -offset
 
@@ -22,7 +35,20 @@ def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> 
 def fix_target_temperature_calibration(
     self: ModelFixHost, entity_id: str, temperature: float
 ) -> float:
-    """Return the given target temperature unchanged."""
+    """Return the given target temperature unchanged.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV whose setpoint is calibrated.
+    temperature : float
+        Requested setpoint temperature.
+
+    Returns
+    -------
+    float
+        The unchanged setpoint temperature.
+    """
     return temperature
 
 
@@ -33,6 +59,18 @@ async def override_set_hvac_mode(
 
     Return False to indicate no custom handling and let the adapter handle
     normal behavior.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV.
+    hvac_mode : str
+        Requested HVAC mode.
+
+    Returns
+    -------
+    bool
+        True if the model handled the change, otherwise False.
     """
     return False
 
@@ -44,5 +82,17 @@ async def override_set_temperature(
 
     Return False to indicate the adapter should use the default set_temperature
     implementation.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV.
+    temperature : float
+        Requested setpoint temperature.
+
+    Returns
+    -------
+    bool
+        True if the model handled the change, otherwise False.
     """
     return False

--- a/custom_components/better_thermostat/model_fixes/ME167.py
+++ b/custom_components/better_thermostat/model_fixes/ME167.py
@@ -14,7 +14,20 @@ _LOGGER = logging.getLogger(__name__)
 def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> float:
     """Adjust the local calibration offset for ME167 devices.
 
-    Just invert the given offset for this model, as they seem to report it in reverse compared to other devices.
+    Just invert the given offset for this model, as they seem to report it in
+    reverse compared to other devices.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV the offset belongs to.
+    offset : float
+        Local calibration offset reported by the device.
+
+    Returns
+    -------
+    float
+        The inverted local calibration offset.
     """
     return -offset
 
@@ -22,7 +35,20 @@ def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> 
 def fix_target_temperature_calibration(
     self: ModelFixHost, entity_id: str, temperature: float
 ) -> float:
-    """Return the given target temperature unchanged."""
+    """Return the given target temperature unchanged.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV whose setpoint is calibrated.
+    temperature : float
+        Requested setpoint temperature.
+
+    Returns
+    -------
+    float
+        The unchanged setpoint temperature.
+    """
     return temperature
 
 
@@ -33,6 +59,18 @@ async def override_set_hvac_mode(
 
     Return False to indicate no custom handling and let the adapter handle
     normal behavior.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV.
+    hvac_mode : str
+        Requested HVAC mode.
+
+    Returns
+    -------
+    bool
+        True if the model handled the change, otherwise False.
     """
     return False
 
@@ -44,5 +82,17 @@ async def override_set_temperature(
 
     Return False to indicate the adapter should use the default set_temperature
     implementation.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV.
+    temperature : float
+        Requested setpoint temperature.
+
+    Returns
+    -------
+    bool
+        True if the model handled the change, otherwise False.
     """
     return False

--- a/custom_components/better_thermostat/model_fixes/SEA801-Zigbee_SEA802-Zigbee.py
+++ b/custom_components/better_thermostat/model_fixes/SEA801-Zigbee_SEA802-Zigbee.py
@@ -19,6 +19,18 @@ def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> 
 
     The function applies small adjustments based on the external and target
     temperatures to avoid incorrect temperature behavior.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV the offset belongs to.
+    offset : float
+        Local calibration offset reported by the device.
+
+    Returns
+    -------
+    float
+        The adjusted local calibration offset.
     """
     if entity_uses_mpc_calibration(self, entity_id):
         return offset
@@ -40,6 +52,18 @@ def fix_target_temperature_calibration(
 
     Ensures a minimum distance between the current TRV temperature and the
     target temperature to avoid short-cycling and oscillation.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV whose setpoint is calibrated.
+    temperature : float
+        Requested setpoint temperature.
+
+    Returns
+    -------
+    float
+        The adjusted setpoint temperature.
     """
     _state = self.hass.states.get(entity_id)
     _cur_trv_temp = None
@@ -71,6 +95,18 @@ async def override_set_hvac_mode(
 
     Return False to indicate no custom handling and let the adapter handle
     normal behavior.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV.
+    hvac_mode : str
+        Requested HVAC mode.
+
+    Returns
+    -------
+    bool
+        True if the model handled the change, otherwise False.
     """
     return False
 
@@ -82,5 +118,17 @@ async def override_set_temperature(
 
     Return False to indicate the adapter should use the default set_temperature
     implementation.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV.
+    temperature : float
+        Requested setpoint temperature.
+
+    Returns
+    -------
+    bool
+        True if the model handled the change, otherwise False.
     """
     return False

--- a/custom_components/better_thermostat/model_fixes/TS0601.py
+++ b/custom_components/better_thermostat/model_fixes/TS0601.py
@@ -11,6 +11,18 @@ def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> 
 
     This function performs model-specific rounding/adjustment to avoid
     spurious values that would lead to incorrect behavior.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV the offset belongs to.
+    offset : float
+        Local calibration offset reported by the device.
+
+    Returns
+    -------
+    float
+        The adjusted local calibration offset.
     """
     _cur_external_temp = self.cur_temp
     _target_temp = self.bt_target_temp
@@ -30,6 +42,18 @@ def fix_target_temperature_calibration(
 
     Ensures a minimum distance between the current TRV internal temperature
     and the requested setpoint to avoid oscillation.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV whose setpoint is calibrated.
+    temperature : float
+        Requested setpoint temperature.
+
+    Returns
+    -------
+    float
+        The adjusted setpoint temperature.
     """
     _state = self.hass.states.get(entity_id)
     _cur_trv_temp = None
@@ -50,12 +74,38 @@ def fix_target_temperature_calibration(
 async def override_set_hvac_mode(
     self: ModelFixHost, entity_id: str, hvac_mode: str
 ) -> bool:
-    """No special HVAC mode override for TS0601 devices."""
+    """No special HVAC mode override for TS0601 devices.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV.
+    hvac_mode : str
+        Requested HVAC mode.
+
+    Returns
+    -------
+    bool
+        True if the model handled the change, otherwise False.
+    """
     return False
 
 
 async def override_set_temperature(
     self: ModelFixHost, entity_id: str, temperature: float
 ) -> bool:
-    """No special set_temperature override for TS0601 devices."""
+    """No special set_temperature override for TS0601 devices.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV.
+    temperature : float
+        Requested setpoint temperature.
+
+    Returns
+    -------
+    bool
+        True if the model handled the change, otherwise False.
+    """
     return False

--- a/custom_components/better_thermostat/model_fixes/TS0601_thermostat.py
+++ b/custom_components/better_thermostat/model_fixes/TS0601_thermostat.py
@@ -8,7 +8,20 @@ from custom_components.better_thermostat.model_fixes.types import ModelFixHost
 
 
 def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> float:
-    """Normalize a local calibration offset for TS0601 thermostat devices."""
+    """Normalize a local calibration offset for TS0601 thermostat devices.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV the offset belongs to.
+    offset : float
+        Local calibration offset reported by the device.
+
+    Returns
+    -------
+    float
+        The adjusted local calibration offset.
+    """
     _cur_external_temp = self.cur_temp
     _target_temp = self.bt_target_temp
 
@@ -23,7 +36,20 @@ def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> 
 def fix_target_temperature_calibration(
     self: ModelFixHost, entity_id: str, temperature: float
 ) -> float:
-    """Adjust the target temperature for TS0601 thermostat devices."""
+    """Adjust the target temperature for TS0601 thermostat devices.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV whose setpoint is calibrated.
+    temperature : float
+        Requested setpoint temperature.
+
+    Returns
+    -------
+    float
+        The adjusted setpoint temperature.
+    """
     _state = self.hass.states.get(entity_id)
     _cur_trv_temp = None
     if _state is not None:
@@ -43,12 +69,38 @@ def fix_target_temperature_calibration(
 async def override_set_hvac_mode(
     self: ModelFixHost, entity_id: str, hvac_mode: str
 ) -> bool:
-    """No special override for HVAC mode on TS0601 thermostats."""
+    """No special override for HVAC mode on TS0601 thermostats.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV.
+    hvac_mode : str
+        Requested HVAC mode.
+
+    Returns
+    -------
+    bool
+        True if the model handled the change, otherwise False.
+    """
     return False
 
 
 async def override_set_temperature(
     self: ModelFixHost, entity_id: str, temperature: float
 ) -> bool:
-    """No special override for target temperature on TS0601 thermostats."""
+    """No special override for target temperature on TS0601 thermostats.
+
+    Parameters
+    ----------
+    entity_id : str
+        Entity id of the TRV.
+    temperature : float
+        Requested setpoint temperature.
+
+    Returns
+    -------
+    bool
+        True if the model handled the change, otherwise False.
+    """
     return False


### PR DESCRIPTION
## Summary

Converts the four quirk contract functions across all six Home-Assistant-free model-fix modules to **numpy/Napoleon-style docstrings** with explicit `Parameters` and `Returns` sections, matching the repository's `numpy` pydocstyle convention (`[tool.ruff.lint.pydocstyle] convention = "numpy"`).

Functions covered in each of TS0601, TS0601_thermostat, ME167, COZB0001, BHT-002-GCLZB, SEA801/SEA802:
- `fix_local_calibration`
- `fix_target_temperature_calibration`
- `override_set_hvac_mode`
- `override_set_temperature`

## Context

Addresses CodeRabbit's docstring-format findings on the (now-closed) #2074. CodeRabbit only flagged TS0601 and TS0601_thermostat, but this applies the convention **consistently across all six** modules to avoid a mixed docstring style. Docstrings only — no behavior or type changes.

## Verification

- `ruff check` / `ruff format --check` clean.
- `pyrefly check` → 0 errors.
- Model-fix / calibration / model-detection tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for thermostat model calibration and override functions across multiple device models. Added structured parameter and return descriptions to improve code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->