### PR TITLE
arch 03: orthogonal FSM regions as pure core modules

### DIFF
--- a/custom_components/better_thermostat/core/fsm/__init__.py
+++ b/custom_components/better_thermostat/core/fsm/__init__.py
@@ -1,0 +1,6 @@
+"""Orthogonal finite state machines of the decision kernel.
+
+Each region is a frozen dataclass plus a pure ``step()`` function;
+timers are expressed through the monotonic timestamps carried in the
+state and the ``now`` passed by the caller — no clocks are read here.
+"""

--- a/custom_components/better_thermostat/core/fsm/control_mode.py
+++ b/custom_components/better_thermostat/core/fsm/control_mode.py
@@ -1,0 +1,158 @@
+"""Control-mode region: the fail-soft ladder OPTIMAL -> SENSOR_FALLBACK -> HOLD.
+
+The rungs:
+
+* OPTIMAL — the room sensor delivers; the control law works as configured.
+* SENSOR_FALLBACK — the room sensor is unavailable but at least one TRV
+  reports an internal temperature: after a short debounce the
+  calibration substitutes the mean of the available TRV-internal
+  temperatures for the room temperature. Controlling on a hot-valve
+  sensor is worse than on a room sensor, but strictly better than
+  controlling on a silently stale reading.
+* HOLD — neither room sensor nor any TRV temperature is usable: the
+  controller stops adjusting and keeps the last commanded state; the
+  safety hull keeps enforcing the frost floor at the command boundary.
+
+Transitions degrade quickly (small debounce) and recover slowly: the
+ladder only climbs back up after the capability has been continuously
+restored for ``up_stability_s`` (hysteresis against flapping sensors).
+
+The region is not persisted across restarts: the ladder starts at
+OPTIMAL and re-derives its rung from live observations within one
+debounce window. A persisted rung could only pin stale degradation —
+the observations it was derived from are gone after a restart.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class ControlMode(StrEnum):
+    """Discrete rungs of the degradation ladder."""
+
+    OPTIMAL = "optimal"
+    SENSOR_FALLBACK = "sensor_fallback"
+    HOLD = "hold"
+
+
+@dataclass(frozen=True)
+class LadderParams:
+    """Timing of the ladder transitions in seconds."""
+
+    down_debounce_s: float = 120.0
+    up_stability_s: float = 300.0
+
+
+@dataclass(frozen=True)
+class ControlModeState:
+    """State of the control-mode region."""
+
+    mode: ControlMode = ControlMode.OPTIMAL
+    unavailable_sensors: tuple[str, ...] = ()
+    degraded_since: float | None = None
+    # Pending downgrade (capability lost, debounce running).
+    down_pending_since: float | None = None
+    # Pending upgrade (capability restored, stability window running).
+    up_pending_since: float | None = None
+
+    @property
+    def degraded(self) -> bool:
+        """True while any optional sensor is unavailable."""
+        return bool(self.unavailable_sensors)
+
+
+def step(
+    state: ControlModeState, unavailable_sensors: list[str], now: float
+) -> ControlModeState:
+    """Record the watcher's availability check (annunciation bookkeeping).
+
+    Any unavailable optional sensor is annunciated as degradation. The
+    ladder rung itself is advanced by :func:`step_ladder` from the
+    control-law-relevant capabilities.
+    """
+    if not unavailable_sensors:
+        return ControlModeState(
+            mode=state.mode,
+            down_pending_since=state.down_pending_since,
+            up_pending_since=state.up_pending_since,
+        )
+    return ControlModeState(
+        mode=state.mode,
+        unavailable_sensors=tuple(unavailable_sensors),
+        degraded_since=state.degraded_since if state.degraded else now,
+        down_pending_since=state.down_pending_since,
+        up_pending_since=state.up_pending_since,
+    )
+
+
+def _target_rung(room_sensor_ok: bool, trv_temp_ok: bool) -> ControlMode:
+    if room_sensor_ok:
+        return ControlMode.OPTIMAL
+    if trv_temp_ok:
+        return ControlMode.SENSOR_FALLBACK
+    return ControlMode.HOLD
+
+
+def step_ladder(
+    state: ControlModeState,
+    *,
+    room_sensor_ok: bool,
+    trv_temp_ok: bool,
+    now: float,
+    params: LadderParams,
+) -> ControlModeState:
+    """Advance the ladder rung from the capability observation.
+
+    Downgrades commit after ``down_debounce_s`` of sustained loss;
+    upgrades commit after ``up_stability_s`` of sustained recovery.
+    """
+    target = _target_rung(room_sensor_ok, trv_temp_ok)
+
+    if target == state.mode:
+        return _with_pending(state, down=None, up=None)
+
+    rung_order = (ControlMode.OPTIMAL, ControlMode.SENSOR_FALLBACK, ControlMode.HOLD)
+    degrading = rung_order.index(target) > rung_order.index(state.mode)
+
+    if degrading:
+        since = (
+            state.down_pending_since if state.down_pending_since is not None else now
+        )
+        if now - since >= params.down_debounce_s:
+            return _with_mode(state, target, now)
+        return _with_pending(state, down=since, up=None)
+
+    since = state.up_pending_since if state.up_pending_since is not None else now
+    if now - since >= params.up_stability_s:
+        return _with_mode(state, target, now)
+    return _with_pending(state, down=None, up=since)
+
+
+def _with_mode(
+    state: ControlModeState, mode: ControlMode, now: float
+) -> ControlModeState:
+    return ControlModeState(
+        mode=mode,
+        unavailable_sensors=state.unavailable_sensors,
+        degraded_since=(
+            state.degraded_since
+            if state.degraded_since is not None and mode != ControlMode.OPTIMAL
+            else (now if mode != ControlMode.OPTIMAL else None)
+        ),
+    )
+
+
+def _with_pending(
+    state: ControlModeState, down: float | None, up: float | None
+) -> ControlModeState:
+    if state.down_pending_since == down and state.up_pending_since == up:
+        return state
+    return ControlModeState(
+        mode=state.mode,
+        unavailable_sensors=state.unavailable_sensors,
+        degraded_since=state.degraded_since,
+        down_pending_since=down,
+        up_pending_since=up,
+    )

--- a/custom_components/better_thermostat/core/fsm/lifecycle.py
+++ b/custom_components/better_thermostat/core/fsm/lifecycle.py
@@ -1,0 +1,70 @@
+"""Lifecycle region: INITIALISING -> STARTING(grace) -> RUNNING -> STOPPING.
+
+INITIALISING covers the startup sequence (no control happens), STARTING
+is the post-startup grace window during which degraded-mode annunciation
+stays quiet, RUNNING is normal operation, and STOPPING marks removal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+
+class LifecyclePhase(StrEnum):
+    """Discrete phases of the lifecycle region."""
+
+    INITIALISING = "initialising"
+    STARTING = "starting"
+    RUNNING = "running"
+    STOPPING = "stopping"
+
+
+@dataclass(frozen=True)
+class LifecycleState:
+    """State of the lifecycle region."""
+
+    phase: LifecyclePhase = LifecyclePhase.INITIALISING
+    grace_until: datetime | None = None
+
+    @property
+    def startup_running(self) -> bool:
+        """Whether the startup sequence is still in progress."""
+        return self.phase == LifecyclePhase.INITIALISING
+
+    def in_grace(self, now: datetime) -> bool:
+        """Whether degraded-mode annunciation is still suppressed.
+
+        Mirrors the shell semantics: grace only counts once a deadline
+        has been set after startup.
+        """
+        return self.grace_until is not None and now < self.grace_until
+
+
+def startup_finished(
+    state: LifecycleState, grace_until: datetime | None = None
+) -> LifecycleState:
+    """Move INITIALISING to STARTING; later phases are unchanged."""
+    if state.phase != LifecyclePhase.INITIALISING:
+        return state
+    return LifecycleState(phase=LifecyclePhase.STARTING, grace_until=grace_until)
+
+
+def extend_grace(state: LifecycleState, grace_until: datetime) -> LifecycleState:
+    """Set the annunciation grace deadline while STARTING."""
+    if state.phase != LifecyclePhase.STARTING:
+        return state
+    return LifecycleState(phase=LifecyclePhase.STARTING, grace_until=grace_until)
+
+
+def tick(state: LifecycleState, now: datetime) -> LifecycleState:
+    """Promote STARTING to RUNNING once the grace window has passed."""
+    if state.phase == LifecyclePhase.STARTING and not state.in_grace(now):
+        return LifecycleState(phase=LifecyclePhase.RUNNING)
+    return state
+
+
+def stop(state: LifecycleState) -> LifecycleState:
+    """Move any phase to STOPPING (terminal)."""
+    return LifecycleState(phase=LifecyclePhase.STOPPING)

