### PR TITLE
chore(lint): enforce numpy docstring arg coverage and relax tests

### DIFF
--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -535,6 +535,8 @@ def calculate_calibration_local(self, entity_id) -> float | None:
     ----------
     self :
             self instance of better_thermostat
+    entity_id :
+            entity id of the TRV to calibrate
 
     Returns
     -------
@@ -880,6 +882,8 @@ def calculate_calibration_setpoint(self, entity_id) -> float | None:
     ----------
     self :
             self instance of better_thermostat
+    entity_id :
+            entity id of the TRV to calibrate
 
     Returns
     -------

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -365,7 +365,44 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         Parameters
         ----------
-        TODO
+        name : str
+            Display name of the thermostat.
+        heater_entity_id : str | list[str]
+            TRV (heater) entity id(s) controlled by this thermostat.
+        sensor_entity_id : str | None
+            External temperature sensor entity id.
+        humidity_sensor_entity_id : str | None
+            External humidity sensor entity id.
+        window_id : str | None
+            Window/door contact sensor entity id for open-window detection.
+        window_delay : int
+            Delay in seconds before reacting to a window opening.
+        window_delay_after : int
+            Delay in seconds before reacting to a window closing.
+        weather_entity : str | None
+            Weather entity used as outdoor temperature source.
+        outdoor_sensor : str | None
+            Outdoor temperature sensor entity id.
+        off_temperature : float | None
+            Outdoor temperature above which heating is switched off.
+        tolerance : float
+            Temperature hysteresis in degrees.
+        target_temp_step : str | float | None
+            Step size for target temperature adjustments.
+        model : str
+            Detected TRV model identifier.
+        cooler_entity_id : str | None
+            Cooler entity id.
+        enabled_presets : list[str]
+            Presets enabled for this thermostat.
+        unit : str
+            Temperature unit reported by the entity.
+        unique_id : str
+            Unique id of the config entry.
+        device_class : str | None
+            Device class of the climate entity.
+        state_class : str | None
+            State class of the climate entity.
         """
         self.device_name = name
         self.model = model

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -367,8 +367,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         ----------
         name : str
             Display name of the thermostat.
-        heater_entity_id : str | list[str]
-            TRV (heater) entity id(s) controlled by this thermostat.
+        heater_entity_id : list[dict]
+            TRV configuration entries controlled by this thermostat.
         sensor_entity_id : str | None
             External temperature sensor entity id.
         humidity_sensor_entity_id : str | None

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -405,6 +405,8 @@ def convert_inbound_states(self, entity_id, state: State) -> str | None:
     ----------
     self :
         self instance of better_thermostat
+    entity_id :
+        entity id of the TRV whose state is being converted
     state : State
         Inbound thermostat state, which will be modified
 

--- a/custom_components/better_thermostat/model_fixes/BHT-002-GCLZB.py
+++ b/custom_components/better_thermostat/model_fixes/BHT-002-GCLZB.py
@@ -19,6 +19,8 @@ def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> 
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV the offset belongs to.
     offset : float
@@ -44,6 +46,8 @@ def fix_target_temperature_calibration(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV whose setpoint is calibrated.
     temperature : float
@@ -64,6 +68,8 @@ async def override_set_hvac_mode(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV.
     hvac_mode : str
@@ -84,6 +90,8 @@ async def override_set_temperature(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV.
     temperature : float

--- a/custom_components/better_thermostat/model_fixes/COZB0001.py
+++ b/custom_components/better_thermostat/model_fixes/COZB0001.py
@@ -19,6 +19,8 @@ def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> 
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV the offset belongs to.
     offset : float
@@ -39,6 +41,8 @@ def fix_target_temperature_calibration(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV whose setpoint is calibrated.
     temperature : float
@@ -62,6 +66,8 @@ async def override_set_hvac_mode(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV.
     hvac_mode : str
@@ -85,6 +91,8 @@ async def override_set_temperature(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV.
     temperature : float

--- a/custom_components/better_thermostat/model_fixes/ME167.py
+++ b/custom_components/better_thermostat/model_fixes/ME167.py
@@ -19,6 +19,8 @@ def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> 
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV the offset belongs to.
     offset : float
@@ -39,6 +41,8 @@ def fix_target_temperature_calibration(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV whose setpoint is calibrated.
     temperature : float
@@ -62,6 +66,8 @@ async def override_set_hvac_mode(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV.
     hvac_mode : str
@@ -85,6 +91,8 @@ async def override_set_temperature(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV.
     temperature : float

--- a/custom_components/better_thermostat/model_fixes/SEA801-Zigbee_SEA802-Zigbee.py
+++ b/custom_components/better_thermostat/model_fixes/SEA801-Zigbee_SEA802-Zigbee.py
@@ -22,6 +22,8 @@ def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> 
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV the offset belongs to.
     offset : float
@@ -55,6 +57,8 @@ def fix_target_temperature_calibration(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV whose setpoint is calibrated.
     temperature : float
@@ -98,6 +102,8 @@ async def override_set_hvac_mode(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV.
     hvac_mode : str
@@ -121,6 +127,8 @@ async def override_set_temperature(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV.
     temperature : float

--- a/custom_components/better_thermostat/model_fixes/TS0601.py
+++ b/custom_components/better_thermostat/model_fixes/TS0601.py
@@ -14,6 +14,8 @@ def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> 
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV the offset belongs to.
     offset : float
@@ -45,6 +47,8 @@ def fix_target_temperature_calibration(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV whose setpoint is calibrated.
     temperature : float
@@ -78,6 +82,8 @@ async def override_set_hvac_mode(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV.
     hvac_mode : str
@@ -98,6 +104,8 @@ async def override_set_temperature(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV.
     temperature : float

--- a/custom_components/better_thermostat/model_fixes/TS0601_thermostat.py
+++ b/custom_components/better_thermostat/model_fixes/TS0601_thermostat.py
@@ -12,6 +12,8 @@ def fix_local_calibration(self: ModelFixHost, entity_id: str, offset: float) -> 
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV the offset belongs to.
     offset : float
@@ -40,6 +42,8 @@ def fix_target_temperature_calibration(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV whose setpoint is calibrated.
     temperature : float
@@ -73,6 +77,8 @@ async def override_set_hvac_mode(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV.
     hvac_mode : str
@@ -93,6 +99,8 @@ async def override_set_temperature(
 
     Parameters
     ----------
+    self : ModelFixHost
+        Better Thermostat host providing device state and HA access.
     entity_id : str
         Entity id of the TRV.
     temperature : float

--- a/custom_components/better_thermostat/sensor.py
+++ b/custom_components/better_thermostat/sensor.py
@@ -90,6 +90,12 @@ async def _setup_algorithm_sensors(
 
     Parameters
     ----------
+    hass : HomeAssistant
+        Home Assistant instance.
+    entry : ConfigEntry
+        Config entry the sensors belong to.
+    bt_climate : BetterThermostat
+        Better Thermostat climate entity the sensors report on.
     algorithms_to_create : set | None
         When provided, only sensors for these algorithms are created.
         When ``None`` (initial setup), all active algorithms are created.

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -144,7 +144,9 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str:
     Parameters
     ----------
     self :
-            FIXME
+            self instance of better_thermostat
+    entity_id :
+            entity id of the TRV whose mode is being remapped
     hvac_mode : str
             HVAC mode to be remapped
 
@@ -768,9 +770,12 @@ async def _find_lowest_battery_in_group(self, member_ids, visited=None):
 
     Parameters
     ----------
-    self : BetterThermostat instance
-    member_ids : list of entity_id strings
-    visited : set of already visited entity_ids to prevent infinite recursion
+    self :
+        BetterThermostat instance
+    member_ids :
+        list of entity_id strings to search
+    visited :
+        set of already visited entity_ids to prevent infinite recursion
 
     Returns
     -------
@@ -837,6 +842,8 @@ async def find_local_calibration_entity(self, entity_id):
     ----------
     self :
             self instance of better_thermostat
+    entity_id :
+            entity id of the TRV to find the local calibration entity for
 
     Returns
     -------
@@ -904,6 +911,8 @@ async def get_trv_intigration(self, entity_id):
     ----------
     self :
             self instance of better_thermostat
+    entity_id :
+            entity id of the TRV to look up
 
     Returns
     -------

--- a/custom_components/better_thermostat/utils/migrate_v0_stores.py
+++ b/custom_components/better_thermostat/utils/migrate_v0_stores.py
@@ -52,8 +52,14 @@ def _import_legacy_data(
     ----------
     state_mgr:
         The StateManager to populate.
-    mpc_data / pid_data / tpi_data:
-        Key → raw-dict mappings loaded from the respective legacy stores,
+    mpc_data:
+        Key → raw-dict mapping loaded from the legacy MPC store,
+        already filtered to the current entity prefix.
+    pid_data:
+        Key → raw-dict mapping loaded from the legacy PID store,
+        already filtered to the current entity prefix.
+    tpi_data:
+        Key → raw-dict mapping loaded from the legacy TPI store,
         already filtered to the current entity prefix.
     thermal_data:
         Raw dict for the thermal stats entry of this config entry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ select = [
     "W",      # pycodestyle warnings
     "UP",     # pyupgrade
     "D",      # pydocstyle (docstrings)
+    "D417",   # Require documented args to match the signature (numpy convention disables this by default)
     "C4",     # flake8-comprehensions
     "PL",     # pylint
     "RUF100", # unused noqa directives
@@ -55,8 +56,6 @@ ignore = [
     "D100",   # Missing docstring in public module
     "D104",   # Missing docstring in public package
     "D202",   # No blank lines allowed after function docstring
-    "D203",   # 1 blank line required before class docstring (conflicts with D211)
-    "D213",   # Multi-line docstring summary should start at the second line (conflicts with D212)
     "PLR2004", # Magic value comparison
     "PLR0915", # Too many statements
     "PLR0912", # Too many branches
@@ -67,6 +66,10 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.ruff.lint.per-file-ignores]
+# Test code does not need docstrings on every function/class/method.
+"tests/**" = ["D"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["custom_components.better_thermostat", "tests"]


### PR DESCRIPTION
## Why

The pydocstyle config sets `convention = "numpy"`, but the numpy convention *disables* `D417` (argument-description coverage). That left the `Parameters` sections unvalidated — a docstring could document the wrong argument names, or none at all, and still pass. So the config enforced that *a* docstring exists, never that its numpy sections were correct. Meanwhile docstrings were forced on every test function, which is largely boilerplate.

## What

- **Enable `D417`** (`select`) so documented parameters must match the signature. `numpy` now validates the sections it advertises.
- **Complete the `Parameters` sections** `D417` surfaces across the package: `climate.__init__` (placeholder `TODO`), the calibration helpers, `trv`/`helpers` lookups, `sensor` setup, the legacy-store import, and the `model_fixes` overrides (the `self: ModelFixHost` host parameter).
- **Stop forcing docstrings on test code** via `per-file-ignores` for `tests/**`. Existing test docstrings remain allowed.
- **Drop the redundant `D203`/`D213` ignores** — the numpy convention already disables both, and the inline comments misattributed the reason.

## Verification

- `ruff check custom_components/ tests/` → clean
- `ruff format --check` → clean
- Source-only docstring edits; no signature or behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced parameter documentation across the codebase by adding missing docstring descriptions for function parameters, improving code clarity and IDE support.

* **Chores**
  * Updated linting configuration to enforce comprehensive parameter documentation in docstrings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->