### PR TITLE
arch 01: time seam (Clock) + WorldSnapshot/DesiredState core types

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -11,7 +11,6 @@ from functools import cached_property
 import json
 import logging
 from random import randint
-from time import monotonic
 from typing import Any
 
 # Home Assistant imports
@@ -50,7 +49,6 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.start import async_at_started
 
 # preferred for HA time handling (UTC aware)
-from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 # Local imports
@@ -64,6 +62,7 @@ from .adapters.delegate import (
     set_hvac_mode as adapter_set_hvac_mode,
     set_temperature as adapter_set_temperature,
 )
+from .core.clock import Clock
 from .device_binding import async_bind_trv_device
 from .events.cooler import trigger_cooler_change
 from .events.temperature import trigger_temperature_change
@@ -77,6 +76,7 @@ from .utils.calibration.pid import (
     resolve_unique_id,
     round_to_bucket,
 )
+from .utils.clock import SystemClock
 from .utils.const import (
     ATTR_STATE_BATTERIES,
     ATTR_STATE_CALL_FOR_HEAT,
@@ -481,7 +481,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self._state_class = state_class
         self._hvac_list = [HVACMode.HEAT, HVACMode.OFF]
         self.map_on_hvac_mode = HVACMode.HEAT
-        self.next_valve_maintenance = dt_util.now() + timedelta(
+        self.clock: Clock = SystemClock()
+        self.next_valve_maintenance = self.clock.now() + timedelta(
             hours=randint(1, 24 * 5)
         )
         self.cur_temp = None
@@ -511,9 +512,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.ignore_states = False
         self.last_dampening_timestamp = None
         self.version = VERSION
-        self.last_change = dt_util.now() - timedelta(hours=2)
-        self.last_external_sensor_change = dt_util.now() - timedelta(hours=2)
-        self.last_internal_sensor_change = dt_util.now() - timedelta(hours=2)
+        self.last_change = self.clock.now() - timedelta(hours=2)
+        self.last_external_sensor_change = self.clock.now() - timedelta(hours=2)
+        self.last_internal_sensor_change = self.clock.now() - timedelta(hours=2)
         self._temp_lock = asyncio.Lock()
         self.bt_update_lock = False
         self.startup_running = True
@@ -993,7 +994,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # after) does not raise a premature ``missing_entity`` repair for a
         # slow-to-load underlying integration. The window is re-anchored in
         # ``_finalize_startup`` to cover post-startup reconnection blips.
-        self._critical_grace_until = dt_util.now() + STARTUP_CRITICAL_GRACE_PERIOD
+        self._critical_grace_until = self.clock.now() + STARTUP_CRITICAL_GRACE_PERIOD
         while self.startup_running:
             if self.is_removed:
                 return
@@ -1316,7 +1317,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     self.external_temp_ema = _restored_ema
                     self.cur_temp_filtered = round(_restored_ema, 2)
                     # Reset timestamp to now so the next delta is calculated from restart time
-                    self._external_temp_ema_ts = monotonic()
+                    self._external_temp_ema_ts = self.clock.monotonic()
                     _LOGGER.debug(
                         "better_thermostat %s: restored external_temp_ema from state: %.2f",
                         self.device_name,
@@ -1732,7 +1733,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             thermostat instance.
         """
         remaining = (
-            (grace_until - dt_util.now()).total_seconds() if grace_until else 0.0
+            (grace_until - self.clock.now()).total_seconds() if grace_until else 0.0
         )
         if remaining > 0:
             await asyncio.sleep(remaining)
@@ -1752,7 +1753,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # Likewise give critical (TRV) entities a short grace before raising
         # ``missing_entity`` repairs; cloud-backed valves (Tado, etc.) can lag
         # behind HA startup and would otherwise produce dismissable noise.
-        self._critical_grace_until = dt_util.now() + STARTUP_CRITICAL_GRACE_PERIOD
+        self._critical_grace_until = self.clock.now() + STARTUP_CRITICAL_GRACE_PERIOD
         # Wait for critical entities (TRVs) with increasing retry delays before
         # any startup path can raise a missing_entity repair issue.  Both
         # _trigger_time and _trigger_check_weather below call
@@ -1830,7 +1831,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # During the startup grace window, a transition into degraded mode is
         # logged at DEBUG and the HA repair issue is deferred — slow cloud
         # integrations get time to come online before the user sees a warning.
-        self._degraded_grace_until = dt_util.now() + STARTUP_DEGRADED_GRACE_PERIOD
+        self._degraded_grace_until = self.clock.now() + STARTUP_DEGRADED_GRACE_PERIOD
         await await_optional_sensors(self)
         await check_and_update_degraded_mode(self)
 
@@ -2006,7 +2007,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             return
 
         # Skip if already running or not due
-        now = dt_util.now()
+        now = self.clock.now()
         if self.in_maintenance:
             return
         try:
@@ -2221,7 +2222,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         result = self._heating_tracker.update(
             self.cur_temp,
             current_action,
-            dt_util.utcnow(),
+            self.clock.utcnow(),
             target_temp=self.bt_target_temp,
             outdoor_temp=outdoor_temp,
         )
@@ -2248,7 +2249,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         result = self._loss_tracker.update(
             self.cur_temp,
             current_action,
-            dt_util.utcnow(),
+            self.clock.utcnow(),
             window_open=bool(self.window_open),
         )
 
@@ -2793,7 +2794,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 )
                 return
             # force immediate run
-            self.next_valve_maintenance = dt_util.now()
+            self.next_valve_maintenance = self.clock.now()
             await self._run_valve_maintenance(trvs_to_service)
         except Exception:
             _LOGGER.debug(
@@ -3086,7 +3087,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 # Calculate slope from EMA change
                 old_ema = self.external_temp_ema
                 old_ts = self._slope_periodic_last_ts
-                now_ts = monotonic()
+                now_ts = self.clock.monotonic()
 
                 new_ema = _update_external_temp_ema(self, float(last_raw))
 

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -47,8 +47,6 @@ from homeassistant.helpers.event import (
 )
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.start import async_at_started
-
-# preferred for HA time handling (UTC aware)
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 # Local imports

--- a/custom_components/better_thermostat/core/__init__.py
+++ b/custom_components/better_thermostat/core/__init__.py
@@ -1,0 +1,6 @@
+"""Functional core of Better Thermostat.
+
+This package contains pure, Home-Assistant-free logic: types, time access,
+and (incrementally) the decision kernel. Nothing in here may import from
+``homeassistant``.
+"""

--- a/custom_components/better_thermostat/core/__init__.py
+++ b/custom_components/better_thermostat/core/__init__.py
@@ -1,6 +1,5 @@
 """Functional core of Better Thermostat.
 
 This package contains pure, Home-Assistant-free logic: types, time access,
-and (incrementally) the decision kernel. Nothing in here may import from
-``homeassistant``.
+and the decision kernel. Nothing in here may import from ``homeassistant``.
 """

--- a/custom_components/better_thermostat/core/clock.py
+++ b/custom_components/better_thermostat/core/clock.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+import math
 from typing import Protocol, runtime_checkable
 
 
@@ -45,6 +46,11 @@ class FakeClock:
     monotonic_value: float = 0.0
     now_value: datetime = field(default_factory=_default_now)
 
+    def __post_init__(self) -> None:
+        """Reject inputs that would violate the time-axis invariants."""
+        if self.now_value.tzinfo is None or self.now_value.utcoffset() is None:
+            raise ValueError("now_value must be timezone-aware")
+
     def monotonic(self) -> float:
         """Return the controlled monotonic timestamp."""
         return self.monotonic_value
@@ -59,5 +65,7 @@ class FakeClock:
 
     def advance(self, seconds: float) -> None:
         """Move both time axes forward by ``seconds``."""
+        if not math.isfinite(seconds) or seconds < 0:
+            raise ValueError("seconds must be a finite, non-negative number")
         self.monotonic_value += seconds
         self.now_value += timedelta(seconds=seconds)

--- a/custom_components/better_thermostat/core/clock.py
+++ b/custom_components/better_thermostat/core/clock.py
@@ -1,0 +1,63 @@
+"""Time access for the functional core.
+
+All time-dependent logic receives a :class:`Clock` instead of calling
+``time.monotonic()`` or Home Assistant's ``dt_util`` directly, so that
+tests and offline replay can drive time deterministically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Clock(Protocol):
+    """Source of monotonic and wall-clock time."""
+
+    def monotonic(self) -> float:
+        """Return a monotonically increasing timestamp in seconds."""
+        ...
+
+    def now(self) -> datetime:
+        """Return the current wall-clock time as an aware local datetime."""
+        ...
+
+    def utcnow(self) -> datetime:
+        """Return the current wall-clock time as an aware UTC datetime."""
+        ...
+
+
+def _default_now() -> datetime:
+    """Return the FakeClock epoch (an arbitrary fixed aware datetime)."""
+    return datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+@dataclass
+class FakeClock:
+    """Deterministic :class:`Clock` for tests and offline replay.
+
+    Both time axes advance together via :meth:`advance`; they never move
+    on their own.
+    """
+
+    monotonic_value: float = 0.0
+    now_value: datetime = field(default_factory=_default_now)
+
+    def monotonic(self) -> float:
+        """Return the controlled monotonic timestamp."""
+        return self.monotonic_value
+
+    def now(self) -> datetime:
+        """Return the controlled wall-clock time."""
+        return self.now_value
+
+    def utcnow(self) -> datetime:
+        """Return the controlled wall-clock time in UTC."""
+        return self.now_value.astimezone(UTC)
+
+    def advance(self, seconds: float) -> None:
+        """Move both time axes forward by ``seconds``."""
+        self.monotonic_value += seconds
+        self.now_value += timedelta(seconds=seconds)

--- a/custom_components/better_thermostat/core/desired.py
+++ b/custom_components/better_thermostat/core/desired.py
@@ -1,0 +1,31 @@
+"""Desired state emitted by the decision kernel.
+
+A :class:`DesiredState` expresses intent, not commands: what each TRV
+should be doing right now. The shell translates it into device writes
+(adapters), so the kernel never performs IO itself.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from .snapshot import HvacMode
+
+
+@dataclass(frozen=True)
+class TrvDesired:
+    """Intent for a single TRV."""
+
+    entity_id: str
+    hvac_mode: HvacMode | None = None
+    setpoint: float | None = None
+    valve_percent: float | None = None
+
+
+@dataclass(frozen=True)
+class DesiredState:
+    """Complete intent of one control cycle."""
+
+    call_for_heat: bool = False
+    trvs: Mapping[str, TrvDesired] = field(default_factory=dict)

--- a/custom_components/better_thermostat/core/snapshot.py
+++ b/custom_components/better_thermostat/core/snapshot.py
@@ -1,0 +1,83 @@
+"""Immutable snapshot of the world as the control path sees it.
+
+A :class:`WorldSnapshot` is the raw observation handed to the decision
+kernel: target and measured temperatures, mode flags, environment, and
+the reported state of every TRV. It is built once per control cycle by
+the shell (``utils/snapshot.py``) and never mutated.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+
+
+class HvacMode(StrEnum):
+    """HVAC mode vocabulary of the core.
+
+    Values match Home Assistant's ``HVACMode`` strings so that members
+    compare equal to the shell's enum without importing it.
+    """
+
+    OFF = "off"
+    HEAT = "heat"
+    COOL = "cool"
+    HEAT_COOL = "heat_cool"
+    AUTO = "auto"
+
+
+def parse_hvac_mode(value: str | None) -> HvacMode | None:
+    """Map a raw mode string (or HA's string enum) onto the core vocabulary.
+
+    Returns ``None`` for unknown or missing values.
+    """
+    if value is None:
+        return None
+    try:
+        return HvacMode(str(value))
+    except ValueError:
+        return None
+
+
+@dataclass(frozen=True)
+class TrvReported:
+    """Reported state of a single TRV at snapshot time."""
+
+    entity_id: str
+    available: bool = True
+    hvac_mode: HvacMode | None = None
+    current_temp: float | None = None
+    setpoint: float | None = None
+    min_temp: float | None = None
+    max_temp: float | None = None
+    valve_max_opening: float | None = None
+
+
+@dataclass(frozen=True)
+class WorldSnapshot:
+    """Complete, immutable observation of one control cycle."""
+
+    now: datetime
+    now_monotonic: float
+    target_temp: float | None = None
+    target_cooltemp: float | None = None
+    hvac_mode: HvacMode | None = None
+    room_temp: float | None = None
+    room_temp_filtered: float | None = None
+    temp_slope: float | None = None
+    window_open: bool | None = None
+    call_for_heat: bool = True
+    preset_mode: str | None = None
+    tolerance: float = 0.0
+    outdoor_temp: float | None = None
+    is_day: bool = True
+    solar_intensity: float = 0.0
+    startup_running: bool = False
+    in_maintenance: bool = False
+    ignore_states: bool = False
+    degraded: bool = False
+    min_temp: float | None = None
+    max_temp: float | None = None
+    trvs: Mapping[str, TrvReported] = field(default_factory=dict)

--- a/custom_components/better_thermostat/utils/clock.py
+++ b/custom_components/better_thermostat/utils/clock.py
@@ -1,0 +1,27 @@
+"""System clock implementation backed by Home Assistant time helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import time
+
+from homeassistant.util import dt as dt_util
+
+
+class SystemClock:
+    """Wall-clock and monotonic time from the running system.
+
+    Shell-side implementation of :class:`~..core.clock.Clock`.
+    """
+
+    def monotonic(self) -> float:
+        """Return the system monotonic timestamp."""
+        return time.monotonic()
+
+    def now(self) -> datetime:
+        """Return the current time in Home Assistant's configured timezone."""
+        return dt_util.now()
+
+    def utcnow(self) -> datetime:
+        """Return the current time in UTC."""
+        return dt_util.utcnow()

--- a/custom_components/better_thermostat/utils/snapshot.py
+++ b/custom_components/better_thermostat/utils/snapshot.py
@@ -1,0 +1,90 @@
+"""Shell-side builder for the core WorldSnapshot.
+
+``build_snapshot`` is the single seam where entity attributes and Home
+Assistant states are read and condensed into the immutable
+:class:`~..core.snapshot.WorldSnapshot` consumed by the control path.
+"""
+
+from __future__ import annotations
+
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+
+from ..calibration import _get_current_outdoor_temp, _get_current_solar_intensity
+from ..core.snapshot import TrvReported, WorldSnapshot, parse_hvac_mode
+
+
+def _as_float(value: object) -> float | None:
+    """Best-effort float conversion; None for missing/unparseable values."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _build_trv_reported(self, entity_id: str, data: dict) -> TrvReported:
+    """Condense one ``real_trvs`` entry into a TrvReported."""
+    available = False
+    if self.hass is not None:
+        state = self.hass.states.get(entity_id)
+        available = state is not None and state.state not in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+        )
+    return TrvReported(
+        entity_id=entity_id,
+        available=available,
+        hvac_mode=parse_hvac_mode(data.get("hvac_mode")),
+        current_temp=_as_float(data.get("current_temperature")),
+        setpoint=_as_float(data.get("last_temperature")),
+        min_temp=_as_float(data.get("min_temp")),
+        max_temp=_as_float(data.get("max_temp")),
+        valve_max_opening=_as_float(data.get("valve_max_opening")),
+    )
+
+
+def build_snapshot(self) -> WorldSnapshot:
+    """Build the immutable world snapshot for one control cycle.
+
+    ``self`` is the BetterThermostat entity; this function is the only
+    place that flattens its attributes into the core snapshot type.
+    """
+    trvs = {
+        entity_id: _build_trv_reported(self, entity_id, data or {})
+        for entity_id, data in self.real_trvs.items()
+    }
+
+    is_day = True
+    if self.hass is not None:
+        sun = self.hass.states.get("sun.sun")
+        if sun is not None and sun.state == "below_horizon":
+            is_day = False
+    solar_intensity = _get_current_solar_intensity(self) if is_day else 0.0
+
+    return WorldSnapshot(
+        now=self.clock.now(),
+        now_monotonic=self.clock.monotonic(),
+        target_temp=_as_float(self.bt_target_temp),
+        target_cooltemp=_as_float(self.bt_target_cooltemp),
+        hvac_mode=parse_hvac_mode(self.bt_hvac_mode),
+        room_temp=_as_float(self.cur_temp),
+        room_temp_filtered=_as_float(self.cur_temp_filtered),
+        temp_slope=_as_float(self.temp_slope),
+        window_open=self.window_open,
+        call_for_heat=bool(self.call_for_heat),
+        preset_mode=self.preset_mode,
+        tolerance=_as_float(self.tolerance) or 0.0,
+        outdoor_temp=_get_current_outdoor_temp(self),
+        is_day=is_day,
+        solar_intensity=solar_intensity,
+        startup_running=bool(self.startup_running),
+        in_maintenance=bool(self.in_maintenance),
+        ignore_states=bool(self.ignore_states),
+        degraded=bool(self.degraded_mode),
+        min_temp=_as_float(self.bt_min_temp),
+        max_temp=_as_float(self.bt_max_temp),
+        trvs=trvs,
+    )

--- a/custom_components/better_thermostat/utils/snapshot.py
+++ b/custom_components/better_thermostat/utils/snapshot.py
@@ -15,6 +15,8 @@ from ..core.snapshot import TrvReported, WorldSnapshot, parse_hvac_mode
 
 def _as_float(value: object) -> float | None:
     """Best-effort float conversion; None for missing/unparseable values."""
+    if isinstance(value, bool):
+        return None
     if isinstance(value, (int, float)):
         return float(value)
     if isinstance(value, str):
@@ -25,8 +27,9 @@ def _as_float(value: object) -> float | None:
     return None
 
 
-def _build_trv_reported(self, entity_id: str, data: dict) -> TrvReported:
+def _build_trv_reported(self, entity_id: str, data: object) -> TrvReported:
     """Condense one ``real_trvs`` entry into a TrvReported."""
+    payload = data if isinstance(data, dict) else {}
     available = False
     if self.hass is not None:
         state = self.hass.states.get(entity_id)
@@ -37,12 +40,12 @@ def _build_trv_reported(self, entity_id: str, data: dict) -> TrvReported:
     return TrvReported(
         entity_id=entity_id,
         available=available,
-        hvac_mode=parse_hvac_mode(data.get("hvac_mode")),
-        current_temp=_as_float(data.get("current_temperature")),
-        setpoint=_as_float(data.get("last_temperature")),
-        min_temp=_as_float(data.get("min_temp")),
-        max_temp=_as_float(data.get("max_temp")),
-        valve_max_opening=_as_float(data.get("valve_max_opening")),
+        hvac_mode=parse_hvac_mode(payload.get("hvac_mode")),
+        current_temp=_as_float(payload.get("current_temperature")),
+        setpoint=_as_float(payload.get("last_temperature")),
+        min_temp=_as_float(payload.get("min_temp")),
+        max_temp=_as_float(payload.get("max_temp")),
+        valve_max_opening=_as_float(payload.get("valve_max_opening")),
     )
 
 
@@ -53,7 +56,7 @@ def build_snapshot(self) -> WorldSnapshot:
     place that flattens its attributes into the core snapshot type.
     """
     trvs = {
-        entity_id: _build_trv_reported(self, entity_id, data or {})
+        entity_id: _build_trv_reported(self, entity_id, data)
         for entity_id, data in self.real_trvs.items()
     }
 

--- a/custom_components/better_thermostat/utils/watcher.py
+++ b/custom_components/better_thermostat/utils/watcher.py
@@ -15,7 +15,6 @@ import logging
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 
@@ -483,7 +482,7 @@ async def check_and_update_degraded_mode(self) -> bool:
     self.unavailable_sensors = unavailable
 
     grace_until = getattr(self, "_degraded_grace_until", None)
-    in_grace = grace_until is not None and dt_util.now() < grace_until
+    in_grace = grace_until is not None and self.clock.now() < grace_until
     has_warned = getattr(self, "_degraded_warning_emitted", False)
 
     if self.degraded_mode and not has_warned and not in_grace:

--- a/custom_components/better_thermostat/utils/watcher.py
+++ b/custom_components/better_thermostat/utils/watcher.py
@@ -207,7 +207,7 @@ async def check_critical_entities(self) -> bool:
     """
     critical = get_critical_entities(self)
     grace_until = getattr(self, "_critical_grace_until", None)
-    in_grace = grace_until is not None and dt_util.now() < grace_until
+    in_grace = grace_until is not None and self.clock.now() < grace_until
 
     all_available = True
     for entity in critical:

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -5,7 +5,7 @@ mock_bt fixture (MagicMock with explicit attributes).
 """
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.climate.const import (
     ATTR_HVAC_MODE,
@@ -388,10 +388,9 @@ class TestCalculateHeatingPower:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
-            mock_dt.utcnow.return_value = now
-            await self._call(mock_bt)
+        now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        mock_bt.clock.utcnow.return_value = now
+        await self._call(mock_bt)
 
         assert mock_bt._heating_tracker.start_temp == 20.0
         assert mock_bt._heating_tracker.start_ts == now
@@ -413,9 +412,8 @@ class TestCalculateHeatingPower:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = now
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = now
+        await self._call(mock_bt)
 
         assert mock_bt._heating_tracker.end_temp == 22.0
         assert mock_bt._heating_tracker.end_ts == now
@@ -438,9 +436,8 @@ class TestCalculateHeatingPower:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         assert mock_bt._heating_tracker.end_temp == 22.5
 
@@ -463,9 +460,8 @@ class TestCalculateHeatingPower:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         # Cycle reset after finalization
         assert mock_bt._heating_tracker.start_temp is None
@@ -493,9 +489,8 @@ class TestCalculateHeatingPower:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         assert mock_bt._heating_tracker.start_temp is None
         assert len(mock_bt.last_heating_power_stats) == 1
@@ -519,9 +514,8 @@ class TestCalculateHeatingPower:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         assert mock_bt.heating_power == old_power
         assert len(mock_bt.last_heating_power_stats) == 0
@@ -545,9 +539,8 @@ class TestCalculateHeatingPower:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         assert mock_bt.heating_power == old_power
         assert len(mock_bt.last_heating_power_stats) == 0
@@ -573,9 +566,8 @@ class TestCalculateHeatingPower:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         # Power should have moved towards the observed rate via EMA
         # rate = 2.0/10.0 = 0.2 °C/min, old = 0.05, alpha ~0.10
@@ -605,9 +597,8 @@ class TestCalculateHeatingPower:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         assert mock_bt.heating_power_normalized is not None
         stats = mock_bt.last_heating_power_stats[-1]
@@ -632,9 +623,8 @@ class TestCalculateHeatingPower:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         # MIN_HEATING_POWER = 0.005, MAX_HEATING_POWER = 0.2
         assert mock_bt.heating_power >= 0.005
@@ -658,9 +648,8 @@ class TestCalculateHeatingPower:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         assert len(mock_bt.heating_cycles) == 1
         cycle = mock_bt.heating_cycles[0]
@@ -698,9 +687,8 @@ class TestCalculateHeatLoss:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+        await self._call(mock_bt)
 
         assert mock_bt._loss_tracker.start_temp is None
         assert mock_bt._loss_tracker.end_temp is None
@@ -717,10 +705,9 @@ class TestCalculateHeatLoss:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
-            mock_dt.utcnow.return_value = now
-            await self._call(mock_bt)
+        now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+        mock_bt.clock.utcnow.return_value = now
+        await self._call(mock_bt)
 
         assert mock_bt._loss_tracker.start_temp == 22.0
         assert mock_bt._loss_tracker.start_ts == now
@@ -739,9 +726,8 @@ class TestCalculateHeatLoss:
         mock_bt._loss_tracker.end_temp = 21.8  # current (21.6) is lower
         mock_bt._loss_tracker.end_ts = now - timedelta(minutes=5)
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = now
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = now
+        await self._call(mock_bt)
 
         assert mock_bt._loss_tracker.end_temp == 21.6
 
@@ -763,9 +749,8 @@ class TestCalculateHeatLoss:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         # Cycle finalized (reset)
         assert mock_bt._loss_tracker.start_temp is None
@@ -789,9 +774,8 @@ class TestCalculateHeatLoss:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         assert mock_bt.heat_loss_rate == old_rate
         assert len(mock_bt.last_heat_loss_stats) == 0
@@ -813,9 +797,8 @@ class TestCalculateHeatLoss:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         # rate = 2.0/10.0 = 0.2, old = 0.01, alpha = 0.10
         # new ≈ 0.01 * 0.9 + 0.2 * 0.1 = 0.009 + 0.02 = 0.029
@@ -838,9 +821,8 @@ class TestCalculateHeatLoss:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         # MIN_HEAT_LOSS = 0.001, MAX_HEAT_LOSS = 0.05
         assert mock_bt.heat_loss_rate >= 0.001
@@ -862,9 +844,8 @@ class TestCalculateHeatLoss:
             BetterThermostat._should_heat_with_tolerance(mock_bt, prev, tol)
         )
 
-        with patch("custom_components.better_thermostat.climate.dt_util") as mock_dt:
-            mock_dt.utcnow.return_value = base
-            await self._call(mock_bt)
+        mock_bt.clock.utcnow.return_value = base
+        await self._call(mock_bt)
 
         assert len(mock_bt.loss_cycles) == 1
         cycle = mock_bt.loss_cycles[0]

--- a/tests/unit/test_climate_ema_periodic.py
+++ b/tests/unit/test_climate_ema_periodic.py
@@ -28,6 +28,7 @@ def bt():
     mock._slope_periodic_last_ts = None
     mock.temp_slope = None
     mock.async_write_ha_state = MagicMock()
+    mock.clock = MagicMock()
     return mock
 
 
@@ -56,10 +57,8 @@ async def test_updates_ema_and_writes_state_without_slope(bt):
     """First run (no previous EMA) updates the filter and writes state, no slope."""
     bt.external_temp_ema = None
     bt._slope_periodic_last_ts = None
-    with (
-        patch(_EMA, MagicMock(return_value=20.5)),
-        patch(f"{_CLIMATE}.monotonic", return_value=1000.0),
-    ):
+    bt.clock.monotonic.return_value = 1000.0
+    with patch(_EMA, MagicMock(return_value=20.5)):
         await BetterThermostat._async_update_ema_periodic(bt)
     assert bt.temp_slope is None
     assert bt._slope_periodic_last_ts == 1000.0
@@ -71,10 +70,8 @@ async def test_computes_slope_from_ema_change(bt):
     """With a previous EMA and timestamp, the slope is (Δema / Δt_min)."""
     bt.external_temp_ema = 20.0
     bt._slope_periodic_last_ts = 1000.0  # 600 s before "now"
-    with (
-        patch(_EMA, MagicMock(return_value=21.0)),
-        patch(f"{_CLIMATE}.monotonic", return_value=1600.0),
-    ):
+    bt.clock.monotonic.return_value = 1600.0
+    with patch(_EMA, MagicMock(return_value=21.0)):
         await BetterThermostat._async_update_ema_periodic(bt)
     # Δt = 600 s = 10 min, Δema = 1.0 K  ->  slope = 0.1 K/min
     assert bt.temp_slope == pytest.approx(0.1)
@@ -86,10 +83,8 @@ async def test_tiny_interval_skips_slope(bt):
     """A sub-0.1-minute interval does not produce a slope (avoids noise/div issues)."""
     bt.external_temp_ema = 20.0
     bt._slope_periodic_last_ts = 1599.0  # 1 s before "now"
-    with (
-        patch(_EMA, MagicMock(return_value=21.0)),
-        patch(f"{_CLIMATE}.monotonic", return_value=1600.0),
-    ):
+    bt.clock.monotonic.return_value = 1600.0
+    with patch(_EMA, MagicMock(return_value=21.0)):
         await BetterThermostat._async_update_ema_periodic(bt)
     assert bt.temp_slope is None
     assert bt._slope_periodic_last_ts == 1600.0
@@ -100,10 +95,8 @@ async def test_ema_error_is_caught(bt):
     """An error from the EMA update is swallowed (tick must not crash)."""
     bt.external_temp_ema = 20.0
     bt._slope_periodic_last_ts = 1000.0
-    with (
-        patch(_EMA, MagicMock(side_effect=RuntimeError("boom"))),
-        patch(f"{_CLIMATE}.monotonic", return_value=1600.0),
-    ):
+    bt.clock.monotonic.return_value = 1600.0
+    with patch(_EMA, MagicMock(side_effect=RuntimeError("boom"))):
         await BetterThermostat._async_update_ema_periodic(bt)
     # No slope written, no crash
     assert bt.temp_slope is None

--- a/tests/unit/test_climate_maintenance.py
+++ b/tests/unit/test_climate_maintenance.py
@@ -30,6 +30,8 @@ def bt():
     mock.real_trvs = {"climate.trv": {}}
     mock.hass = MagicMock()
     mock.hass.async_create_background_task = MagicMock()
+    mock.clock = MagicMock()
+    mock.clock.now.return_value = _NOW
     return mock
 
 
@@ -63,9 +65,7 @@ async def test_already_in_maintenance_returns(bt):
     with (
         patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
         patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
-        patch(f"{_CLIMATE}.dt_util") as dt,
     ):
-        dt.now.return_value = _NOW
         await BetterThermostat._maintenance_tick(bt)
     bt.hass.async_create_background_task.assert_not_called()
 
@@ -77,9 +77,7 @@ async def test_not_due_yet_returns(bt):
     with (
         patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
         patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
-        patch(f"{_CLIMATE}.dt_util") as dt,
     ):
-        dt.now.return_value = _NOW
         await BetterThermostat._maintenance_tick(bt)
     bt.hass.async_create_background_task.assert_not_called()
 
@@ -91,9 +89,7 @@ async def test_window_open_postpones_one_hour(bt):
     with (
         patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
         patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
-        patch(f"{_CLIMATE}.dt_util") as dt,
     ):
-        dt.now.return_value = _NOW
         await BetterThermostat._maintenance_tick(bt)
     assert bt.next_valve_maintenance == _NOW + timedelta(hours=1)
     bt.hass.async_create_background_task.assert_not_called()
@@ -106,9 +102,7 @@ async def test_hvac_off_postpones_one_hour(bt):
     with (
         patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
         patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
-        patch(f"{_CLIMATE}.dt_util") as dt,
     ):
-        dt.now.return_value = _NOW
         await BetterThermostat._maintenance_tick(bt)
     assert bt.next_valve_maintenance == _NOW + timedelta(hours=1)
     bt.hass.async_create_background_task.assert_not_called()
@@ -121,9 +115,7 @@ async def test_no_enabled_trvs_schedules_far_future(bt):
         patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
         patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
         patch(f"{_CLIMATE}.collect_maintenance_trvs", MagicMock(return_value=[])),
-        patch(f"{_CLIMATE}.dt_util") as dt,
     ):
-        dt.now.return_value = _NOW
         await BetterThermostat._maintenance_tick(bt)
     assert bt.next_valve_maintenance == _NOW + timedelta(days=7)
     bt.hass.async_create_background_task.assert_not_called()
@@ -139,8 +131,6 @@ async def test_due_and_enabled_dispatches_maintenance(bt):
             f"{_CLIMATE}.collect_maintenance_trvs",
             MagicMock(return_value=["climate.trv"]),
         ),
-        patch(f"{_CLIMATE}.dt_util") as dt,
     ):