--- a/custom_components/better_thermostat/core/fsm/lifecycle.py
+++ b/custom_components/better_thermostat/core/fsm/lifecycle.py
@@ -45,26 +45,76 @@ class LifecycleState:
 def startup_finished(
     state: LifecycleState, grace_until: datetime | None = None
 ) -> LifecycleState:
-    """Move INITIALISING to STARTING; later phases are unchanged."""
+    """Move INITIALISING to STARTING; later phases are unchanged.
+
+    Parameters
+    ----------
+    state : LifecycleState
+        Current lifecycle state.
+    grace_until : datetime | None, optional
+        Deadline until which degraded-mode annunciation stays suppressed.
+
+    Returns
+    -------
+    LifecycleState
+        STARTING state when previously INITIALISING, otherwise ``state``.
+    """
     if state.phase != LifecyclePhase.INITIALISING:
         return state
     return LifecycleState(phase=LifecyclePhase.STARTING, grace_until=grace_until)
 
 
 def extend_grace(state: LifecycleState, grace_until: datetime) -> LifecycleState:
-    """Set the annunciation grace deadline while STARTING."""
+    """Set the annunciation grace deadline while STARTING.
+
+    Parameters
+    ----------
+    state : LifecycleState
+        Current lifecycle state.
+    grace_until : datetime
+        New grace deadline.
+
+    Returns
+    -------
+    LifecycleState
+        Updated state while STARTING, otherwise ``state`` unchanged.
+    """
     if state.phase != LifecyclePhase.STARTING:
         return state
     return LifecycleState(phase=LifecyclePhase.STARTING, grace_until=grace_until)
 
 
 def tick(state: LifecycleState, now: datetime) -> LifecycleState:
-    """Promote STARTING to RUNNING once the grace window has passed."""
+    """Promote STARTING to RUNNING once the grace window has passed.
+
+    Parameters
+    ----------
+    state : LifecycleState
+        Current lifecycle state.
+    now : datetime
+        Current time used to evaluate the grace window.
+
+    Returns
+    -------
+    LifecycleState
+        RUNNING state once the grace window elapsed, otherwise ``state``.
+    """
     if state.phase == LifecyclePhase.STARTING and not state.in_grace(now):
         return LifecycleState(phase=LifecyclePhase.RUNNING)
     return state
 
 
 def stop(state: LifecycleState) -> LifecycleState:
-    """Move any phase to STOPPING (terminal)."""
+    """Move any phase to STOPPING (terminal).
+
+    Parameters
+    ----------
+    state : LifecycleState
+        Current lifecycle state.
+
+    Returns
+    -------
+    LifecycleState
+        The terminal STOPPING state.
+    """
     return LifecycleState(phase=LifecyclePhase.STOPPING)

--- a/custom_components/better_thermostat/core/fsm/maintenance.py
+++ b/custom_components/better_thermostat/core/fsm/maintenance.py
@@ -60,6 +60,24 @@ def evaluate_tick(
     Postpone rules mirror the shell behavior: an open window or OFF mode
     pushes the schedule out an hour; without any maintenance-enabled TRV
     the next check moves a week out. Otherwise a due schedule arms DUE.
+
+    Parameters
+    ----------
+    state : MaintenanceState
+        Current maintenance state.
+    now : datetime
+        Current time used to evaluate the schedule.
+    window_open : bool
+        Whether a window is currently open.
+    hvac_off : bool
+        Whether the thermostat is in OFF mode.
+    has_enabled_trvs : bool
+        Whether any TRV has valve maintenance enabled.
+
+    Returns
+    -------
+    MaintenanceState
+        The advanced state (possibly DUE or with a postponed schedule).
     """
     if state.phase != MaintenancePhase.IDLE:
         return state
@@ -73,7 +91,20 @@ def evaluate_tick(
 
 
 def start_run(state: MaintenanceState, now_monotonic: float) -> MaintenanceState:
-    """DUE -> RUNNING; any other phase is unchanged (no double starts)."""
+    """Move DUE to RUNNING; any other phase is unchanged (no double starts).
+
+    Parameters
+    ----------
+    state : MaintenanceState
+        Current maintenance state.
+    now_monotonic : float
+        Monotonic timestamp marking the start of the run.
+
+    Returns
+    -------
+    MaintenanceState
+        RUNNING state when previously DUE, otherwise ``state`` unchanged.
+    """
     if state.phase != MaintenancePhase.DUE:
         return state
     return MaintenanceState(
@@ -87,5 +118,17 @@ def finish_run(state: MaintenanceState, next_due: datetime | None) -> Maintenanc
     """Return the region to IDLE with the new schedule.
 
     Finishing is unconditional so the region can never stay RUNNING.
+
+    Parameters
+    ----------
+    state : MaintenanceState
+        Current maintenance state.
+    next_due : datetime | None
+        When the next maintenance check is scheduled.
+
+    Returns
+    -------
+    MaintenanceState
+        A fresh IDLE state carrying ``next_due``.
     """
     return MaintenanceState(next_due=next_due)

--- a/custom_components/better_thermostat/core/fsm/maintenance.py
+++ b/custom_components/better_thermostat/core/fsm/maintenance.py
@@ -1,0 +1,91 @@
+"""Maintenance region: idle -> due -> running -> idle (rescheduled).
+
+The region owns the schedule (``next_due``) and the run guard. The
+invariant that motivated it: a maintenance run must never be able to
+block control permanently — ``is_blocking`` stops honoring a RUNNING
+phase once it exceeds the configured maximum runtime, and finishing a
+run always reschedules and returns to IDLE.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import StrEnum
+
+# A valve exercise takes a few minutes per TRV; an hour means it died.
+MAX_RUN_S = 3600.0
+
+
+class MaintenancePhase(StrEnum):
+    """Discrete phases of the maintenance region."""
+
+    IDLE = "idle"
+    DUE = "due"
+    RUNNING = "running"
+
+
+@dataclass(frozen=True)
+class MaintenanceState:
+    """State of the maintenance region."""
+
+    phase: MaintenancePhase = MaintenancePhase.IDLE
+    next_due: datetime | None = None
+    running_since: float | None = None
+
+    def is_blocking(self, now_monotonic: float, max_run_s: float = MAX_RUN_S) -> bool:
+        """Whether this region currently pre-empts control.
+
+        A RUNNING phase older than ``max_run_s`` is treated as dead and
+        stops blocking, bounding how long maintenance can pre-empt
+        control.
+        """
+        if self.phase != MaintenancePhase.RUNNING:
+            return False
+        if self.running_since is None:
+            return True
+        return (now_monotonic - self.running_since) < max_run_s
+
+
+def evaluate_tick(
+    state: MaintenanceState,
+    now: datetime,
+    *,
+    window_open: bool,
+    hvac_off: bool,
+    has_enabled_trvs: bool,
+) -> MaintenanceState:
+    """Advance the region on a scheduler tick.
+
+    Postpone rules mirror the shell behavior: an open window or OFF mode
+    pushes the schedule out an hour; without any maintenance-enabled TRV
+    the next check moves a week out. Otherwise a due schedule arms DUE.
+    """
+    if state.phase != MaintenancePhase.IDLE:
+        return state
+    if state.next_due is not None and now < state.next_due:
+        return state
+    if window_open or hvac_off:
+        return MaintenanceState(next_due=now + timedelta(hours=1))
+    if not has_enabled_trvs:
+        return MaintenanceState(next_due=now + timedelta(days=7))
+    return MaintenanceState(phase=MaintenancePhase.DUE, next_due=state.next_due)
+
+
+def start_run(state: MaintenanceState, now_monotonic: float) -> MaintenanceState:
+    """DUE -> RUNNING; any other phase is unchanged (no double starts)."""
+    if state.phase != MaintenancePhase.DUE:
+        return state
+    return MaintenanceState(
+        phase=MaintenancePhase.RUNNING,
+        next_due=state.next_due,
+        running_since=now_monotonic,
+    )
+
+
+def finish_run(state: MaintenanceState, next_due: datetime | None) -> MaintenanceState:
+    """Return the region to IDLE with the new schedule.
+
+    Finishing is unconditional so the region can never stay RUNNING.
+    """
+    return MaintenanceState(next_due=next_due)

--- a/custom_components/better_thermostat/core/fsm/mode.py
+++ b/custom_components/better_thermostat/core/fsm/mode.py
@@ -1,0 +1,38 @@
+"""Mode region: OFF / HEAT / COOL / HEAT_COOL, crossed with a preset.
+
+The region is a validated value holder: invalid or unknown inputs leave
+the state unchanged instead of corrupting it, and the preset axis is
+orthogonal to the HVAC mode axis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..snapshot import HvacMode, parse_hvac_mode
+
+# Preset value meaning "no preset"; matches HA's PRESET_NONE.
+PRESET_NONE = "none"
+
+
+@dataclass(frozen=True)
+class ModeState:
+    """State of the mode region."""
+
+    hvac_mode: HvacMode = HvacMode.OFF
+    preset: str | None = None
+
+
+def set_hvac_mode(state: ModeState, mode: str | None) -> ModeState:
+    """Set the HVAC mode; unknown or missing values leave the state unchanged."""
+    parsed = parse_hvac_mode(mode)
+    if parsed is None:
+        return state
+    return ModeState(hvac_mode=parsed, preset=state.preset)
+
+
+def set_preset(state: ModeState, preset: str | None) -> ModeState:
+    """Set the preset; PRESET_NONE and empty values clear it."""
+    if preset is None or preset in (PRESET_NONE, ""):
+        return ModeState(hvac_mode=state.hvac_mode, preset=None)
+    return ModeState(hvac_mode=state.hvac_mode, preset=preset)

--- a/custom_components/better_thermostat/core/fsm/mode.py
+++ b/custom_components/better_thermostat/core/fsm/mode.py
@@ -17,14 +17,35 @@ PRESET_NONE = "none"
 
 @dataclass(frozen=True)
 class ModeState:
-    """State of the mode region."""
+    """State of the mode region.
+
+    Attributes
+    ----------
+    hvac_mode : HvacMode
+        Current HVAC operating mode (OFF, HEAT, COOL, HEAT_COOL).
+    preset : str | None
+        Active preset name, or ``None`` when no preset is active.
+    """
 
     hvac_mode: HvacMode = HvacMode.OFF
     preset: str | None = None
 
 
 def set_hvac_mode(state: ModeState, mode: str | None) -> ModeState:
-    """Set the HVAC mode; unknown or missing values leave the state unchanged."""
+    """Set the HVAC mode; unknown or missing values leave the state unchanged.
+
+    Parameters
+    ----------
+    state : ModeState
+        Current mode state.
+    mode : str | None
+        HVAC mode string to parse and apply.
+
+    Returns
+    -------
+    ModeState
+        Updated state, or ``state`` unchanged when ``mode`` is invalid.
+    """
     parsed = parse_hvac_mode(mode)
     if parsed is None:
         return state
@@ -32,7 +53,21 @@ def set_hvac_mode(state: ModeState, mode: str | None) -> ModeState:
 
 
 def set_preset(state: ModeState, preset: str | None) -> ModeState:
-    """Set the preset; PRESET_NONE and empty values clear it."""
+    """Set the preset; PRESET_NONE and empty values clear it.
+
+    Parameters
+    ----------
+    state : ModeState
+        Current mode state.
+    preset : str | None
+        Preset name to apply; ``None``, ``PRESET_NONE`` or an empty string
+        clears the active preset.
+
+    Returns
+    -------
+    ModeState
+        Updated state with the new (or cleared) preset.
+    """
     if preset is None or preset in (PRESET_NONE, ""):
         return ModeState(hvac_mode=state.hvac_mode, preset=None)
     return ModeState(hvac_mode=state.hvac_mode, preset=preset)

--- a/custom_components/better_thermostat/core/fsm/reachability.py
+++ b/custom_components/better_thermostat/core/fsm/reachability.py
@@ -9,9 +9,15 @@ recorded with every decision tuple for outage diagnosis.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
 
 RETRY_INITIAL_S = 30.0
 RETRY_MAX_S = 600.0
+
+# Exponent at which the backoff already saturates at RETRY_MAX_S. Clamping the
+# exponent to this before ``2.0**`` keeps long outages from overflowing the
+# float power before the ``min`` clamp would cap it.
+_MAX_BACKOFF_EXP = math.ceil(math.log2(RETRY_MAX_S / RETRY_INITIAL_S))
 
 
 @dataclass(frozen=True)
@@ -25,8 +31,22 @@ class ReachabilityState:
 
 
 def _backoff(retry_count: int) -> float:
-    """Exponential backoff: 30 s doubling up to 10 min."""
-    return min(RETRY_MAX_S, RETRY_INITIAL_S * (2.0**retry_count))
+    """Return the retry interval in seconds for ``retry_count`` elapsed retries.
+
+    Parameters
+    ----------
+    retry_count : int
+        Number of retries already elapsed while offline.
+
+    Returns
+    -------
+    float
+        Exponential backoff (30 s doubling) capped at ``RETRY_MAX_S``.
+    """
+    if retry_count <= 0:
+        return RETRY_INITIAL_S
+    clamped = min(retry_count, _MAX_BACKOFF_EXP)
+    return min(RETRY_MAX_S, RETRY_INITIAL_S * (2.0**clamped))
 
 
 def step(

--- a/custom_components/better_thermostat/core/fsm/reachability.py
+++ b/custom_components/better_thermostat/core/fsm/reachability.py
@@ -1,0 +1,55 @@
+"""Reachability region (per TRV): online <-> offline with retry backoff.
+
+The region debounces nothing — addressing skips an unavailable TRV
+directly via the snapshot. What the region carries is the typed record
+of *since when* a TRV is offline and how many retries have elapsed,
+recorded with every decision tuple for outage diagnosis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+RETRY_INITIAL_S = 30.0
+RETRY_MAX_S = 600.0
+
+
+@dataclass(frozen=True)
+class ReachabilityState:
+    """State of one TRV's reachability region."""
+
+    online: bool = True
+    offline_since: float | None = None
+    retry_count: int = 0
+    retry_at: float | None = None
+
+
+def _backoff(retry_count: int) -> float:
+    """Exponential backoff: 30 s doubling up to 10 min."""
+    return min(RETRY_MAX_S, RETRY_INITIAL_S * (2.0**retry_count))
+
+
+def step(
+    state: ReachabilityState, reported_available: bool, now: float
+) -> ReachabilityState:
+    """Advance the region from one availability observation."""
+    if reported_available:
+        return ReachabilityState()
+
+    if state.online:
+        # Fresh transition to offline: schedule the first retry.
+        return ReachabilityState(
+            online=False, offline_since=now, retry_count=0, retry_at=now + _backoff(0)
+        )
+
+    if state.retry_at is not None and now >= state.retry_at:
+        # Retry window reached while still offline: back off further.
+        retry_count = state.retry_count + 1
+        return ReachabilityState(
+            online=False,
+            offline_since=state.offline_since,
+            retry_count=retry_count,
+            retry_at=now + _backoff(retry_count),
+        )
+
+    return state

--- a/custom_components/better_thermostat/core/fsm/window.py
+++ b/custom_components/better_thermostat/core/fsm/window.py
@@ -1,0 +1,92 @@
+"""Window region: closed -> opening -> open -> closing -> closed.
+
+The sensor's raw reading is debounced in both directions: a change only
+commits after it has persisted for the configured delay. While a change
+is pending, the *committed* phase keeps ruling the control law.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class WindowPhase(StrEnum):
+    """Discrete phases of the window region."""
+
+    CLOSED = "closed"
+    OPENING = "opening"
+    OPEN = "open"
+    CLOSING = "closing"
+
+
+@dataclass(frozen=True)
+class WindowState:
+    """State of the window region.
+
+    ``pending_since`` carries the monotonic timestamp at which the
+    currently pending transition (OPENING/CLOSING) was observed.
+    """
+
+    phase: WindowPhase = WindowPhase.CLOSED
+    pending_since: float | None = None
+
+    @property
+    def effective_open(self) -> bool:
+        """Whether the control law should treat the window as open."""
+        return self.phase in (WindowPhase.OPEN, WindowPhase.CLOSING)
+
+
+@dataclass(frozen=True)
+class WindowParams:
+    """Debounce delays in seconds (open and close direction)."""
+
+    open_delay_s: float = 0.0
+    close_delay_s: float = 0.0
+
+
+def step(
+    state: WindowState, sensor_open: bool, now: float, params: WindowParams
+) -> WindowState:
+    """Advance the window region by one observation.
+
+    ``sensor_open`` is the raw sensor reading, ``now`` the monotonic time
+    of the observation. The caller re-steps after the configured delay to
+    let a pending transition commit.
+    """
+    phase = state.phase
+
+    if phase == WindowPhase.CLOSED:
+        if sensor_open:
+            state = WindowState(phase=WindowPhase.OPENING, pending_since=now)
+            return _commit_if_due(state, now, params)
+        return state
+
+    if phase == WindowPhase.OPENING:
+        if not sensor_open:
+            # False positive: the window closed again before the delay ran out.
+            return WindowState(phase=WindowPhase.CLOSED)
+        return _commit_if_due(state, now, params)
+
+    if phase == WindowPhase.OPEN:
+        if not sensor_open:
+            state = WindowState(phase=WindowPhase.CLOSING, pending_since=now)
+            return _commit_if_due(state, now, params)
+        return state
+
+    # CLOSING
+    if sensor_open:
+        # False positive: the window reopened before the delay ran out.
+        return WindowState(phase=WindowPhase.OPEN)
+    return _commit_if_due(state, now, params)
+
+
+def _commit_if_due(state: WindowState, now: float, params: WindowParams) -> WindowState:
+    """Commit a pending transition once its delay has elapsed."""
+    if state.phase == WindowPhase.OPENING and state.pending_since is not None:
+        if now - state.pending_since >= params.open_delay_s:
+            return WindowState(phase=WindowPhase.OPEN)
+    if state.phase == WindowPhase.CLOSING and state.pending_since is not None:
+        if now - state.pending_since >= params.close_delay_s:
+            return WindowState(phase=WindowPhase.CLOSED)
+    return state

--- a/tests/unit/test_fsm_control_mode.py
+++ b/tests/unit/test_fsm_control_mode.py
@@ -1,0 +1,50 @@
+"""Pure tests for the control-mode FSM (annunciation of degradation)."""
+
+from custom_components.better_thermostat.core.fsm.control_mode import (
+    ControlMode,
+    ControlModeState,
+    step,
+)
+
+
+def test_initial_state_is_optimal():
+    """A fresh region is OPTIMAL and not degraded."""
+    state = ControlModeState()
+    assert state.mode == ControlMode.OPTIMAL
+    assert state.degraded is False
+    assert state.unavailable_sensors == ()
+
+
+def test_unavailable_sensor_degrades():
+    """Any unavailable optional sensor marks the region as degraded.
+
+    The ladder rung itself only moves via step_ladder (debounced).
+    """
+    state = step(ControlModeState(), ["sensor.outdoor"], now=100.0)
+    assert state.mode == ControlMode.OPTIMAL
+    assert state.degraded is True
+    assert state.unavailable_sensors == ("sensor.outdoor",)
+    assert state.degraded_since == 100.0
+
+
+def test_degraded_since_is_kept_while_degraded():
+    """The first degradation timestamp survives further degraded steps."""
+    state = step(ControlModeState(), ["sensor.outdoor"], now=100.0)
+    state = step(state, ["sensor.outdoor", "weather.home"], now=200.0)
+    assert state.degraded_since == 100.0
+    assert state.unavailable_sensors == ("sensor.outdoor", "weather.home")
+
+
+def test_recovery_returns_to_optimal():
+    """No unavailable sensors returns the region to OPTIMAL and clears it."""
+    state = step(ControlModeState(), ["sensor.outdoor"], now=100.0)
+    state = step(state, [], now=300.0)
+    assert state == ControlModeState()
+
+
+def test_redegradation_restarts_the_clock():
+    """A new degradation after recovery gets a fresh timestamp."""
+    state = step(ControlModeState(), ["sensor.outdoor"], now=100.0)
+    state = step(state, [], now=300.0)
+    state = step(state, ["sensor.outdoor"], now=400.0)
+    assert state.degraded_since == 400.0

--- a/tests/unit/test_fsm_ladder.py
+++ b/tests/unit/test_fsm_ladder.py
@@ -1,0 +1,98 @@
+"""Pure tests for the fail-soft ladder: debounced down, hysteretic up."""
+
+from custom_components.better_thermostat.core.fsm.control_mode import (
+    ControlMode,
+    ControlModeState,
+    LadderParams,
+    step_ladder,
+)
+
+P = LadderParams(down_debounce_s=120.0, up_stability_s=300.0)
+
+
+def _down(state, now, room_ok=False, trv_ok=True):
+    return step_ladder(
+        state, room_sensor_ok=room_ok, trv_temp_ok=trv_ok, now=now, params=P
+    )
+
+
+def _up(state, now):
+    return step_ladder(state, room_sensor_ok=True, trv_temp_ok=True, now=now, params=P)
+
+
+def test_initial_state_is_optimal():
+    """A fresh ladder sits on OPTIMAL."""
+    assert ControlModeState().mode == ControlMode.OPTIMAL
+
+
+def test_downgrade_commits_after_debounce():
+    """Sensor loss moves to SENSOR_FALLBACK only after the debounce."""
+    state = _down(ControlModeState(), now=0.0)
+    assert state.mode == ControlMode.OPTIMAL  # debounce running
+    state = _down(state, now=60.0)
+    assert state.mode == ControlMode.OPTIMAL
+    state = _down(state, now=120.0)
+    assert state.mode == ControlMode.SENSOR_FALLBACK
+    assert state.degraded_since == 120.0
+
+
+def test_flap_during_debounce_cancels_downgrade():
+    """A recovering sensor during the debounce keeps OPTIMAL (no flapping)."""
+    state = _down(ControlModeState(), now=0.0)
+    state = _up(state, now=60.0)
+    assert state.mode == ControlMode.OPTIMAL
+    # Loss must persist for the full debounce again.
+    state = _down(state, now=70.0)
+    state = _down(state, now=170.0)
+    assert state.mode == ControlMode.OPTIMAL
+    state = _down(state, now=190.0)
+    assert state.mode == ControlMode.SENSOR_FALLBACK
+
+
+def test_hold_when_no_trv_temperature_either():
+    """Without any usable temperature the ladder bottoms out on HOLD."""
+    state = ControlModeState()
+    state = _down(state, now=0.0, trv_ok=False)
+    state = _down(state, now=120.0, trv_ok=False)
+    assert state.mode == ControlMode.HOLD
+
+
+def test_upgrade_requires_sustained_recovery():
+    """The ladder climbs back only after up_stability_s of recovery."""
+    state = ControlModeState(mode=ControlMode.SENSOR_FALLBACK, degraded_since=0.0)
+    state = _up(state, now=1000.0)
+    assert state.mode == ControlMode.SENSOR_FALLBACK  # stability window running
+    state = _up(state, now=1200.0)
+    assert state.mode == ControlMode.SENSOR_FALLBACK
+    state = _up(state, now=1300.0)
+    assert state.mode == ControlMode.OPTIMAL
+    assert state.degraded_since is None
+
+
+def test_flap_during_recovery_restarts_the_window():
+    """A relapse during the stability window restarts the upgrade clock."""
+    state = ControlModeState(mode=ControlMode.SENSOR_FALLBACK, degraded_since=0.0)
+    state = _up(state, now=1000.0)
+    state = _down(state, now=1100.0)  # relapse
+    state = _up(state, now=1150.0)
+    state = _up(state, now=1400.0)
+    assert state.mode == ControlMode.SENSOR_FALLBACK
+    state = _up(state, now=1450.0)
+    assert state.mode == ControlMode.OPTIMAL
+
+
+def test_hold_recovers_stepwise_to_fallback():
+    """From HOLD, regained TRV temperature climbs to SENSOR_FALLBACK."""
+    state = ControlModeState(mode=ControlMode.HOLD, degraded_since=0.0)
+    state = _down(state, now=1000.0, trv_ok=True)  # room still dead, TRV back
+    state = _down(state, now=1300.0, trv_ok=True)
+    assert state.mode == ControlMode.SENSOR_FALLBACK
+
+
+def test_degraded_since_survives_rung_changes():
+    """The first degradation timestamp survives moving between rungs."""
+    state = ControlModeState(mode=ControlMode.SENSOR_FALLBACK, degraded_since=50.0)
+    state = _down(state, now=1000.0, trv_ok=False)
+    state = _down(state, now=1120.0, trv_ok=False)
+    assert state.mode == ControlMode.HOLD
+    assert state.degraded_since == 50.0

--- a/tests/unit/test_fsm_lifecycle.py
+++ b/tests/unit/test_fsm_lifecycle.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from custom_components.better_thermostat.core.fsm.lifecycle import (
     LifecyclePhase,
     LifecycleState,
+    extend_grace,
     startup_finished,
     stop,
     tick,
@@ -57,7 +58,6 @@ def test_stop_is_terminal():
 
 def test_extend_grace_updates_the_deadline_while_starting():
     """extend_grace sets the annunciation deadline in STARTING."""
-    from custom_components.better_thermostat.core.fsm.lifecycle import extend_grace
 
     state = startup_finished(LifecycleState())
     assert state.grace_until is None
@@ -68,7 +68,6 @@ def test_extend_grace_updates_the_deadline_while_starting():
 
 def test_extend_grace_is_a_noop_outside_starting():
     """extend_grace leaves other phases untouched."""
-    from custom_components.better_thermostat.core.fsm.lifecycle import extend_grace
 
     running = LifecycleState(phase=LifecyclePhase.RUNNING)
     assert extend_grace(running, GRACE_END) == running

--- a/tests/unit/test_fsm_lifecycle.py
+++ b/tests/unit/test_fsm_lifecycle.py
@@ -1,0 +1,76 @@
+"""Pure tests for the lifecycle FSM (startup, grace, running, stopping)."""
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.better_thermostat.core.fsm.lifecycle import (
+    LifecyclePhase,
+    LifecycleState,
+    startup_finished,
+    stop,
+    tick,
+)
+
+NOW = datetime(2026, 1, 10, 6, 0, tzinfo=UTC)
+GRACE_END = NOW + timedelta(minutes=15)
+
+
+def test_initial_state_is_initialising():
+    """A fresh region is INITIALISING with startup running and in grace."""
+    state = LifecycleState()
+    assert state.phase == LifecyclePhase.INITIALISING
+    assert state.startup_running is True
+    # Grace only counts once a deadline is set after startup.
+    assert state.in_grace(NOW) is False
+
+
+def test_startup_finished_enters_grace():
+    """Finishing startup moves to STARTING with the grace deadline."""
+    state = startup_finished(LifecycleState(), grace_until=GRACE_END)
+    assert state.phase == LifecyclePhase.STARTING
+    assert state.startup_running is False
+    assert state.in_grace(NOW) is True
+    assert state.in_grace(GRACE_END) is False
+
+
+def test_startup_finished_is_idempotent_after_starting():
+    """A second startup_finished does not reset a later phase."""
+    state = startup_finished(LifecycleState(), grace_until=GRACE_END)
+    running = tick(state, GRACE_END)
+    assert startup_finished(running, grace_until=GRACE_END) == running
+
+
+def test_tick_promotes_to_running_after_grace():
+    """The grace window expiring promotes STARTING to RUNNING."""
+    state = startup_finished(LifecycleState(), grace_until=GRACE_END)
+    assert tick(state, NOW) == state
+    promoted = tick(state, GRACE_END)
+    assert promoted.phase == LifecyclePhase.RUNNING
+    assert promoted.in_grace(GRACE_END) is False
+
+
+def test_stop_is_terminal():
+    """stop() moves any phase to STOPPING."""
+    assert stop(LifecycleState()).phase == LifecyclePhase.STOPPING
+    running = LifecycleState(phase=LifecyclePhase.RUNNING)
+    assert stop(running).phase == LifecyclePhase.STOPPING
+
+
+def test_extend_grace_updates_the_deadline_while_starting():
+    """extend_grace sets the annunciation deadline in STARTING."""
+    from custom_components.better_thermostat.core.fsm.lifecycle import extend_grace
+
+    state = startup_finished(LifecycleState())
+    assert state.grace_until is None
+    state = extend_grace(state, GRACE_END)
+    assert state.phase == LifecyclePhase.STARTING
+    assert state.grace_until == GRACE_END
+
+
+def test_extend_grace_is_a_noop_outside_starting():
+    """extend_grace leaves other phases untouched."""
+    from custom_components.better_thermostat.core.fsm.lifecycle import extend_grace
+
+    running = LifecycleState(phase=LifecyclePhase.RUNNING)
+    assert extend_grace(running, GRACE_END) == running
+    stopped = stop(LifecycleState())
+    assert extend_grace(stopped, GRACE_END) == stopped

--- a/tests/unit/test_fsm_maintenance.py
+++ b/tests/unit/test_fsm_maintenance.py
@@ -1,0 +1,125 @@
+"""Pure tests for the maintenance FSM (schedule, run guard, liveness)."""
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.better_thermostat.core.fsm.maintenance import (
+    MaintenancePhase,
+    MaintenanceState,
+    evaluate_tick,
+    finish_run,
+    start_run,
+)
+
+NOW = datetime(2026, 1, 10, 3, 0, tzinfo=UTC)
+
+
+def test_initial_state_idle_not_blocking():
+    """A fresh region is idle and never blocks control."""
+    state = MaintenanceState()
+    assert state.phase == MaintenancePhase.IDLE
+    assert state.is_blocking(now_monotonic=0.0) is False
+
+
+def test_not_due_stays_idle():
+    """Before the schedule, ticks change nothing."""
+    state = MaintenanceState(next_due=NOW + timedelta(hours=2))
+    out = evaluate_tick(
+        state, NOW, window_open=False, hvac_off=False, has_enabled_trvs=True
+    )
+    assert out == state
+
+
+def test_due_arms_the_region():
+    """A due schedule moves the region to DUE."""
+    state = MaintenanceState(next_due=NOW - timedelta(minutes=1))
+    out = evaluate_tick(
+        state, NOW, window_open=False, hvac_off=False, has_enabled_trvs=True
+    )
+    assert out.phase == MaintenancePhase.DUE
+
+
+def test_window_open_postpones_an_hour():
+    """An open window postpones by one hour instead of arming."""
+    state = MaintenanceState(next_due=NOW - timedelta(minutes=1))
+    out = evaluate_tick(
+        state, NOW, window_open=True, hvac_off=False, has_enabled_trvs=True
+    )
+    assert out.phase == MaintenancePhase.IDLE
+    assert out.next_due == NOW + timedelta(hours=1)
+
+
+def test_hvac_off_postpones_an_hour():
+    """OFF mode postpones by one hour instead of arming."""
+    out = evaluate_tick(
+        MaintenanceState(), NOW, window_open=False, hvac_off=True, has_enabled_trvs=True
+    )
+    assert out.phase == MaintenancePhase.IDLE
+    assert out.next_due == NOW + timedelta(hours=1)
+
+
+def test_no_enabled_trvs_schedules_a_week_out():
+    """Without maintenance-enabled TRVs the next check moves a week out."""
+    out = evaluate_tick(
+        MaintenanceState(),
+        NOW,
+        window_open=False,
+        hvac_off=False,
+        has_enabled_trvs=False,
+    )
+    assert out.phase == MaintenancePhase.IDLE
+    assert out.next_due == NOW + timedelta(days=7)
+
+
+def test_start_requires_due():
+    """start_run is a no-op unless the region is armed."""
+    idle = MaintenanceState()
+    assert start_run(idle, now_monotonic=100.0) == idle
+
+    due = MaintenanceState(phase=MaintenancePhase.DUE)
+    running = start_run(due, now_monotonic=100.0)
+    assert running.phase == MaintenancePhase.RUNNING
+    assert running.running_since == 100.0
+    assert running.is_blocking(now_monotonic=150.0) is True
+
+
+def test_no_double_start():
+    """A RUNNING region cannot be started again."""
+    running = start_run(MaintenanceState(phase=MaintenancePhase.DUE), 100.0)
+    assert start_run(running, 200.0) == running
+
+
+def test_finish_always_returns_to_idle():
+    """finish_run unconditionally reschedules and idles the region."""
+    running = start_run(MaintenanceState(phase=MaintenancePhase.DUE), 100.0)
+    out = finish_run(running, next_due=NOW + timedelta(days=14))
+    assert out.phase == MaintenancePhase.IDLE
+    assert out.next_due == NOW + timedelta(days=14)
+    assert out.is_blocking(now_monotonic=999.0) is False
+
+
+def test_running_cannot_block_forever():
+    """Invariant: a stale RUNNING phase stops blocking after max_run_s."""
+    running = start_run(MaintenanceState(phase=MaintenancePhase.DUE), 100.0)
+    assert running.is_blocking(now_monotonic=100.0 + 3599.0) is True
+    assert running.is_blocking(now_monotonic=100.0 + 3600.0) is False
+
+
+def test_running_without_timestamp_blocks():
+    """A RUNNING phase without a start timestamp is treated as blocking."""
+    state = MaintenanceState(phase=MaintenancePhase.RUNNING, running_since=None)
+    assert state.is_blocking(now_monotonic=99_999.0) is True
+
+
+def test_tick_leaves_non_idle_phases_alone():
+    """evaluate_tick never advances a DUE or RUNNING region."""
+    due = MaintenanceState(phase=MaintenancePhase.DUE)
+    out = evaluate_tick(
+        due, NOW, window_open=True, hvac_off=True, has_enabled_trvs=False
+    )
+    assert out == due
+
+    running = start_run(MaintenanceState(phase=MaintenancePhase.DUE), 100.0)
+    out = evaluate_tick(
+        running, NOW, window_open=False, hvac_off=False, has_enabled_trvs=True
+    )
+    assert out == running

--- a/tests/unit/test_fsm_mode.py
+++ b/tests/unit/test_fsm_mode.py
@@ -1,0 +1,50 @@
+"""Pure tests for the mode FSM (validated hvac mode x preset)."""
+
+from custom_components.better_thermostat.core.fsm.mode import (
+    ModeState,
+    set_hvac_mode,
+    set_preset,
+)
+from custom_components.better_thermostat.core.snapshot import HvacMode
+
+
+def test_initial_state():
+    """A fresh region is OFF without preset."""
+    state = ModeState()
+    assert state.hvac_mode == HvacMode.OFF
+    assert state.preset is None
+
+
+def test_set_known_modes():
+    """Known mode strings (and HA's string enums) are accepted."""
+    state = set_hvac_mode(ModeState(), "heat")
+    assert state.hvac_mode == HvacMode.HEAT
+    state = set_hvac_mode(state, "heat_cool")
+    assert state.hvac_mode == HvacMode.HEAT_COOL
+    state = set_hvac_mode(state, "off")
+    assert state.hvac_mode == HvacMode.OFF
+
+
+def test_invalid_mode_is_ignored():
+    """Unknown or missing modes leave the region unchanged."""
+    state = set_hvac_mode(ModeState(), "heat")
+    assert set_hvac_mode(state, "bogus") == state
+    assert set_hvac_mode(state, None) == state
+
+
+def test_preset_axis_is_orthogonal():
+    """Setting a preset keeps the mode; setting the mode keeps the preset."""
+    state = set_hvac_mode(ModeState(), "heat")
+    state = set_preset(state, "eco")
+    assert state.hvac_mode == HvacMode.HEAT
+    assert state.preset == "eco"
+    state = set_hvac_mode(state, "off")
+    assert state.preset == "eco"
+
+
+def test_preset_none_clears():
+    """PRESET_NONE and empty values clear the preset."""
+    state = set_preset(ModeState(), "boost")
+    assert set_preset(state, "none").preset is None
+    assert set_preset(state, "").preset is None
+    assert set_preset(state, None).preset is None

--- a/tests/unit/test_fsm_reachability.py
+++ b/tests/unit/test_fsm_reachability.py
@@ -1,6 +1,7 @@
 """Pure tests for the per-TRV reachability FSM (offline record + backoff)."""
 
 from custom_components.better_thermostat.core.fsm.reachability import (
+    RETRY_MAX_S,
     ReachabilityState,
     step,
 )
@@ -33,9 +34,12 @@ def test_retry_backoff_doubles_up_to_cap():
     state = step(state, reported_available=False, now=90.0)
     assert state.retry_at == 90.0 + 120.0
     for _ in range(10):
-        state = step(state, reported_available=False, now=state.retry_at)
-    assert state.retry_at - state.offline_since <= 10_000
-    assert state.retry_at is not None
+        assert state.retry_at is not None
+        now = state.retry_at
+        state = step(state, reported_available=False, now=now)
+        assert state.retry_at is not None
+        # Each retry interval is capped at RETRY_MAX_S, even after saturation.
+        assert state.retry_at - now <= RETRY_MAX_S
 
 
 def test_observation_before_retry_window_changes_nothing():

--- a/tests/unit/test_fsm_reachability.py
+++ b/tests/unit/test_fsm_reachability.py
@@ -1,0 +1,51 @@
+"""Pure tests for the per-TRV reachability FSM (offline record + backoff)."""
+
+from custom_components.better_thermostat.core.fsm.reachability import (
+    ReachabilityState,
+    step,
+)
+
+
+def test_initial_state_is_online():
+    """A fresh region is online with no retry schedule."""
+    state = ReachabilityState()
+    assert state.online is True
+    assert state.offline_since is None
+    assert state.retry_at is None
+
+
+def test_going_offline_records_since_and_schedules_retry():
+    """The first unavailable observation records the time and first retry."""
+    state = step(ReachabilityState(), reported_available=False, now=100.0)
+    assert state.online is False
+    assert state.offline_since == 100.0
+    assert state.retry_count == 0
+    assert state.retry_at == 130.0
+
+
+def test_retry_backoff_doubles_up_to_cap():
+    """Each missed retry doubles the backoff, capped at ten minutes."""
+    state = step(ReachabilityState(), reported_available=False, now=0.0)
+    assert state.retry_at == 30.0
+    state = step(state, reported_available=False, now=30.0)
+    assert state.retry_count == 1
+    assert state.retry_at == 30.0 + 60.0
+    state = step(state, reported_available=False, now=90.0)
+    assert state.retry_at == 90.0 + 120.0
+    for _ in range(10):
+        state = step(state, reported_available=False, now=state.retry_at)
+    assert state.retry_at - state.offline_since <= 10_000
+    assert state.retry_at is not None
+
+
+def test_observation_before_retry_window_changes_nothing():
+    """Offline observations before the retry window leave the state as is."""
+    state = step(ReachabilityState(), reported_available=False, now=100.0)
+    assert step(state, reported_available=False, now=110.0) == state
+
+
+def test_coming_back_online_resets():
+    """An available observation fully resets the region."""
+    state = step(ReachabilityState(), reported_available=False, now=100.0)
+    state = step(state, reported_available=False, now=130.0)
+    assert step(state, reported_available=True, now=200.0) == ReachabilityState()

--- a/tests/unit/test_fsm_sweeps.py
+++ b/tests/unit/test_fsm_sweeps.py
@@ -1,0 +1,343 @@
+"""Exhaustive invariant sweeps over every FSM region.
+
+The per-FSM test files pin individual transitions; these sweeps walk
+the full input cross-product of each region with ``itertools.product``
+and assert the structural invariants that must hold on every single
+combination — the class of bug a hand-picked example test misses.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import itertools
+
+import pytest
+
+from custom_components.better_thermostat.core.fsm import (
+    control_mode as cm,
+    lifecycle as lc,
+    maintenance as mt,
+    mode as md,
+    reachability as rb,
+    window as wd,
+)
+from custom_components.better_thermostat.core.snapshot import HvacMode
+
+NOW = 10_000.0
+NOW_DT = datetime(2026, 1, 2, 8, 30, tzinfo=UTC)
+
+
+def _window_states():
+    """All well-formed region states: only pending phases carry a timestamp."""
+    for phase in wd.WindowPhase:
+        if phase in (wd.WindowPhase.OPENING, wd.WindowPhase.CLOSING):
+            pendings = (NOW - 5.0, NOW - 30.0)
+        else:
+            pendings = (None,)
+        for pending in pendings:
+            yield wd.WindowState(phase=phase, pending_since=pending)
+
+
+class TestWindowSweep:
+    """closed -> opening -> open -> closing with debounce, exhaustively."""
+
+    PARAMS = (
+        wd.WindowParams(),
+        wd.WindowParams(open_delay_s=10.0, close_delay_s=10.0),
+        wd.WindowParams(open_delay_s=60.0, close_delay_s=60.0),
+    )
+
+    @pytest.mark.parametrize(
+        ("state", "sensor_open", "params"),
+        list(itertools.product(_window_states(), (False, True), PARAMS)),
+    )
+    def test_invariants_hold_for_every_combination(self, state, sensor_open, params):
+        """Every step keeps the region structurally sound."""
+        result = wd.step(state, sensor_open, NOW, params)
+
+        # Pending phases always carry their timestamp.
+        if result.phase in (wd.WindowPhase.OPENING, wd.WindowPhase.CLOSING):
+            assert result.pending_since is not None
+        # Committed phases never carry one.
+        if result.phase in (wd.WindowPhase.CLOSED, wd.WindowPhase.OPEN):
+            assert result.pending_since is None
+
+        # effective_open is a pure function of the phase.
+        assert result.effective_open == (
+            result.phase in (wd.WindowPhase.OPEN, wd.WindowPhase.CLOSING)
+        )
+
+        # A pending transition only commits after its full delay.
+        if state.phase == wd.WindowPhase.OPENING and sensor_open:
+            elapsed = NOW - state.pending_since if state.pending_since else None
+            if elapsed is not None and elapsed < params.open_delay_s:
+                assert result.phase == wd.WindowPhase.OPENING
+
+        # Stepping again with the same observation changes nothing.
+        assert wd.step(result, sensor_open, NOW, params) == result
+
+
+class TestLadderSweep:
+    """The fail-soft ladder degrades fast and recovers slowly, exhaustively."""
+
+    PARAMS = cm.LadderParams(down_debounce_s=120.0, up_stability_s=300.0)
+    RUNGS = tuple(cm.ControlMode)
+    # Pending ages: fresh, just below both thresholds, past debounce,
+    # past stability.
+    AGES = (None, NOW - 1.0, NOW - 119.0, NOW - 120.0, NOW - 300.0)
+
+    @pytest.mark.parametrize(
+        ("mode", "down_since", "up_since", "room_ok", "trv_ok"),
+        list(itertools.product(RUNGS, AGES, AGES, (False, True), (False, True))),
+    )
+    def test_invariants_hold_for_every_combination(
+        self, mode, down_since, up_since, room_ok, trv_ok
+    ):
+        """Every step lands on the old rung or the capability target."""
+        state = cm.ControlModeState(
+            mode=mode,
+            down_pending_since=down_since,
+            up_pending_since=up_since,
+            degraded_since=None if mode == cm.ControlMode.OPTIMAL else NOW - 500.0,
+        )
+        target = cm._target_rung(room_ok, trv_ok)
+        result = cm.step_ladder(
+            state,
+            room_sensor_ok=room_ok,
+            trv_temp_ok=trv_ok,
+            now=NOW,
+            params=self.PARAMS,
+        )
+
+        # The rung only ever moves to the capability target.
+        assert result.mode in (mode, target)
+
+        order = (
+            cm.ControlMode.OPTIMAL,
+            cm.ControlMode.SENSOR_FALLBACK,
+            cm.ControlMode.HOLD,
+        )
+        if result.mode != mode:
+            degrading = order.index(target) > order.index(mode)
+            threshold = (
+                self.PARAMS.down_debounce_s if degrading else self.PARAMS.up_stability_s
+            )
+            since = down_since if degrading else up_since
+            # A commit requires the full debounce/stability window.
+            assert since is not None and NOW - since >= threshold
+
+        # Matching capability clears all pending timers.
+        if target == mode:
+            assert result.down_pending_since is None
+            assert result.up_pending_since is None
+
+        # After a commit, degraded_since exactly mirrors the new rung.
+        if result.mode != mode:
+            if result.mode == cm.ControlMode.OPTIMAL:
+                assert result.degraded_since is None
+            else:
+                assert result.degraded_since is not None
+
+
+class TestReachabilitySweep:
+    """Per-TRV online/offline with exponential backoff, exhaustively."""
+
+    STATES = (
+        rb.ReachabilityState(),
+        rb.ReachabilityState(
+            online=False, offline_since=NOW - 10.0, retry_count=0, retry_at=NOW + 20.0
+        ),
+        rb.ReachabilityState(
+            online=False, offline_since=NOW - 600.0, retry_count=3, retry_at=NOW - 1.0
+        ),
+        rb.ReachabilityState(
+            online=False, offline_since=NOW - 9000.0, retry_count=9, retry_at=NOW - 1.0
+        ),
+    )
+
+    @pytest.mark.parametrize(
+        ("state", "reported"), list(itertools.product(STATES, (False, True)))
+    )
+    def test_invariants_hold_for_every_combination(self, state, reported):
+        """Recovery is total, offline bookkeeping is monotone and capped."""
+        result = rb.step(state, reported, NOW)
+
+        if reported:
+            # Any available report fully resets the region.
+            assert result == rb.ReachabilityState()
+            return
+
+        assert result.online is False
+        assert result.offline_since is not None
+        # offline_since is sticky for the whole offline episode.
+        if not state.online:
+            assert result.offline_since == state.offline_since
+        # The retry schedule only moves forward and the backoff is capped.
+        assert result.retry_at is not None
+        assert result.retry_at > NOW - 1.0
+        if result.retry_count != state.retry_count:
+            assert result.retry_at - NOW <= rb.RETRY_MAX_S
+
+    def test_backoff_doubles_and_caps(self):
+        """30 s doubling, hard-capped at 10 min."""
+        delays = [rb._backoff(n) for n in range(8)]
+        assert delays[:5] == [30.0, 60.0, 120.0, 240.0, 480.0]
+        assert all(d == rb.RETRY_MAX_S for d in delays[5:])
+
+
+class TestModeSweep:
+    """The mode region never holds an invalid value, exhaustively."""
+
+    INPUTS = (
+        None,
+        "",
+        "heat",
+        "cool",
+        "off",
+        "heat_cool",
+        "auto",
+        "dry",
+        "fan_only",
+        "HEAT",
+        "banana",
+        " heat ",
+    )
+
+    @pytest.mark.parametrize(
+        ("current", "value"), list(itertools.product(tuple(HvacMode), INPUTS))
+    )
+    def test_hvac_mode_stays_valid(self, current, value):
+        """Unknown inputs leave the state unchanged; known ones apply."""
+        state = md.ModeState(hvac_mode=current, preset="eco")
+        result = md.set_hvac_mode(state, value)
+        assert isinstance(result.hvac_mode, HvacMode)
+        if result.hvac_mode != current:
+            assert value is not None and result.hvac_mode == value.strip().lower()
+        # The preset axis is untouched by the mode axis.
+        assert result.preset == "eco"
+
+    @pytest.mark.parametrize(
+        ("current", "preset"),
+        list(
+            itertools.product(
+                (None, "eco", "boost"), (None, "", "none", "eco", "boost", "away")
+            )
+        ),
+    )
+    def test_preset_clears_or_applies(self, current, preset):
+        """PRESET_NONE and empty values clear; the mode axis is untouched."""
+        state = md.ModeState(hvac_mode=HvacMode.HEAT, preset=current)
+        result = md.set_preset(state, preset)
+        if preset in (None, "", md.PRESET_NONE):
+            assert result.preset is None
+        else:
+            assert result.preset == preset
+        assert result.hvac_mode == HvacMode.HEAT
+
+
+class TestLifecycleSweep:
+    """The lifecycle only ever moves forward, exhaustively."""
+
+    ORDER = (
+        lc.LifecyclePhase.INITIALISING,
+        lc.LifecyclePhase.STARTING,
+        lc.LifecyclePhase.RUNNING,
+        lc.LifecyclePhase.STOPPING,
+    )
+    GRACES = (None, NOW_DT - timedelta(seconds=1), NOW_DT + timedelta(seconds=60))
+
+    @pytest.mark.parametrize(("phase", "grace"), list(itertools.product(ORDER, GRACES)))
+    def test_transitions_never_move_backwards(self, phase, grace):
+        """startup_finished, tick, and stop are monotone in phase order."""
+        state = lc.LifecycleState(phase=phase, grace_until=grace)
+        for result in (
+            lc.startup_finished(state),
+            lc.tick(state, NOW_DT),
+            lc.stop(state),
+        ):
+            assert self.ORDER.index(result.phase) >= self.ORDER.index(phase)
+
+        # Grace only counts while a deadline is set and in the future.
+        assert state.in_grace(NOW_DT) == (grace is not None and NOW_DT < grace)
+        # startup_running is exactly the INITIALISING phase.
+        assert state.startup_running == (phase == lc.LifecyclePhase.INITIALISING)
+
+    def test_tick_promotes_only_after_grace(self):
+        """STARTING holds while in grace and promotes when it lapses."""
+        staying = lc.LifecycleState(
+            phase=lc.LifecyclePhase.STARTING, grace_until=NOW_DT + timedelta(seconds=60)
+        )
+        assert lc.tick(staying, NOW_DT).phase == lc.LifecyclePhase.STARTING
+        lapsed = lc.LifecycleState(
+            phase=lc.LifecyclePhase.STARTING, grace_until=NOW_DT - timedelta(seconds=1)
+        )
+        assert lc.tick(lapsed, NOW_DT).phase == lc.LifecyclePhase.RUNNING
+
+
+class TestMaintenanceSweep:
+    """The maintenance region can never block control forever, exhaustively."""
+
+    DUES = (None, NOW_DT - timedelta(minutes=1), NOW_DT + timedelta(days=1))
+
+    @pytest.mark.parametrize(
+        ("phase", "due", "window_open", "hvac_off", "has_trvs"),
+        list(
+            itertools.product(
+                tuple(mt.MaintenancePhase),
+                (None, NOW_DT - timedelta(minutes=1), NOW_DT + timedelta(days=1)),
+                (False, True),
+                (False, True),
+                (False, True),
+            )
+        ),
+    )
+    def test_evaluate_tick_invariants(
+        self, phase, due, window_open, hvac_off, has_trvs
+    ):
+        """DUE only arms from an unblocked, due, idle schedule."""
+        state = mt.MaintenanceState(
+            phase=phase,
+            next_due=due,
+            running_since=NOW - 5.0 if phase == mt.MaintenancePhase.RUNNING else None,
+        )
+        result = mt.evaluate_tick(
+            state,
+            NOW_DT,
+            window_open=window_open,
+            hvac_off=hvac_off,
+            has_enabled_trvs=has_trvs,
+        )
+
+        # Only the IDLE phase reacts to the scheduler tick.
+        if phase != mt.MaintenancePhase.IDLE:
+            assert result == state
+            return
+        # A future schedule stays untouched.
+        if due is not None and NOW_DT < due:
+            assert result == state
+            return
+        # Blocked or TRV-less ticks postpone instead of arming.
+        if window_open or hvac_off or not has_trvs:
+            assert result.phase == mt.MaintenancePhase.IDLE
+            assert result.next_due is not None and result.next_due > NOW_DT
+        else:
+            assert result.phase == mt.MaintenancePhase.DUE
+
+    @pytest.mark.parametrize("phase", tuple(mt.MaintenancePhase))
+    def test_finish_run_always_returns_to_idle(self, phase):
+        """finish_run is unconditional — RUNNING can never be sticky."""
+        state = mt.MaintenanceState(phase=phase, running_since=NOW)
+        result = mt.finish_run(state, NOW_DT + timedelta(days=5))
+        assert result.phase == mt.MaintenancePhase.IDLE
+        assert result.running_since is None
+
+    def test_overrunning_maintenance_stops_blocking(self):
+        """A RUNNING phase past MAX_RUN_S is dead and no longer blocks."""
+        state = mt.MaintenanceState(
+            phase=mt.MaintenancePhase.RUNNING, running_since=NOW - mt.MAX_RUN_S
+        )
+        assert state.is_blocking(NOW) is False
+        fresh = mt.MaintenanceState(
+            phase=mt.MaintenancePhase.RUNNING, running_since=NOW - 10.0
+        )
+        assert fresh.is_blocking(NOW) is True

--- a/tests/unit/test_fsm_window.py
+++ b/tests/unit/test_fsm_window.py
@@ -1,0 +1,77 @@
+"""Pure tests for the window FSM (debounced open/close transitions)."""
+
+from custom_components.better_thermostat.core.fsm.window import (
+    WindowParams,
+    WindowPhase,
+    WindowState,
+    step,
+)
+
+P = WindowParams(open_delay_s=10.0, close_delay_s=30.0)
+
+
+def test_initial_state_is_closed():
+    """A fresh region starts closed and not effectively open."""
+    state = WindowState()
+    assert state.phase == WindowPhase.CLOSED
+    assert state.effective_open is False
+
+
+def test_open_commits_only_after_delay():
+    """An open reading enters OPENING and commits after open_delay_s."""
+    state = step(WindowState(), sensor_open=True, now=100.0, params=P)
+    assert state.phase == WindowPhase.OPENING
+    assert state.effective_open is False
+
+    state = step(state, sensor_open=True, now=105.0, params=P)
+    assert state.phase == WindowPhase.OPENING
+
+    state = step(state, sensor_open=True, now=110.0, params=P)
+    assert state.phase == WindowPhase.OPEN
+    assert state.effective_open is True
+
+
+def test_open_false_positive_cancels():
+    """Closing again before the delay returns to CLOSED without opening."""
+    state = step(WindowState(), sensor_open=True, now=100.0, params=P)
+    state = step(state, sensor_open=False, now=104.0, params=P)
+    assert state.phase == WindowPhase.CLOSED
+    assert state.effective_open is False
+
+
+def test_close_commits_only_after_delay():
+    """A close reading enters CLOSING; control still sees the window open."""
+    state = WindowState(phase=WindowPhase.OPEN)
+    state = step(state, sensor_open=False, now=200.0, params=P)
+    assert state.phase == WindowPhase.CLOSING
+    assert state.effective_open is True
+
+    state = step(state, sensor_open=False, now=230.0, params=P)
+    assert state.phase == WindowPhase.CLOSED
+    assert state.effective_open is False
+
+
+def test_close_false_positive_cancels():
+    """Reopening during CLOSING returns to OPEN."""
+    state = WindowState(phase=WindowPhase.OPEN)
+    state = step(state, sensor_open=False, now=200.0, params=P)
+    state = step(state, sensor_open=True, now=210.0, params=P)
+    assert state.phase == WindowPhase.OPEN
+    assert state.effective_open is True
+
+
+def test_zero_delay_commits_immediately():
+    """With zero delays a change commits in the same step."""
+    fast = WindowParams()
+    state = step(WindowState(), sensor_open=True, now=1.0, params=fast)
+    assert state.phase == WindowPhase.OPEN
+    state = step(state, sensor_open=False, now=2.0, params=fast)
+    assert state.phase == WindowPhase.CLOSED
+
+
+def test_steady_inputs_are_idempotent():
+    """Repeating the committed reading does not change the state."""
+    state = WindowState(phase=WindowPhase.OPEN)
+    assert step(state, sensor_open=True, now=500.0, params=P) == state
+    closed = WindowState()
+    assert step(closed, sensor_open=False, now=500.0, params=P) == closed


### PR DESCRIPTION
Adds the six orthogonal control regions as HA-free FSMs under `core/fsm/`:

- `window.py` — closed → opening → open → closing debounce on monotonic timestamps
- `maintenance.py` — maintenance window with a liveness bound
- `lifecycle.py` — startup / running gate
- `mode.py` — validated mode region
- `control_mode.py` — control-mode / fail-soft ladder annunciation
- `reachability.py` — per-TRV reachability

Regions gate; controllers compute. Each ships with unit tests and full state-sweep coverage.

### Verification
- `pytest`: 2149 unit + 4 integration pass.
- `ruff` and `pyrefly check` (strict on `core/`): clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a set of finite-state-machine regions for more reliable thermostat behavior, including fail-soft control mode with degradation/recovery, lifecycle startup/grace handling, debounced window detection, improved reachability tracking with retry backoff, and scheduled maintenance runs.
* **Tests**
  * Added unit tests for each new state machine region and added invariant sweep coverage to validate timing, stability (debouncing/hysteresis), and recovery behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->