-        dt.now.return_value = _NOW
         await BetterThermostat._maintenance_tick(bt)
     bt.hass.async_create_background_task.assert_called_once()

--- a/tests/unit/test_climate_post_grace_recheck.py
+++ b/tests/unit/test_climate_post_grace_recheck.py
@@ -10,11 +10,11 @@ been removed in the meantime.
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from homeassistant.util import dt as dt_util
 import pytest
 
 import custom_components.better_thermostat.climate as climate_module
 from custom_components.better_thermostat.climate import BetterThermostat
+from custom_components.better_thermostat.core.clock import FakeClock
 
 GRACE_SECONDS = 90
 
@@ -25,6 +25,7 @@ def bt():
     mock = MagicMock(spec=BetterThermostat)
     mock.device_name = "Test BT"
     mock.is_removed = False
+    mock.clock = FakeClock()
     return mock
 
 
@@ -34,7 +35,7 @@ class TestPostGraceRecheck:
     @pytest.mark.asyncio
     async def test_sleeps_remaining_grace_then_rechecks(self, bt):
         """With grace time remaining, sleep the remainder and run the check."""
-        grace_until = dt_util.now() + timedelta(seconds=GRACE_SECONDS)
+        grace_until = bt.clock.now() + timedelta(seconds=GRACE_SECONDS)
         with (
             patch.object(
                 climate_module, "check_critical_entities", new_callable=AsyncMock
@@ -53,7 +54,7 @@ class TestPostGraceRecheck:
     @pytest.mark.asyncio
     async def test_removed_during_sleep_skips_recheck(self, bt):
         """When the entity is removed while sleeping, skip the recheck."""
-        grace_until = dt_util.now() + timedelta(seconds=GRACE_SECONDS)
+        grace_until = bt.clock.now() + timedelta(seconds=GRACE_SECONDS)
 
         async def _remove_during_sleep(_delay):
             bt.is_removed = True
@@ -78,7 +79,7 @@ class TestPostGraceRecheck:
     @pytest.mark.asyncio
     async def test_expired_grace_rechecks_without_sleep(self, bt):
         """With the grace window already over, recheck immediately."""
-        grace_until = dt_util.now() - timedelta(seconds=1)
+        grace_until = bt.clock.now() - timedelta(seconds=1)
         with (
             patch.object(
                 climate_module, "check_critical_entities", new_callable=AsyncMock

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -42,6 +42,7 @@ HUMIDITY_ID = "sensor.humidity"
 def bt():
     """Create a mock BetterThermostat with sensible defaults."""
     mock = MagicMock(spec=BetterThermostat)
+    mock.clock = MagicMock()
     mock.hass = MagicMock()
     mock.device_name = "Test BT"
     mock.sensor_entity_id = SENSOR_ID

--- a/tests/unit/test_core_clock.py
+++ b/tests/unit/test_core_clock.py
@@ -1,6 +1,9 @@
 """Tests for the core Clock protocol and its implementations."""
 
 from datetime import UTC, datetime, timedelta, timezone
+import math
+
+import pytest
 
 from custom_components.better_thermostat.core.clock import Clock, FakeClock
 from custom_components.better_thermostat.utils.clock import SystemClock
@@ -41,6 +44,25 @@ class TestFakeClock:
     def test_satisfies_clock_protocol(self):
         """FakeClock structurally implements Clock."""
         assert isinstance(FakeClock(), Clock)
+
+    def test_rejects_naive_now_value(self):
+        """A naive now_value violates the aware-datetime contract."""
+        with pytest.raises(ValueError, match="timezone-aware"):
+            FakeClock(now_value=datetime(2025, 1, 1, 12, 0, 0))
+
+    def test_advance_rejects_negative(self):
+        """advance() never moves time backwards."""
+        clock = FakeClock()
+        with pytest.raises(ValueError, match="non-negative"):
+            clock.advance(-1.0)
+
+    def test_advance_rejects_non_finite(self):
+        """advance() rejects nan/inf that would poison the time axes."""
+        clock = FakeClock()
+        with pytest.raises(ValueError, match="finite"):
+            clock.advance(math.inf)
+        with pytest.raises(ValueError, match="finite"):
+            clock.advance(math.nan)
 
 
 class TestSystemClock:

--- a/tests/unit/test_core_clock.py
+++ b/tests/unit/test_core_clock.py
@@ -1,0 +1,63 @@
+"""Tests for the core Clock protocol and its implementations."""
+
+from datetime import UTC, datetime, timedelta, timezone
+
+from custom_components.better_thermostat.core.clock import Clock, FakeClock
+from custom_components.better_thermostat.utils.clock import SystemClock
+
+
+class TestFakeClock:
+    """FakeClock drives both time axes deterministically."""
+
+    def test_defaults_are_deterministic(self):
+        """Two fresh FakeClocks read identical times."""
+        a = FakeClock()
+        b = FakeClock()
+        assert a.monotonic() == b.monotonic() == 0.0
+        assert a.now() == b.now()
+        assert a.now().tzinfo is not None
+
+    def test_time_does_not_move_on_its_own(self):
+        """Repeated reads return the same instant."""
+        clock = FakeClock()
+        assert clock.monotonic() == clock.monotonic()
+        assert clock.now() == clock.now()
+
+    def test_advance_moves_both_axes(self):
+        """advance() shifts monotonic and wall-clock time together."""
+        clock = FakeClock()
+        start_now = clock.now()
+        clock.advance(90.0)
+        assert clock.monotonic() == 90.0
+        assert clock.now() == start_now + timedelta(seconds=90)
+
+    def test_utcnow_converts_to_utc(self):
+        """utcnow() returns the same instant expressed in UTC."""
+        cet = timezone(timedelta(hours=1))
+        clock = FakeClock(now_value=datetime(2025, 6, 1, 13, 0, 0, tzinfo=cet))
+        assert clock.utcnow() == datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+        assert clock.utcnow().tzinfo == UTC
+
+    def test_satisfies_clock_protocol(self):
+        """FakeClock structurally implements Clock."""
+        assert isinstance(FakeClock(), Clock)
+
+
+class TestSystemClock:
+    """SystemClock bridges to real system/Home Assistant time."""
+
+    def test_satisfies_clock_protocol(self):
+        """SystemClock structurally implements Clock."""
+        assert isinstance(SystemClock(), Clock)
+
+    def test_monotonic_increases(self):
+        """Successive monotonic reads never go backwards."""
+        clock = SystemClock()
+        first = clock.monotonic()
+        assert clock.monotonic() >= first
+
+    def test_now_and_utcnow_are_aware(self):
+        """Both wall-clock readings carry timezone information."""
+        clock = SystemClock()
+        assert clock.now().tzinfo is not None
+        assert clock.utcnow().tzinfo is not None

--- a/tests/unit/test_desired_state.py
+++ b/tests/unit/test_desired_state.py
@@ -53,7 +53,7 @@ class TestDesiredState:
             desired.trvs["climate.trv"].setpoint = 5.0
 
     def test_serializable_for_flight_recorder(self):
-        """asdict() output survives json round-tripping (M10 requirement)."""
+        """asdict() output survives json round-tripping."""
         payload = json.dumps(asdict(_sample()))
         restored = json.loads(payload)
         assert restored["call_for_heat"] is True

--- a/tests/unit/test_desired_state.py
+++ b/tests/unit/test_desired_state.py
@@ -1,0 +1,61 @@
+"""Tests for the core DesiredState type."""
+
+from dataclasses import FrozenInstanceError, asdict
+import json
+
+import pytest
+
+from custom_components.better_thermostat.core.desired import DesiredState, TrvDesired
+from custom_components.better_thermostat.core.snapshot import HvacMode
+
+
+def _sample() -> DesiredState:
+    return DesiredState(
+        call_for_heat=True,
+        trvs={
+            "climate.trv": TrvDesired(
+                entity_id="climate.trv",
+                hvac_mode=HvacMode.HEAT,
+                setpoint=21.5,
+                valve_percent=40.0,
+            )
+        },
+    )
+
+
+class TestDesiredState:
+    """Construction, equality, immutability, and serializability."""
+
+    def test_value_equality(self):
+        """Two identically built DesiredStates compare equal."""
+        assert _sample() == _sample()
+
+    def test_inequality_on_differing_intent(self):
+        """A different setpoint yields a different DesiredState."""
+        other = DesiredState(
+            call_for_heat=True,
+            trvs={"climate.trv": TrvDesired(entity_id="climate.trv", setpoint=19.0)},
+        )
+        assert _sample() != other
+
+    def test_defaults_express_no_intent(self):
+        """The default DesiredState wants no heat and addresses no TRV."""
+        desired = DesiredState()
+        assert desired.call_for_heat is False
+        assert dict(desired.trvs) == {}
+
+    def test_is_frozen(self):
+        """DesiredState and TrvDesired fields cannot be reassigned."""
+        desired = _sample()
+        with pytest.raises(FrozenInstanceError):
+            desired.call_for_heat = False
+        with pytest.raises(FrozenInstanceError):
+            desired.trvs["climate.trv"].setpoint = 5.0
+
+    def test_serializable_for_flight_recorder(self):
+        """asdict() output survives json round-tripping (M10 requirement)."""
+        payload = json.dumps(asdict(_sample()))
+        restored = json.loads(payload)
+        assert restored["call_for_heat"] is True
+        assert restored["trvs"]["climate.trv"]["setpoint"] == 21.5
+        assert restored["trvs"]["climate.trv"]["hvac_mode"] == "heat"

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -7,6 +7,7 @@ optional vs critical sensor classification, and degraded mode state management.
 import inspect
 from unittest.mock import MagicMock, patch
 
+from homeassistant.util import dt as dt_util
 import pytest
 
 
@@ -51,6 +52,8 @@ def mock_bt_instance(mock_hass):
     bt._degraded_warning_emitted = False
     bt._critical_grace_until = None
     bt.is_removed = False
+    bt.clock = MagicMock()
+    bt.clock.now.side_effect = dt_util.now
     return bt
 
 
@@ -497,8 +500,6 @@ class TestDegradedModeGracePeriod:
         """Grace active → degraded transition logs DEBUG, no issue, no WARNING."""
         from datetime import timedelta
 
-        from homeassistant.util import dt as dt_util
-
         from custom_components.better_thermostat.utils.watcher import (
             check_and_update_degraded_mode,
         )
@@ -521,8 +522,6 @@ class TestDegradedModeGracePeriod:
     async def test_warns_after_grace_expires(self, mock_bt_instance, caplog):
         """Grace passed → still-degraded re-check logs WARNING and raises issue."""
         from datetime import timedelta
-
-        from homeassistant.util import dt as dt_util
 
         from custom_components.better_thermostat.utils.watcher import (
             check_and_update_degraded_mode,
@@ -548,8 +547,6 @@ class TestDegradedModeGracePeriod:
     async def test_silent_recovery_during_grace(self, mock_bt_instance, caplog):
         """Recover during grace → no INFO log, no issue deleted (none was created)."""
         from datetime import timedelta
-
-        from homeassistant.util import dt as dt_util
 
         from custom_components.better_thermostat.utils.watcher import (
             check_and_update_degraded_mode,

--- a/tests/unit/test_world_snapshot.py
+++ b/tests/unit/test_world_snapshot.py
@@ -2,7 +2,7 @@
 
 The completeness table pins that every entity attribute the control path
 reads today has a corresponding snapshot field and that ``build_snapshot``
-copies each one. A forgotten field would surface here, not deep in M2.
+copies each one. A forgotten field would surface here.
 """
 
 from dataclasses import FrozenInstanceError, fields

--- a/tests/unit/test_world_snapshot.py
+++ b/tests/unit/test_world_snapshot.py
@@ -1,0 +1,203 @@
+"""Tests for the core WorldSnapshot type and the shell-side builder.
+
+The completeness table pins that every entity attribute the control path
+reads today has a corresponding snapshot field and that ``build_snapshot``
+copies each one. A forgotten field would surface here, not deep in M2.
+"""
+
+from dataclasses import FrozenInstanceError, fields
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.better_thermostat.core.clock import FakeClock
+from custom_components.better_thermostat.core.snapshot import (
+    HvacMode,
+    TrvReported,
+    WorldSnapshot,
+    parse_hvac_mode,
+)
+from custom_components.better_thermostat.utils.snapshot import build_snapshot
+
+
+def _make_bt() -> MagicMock:
+    """Return a fully populated BetterThermostat stand-in."""
+    bt = MagicMock()
+    bt.clock = FakeClock(
+        monotonic_value=1234.5, now_value=datetime(2026, 1, 2, 8, 30, tzinfo=UTC)
+    )
+    bt.bt_target_temp = 21.5
+    bt.bt_target_cooltemp = 24.0
+    bt.bt_hvac_mode = "heat"
+    bt.cur_temp = 20.1
+    bt.cur_temp_filtered = 20.2
+    bt.temp_slope = 0.05
+    bt.window_open = False
+    bt.call_for_heat = True
+    bt.preset_mode = "eco"
+    bt.tolerance = 0.3
+    bt.outdoor_sensor = None
+    bt.weather_entity = None
+    bt.startup_running = False
+    bt.in_maintenance = False
+    bt.ignore_states = False
+    bt.degraded_mode = False
+    bt.bt_min_temp = 5.0
+    bt.bt_max_temp = 30.0
+    bt.real_trvs = {
+        "climate.trv": {
+            "hvac_mode": "heat",
+            "current_temperature": 21.0,
+            "last_temperature": 22.0,
+            "min_temp": 5.0,
+            "max_temp": 30.0,
+            "valve_max_opening": 80.0,
+        }
+    }
+    trv_state = MagicMock()
+    trv_state.state = "heat"
+    bt.hass.states.get.return_value = trv_state
+    return bt
+
+
+# Entity attribute -> snapshot field, value from _make_bt.
+COMPLETENESS_TABLE = [
+    ("bt_target_temp", "target_temp", 21.5),
+    ("bt_target_cooltemp", "target_cooltemp", 24.0),
+    ("bt_hvac_mode", "hvac_mode", HvacMode.HEAT),
+    ("cur_temp", "room_temp", 20.1),
+    ("cur_temp_filtered", "room_temp_filtered", 20.2),
+    ("temp_slope", "temp_slope", 0.05),
+    ("window_open", "window_open", False),
+    ("call_for_heat", "call_for_heat", True),
+    ("preset_mode", "preset_mode", "eco"),
+    ("tolerance", "tolerance", 0.3),
+    ("startup_running", "startup_running", False),
+    ("in_maintenance", "in_maintenance", False),
+    ("ignore_states", "ignore_states", False),
+    ("degraded_mode", "degraded", False),
+    ("bt_min_temp", "min_temp", 5.0),
+    ("bt_max_temp", "max_temp", 30.0),
+]
+
+
+class TestSnapshotCompleteness:
+    """Every control-path input is mapped onto a snapshot field."""
+
+    @pytest.mark.parametrize(
+        ("entity_attr", "snapshot_field", "expected"), COMPLETENESS_TABLE
+    )
+    def test_field_is_copied(self, entity_attr, snapshot_field, expected):
+        """build_snapshot copies the entity attribute into the snapshot."""
+        bt = _make_bt()
+        snapshot = build_snapshot(bt)
+        assert getattr(snapshot, snapshot_field) == expected
+
+    def test_no_snapshot_field_is_unmapped(self):
+        """Each WorldSnapshot field is produced by the builder (none forgotten)."""
+        mapped = {snapshot_field for _, snapshot_field, _ in COMPLETENESS_TABLE}
+        produced_elsewhere = {
+            "now",
+            "now_monotonic",
+            "outdoor_temp",
+            "is_day",
+            "solar_intensity",
+            "trvs",
+        }
+        all_fields = {f.name for f in fields(WorldSnapshot)}
+        assert all_fields == mapped | produced_elsewhere
+
+    def test_time_comes_from_the_injected_clock(self):
+        """The snapshot carries both clock axes at build time."""
+        bt = _make_bt()
+        snapshot = build_snapshot(bt)
+        assert snapshot.now == datetime(2026, 1, 2, 8, 30, tzinfo=UTC)
+        assert snapshot.now_monotonic == 1234.5
+
+
+class TestTrvReportedBuilding:
+    """The TRV part is condensed into typed TrvReported entries."""
+
+    def test_reported_values_are_copied(self):
+        """All reported TRV values land in the typed structure."""
+        bt = _make_bt()
+        snapshot = build_snapshot(bt)
+        trv = snapshot.trvs["climate.trv"]
+        assert trv == TrvReported(
+            entity_id="climate.trv",
+            available=True,
+            hvac_mode=HvacMode.HEAT,
+            current_temp=21.0,
+            setpoint=22.0,
+            min_temp=5.0,
+            max_temp=30.0,
+            valve_max_opening=80.0,
+        )
+
+    def test_unavailable_state_marks_trv_unavailable(self):
+        """An unavailable HA state yields available=False."""
+        bt = _make_bt()
+        trv_state = MagicMock()
+        trv_state.state = "unavailable"
+        bt.hass.states.get.return_value = trv_state
+        snapshot = build_snapshot(bt)
+        assert snapshot.trvs["climate.trv"].available is False
+
+    def test_missing_state_marks_trv_unavailable(self):
+        """A missing HA state yields available=False."""
+        bt = _make_bt()
+        bt.hass.states.get.return_value = None
+        snapshot = build_snapshot(bt)
+        assert snapshot.trvs["climate.trv"].available is False
+
+    def test_unparseable_values_become_none(self):
+        """Garbage in the real_trvs entry degrades to None, not a crash."""
+        bt = _make_bt()
+        bt.real_trvs["climate.trv"]["current_temperature"] = "oops"
+        bt.real_trvs["climate.trv"]["hvac_mode"] = "bogus"
+        snapshot = build_snapshot(bt)
+        trv = snapshot.trvs["climate.trv"]
+        assert trv.current_temp is None
+        assert trv.hvac_mode is None
+
+
+class TestWorldSnapshotType:
+    """Type-level guarantees of the snapshot."""
+
+    def test_snapshot_is_frozen(self):
+        """Snapshot fields cannot be reassigned."""
+        snapshot = build_snapshot(_make_bt())
+        with pytest.raises(FrozenInstanceError):
+            snapshot.room_temp = 99.0
+
+    def test_trv_reported_is_frozen(self):
+        """TrvReported fields cannot be reassigned."""
+        trv = TrvReported(entity_id="climate.trv")
+        with pytest.raises(FrozenInstanceError):
+            trv.current_temp = 99.0
+
+
+class TestParseHvacMode:
+    """parse_hvac_mode maps raw values onto the core vocabulary."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("heat", HvacMode.HEAT),
+            ("off", HvacMode.OFF),
+            ("cool", HvacMode.COOL),
+            ("heat_cool", HvacMode.HEAT_COOL),
+            ("auto", HvacMode.AUTO),
+            (None, None),
+            ("bogus", None),
+        ],
+    )
+    def test_parse(self, raw, expected):
+        """Known strings map to members, unknown to None."""
+        assert parse_hvac_mode(raw) == expected
+
+    def test_members_compare_equal_to_ha_strings(self):
+        """Core values are HA's mode strings, so equality is interoperable."""
+        assert HvacMode.OFF == "off"
+        assert HvacMode.HEAT == "heat"

--- a/tests/unit/test_world_snapshot.py
+++ b/tests/unit/test_world_snapshot.py
@@ -9,6 +9,7 @@ from dataclasses import FrozenInstanceError, fields
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
+from homeassistant.core import State
 import pytest
 
 from custom_components.better_thermostat.core.clock import FakeClock
@@ -55,9 +56,7 @@ def _make_bt() -> MagicMock:
             "valve_max_opening": 80.0,
         }
     }
-    trv_state = MagicMock()
-    trv_state.state = "heat"
-    bt.hass.states.get.return_value = trv_state
+    bt.hass.states.get.return_value = State("climate.trv", "heat")
     return bt
 
 
@@ -138,9 +137,7 @@ class TestTrvReportedBuilding:
     def test_unavailable_state_marks_trv_unavailable(self):
         """An unavailable HA state yields available=False."""
         bt = _make_bt()
-        trv_state = MagicMock()
-        trv_state.state = "unavailable"
-        bt.hass.states.get.return_value = trv_state
+        bt.hass.states.get.return_value = State("climate.trv", "unavailable")
         snapshot = build_snapshot(bt)
         assert snapshot.trvs["climate.trv"].available is False
 
@@ -156,6 +153,22 @@ class TestTrvReportedBuilding:
         bt = _make_bt()
         bt.real_trvs["climate.trv"]["current_temperature"] = "oops"
         bt.real_trvs["climate.trv"]["hvac_mode"] = "bogus"
+        snapshot = build_snapshot(bt)
+        trv = snapshot.trvs["climate.trv"]
+        assert trv.current_temp is None
+        assert trv.hvac_mode is None
+
+    def test_boolean_values_are_not_coerced_to_float(self):
+        """A bool reading does not silently become 1.0/0.0."""
+        bt = _make_bt()
+        bt.real_trvs["climate.trv"]["current_temperature"] = True
+        snapshot = build_snapshot(bt)
+        assert snapshot.trvs["climate.trv"].current_temp is None
+
+    def test_non_dict_payload_does_not_crash(self):
+        """A malformed (non-dict) real_trvs entry degrades to an empty report."""
+        bt = _make_bt()
+        bt.real_trvs["climate.trv"] = "not-a-dict"
         snapshot = build_snapshot(bt)
         trv = snapshot.trvs["climate.trv"]
         assert trv.current_temp is None


### PR DESCRIPTION
Part of the functional-core / imperative-shell architecture. Builds on `v2`.

Introduces the HA-free `core/` package and the time seam the control path builds on:

- `core/clock.py` — the `Clock` protocol (`now`, `monotonic`); the climate entity reads time through an injected `SystemClock`, making its time-dependent behaviour deterministically testable.
- `core/snapshot.py` — `WorldSnapshot` + `TrvReported` + `parse_hvac_mode`: the flat, immutable view of the world the decision path consumes.
- `core/desired.py` — `DesiredState`: the intent the shell applies to devices.
- `utils/snapshot.py` — `build_snapshot()`, the single seam that flattens entity attributes and Home Assistant state into a `WorldSnapshot`.

`core/` imports no Home Assistant code and carries `py.typed`.

### Verification
- `pytest`: 1564 unit + 4 integration pass.
- `ruff` and `pyrefly check` (strict on `core/`): clean.