### PR TITLE
arch 05: developer handbook for the core/shell architecture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,10 @@ decide(snapshot, state) -> (desired, state')
 - `desired.py` — `DesiredState` / `TrvDesired`: the intent per TRV
   (mode, setpoint, valve percent, offset). Intent, not commands.
 - `decide.py` — the precedence cascade: lifecycle gate → mode OFF →
-  open window → reachability → call-for-heat → heating. `decide()` never
-  mutates its input state; it returns a successor state.
+  open window → call-for-heat → heating. Reachability is an address
+  filter applied across it (unreachable TRVs are dropped from the
+  commanded set), not a cascade tier. `decide()` never mutates its input
+  state; it returns a successor state.
 - `fsm/` — one small state machine per concern (*region*): `window`
   (debounced open/closed), `maintenance` (valve exercise with a liveness
   bound), `lifecycle` (startup/running/stopped), `mode`, `control_mode`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,86 @@ document in a pull request.
 - Test BT in a specific HA version -> Run "Install a specific version of Home Assistant" in Task Runner and the version you want to test in the terminal prompt.
 - Test BT with the latest HA version -> Run "upgrade Home Assistant to latest dev" in Task Runner
 
+## Architecture
+
+Better Thermostat separates a pure decision core from an imperative shell.
+The core computes *what* every TRV should do; the shell observes Home
+Assistant and performs the device writes.
+
+### The core (`custom_components/better_thermostat/core/`)
+
+The core imports no Home Assistant code, performs no IO, and reads no
+clocks — time arrives inside its inputs. Its heart is one function:
+
+```
+decide(snapshot, state) -> (desired, state')
+```
+
+- `snapshot.py` — `WorldSnapshot`: the immutable observation of one control
+  cycle (temperatures, modes, environment, per-TRV reported state).
+- `desired.py` — `DesiredState` / `TrvDesired`: the intent per TRV
+  (mode, setpoint, valve percent, offset). Intent, not commands.
+- `decide.py` — the precedence cascade: lifecycle gate → mode OFF →
+  open window → reachability → call-for-heat → heating. `decide()` never
+  mutates its input state; it returns a successor state.
+- `fsm/` — one small state machine per concern (*region*): `window`
+  (debounced open/closed), `maintenance` (valve exercise with a liveness
+  bound), `lifecycle` (startup/running/stopped), `mode`, `control_mode`
+  (the fail-soft ladder OPTIMAL → SENSOR_FALLBACK → HOLD), `reachability`
+  (per-TRV online/offline with retry backoff). Regions gate; controllers
+  compute. Regions never read each other's internals.
+- `safety.py` — the safety hull: clamps every outgoing setpoint, offset,
+  and valve percentage to device limits and the frost floor. Every device
+  write passes through it.
+- `watchdog.py` — detects a silently stalled control loop.
+- `recorder.py` — the flight recorder: a bounded ring of
+  (snapshot, pre-decide state, desired) tuples. Exported in the HA
+  diagnostics download; `replay()` re-runs an exported tuple through the
+  kernel deterministically.
+- `clock.py` — the `Clock` protocol plus a deterministic `FakeClock` for
+  tests and replay.
+- `calibrator.py` — the contract calibration strategies implement
+  (capabilities, health).
+
+### The shell
+
+- `utils/snapshot.py` — `build_snapshot()`: the single seam that flattens
+  entity attributes and HA states into a `WorldSnapshot`.
+- `utils/controlling.py` — `compute_control_cycle()` (one observation and
+  decision per cycle, recorded once), `control_trv()` (translates intent
+  into adapter calls), the per-TRV/per-channel write budget (minimum
+  spacing between non-safety writes), and `reconcile_tick()` (periodic:
+  re-converges devices whose reported state diverged from the intent).
+- `utils/scheduler.py` — `request_control_cycle()`: the only way to ask
+  for a control cycle; requests coalesce.
+- `climate.py` — the entity: HA lifecycle, event listeners, persistence
+  (via `utils/state_manager.py`), and the kernel state it threads through
+  the cycles.
+
+### Control cycles: pulled, not polled
+
+A control cycle is one pass of `build_snapshot() → decide() → apply`.
+The snapshot is not a maintained cache — it is built fresh per cycle,
+so a decision always sees one coherent world; reactivity comes from
+events, user actions, and the five-minute ticks each *requesting* a
+cycle (requests coalesce). A cycle writes only differences;
+safety-relevant writes go out immediately, everything else is spaced by
+the 30-second per-channel write budget. The full trigger and write
+model, the regions, the fail-soft ladder, and the test strategy are
+documented in depth under [docs/internals/](docs/internals/architecture.md)
+(published at better-thermostat.org under *Internals*).
+
+### Where new logic goes
+
+A new rule about *what should happen* (a gate, a precedence, a mode)
+belongs in the core: extend `decide()` or a region, with pure unit tests.
+New *device interaction* belongs in the shell behind the existing
+boundaries — writes go through the safety hull and the write budget, and
+cycles are requested through the scheduler. The shell applies intent; it
+does not second-guess the kernel after `decide()` ran.
+
+Run the test suite with `pytest tests/`.
+
 ## How Can I Contribute?
 
 ## New Adapter

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Assistant and performs the device writes.
 The core imports no Home Assistant code, performs no IO, and reads no
 clocks — time arrives inside its inputs. Its heart is one function:
 
-```
+```text
 decide(snapshot, state) -> (desired, state')
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This integration brings some smartness to your connected radiator thermostats se
 - Dynamic preset temperature learning & persistence (baseline/"no preset" remembers the last temperature you set and survives restarts)
 - **Advanced Control Algorithms**: Choose between MPC, PID, TPI, AI Time Based or simple target temperature matching for precise control.
 - **Selectable Presets**: Configure which preset modes are available for your thermostat during setup.
-- **Fail-soft and observable**: keeps controlling when sensors drop out (graceful degradation with repair issues), spaces radio writes to protect TRV batteries, and ships a flight recorder in the diagnostics download for bug reports.
+- **Fail-soft and observable**: keeps controlling while a usable temperature source remains (a dead room sensor falls back to the TRV-internal mean) and drops to HOLD — last commanded state with the frost floor, no new setpoints — when none is left, all surfaced as repair issues; spaces radio writes to protect TRV batteries, and ships a flight recorder in the diagnostics download for bug reports.
 
 ### Advanced Control Algorithms
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ We've created a companion UI element which can display more information than the
 
 - If you have a question or need help please create a new [discussion](https://github.com/KartoffelToby/better_thermostat/discussions) or check if your question is already answered
 - If you have a suggestion, found a bug, or want to add a new device or function create a new [issue](https://github.com/KartoffelToby/better_thermostat/issues)
-- If you want to contribute to this project create a new [pull request](https://github.com/KartoffelToby/better_thermostat/pulls)
+- If you want to contribute to this project create a new [pull request](https://github.com/KartoffelToby/better_thermostat/pulls) — the architecture is documented under [Internals](https://better-thermostat.org/internals/architecture/)
 
 ### Features
 
@@ -36,6 +36,7 @@ This integration brings some smartness to your connected radiator thermostats se
 - Dynamic preset temperature learning & persistence (baseline/"no preset" remembers the last temperature you set and survives restarts)
 - **Advanced Control Algorithms**: Choose between MPC, PID, TPI, AI Time Based or simple target temperature matching for precise control.
 - **Selectable Presets**: Configure which preset modes are available for your thermostat during setup.
+- **Fail-soft and observable**: keeps controlling when sensors drop out (graceful degradation with repair issues), spaces radio writes to protect TRV batteries, and ships a flight recorder in the diagnostics download for bug reports.
 
 ### Advanced Control Algorithms
 

--- a/docs/Configuration/algorithms.md
+++ b/docs/Configuration/algorithms.md
@@ -6,6 +6,10 @@ slug: calibration_algorithms
 
 Better Thermostat offers several calibration algorithms (also called "Calibration Modes") that control how your TRV (Thermostatic Radiator Valve) is adjusted to maintain your desired temperature. Each algorithm has different characteristics and is suited for different situations.
 
+How the calibration machinery works under the hood — the two
+calibration channels, the controllers, and how changes are verified —
+is documented under [Internals: Calibration](/internals/calibration/).
+
 ## Choosing the Right Algorithm
 
 If you're unsure which algorithm to use, here's a quick guide:

--- a/docs/Configuration/configuration.md
+++ b/docs/Configuration/configuration.md
@@ -46,7 +46,7 @@ group:
 
 **Your weather entity for outdoor temperature** This is an optional field. It should be empty if you have an outdoor sensor. This is the weather entity you want to use to get the outdoor temperature. It uses the mean of the last 3 days and checks it every morning at 5:00 AM.
 
-**Window delay** This is an optional field. If you don't want to turn off the thermostat instantly when the window is open, you can set a delay. This goes in both directions, so if you want to turn it on again after the window is closed, you can set a delay here too.
+**Window delay** This is an optional field. If you don't want to turn off the thermostat instantly when the window is open, you can set a delay. This goes in both directions, so if you want to turn it on again after the window is closed, you can set a delay here too. Accepted sensor states and the exact debounce behavior are described on the [window sensor page](/qanda/window_sensor).
 
 **The outdoor temperature threshold** This is an optional field. If you have an outdoor sensor or a weather entity, you can set a threshold. If the outdoor temperature is higher than the threshold, the thermostat will be turned off. If the outdoor temperature is lower than the threshold, the thermostat will be turned on. If you don't have an outdoor sensor or a weather entity, this field will be ignored.
 

--- a/docs/faq/common-questions.md
+++ b/docs/faq/common-questions.md
@@ -28,6 +28,21 @@ Start with **AI Time Based**. It is the best default for most homes.
 
 If you want tighter overshoot control and have stable sensors, try **MPC Predictive**.
 
+## Why does my TRV pick up a change with a delay?
+
+Better Thermostat spaces writes to each TRV at least 30 seconds apart,
+separately for setpoint, offset, and valve commands. TRVs are battery-
+and radio-constrained devices; bursts of writes drain batteries and
+congest the radio network.
+
+A change that arrives inside that window is sent automatically as soon
+as the slot is free — at most 30 seconds later. Safety-relevant writes
+(frost protection, turning off, closing the valve) are sent immediately.
+
+If a write gets lost on the radio anyway, the periodic reconciliation
+detects the mismatch between the intended and the reported state and
+re-sends it within a few minutes.
+
 ## Where do I find advanced tuning info?
 
 See:

--- a/docs/faq/debugging.md
+++ b/docs/faq/debugging.md
@@ -1,7 +1,24 @@
 ---
 title: Debugging
-description: Enable debug logs and verify Better Thermostat behavior.
+description: Download diagnostics, enable debug logs, and verify Better Thermostat behavior.
 ---
+
+## Download diagnostics
+
+For bug reports, the diagnostics download is the most useful artifact —
+attach it before reaching for debug logs.
+
+Go to **Settings → Devices & services → Better Thermostat**, open the
+three-dot menu of the entry, and choose **Download diagnostics**. The
+file contains:
+
+- the configuration of the entry and the state of every configured TRV
+  and sensor,
+- the **flight recorder**: the last control decisions, each as the
+  observation, the controller state, and the resulting intent. It shows
+  *why* Better Thermostat did what it did, which a log line usually
+  cannot (see [Internals: Observability](/internals/observability-and-testing/)
+  for how it works).
 
 ## Enable debug logging via configuration.yaml
 

--- a/docs/faq/degraded-mode.md
+++ b/docs/faq/degraded-mode.md
@@ -1,38 +1,55 @@
 ---
 title: Degraded mode
-description: What the "degraded mode" repair issue means and how to fix it.
-slug: faq/degraded-mode
+description: What the degraded-mode warning means and how Better Thermostat keeps controlling when sensors fail.
+slug: qanda/degraded_mode
 ---
 
-Better Thermostat raises a **degraded mode** repair issue when one or
-more of its configured sensors become unavailable — the room temperature
-sensor, a window sensor, a humidity sensor, an outdoor sensor, or the
-weather entity.
+Better Thermostat raises a **degraded mode** repair issue when one of the
+sensors it was configured with becomes unavailable — the room temperature
+sensor, the window sensor, the humidity sensor, the outdoor sensor, or the
+weather entity. The thermostat keeps running; the issue tells you that it
+is working with less information than you configured.
 
-Better Thermostat keeps controlling your heating in degraded mode: if
-the room temperature sensor is unavailable it falls back to the TRV's
-internal temperature reading, and unavailable optional sensors are
-simply left out of the control decisions. Expect less accurate control
-until all sensors are back.
+During the first five minutes after startup the warning is suppressed so
+that slow integrations (for example cloud-based weather providers) get
+time to come online before you see it.
 
-During Home Assistant startup, sensors are often briefly unavailable
-while their integrations load. Better Thermostat waits out a grace
-period before raising the issue, so a warning means a sensor stayed
-unavailable beyond startup.
+## What still works
 
-## Common causes
+Better Thermostat degrades step by step instead of stopping. The control
+quality steps down a ladder, one rung at a time:
 
-- The sensor's battery is empty or the device lost its radio connection.
-- The integration providing the sensor is not loaded or failed to start.
-- The sensor was renamed or removed, so the entity id Better Thermostat
-  was configured with no longer exists.
+1. **Optimal** — the room sensor delivers; everything works as configured.
+2. **Sensor fallback** — the room temperature sensor is unavailable, but
+   at least one TRV reports its internal temperature. Better Thermostat
+   then controls on the average of the TRV-internal temperatures. TRVs
+   measure next to the hot valve, so expect less accuracy — but it is
+   strictly better than controlling on a frozen last reading.
+3. **Hold** — neither the room sensor nor any TRV temperature is usable
+   (for example during a Zigbee outage). The controller stops adjusting
+   and the TRVs keep their last commanded state. Frost protection stays
+   enforced on every write.
 
-## How to fix it
+A rung steps down after the loss has persisted for about two minutes, and
+climbs back up after the sensors have been stable again for about five
+minutes — short sensor flaps do not flip the behavior back and forth.
 
-1. The repair issue lists the unavailable sensors. Check each one under
-   **Settings → Devices & services**: replace the battery or reconnect
-   the device if needed.
-2. If an entity id changed, update the Better Thermostat configuration
-   to the new entity id (open the Better Thermostat entry and
-   reconfigure it).
-3. The issue clears on its own once all sensors are available again.
+## How to see the current rung
+
+The Better Thermostat climate entity exposes the rung as the
+`control_mode` attribute (`optimal`, `sensor_fallback`, or `hold`),
+along with `degraded_for_s` (how long the degradation has lasted) and
+`unavailable_sensors`. The `calibrator_health` attribute reports per
+TRV whether its calibration controller is healthy or has self-healed
+(for example after a poisoned learning state) or shows oscillating
+output. Check them under **Developer tools → States**.
+
+## What you should do
+
+- Check the listed sensors: battery, power, and whether the entity shows
+  `unavailable` or `unknown` in Home Assistant.
+- For cloud-based weather or outdoor entities, check the integration that
+  provides them.
+
+The repair issue disappears on its own once all configured sensors are
+available again.

--- a/docs/faq/window-sensor.md
+++ b/docs/faq/window-sensor.md
@@ -1,45 +1,43 @@
 ---
-title: Window sensor states
-description: What the "invalid window sensor state" repair issue means and how to fix it.
-slug: faq/window-sensor
+title: Window sensor
+description: How Better Thermostat reads the window sensor and how the open/close delays behave.
+slug: qanda/window_sensor
 ---
 
-Better Thermostat expects the configured window sensor to behave like a
-binary sensor:
+When the configured window sensor reports **open**, Better Thermostat
+turns the heating off; when it reports **closed**, heating resumes. TRVs
+that cannot be switched off receive their minimum temperature instead.
 
-- `on`, `true` or `open` — window is open, heating pauses
-- `off`, `false` or `closed` — window is closed, heating resumes
-- `unknown` or `unavailable` — Better Thermostat assumes the window is
-  closed so heating continues (a lost sensor must not stop heating); the
-  unavailability is still reported
+## Sensor states
 
-If the sensor reports anything else, Better Thermostat raises an
-**invalid window sensor state** repair issue and ignores the state
-change.
+Better Thermostat expects a binary sensor:
 
-## Common causes
+- `on`, `true`, `open` — window open.
+- `off`, `false`, `closed` — window closed.
+- `unknown` and `unavailable` count as **closed** so heating continues:
+  windows are usually closed and a lost sensor (e.g. a dead battery) must
+  not stop heating. The frost floor still applies and the unavailability
+  is still reported.
 
-- The configured entity is not a binary sensor — for example a numeric
-  sensor, an input helper with custom values, or a template that returns
-  something other than `on`/`off`.
-- A group helper that aggregates non-binary entities.
+Any other state raises a repair issue — normalize the entity to one of
+the values above, for example with a
+[group helper](https://www.home-assistant.io/integrations/group/) or a
+[template binary sensor](https://www.home-assistant.io/integrations/template/).
 
-## How to fix it
+## The open and close delays
 
-1. Check the sensor's actual state under **Developer tools → States**.
-2. Use a `binary_sensor` (device class `window`/`door`/`opening`), or a
-   group of binary sensors:
+Two options debounce the sensor:
 
-   ```yaml
-   group:
-     livingroom_windows:
-       name: Livingroom Windows
-       icon: mdi:window-open-variant
-       all: false
-       entities:
-         - binary_sensor.openclose_1
-         - binary_sensor.openclose_2
-   ```
+- **"Delay before the thermostat turns off when the window is opened"**
+- **"Delay before the thermostat turns on when the window is closed"**
 
-3. If you template your own sensor, make sure it only ever renders
-   `on` or `off`.
+A state change only takes effect after it has persisted for the whole
+delay. A window that closes again within the open delay (or reopens
+within the close delay) changes nothing — short flaps, such as a door
+slamming or a quick airing check, are filtered out.
+
+- With a delay of `0` the change takes effect immediately with the event.
+- While the delay is running, the displayed window state keeps showing
+  the previous, committed state.
+- Changing a delay in the options applies to a wait that is already in
+  progress: the remaining time is recomputed from the new value.

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -95,9 +95,11 @@ flowchart TD
 OFF intents carry their **suppression reason** so the shell can choose
 between a literal OFF (window, no heat demand) and the device-specific
 remap of the user's OFF mode — without reading the kernel's internals.
-Unreachable TRVs receive no intent at all (their native thermostat
-keeps controlling at the last commanded state), and one dead TRV never
-drags the others down: intents are strictly per TRV.
+Reachability is an address filter rather than a cascade tier: an
+unreachable TRV is dropped from the commanded set and receives no intent
+at all (its native thermostat keeps controlling at the last commanded
+state), and one dead TRV never drags the others down: intents are
+strictly per TRV.
 
 ## Where things live
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -10,7 +10,7 @@ Better Thermostat separates a **pure decision core** from an
 shell observes Home Assistant and performs the device writes. The
 boundary is one function:
 
-```
+```text
 decide(snapshot, state) -> (desired, state')
 ```
 

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -1,0 +1,119 @@
+---
+title: Architecture overview
+description: Functional core, imperative shell, and how a control cycle flows from an event to a device write.
+sidebar:
+  order: 1
+---
+
+Better Thermostat separates a **pure decision core** from an
+**imperative shell**. The core computes *what* every TRV should do; the
+shell observes Home Assistant and performs the device writes. The
+boundary is one function:
+
+```
+decide(snapshot, state) -> (desired, state')
+```
+
+- A `WorldSnapshot` is the immutable observation of one control cycle:
+  temperatures, modes, environment, and the reported state of every TRV.
+- The `KernelState` aggregates the discrete state machines (the
+  [regions](/internals/regions/)) that persist between cycles.
+- A `DesiredState` expresses intent per TRV — mode, setpoint, valve
+  percent, offset, and *why* heating is suppressed. Intent, not
+  commands: the shell translates it into device writes.
+
+`decide()` imports no Home Assistant code, performs no IO, reads no
+clocks (time arrives inside the snapshot), and never mutates its input
+state. The same inputs always produce the same decision — which is what
+makes the [flight recorder](/internals/observability-and-testing/)
+replayable.
+
+## One control cycle
+
+```mermaid
+flowchart LR
+    subgraph Triggers
+        EV[Sensor events]
+        UA[User actions]
+        TK[5-minute ticks]
+    end
+    EV --> RQ["request_control_cycle()"]
+    UA --> RQ
+    TK --> RQ
+    RQ --> Q["Queue (max. 1 pending)"]
+    Q --> SN["build_snapshot()"]
+    SN --> DE["decide(snapshot, state)"]
+    DE --> FR[Flight recorder]
+    DE --> HU[Safety hull]
+    HU --> WB[Write budget]
+    WB --> AD[Adapter / quirks]
+    AD --> TRV[(TRV)]
+```
+
+The snapshot is **pulled, not maintained**: it is built fresh at the
+start of each cycle and discarded afterwards, so a decision always sees
+one coherent world. Reactivity comes from the push side — every trigger
+requests a cycle, and the queue holds at most one pending request. A
+pending cycle automatically covers any state change that arrives before
+it runs, so bursts of events coalesce into one decision instead of many.
+
+A cycle runs on:
+
+- **sensor events** — a relevant room-temperature change, a TRV state
+  change, a window transition (after the configured debounce; window
+  kicks replace a pending request),
+- **user actions** on the entity — target temperature, preset, HVAC
+  mode (the service path requests the cycle directly),
+- **the five-minute ticks** — the calibration tick (controller modes)
+  and the [reconciler](/internals/writes-and-reconciliation/),
+- **the follow-up** a budget-deferred write schedules for itself.
+
+Only one cycle runs at a time. The worst-case latency from event to
+decision is the remainder of the cycle currently running — a few
+seconds, dominated by device writes and their propagation wait.
+
+## The decision cascade
+
+`decide()` evaluates one precedence cascade; the first tier that fires
+wins:
+
+```mermaid
+flowchart TD
+    A{Startup or maintenance running?} -->|yes| A1[No intents]
+    A -->|no| B{Mode OFF?}
+    B -->|yes| B1[OFF intent for every TRV]
+    B -->|no| C{Window open?}
+    C -->|yes| C1[OFF intent, suppression = window]
+    C -->|no| D{Call for heat?}
+    D -->|no| D1[OFF intent, suppression = no_call_for_heat]
+    D -->|yes| E[Heating intent: mode + setpoint]
+    E --> F{HOLD rung?}
+    F -->|yes| F1[Intent keeps the mode, carries no setpoint]
+    F -->|no| F2[Setpoint = room target]
+```
+
+OFF intents carry their **suppression reason** so the shell can choose
+between a literal OFF (window, no heat demand) and the device-specific
+remap of the user's OFF mode — without reading the kernel's internals.
+Unreachable TRVs receive no intent at all (their native thermostat
+keeps controlling at the last commanded state), and one dead TRV never
+drags the others down: intents are strictly per TRV.
+
+## Where things live
+
+| Concern | Home |
+|---|---|
+| Decisions (gates, precedence, modes) | `core/decide.py` + the regions |
+| Observation | `utils/snapshot.py` → `core/snapshot.py` |
+| Device writes | `utils/controlling.py` behind hull + budget |
+| Cycle scheduling | `utils/scheduler.py` (requests coalesce) |
+| Calibration math | `calibration.py` + `utils/calibration/` |
+| Persistence | `utils/state_manager.py` |
+| Diagnostics | `core/recorder.py` + `diagnostics.py` |
+
+The placement rule for new code: a new rule about *what should happen*
+belongs in the core, with pure unit tests. New *device interaction*
+belongs in the shell behind the existing boundaries — writes go through
+the safety hull and the write budget, cycles are requested through the
+scheduler, and the shell applies intent without second-guessing the
+kernel after `decide()` ran.

--- a/docs/internals/calibration.md
+++ b/docs/internals/calibration.md
@@ -1,0 +1,86 @@
+---
+title: Calibration
+description: The two calibration channels, the per-mode traits table, the controllers, and the standby contract.
+sidebar:
+  order: 5
+---
+
+A TRV measures temperature next to its own hot valve, so it throttles
+too early. Calibration corrects this using the external room sensor,
+through one of two **channels** depending on what the device supports:
+
+- **Local offset** — the device exposes a calibration entity; Better
+  Thermostat writes an offset so the TRV's internal reading matches the
+  room sensor.
+- **Setpoint** — no calibration entity; Better Thermostat shifts the
+  *target* it sends so the device's internal logic lands on the real
+  room target.
+
+Both channels share one cascade — base value, controller contribution,
+per-mode adjustments, direction-aware rounding — and differ only in
+direction and reference values.
+
+## The traits table
+
+Everything mode-specific is data, not branches: `MODE_TRAITS` maps each
+calibration mode to its traits — whether a controller (balance
+strategy) contributes, whether the tolerance band applies, whether
+post-adjustments run, and an optional per-mode adjustment hook that
+serves both channels through a `ChannelAdjustment` (direction, neutral
+reference, hold value, legacy fallback).
+
+| Mode | Controller | Tolerance band | Post-adjustments |
+|---|---|---|---|
+| Default | — | — | — |
+| MPC / TPI / PID | ✓ | ✓ | — |
+| Aggressive | — | ✓ | boost hook, no tolerance delay |
+| Heating power | — | ✓ | learned-power hook (decides its own skip) |
+| No calibration | — | ✓ | plain cascade |
+
+Within the tolerance band (room between target − tolerance and target)
+the calibration holds its last value, but a controller keeps its valve
+data fresh — so leaving the band resumes from a current model, not a
+stale one.
+
+## The controllers
+
+MPC, TPI, and PID are pure functions in `utils/calibration/`:
+`compute_*(input, params, state) -> (output, state')`. Each strategy
+owns its state; the `StateManager` is the only persistence authority.
+The strategy layer (`BalanceStrategy`) wraps each computation behind
+the core `Calibrator` contract (observe / actuate / capability /
+health) for the eventual move into the core.
+
+## The standby contract
+
+While heating is suppressed (open window, OFF, HOLD), **observe means
+tracking, never learning**:
+
+- the *entity-level* estimates (temperature EMA, slope) keep converging
+  — sensor events are processed regardless of window state,
+- the controllers do not integrate error (no windup on the growing
+  error of a cooling room: PID and TPI simply do not step),
+- MPC drops its in-flight learning interval — a half-heated interval
+  would teach the model that heating does not work — while the learned
+  parameters survive,
+- re-entry resumes from held controller state plus fresh estimates,
+  which is what makes the transfer bumpless.
+
+This contract is pinned as a named test
+(`tests/unit/test_standby_contract.py`); a regression in any layer
+reads as a standby-contract break, not as an unrelated unit failure.
+
+There is deliberately **no external readiness gate** in front of
+actuation: closed-loop learners bootstrap *through* actuation — an
+external "only actuate when ready" gate would prevent them from ever
+warming up. The controllers gate themselves (standby skips, gap resets,
+warmup bootstrapping), and capability/health reporting is annunciation.
+
+## Verifying changes
+
+Calibration is the most behavior-sensitive code in the project. Two
+nets pin it: the per-mode unit suites, and the seeded calibration
+benchmark (`python -m tests.benchmark.runner`) — a pure thermal
+simulation across all controllers and ~37 scenarios whose output is
+deterministic and therefore diffable. A refactoring of this code is
+proven by a byte-identical benchmark before and after.

--- a/docs/internals/calibration.md
+++ b/docs/internals/calibration.md
@@ -80,7 +80,6 @@ warmup bootstrapping), and capability/health reporting is annunciation.
 
 Calibration is the most behavior-sensitive code in the project. Two
 nets pin it: the per-mode unit suites, and the seeded calibration
-benchmark (`python -m tests.benchmark.runner`) — a pure thermal
-simulation across all controllers and ~37 scenarios whose output is
-deterministic and therefore diffable. A refactoring of this code is
+benchmark — a pure thermal simulation across all controllers and ~37
+scenarios whose output is deterministic and therefore diffable. A refactoring of this code is
 proven by a byte-identical benchmark before and after.

--- a/docs/internals/calibration.md
+++ b/docs/internals/calibration.md
@@ -44,8 +44,10 @@ stale one.
 
 ## The controllers
 
-MPC, TPI, and PID are pure functions in `utils/calibration/`:
-`compute_*(input, params, state) -> (output, state')`. Each strategy
+MPC, TPI, and PID are deterministic, state-threading helpers in
+`utils/calibration/`: `compute_*(input, params, state) -> (output,
+state')`, and standby paths such as `observe_standby()` update the
+passed state in place. Each strategy
 owns its state; the `StateManager` is the only persistence authority.
 The strategy layer (`BalanceStrategy`) wraps each computation behind
 the core `Calibrator` contract (observe / actuate / capability /

--- a/docs/internals/design-decisions.md
+++ b/docs/internals/design-decisions.md
@@ -1,0 +1,84 @@
+---
+title: Design decisions
+description: The structural decisions and the chosen constants — what anchors each value, and what would change it.
+sidebar:
+  order: 8
+---
+
+Two kinds of decisions live in this codebase, and they deserve
+different scrutiny. **Anchored thresholds** derive from a physical or
+device-given limit — challenging them means challenging the anchor.
+**Chosen constants** are engineering trade-offs between two named
+pressures — they are legitimate to revisit, and this page names the
+pressures so a revisit argues against the right thing.
+
+## Structural decisions
+
+**The snapshot is pulled, not maintained.** A per-cycle observation
+guarantees every decision sees one coherent world and makes replay
+deterministic. An event-maintained snapshot would buy nothing (the
+write path is serialized anyway) and cost torn reads.
+
+**Regions are not persisted.** Window, maintenance, lifecycle, mode,
+ladder, reachability all re-derive from live observations within one
+debounce window. A persisted region could only pin stale conclusions
+whose inputs are gone after a restart. Only state with learning value
+(controller models, thermal stats, filters) persists.
+
+**Standby is tracking, never learning.** Entity-level estimates keep
+converging while heating is suppressed; controllers neither integrate
+error (windup) nor learn parameters from disturbance-flagged samples
+(model poisoning: a window-open interval would teach the model that
+heating does not work). Re-entry from held controller state plus fresh
+estimates is what makes the transfer bumpless.
+
+**Self-healing only for unambiguous pathologies; oscillation is
+annunciation-only.** Non-finite state, runaway gains, and wound-up
+integrators have crisp definitions and safe resets. An oscillation
+detector with an automatic gain backoff would thrash the controller on
+a false positive — worse than the oscillation it reacts to. Backoff
+stays manual until the detector is validated against the benchmark.
+
+**No external readiness gate in front of actuation.** Closed-loop
+learners bootstrap *through* actuation; an external "only actuate when
+ready" gate would prevent them from ever warming up. The controllers
+gate themselves (standby skips, gap resets), and capability/health is
+annunciation.
+
+**Reachability is diagnosis, not control law.** In Home Assistant,
+availability is push-based: writing to an unavailable entity does
+nothing, and the device's return triggers events that resume control.
+A write-backoff consumer would model a polling world that does not
+exist here; flapping churn is already bounded by the write budget. The
+region's value is the flight-recorder trail during outage analysis.
+
+**HOLD keeps the last commanded state instead of handing over to the
+TRV.** With no usable temperature anywhere, both options are blind;
+keeping the last commanded state is the predictable one, and the frost
+floor stays enforced. For a *single* dead TRV the hand-over happens
+naturally: it receives no intent and its native thermostat continues.
+
+**`unknown`/`unavailable` window readings count as open.** With no
+trustworthy reading, not heating out of the window is the cheap-failure
+direction; the reverse error heats the street.
+
+## Chosen constants
+
+| Value | What | The two pressures | Anchor / revisit trigger |
+|---|---|---|---|
+| **30 s** | write budget per TRV and channel | battery & radio load ↔ worst-case latency of a fine-tuning write | TRVs are battery devices on contended radio; write bursts are a real failure cause. 30 s caps a channel at ~120 writes/h while keeping deferred writes promptly delivered (safety writes bypass entirely). Faster budgets mainly buy more radio traffic, not better control — room dynamics are far slower. |
+| **5 min** | calibration tick (controller modes) | control freshness without events ↔ pointless wake-ups | Room thermal time constants are tens of minutes; 5 min samples the plant several times per time constant. A faster tick could not act faster anyway — actuation is bounded by the 30 s budget. |
+| **5 min** | reconciler tick | healing latency for lost writes ↔ cost of observe+decide per tick | Lost writes are rare and not safety-relevant (those bypass and confirm); healing within minutes suffices. |
+| **2 min / 5 min** | ladder down-debounce / up-stability | reacting to real outages ↔ flapping on sensor blips | Asymmetric on purpose: degrade quickly enough to matter, re-promote only after sustained recovery — classic reversionary-mode hysteresis. |
+| **15 min** | watchdog stall threshold | catching a silent hang ↔ false alarms | Anchored: the 5-minute ticks guarantee a cycle at least every 5 minutes, so 15 minutes = three missed ticks = a real hang, not jitter. |
+| **1 h** | maintenance max runtime | letting a slow valve exercise finish ↔ a dead run blocking control forever | A valve exercise takes minutes per TRV; an hour means the run died. The bound exists so maintenance can never block control permanently. |
+| **3 s** | post-write propagation wait | reading the device echo as confirmation ↔ misreading it as an external change | Typical Zigbee/MQTT echo latency; without the wait, BT would treat its own write's echo as a user action. |
+| **0.05 K + half device step** | reconcile setpoint tolerance | detecting lost writes ↔ fighting device quantization | Anchored: a device snapping a value onto its own grid moves it at most half a step; below that is float noise. Fighting quantization would re-send every 5 minutes and drain batteries. |
+| **5 points** | reconcile valve tolerance | detecting lost valve writes ↔ fighting device-side modulation | Real lost writes look like 0 vs 80, not 77 vs 80. |
+| **4 reversals / ≥20-point swings / 10 samples** | oscillation detector | catching thrash ↔ false positives | Deliberately biased toward quiet (annunciation-only makes a miss cheap and a false alarm noisy). To be tightened against benchmark data. |
+| **×10 band around default gains** | runaway-gain reset (PID auto-tune) | never clipping a legitimate tune ↔ catching divergence | Legitimate room dynamics vary roughly 3–5×; a 10× band never bites a real tune. Deliberately generous — tighten once benchmark/telemetry data justifies it. |
+| **5 min** | startup degraded-mode grace | alarming on real outages ↔ alarming on slow cloud integrations at boot | Weather/cloud entities routinely need minutes to come online after a restart. |
+| **50 entries** | flight-recorder ring | covering the window around an incident ↔ diagnostics download size | With background ticks every 5 minutes, 50 tuples span hours around the moment a user hits "download diagnostics". |
+
+When one of these constants changes, the table entry is the review
+checklist: name which pressure moved and what evidence moved it.

--- a/docs/internals/design-decisions.md
+++ b/docs/internals/design-decisions.md
@@ -58,9 +58,12 @@ keeping the last commanded state is the predictable one, and the frost
 floor stays enforced. For a *single* dead TRV the hand-over happens
 naturally: it receives no intent and its native thermostat continues.
 
-**`unknown`/`unavailable` window readings count as open.** With no
-trustworthy reading, not heating out of the window is the cheap-failure
-direction; the reverse error heats the street.
+**`unknown`/`unavailable` window readings count as closed.** Windows are
+usually closed, and a lost sensor (e.g. a dead battery) must not stop
+heating and leave the room cold; the frost floor still applies, and the
+unavailability is surfaced separately. The reverse — treating an absent
+reading as open — heats the street only when a window is actually open,
+but freezes the occupant on every dead battery.
 
 ## Chosen constants
 

--- a/docs/internals/observability-and-testing.md
+++ b/docs/internals/observability-and-testing.md
@@ -1,0 +1,67 @@
+---
+title: Observability and testing
+description: The flight recorder, the diagnostics download, the annunciation attributes, and the test strategy.
+sidebar:
+  order: 7
+---
+
+## Mode annunciation
+
+Degradation is never silent. The climate entity exposes:
+
+- `control_mode` — the fail-soft rung (`optimal`, `sensor_fallback`,
+  `hold`),
+- `degraded_for_s` and `unavailable_sensors` — what is degraded, since
+  when,
+- `calibrator_health` — per TRV, whether its calibration controller is
+  healthy, has self-healed, or shows oscillating output.
+
+Entering degraded mode raises a repair issue (suppressed during the
+five-minute startup grace window so slow cloud integrations do not
+alarm) which clears itself on recovery.
+
+## The flight recorder
+
+Because `decide()` is pure, recording the tuple
+`(snapshot, pre-decide state, desired)` per control cycle is enough to
+reproduce any decision offline. `core/recorder.py` keeps a bounded ring
+of the last 50 decision tuples; the **diagnostics download**
+(Settings → Devices & services → Better Thermostat → Download
+diagnostics) exports it alongside the configuration and device states.
+
+`replay()` feeds an exported tuple back through the kernel and compares
+— a bug report's diagnostics file answers *why* Better Thermostat did
+what it did, deterministically, on the developer's machine. A
+completeness test forces every new field of the recorded types through
+the export/reconstruct round-trip, so the replay side cannot silently
+drift from the dataclasses.
+
+## Test strategy
+
+Four nets with distinct failure modes they catch:
+
+1. **Pure unit tests** (`tests/unit/`, the bulk) — the core is HA-free,
+   so the kernel, the regions, the safety hull, and the recorder are
+   tested without mocks; the shell is tested against `MagicMock`
+   entities. The core sits at 100% coverage.
+2. **Integration tests** (`tests/integration/`) — a real config entry
+   against a real (simulated) climate entity in a real Home Assistant
+   instance. They exist because a control path that silently writes
+   nothing keeps every unit test green: the assertions are the service
+   calls that arrive at the device. Covered end to end: startup sync,
+   window → OFF, restore after restart, unload/reload, and the
+   reconciler healing a dropped write.
+3. **The calibration benchmark** (`tests/benchmark/`) — a pure thermal
+   simulation comparing all controllers across ~37 scenarios. Seeded
+   and deterministic, so two runs are byte-identical: refactorings of
+   the calibration code are proven behavior-preserving by diffing the
+   benchmark output before and after.
+4. **Golden replays** (`tests/fixtures/replay_corpus/`) — one committed
+   decision tuple per kernel tier, pinned byte-stable. An intentional
+   kernel change regenerates them (`BT_REGEN_GOLDENS=1`) and the diff
+   shows exactly which decisions changed.
+
+Named contracts deserve named tests: the standby contract, the
+no-raw-dict-access guard, and the controller state-threading contract
+each live in their own file, so a regression reads as a broken contract
+rather than an incidental unit failure.

--- a/docs/internals/observability-and-testing.md
+++ b/docs/internals/observability-and-testing.md
@@ -43,7 +43,8 @@ Four nets with distinct failure modes they catch:
 1. **Pure unit tests** (`tests/unit/`, the bulk) — the core is HA-free,
    so the kernel, the regions, the safety hull, and the recorder are
    tested without mocks; the shell is tested against `MagicMock`
-   entities. The core sits at 100% coverage.
+   entities. The core is covered exhaustively — every branch of the
+   decision path and every region transition has a test.
 2. **Integration tests** (`tests/integration/`) — a real config entry
    against a real (simulated) climate entity in a real Home Assistant
    instance. They exist because a control path that silently writes

--- a/docs/internals/persistence.md
+++ b/docs/internals/persistence.md
@@ -44,9 +44,9 @@ old entity attributes only when the store has nothing.
 Persisted state is treated as untrusted input, absorbed at three
 layers:
 
-1. **Per field at load:** deserialization skips wrong-typed and
-   non-finite values field by field; a corrupt section yields that
-   section's defaults.
+1. **Per field at load:** deserialization skips a wrong-typed field
+   individually, while a non-finite value poisons the whole stored entry,
+   which then falls back to its defaults.
 2. **Per store at load:** if deserialization itself breaks on an
    unexpected shape, the store starts fresh with a warning instead of
    killing the startup task — relearning replaces anything a poisoned

--- a/docs/internals/persistence.md
+++ b/docs/internals/persistence.md
@@ -1,0 +1,57 @@
+---
+title: Persistence
+description: What survives a restart, what is rebuilt from live data, and how poisoned state is absorbed.
+sidebar:
+  order: 6
+---
+
+The dividing line: **only state with learning value persists.**
+Everything that can be re-derived from live observations is rebuilt
+after a restart instead of restored — a persisted conclusion could only
+pin stale knowledge whose inputs are gone.
+
+| Data | Lifecycle | Home |
+|---|---|---|
+| Configuration (sensors, delays, tolerances) | set once at setup | config entry → `BtConfig` |
+| Live operating values (temperatures, targets, flags) | rebuilt per observation | `BtRuntime` + the regions |
+| Controller state (PID/MPC/TPI), thermal stats, filters | learned, persists | `StateManager` (HA Store) |
+| User inputs on helper entities (presets) | persists | `RestoreEntity` (genuinely HA-owned) |
+
+The discrete mode flags (window open, startup, maintenance, degraded)
+live in the kernel's regions and are exposed as derived read-only
+properties — they have no second home, and none of the regions is
+persisted: lifecycle re-derives through the startup sequence,
+window/maintenance/mode from the first events, the ladder within one
+debounce window.
+
+## One persistence axis
+
+The `StateManager` is the single authority for learned state: one HA
+Store per config entry, holding the per-key controller states
+(PID/MPC/TPI), the thermal stats (heating power, heat loss), and the
+runtime filters (temperature EMA, slope). The entity pushes its held
+values into the store through one seam before every debounced save,
+and hydrates from it at startup.
+
+`RestoreEntity` remains only for data Home Assistant genuinely owns:
+the climate entity's target/mode and the helper number entities' user
+inputs. The legacy attribute fallback in the restore path stays as a
+migration window for installations that predate the store — it reads
+old entity attributes only when the store has nothing.
+
+## Poison resistance
+
+Persisted state is treated as untrusted input, absorbed at three
+layers:
+
+1. **Per field at load:** deserialization skips wrong-typed and
+   non-finite values field by field; a corrupt section yields that
+   section's defaults.
+2. **Per store at load:** if deserialization itself breaks on an
+   unexpected shape, the store starts fresh with a warning instead of
+   killing the startup task — relearning replaces anything a poisoned
+   store could offer.
+3. **Per cycle at compute:** the sanitize step heals whatever still
+   reaches a controller (non-finite state, runaway gains, wound-up
+   integrators) and annunciates the verdict as
+   [calibrator health](/internals/safety-and-degradation/).

--- a/docs/internals/regions.md
+++ b/docs/internals/regions.md
@@ -69,9 +69,9 @@ come online before the user sees a repair issue.
 
 ## Mode — the user's HVAC mode
 
-A validated mirror of the user's selected mode (heat / off /
-heat-cool). The mode tier of the cascade reads it; setting the mode on
-the entity advances the region.
+A validated mirror of the user's selected mode (off / heat / cool /
+heat-cool), with the preset axis orthogonal to it. The mode tier of the
+cascade reads it; setting the mode on the entity advances the region.
 
 ## Control mode — the fail-soft ladder
 

--- a/docs/internals/regions.md
+++ b/docs/internals/regions.md
@@ -1,0 +1,93 @@
+---
+title: The regions
+description: Six orthogonal state machines gate the control law; controllers compute, regions gate.
+sidebar:
+  order: 2
+---
+
+Discrete concerns — is a window open, is maintenance running, which
+fail-soft rung rules — live in six small, orthogonal state machines
+under `core/fsm/`, collectively the **regions** of the `KernelState`.
+Two rules hold everywhere:
+
+1. **Regions gate, controllers compute.** A region decides *whether*
+   heating may happen; the continuous controllers (PID/MPC/TPI) decide
+   *how much*. The two never mix.
+2. **Regions never read each other's internals.** They compose through
+   their inputs and through the decision cascade's precedence — data
+   influence is allowed, state peeking is not.
+
+All regions are plain frozen dataclasses with pure transition
+functions; none of them is persisted across restarts. They re-derive
+from live observations: lifecycle through the startup sequence,
+window/maintenance/mode from the first events, the ladder and
+reachability within one debounce window.
+
+## Window — debounced open/closed
+
+```mermaid
+stateDiagram-v2
+    CLOSED --> OPENING: sensor open
+    OPENING --> OPEN: delay elapsed
+    OPENING --> CLOSED: sensor closed again (false positive)
+    OPEN --> CLOSING: sensor closed
+    CLOSING --> CLOSED: delay elapsed
+    CLOSING --> OPEN: sensor open again (false positive)
+```
+
+The *committed* phase rules the control law while a change is pending
+(`effective_open` is true in OPEN and CLOSING). The region owns the
+debounce timing: the queue handler sleeps exactly the remaining delay
+the region asks for, re-reads the sensor, and re-steps until no
+transition is pending — a delay reconfigured mid-flight changes the
+next sleep, and a sensor that reverted cancels the transition. With a
+delay of zero, the transition commits at the event itself.
+
+## Maintenance — valve exercise with a liveness bound
+
+```mermaid
+stateDiagram-v2
+    IDLE --> DUE: schedule reached
+    DUE --> RUNNING: run starts
+    RUNNING --> IDLE: finished (reschedules)
+```
+
+The invariant that motivated the region: **a maintenance run must never
+block control permanently.** `is_blocking()` stops honoring a RUNNING
+phase once it exceeds the maximum runtime (one hour), and finishing a
+run always returns to IDLE. An open window or OFF mode postpones the
+schedule by an hour; without any maintenance-enabled TRV the next check
+moves a week out.
+
+## Lifecycle — startup, running, stopped
+
+INITIALISING → STARTING (grace) → RUNNING → STOPPING. While startup
+runs, `decide()` addresses no TRVs — the initial device sync happens
+right after the startup-finished transition. The grace window also
+defers the degraded-mode warning so slow cloud integrations get time to
+come online before the user sees a repair issue.
+
+## Mode — the user's HVAC mode
+
+A validated mirror of the user's selected mode (heat / off /
+heat-cool). The mode tier of the cascade reads it; setting the mode on
+the entity advances the region.
+
+## Control mode — the fail-soft ladder
+
+OPTIMAL → SENSOR_FALLBACK → HOLD. Downgrades commit after ~2 minutes of
+sustained capability loss; upgrades only after ~5 minutes of sustained
+recovery — hysteresis against flapping sensors. What each rung does is
+described under [Safety and degradation](/internals/safety-and-degradation/).
+
+## Reachability — per-TRV online/offline
+
+Tracks per TRV when it went offline and how often a retry was
+considered. Deliberately **diagnosis only**: in Home Assistant,
+availability is push-based — writing to an unavailable entity does
+nothing, and the device's return triggers state events that resume
+control naturally. The region's value is the flight-recorder trail
+(`offline_since`, `retry_count`) when analyzing an outage. The actual
+gate is in the cascade: unreachable TRVs simply receive no intent
+(except while boost heating is active, which keeps commanding so the
+TRV catches up the moment it returns).

--- a/docs/internals/regions.md
+++ b/docs/internals/regions.md
@@ -88,6 +88,7 @@ availability is push-based — writing to an unavailable entity does
 nothing, and the device's return triggers state events that resume
 control naturally. The region's value is the flight-recorder trail
 (`offline_since`, `retry_count`) when analyzing an outage. The actual
-gate is in the cascade: unreachable TRVs simply receive no intent
-(except while boost heating is active, which keeps commanding so the
-TRV catches up the moment it returns).
+effect is an address filter, not a cascade tier: unreachable TRVs are
+dropped from the commanded set and receive no intent (except while boost
+heating is active, which keeps commanding so the TRV catches up the
+moment it returns).

--- a/docs/internals/safety-and-degradation.md
+++ b/docs/internals/safety-and-degradation.md
@@ -1,0 +1,97 @@
+---
+title: Safety and degradation
+description: The safety hull, the fail-soft ladder, the watchdog, and calibrator self-healing.
+sidebar:
+  order: 3
+---
+
+The guiding principle: **controlling worse is acceptable; not
+controlling at all — or silently hanging — is not.** Degradation is
+explicit, annunciated, and reversible.
+
+## The safety hull
+
+Every outgoing value passes `core/safety.py` at the command boundary:
+setpoints are clamped to the device's min/max including the frost
+floor, calibration offsets to the device's calibration range, valve
+percentages to 0..`valve_max_opening`. The hull is the *second* guard —
+the calibration math keeps its own intermediate clamps for bit-exact
+debuggability — but it is the one that owns the boundary: no write path
+may bypass it, including special cases like the boost safety reset.
+
+Safety-relevant writes (OFF for an open window or absent heat demand,
+frost-floor rewrites, closing the valve) also bypass the
+[write budget](/internals/writes-and-reconciliation/): safety is never
+throttled.
+
+## The fail-soft ladder
+
+```mermaid
+stateDiagram-v2
+    OPTIMAL --> SENSOR_FALLBACK: room sensor lost (~2 min debounce)
+    SENSOR_FALLBACK --> HOLD: no TRV temperature usable either
+    HOLD --> SENSOR_FALLBACK: TRV temperatures back (~5 min stability)
+    SENSOR_FALLBACK --> OPTIMAL: room sensor back (~5 min stability)
+```
+
+- **OPTIMAL** — the external room sensor delivers; the control law
+  works as configured.
+- **SENSOR_FALLBACK** — the room sensor is unavailable, but at least
+  one *reachable* TRV reports an internal temperature: calibration
+  substitutes the mean of the TRV-internal readings. Controlling on a
+  hot-valve sensor is worse than on a room sensor, but strictly better
+  than controlling on a silently stale reading. A stored reading only
+  counts while its TRV is actually reachable, and going unavailable
+  invalidates it — pre-outage values cannot masquerade as live.
+- **HOLD** — neither the room sensor nor any TRV temperature is usable
+  (for example during a Zigbee outage). The kernel keeps the mode but
+  emits no setpoint: the controller stops adjusting, devices keep their
+  last commanded state, and the frost floor stays enforced on every
+  write. Nothing downstream of the HOLD decision may re-introduce an
+  adjustment — boost included.
+
+Downgrades are debounced (~2 min) so a flapping sensor does not flip
+behavior; upgrades require sustained recovery (~5 min). The rung is
+visible as the `control_mode` attribute, along with `degraded_for_s`
+and `unavailable_sensors`; entering degraded mode raises a repair issue
+that clears itself on recovery.
+
+Per-TRV, the bulkhead is the cascade itself: a dead TRV receives no
+intent and its native thermostat keeps controlling at the last
+commanded state — de-facto passthrough — while the other TRVs stay
+fully controlled.
+
+## The watchdog
+
+`core/watchdog.py` answers one question: did a control cycle complete
+recently? The heartbeat is stamped on every *deliberate* outcome of a
+cycle — including skipping an unavailable TRV or deferring a write to
+the budget — while error paths that bail out leave it alone, so a
+genuine silent hang (no cycle for 15 minutes) raises an error and
+forces a cycle through the reconciler tick.
+
+## Calibrator self-healing and health
+
+Self-healing applies where the pathology is unambiguous; everything
+else is annunciation only:
+
+| Pathology | Reaction | Threshold anchor |
+|---|---|---|
+| Non-finite values in learned state | Discard state, relearn from live data | none needed (NaN/Inf) |
+| Runaway auto-tuned gains (PID) | Reset gains to defaults | configured gain ranges |
+| Wound-up integrator (PID) | Reset integrator | actuator-derived integrator limits |
+| Oscillating output | **Annunciate only** | ≥4 reversals between ≥20-point swings in the last 10 outputs |
+
+Oscillation deliberately triggers no automatic gain backoff: a detector
+that backs gains off on a false positive thrashes the controller —
+worse than the oscillation it reacts to — so backoff stays a manual
+decision until the detector is validated against the calibration
+benchmark. Every verdict lands per TRV in the `calibrator_health`
+attribute; a healthy verdict clears only the grades its reporter owns,
+so the sanitize path and the oscillation watcher cannot flap each
+other's annunciations.
+
+Persisted state is hardened at three layers: deserialization skips
+wrong-typed and non-finite fields per field, an unreadable store yields
+defaults instead of killing startup, and the sanitize step heals
+whatever still reaches a controller.

--- a/docs/internals/safety-and-degradation.md
+++ b/docs/internals/safety-and-degradation.md
@@ -50,15 +50,16 @@ stateDiagram-v2
   write. Nothing downstream of the HOLD decision may re-introduce an
   adjustment — boost included.
 
-Downgrades are debounced (~2 min) so a flapping sensor does not flip
-behavior; upgrades require sustained recovery (~5 min). The rung is
+Downgrades are debounced (`down_debounce_s`, 120 s) so a flapping sensor
+does not flip behavior; upgrades require sustained recovery
+(`up_stability_s`, 300 s). The rung is
 visible as the `control_mode` attribute, along with `degraded_for_s`
 and `unavailable_sensors`; entering degraded mode raises a repair issue
 that clears itself on recovery.
 
 Per-TRV, the bulkhead is the cascade itself: a dead TRV receives no
 intent and its native thermostat keeps controlling at the last
-commanded state — de-facto passthrough — while the other TRVs stay
+commanded state — effectively in passthrough mode — while the other TRVs stay
 fully controlled.
 
 ## The watchdog

--- a/docs/internals/writes-and-reconciliation.md
+++ b/docs/internals/writes-and-reconciliation.md
@@ -72,8 +72,7 @@ On divergence the reconciler queues one ordinary control cycle — the
 general healing mechanism that replaces per-case keepalives. The
 tolerances are deliberate: a reconciler that fights device quantization
 or normal modulation would re-send the same value every five minutes
-and drain batteries, which is exactly what the budget exists to
-prevent.
+and drain batteries, which is what the budget exists to prevent.
 
 The same tick hosts the watchdog check: if no control cycle completed
 for 15 minutes, it logs an error and forces one.

--- a/docs/internals/writes-and-reconciliation.md
+++ b/docs/internals/writes-and-reconciliation.md
@@ -1,0 +1,79 @@
+---
+title: Writes and reconciliation
+description: The write budget, the reconciler, and how intent reaches a device through adapters and quirks.
+sidebar:
+  order: 4
+---
+
+TRVs are battery- and radio-constrained devices, and writes get lost on
+the air. Two mechanisms address this pair of facts: the **write
+budget** spaces writes out, the **reconciler** heals the ones that got
+lost. Deciding is never throttled — only the radio traffic is.
+
+## The write path
+
+A cycle writes only differences: a device already matching the intent
+gets no write. For each TRV the shell translates the intent per
+channel — HVAC mode, setpoint, calibration offset, valve percentage —
+through the safety hull, the write budget, and finally the device
+adapter:
+
+```mermaid
+flowchart LR
+    I[TrvDesired] --> H[Safety hull clamp]
+    H --> B{Budget slot free or safety-relevant?}
+    B -->|yes| A[Adapter / model quirk]
+    B -->|no| D[Defer + schedule follow-up]
+    A --> T[(TRV)]
+    D -.->|budget reopens| RQ[request_control_cycle]
+```
+
+**Adapters** (`adapters/`) speak the integration's dialect — Zigbee2MQTT,
+deCONZ, Tado, generic climate services. **Model quirks**
+(`model_fixes/`) override single operations for devices that need
+special sequences (for example valve writes on the Sonoff TRVZB). The
+`Trv` object carries both, plus a `TrvCapabilities` descriptor derived
+in one place — whether the device supports offset writes or direct
+valve writes — so the rest of the code consults capabilities instead of
+probing quirk modules.
+
+## The write budget
+
+Non-safety writes to one TRV keep a minimum spacing of 30 seconds,
+**per channel** (setpoint, offset, valve), so one channel's writes
+cannot starve another's slot. Safety-relevant writes — OFF for an open
+window or absent heat demand, frost-floor rewrites, closing the
+valve — always bypass the budget but still stamp the slot, so the
+spacing stays accurate.
+
+A deferred setpoint write is not dropped: the defer path schedules one
+coalesced control cycle for the moment the budget reopens. Deferred
+offset writes re-derive on the next calibration tick.
+
+## The reconciler
+
+Every five minutes, `reconcile_tick` runs the same observe-decide step
+as a control cycle (without a flight-recorder entry) and compares the
+intent against what the devices report:
+
+- **mode** — an OFF intent against a device reporting a heating mode
+  (devices that cannot switch off legitimately stay in a heating mode
+  at their minimum temperature and are compared by setpoint instead),
+- **setpoint** — the last commanded value against the reported target,
+  with a tolerance of half the device-reported step: firmware snapping
+  a value onto its own coarser grid is convergence, not divergence,
+- **offset** — the commanded calibration against the calibration
+  entity, once the device confirmed the last write (in-flight writes
+  remain the write path's business),
+- **valve** — the commanded percentage against the adapter-written
+  number entity, with a 5-point tolerance for device-side modulation.
+
+On divergence the reconciler queues one ordinary control cycle — the
+general healing mechanism that replaces per-case keepalives. The
+tolerances are deliberate: a reconciler that fights device quantization
+or normal modulation would re-send the same value every five minutes
+and drain batteries, which is exactly what the budget exists to
+prevent.
+
+The same tick hosts the watchdog check: if no control cycle completed
+for 15 minutes, it logs an error and forces one.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
+import mermaid from "astro-mermaid";
 import starlightThemeFlexoki from "starlight-theme-flexoki";
 import lit from "@astrojs/lit";
 
@@ -19,6 +20,7 @@ export default defineConfig({
   },
 
   integrations: [
+    mermaid({ theme: "neutral" }),
     lit(),
     starlight({
       title: "Better Thermostat",
@@ -46,6 +48,10 @@ export default defineConfig({
         {
           label: "Deep explanations",
           autogenerate: { directory: "deep-explanations" },
+        },
+        {
+          label: "Internals",
+          autogenerate: { directory: "internals" },
         },
         {
           label: "Support",

--- a/website/bun.lock
+++ b/website/bun.lock
@@ -7,9 +7,11 @@
         "@astrojs/lit": "^4.3.0",
         "@astrojs/starlight": "^0.32.6",
         "astro": "^5.17.3",
+        "astro-mermaid": "^2.0.2",
         "astro-vtbot": "^2.1.11",
         "gsap": "^3.14.2",
         "lit": "^3.3.2",
+        "mermaid": "^11.15.0",
         "node-gyp": "^12.2.0",
         "sharp": "^0.32.6",
         "starlight-theme-flexoki": "^0.1.0",
@@ -17,6 +19,8 @@
     },
   },
   "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
     "@astrojs/compiler": ["@astrojs/compiler@2.13.0", "", {}, "sha512-mqVORhUJViA28fwHYaWmsXSzLO9osbdZ5ImUfxBarqsYdMlPbqAqGJCxsNzvppp1BEzc1mJNjOVvQqeDN8Vspw=="],
 
     "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.7.5", "", {}, "sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA=="],
@@ -45,7 +49,11 @@
 
     "@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
 
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
     "@ctrl/tinycolor": ["@ctrl/tinycolor@4.1.0", "", {}, "sha512-WyOx8cJQ+FQus4Mm4uPIZA64gbk3Wxh0so5Lcii0aJifqwoVOlfFtorjLE0Hen4OYyHZMXDWqMmaQemBhgxFRQ=="],
 
@@ -110,6 +118,10 @@
     "@expressive-code/plugin-shiki": ["@expressive-code/plugin-shiki@0.40.2", "", { "dependencies": { "@expressive-code/core": "^0.40.2", "shiki": "^1.26.1" } }, "sha512-t2HMR5BO6GdDW1c1ISBTk66xO503e/Z8ecZdNcr6E4NpUfvY+MRje+LtrcvbBqMwWBBO8RpVKcam/Uy+1GxwKQ=="],
 
     "@expressive-code/plugin-text-markers": ["@expressive-code/plugin-text-markers@0.40.2", "", { "dependencies": { "@expressive-code/core": "^0.40.2" } }, "sha512-/XoLjD67K9nfM4TgDlXAExzMJp6ewFKxNpfUw4F7q5Ecy+IU3/9zQQG/O70Zy+RxYTwKGw2MA9kd7yelsxnSmw=="],
+
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.3", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
@@ -178,6 +190,8 @@
     "@lit/reactive-element": ["@lit/reactive-element@2.1.2", "", { "dependencies": { "@lit-labs/ssr-dom-shim": "^1.5.0" } }, "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.0", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.1.1", "", { "dependencies": { "@chevrotain/types": "~11.1.1" } }, "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw=="],
 
     "@npmcli/agent": ["@npmcli/agent@4.0.0", "", { "dependencies": { "agent-base": "^7.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.1", "lru-cache": "^11.2.1", "socks-proxy-agent": "^8.0.3" } }, "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA=="],
 
@@ -255,11 +269,75 @@
 
     "@types/acorn": ["@types/acorn@4.0.6", "", { "dependencies": { "@types/estree": "*" } }, "sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.3", "", {}, "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -282,6 +360,8 @@
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@vtbag/cam-shaft": ["@vtbag/cam-shaft@1.0.6", "", {}, "sha512-Xy1bmJJLXuCqxmY2agwPfhGNv1XZViqh54H0VGK4mouGsItFsh8Mz/wWAP6mZwAOEuu9bEOJ1mJ+oNoaczZ1zw=="],
 
@@ -324,6 +404,8 @@
     "astro": ["astro@5.17.3", "", { "dependencies": { "@astrojs/compiler": "^2.13.0", "@astrojs/internal-helpers": "0.7.5", "@astrojs/markdown-remark": "6.3.10", "@astrojs/telemetry": "3.3.0", "@capsizecss/unpack": "^4.0.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "acorn": "^8.15.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "boxen": "8.0.1", "ci-info": "^4.3.1", "clsx": "^2.1.1", "common-ancestor-path": "^1.0.1", "cookie": "^1.1.1", "cssesc": "^3.0.0", "debug": "^4.4.3", "deterministic-object-hash": "^2.0.2", "devalue": "^5.6.2", "diff": "^8.0.3", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^1.7.0", "esbuild": "^0.27.3", "estree-walker": "^3.0.3", "flattie": "^1.1.1", "fontace": "~0.4.0", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "import-meta-resolve": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.1", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "p-limit": "^6.2.0", "p-queue": "^8.1.1", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.3", "prompts": "^2.4.2", "rehype": "^13.0.2", "semver": "^7.7.3", "shiki": "^3.21.0", "smol-toml": "^1.6.0", "svgo": "^4.0.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.3", "unist-util-visit": "^5.0.0", "unstorage": "^1.17.4", "vfile": "^6.0.3", "vite": "^6.4.1", "vitefu": "^1.1.1", "xxhash-wasm": "^1.1.0", "yargs-parser": "^21.1.1", "yocto-spinner": "^0.2.3", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.1", "zod-to-ts": "^1.2.0" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "astro.js" } }, "sha512-69dcfPe8LsHzklwj+hl+vunWUbpMB6pmg35mACjetxbJeUNNys90JaBM8ZiwsPK689SAj/4Zqb1ayaANls9/MA=="],
 
     "astro-expressive-code": ["astro-expressive-code@0.40.2", "", { "dependencies": { "rehype-expressive-code": "^0.40.2" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0" } }, "sha512-yJMQId0yXSAbW9I6yqvJ3FcjKzJ8zRL7elbJbllkv1ZJPlsI0NI83Pxn1YL1IapEM347EvOOkSW2GL+2+NO61w=="],
+
+    "astro-mermaid": ["astro-mermaid@2.0.2", "", { "dependencies": { "import-meta-resolve": "^4.2.0", "mdast-util-to-string": "^4.0.0", "unist-util-visit": "^5.0.0" }, "peerDependencies": { "@mermaid-js/layout-elk": "^0.2.0", "astro": ">=4", "mermaid": "^10.0.0 || ^11.0.0" }, "optionalPeers": ["@mermaid-js/layout-elk"] }, "sha512-ihx63qwZ0hlu9mDjs6auQEXyo13s9h5HFHFIHovjTJH6ot97u0VqyGk3P1kkjPYZeOMrZ1Y7QAOevUfLs9cDfA=="],
 
     "astro-vtbot": ["astro-vtbot@2.1.11", "", { "dependencies": { "@vtbag/cam-shaft": "^1.0.6", "@vtbag/element-crossing": "^1.1.0", "@vtbag/inspection-chamber": "^1.0.24", "@vtbag/turn-signal": "^1.3.1", "@vtbag/utensil-drawer": "^1.2.15" } }, "sha512-M0b2y2Kh4BcHryfY2dP+xrZOH2zYHEYM+x+1NFvCoK+g8iGRE/va6DxPN/zJ07IwWYjGl9PizLA0ZLJJl0a2sg=="],
 
@@ -405,6 +487,8 @@
 
     "cookie-es": ["cookie-es@1.2.2", "", {}, "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="],
 
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
     "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
@@ -419,7 +503,81 @@
 
     "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
 
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -430,6 +588,8 @@
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
@@ -455,6 +615,8 @@
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
+    "dompurify": ["dompurify@3.4.9", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ=="],
+
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
@@ -476,6 +638,8 @@
     "err-code": ["err-code@2.0.3", "", {}, "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "es-toolkit": ["es-toolkit@1.47.0", "", {}, "sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
@@ -542,6 +706,8 @@
     "gsap": ["gsap@3.14.2", "", {}, "sha512-P8/mMxVLU7o4+55+1TCnQrPmgjPKnwkzkXOK1asnR9Jg2lna4tEY5qBJjMmAaOBDDZWtlRjBXjLa0w53G/uBLA=="],
 
     "h3": ["h3@1.15.5", "", { "dependencies": { "cookie-es": "^1.2.2", "crossws": "^0.3.5", "defu": "^6.1.4", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg=="],
+
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
 
     "hast-util-embedded": ["hast-util-embedded@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-is-element": "^3.0.0" } }, "sha512-naH8sld4Pe2ep03qqULEtvYr7EjrLK2QHY8KJR6RJkTUjPGObe1vnx585uzem2hGra+s1q08DZZpfgDVYRbaXA=="],
 
@@ -611,6 +777,8 @@
 
     "inline-style-parser": ["inline-style-parser@0.2.4", "", {}, "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="],
 
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
     "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "iron-webcrypto": ["iron-webcrypto@1.2.1", "", {}, "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg=="],
@@ -639,15 +807,23 @@
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "klona": ["klona@2.0.6", "", {}, "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "lit": ["lit@3.3.2", "", { "dependencies": { "@lit/reactive-element": "^2.1.0", "lit-element": "^4.2.0", "lit-html": "^3.3.0" } }, "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ=="],
 
     "lit-element": ["lit-element@4.2.2", "", { "dependencies": { "@lit-labs/ssr-dom-shim": "^1.5.0", "@lit/reactive-element": "^2.1.0", "lit-html": "^3.3.0" } }, "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w=="],
 
     "lit-html": ["lit-html@3.3.2", "", { "dependencies": { "@types/trusted-types": "^2.0.2" } }, "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
@@ -662,6 +838,8 @@
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "mdast-util-definitions": ["mdast-util-definitions@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ=="],
 
@@ -700,6 +878,8 @@
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "mdn-data": ["mdn-data@2.12.2", "", {}, "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="],
+
+    "mermaid": ["mermaid@11.15.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.1", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "es-toolkit": "^1.45.1", "katex": "^0.16.25", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw=="],
 
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
@@ -857,6 +1037,8 @@
 
     "parse5": ["parse5@7.2.1", "", { "dependencies": { "entities": "^4.5.0" } }, "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ=="],
 
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
     "path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
 
     "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
@@ -864,6 +1046,10 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "postcss": ["postcss@8.5.3", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A=="],
 
@@ -947,7 +1133,13 @@
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rollup": ["rollup@4.35.0", "", { "dependencies": { "@types/estree": "1.0.6" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.35.0", "@rollup/rollup-android-arm64": "4.35.0", "@rollup/rollup-darwin-arm64": "4.35.0", "@rollup/rollup-darwin-x64": "4.35.0", "@rollup/rollup-freebsd-arm64": "4.35.0", "@rollup/rollup-freebsd-x64": "4.35.0", "@rollup/rollup-linux-arm-gnueabihf": "4.35.0", "@rollup/rollup-linux-arm-musleabihf": "4.35.0", "@rollup/rollup-linux-arm64-gnu": "4.35.0", "@rollup/rollup-linux-arm64-musl": "4.35.0", "@rollup/rollup-linux-loongarch64-gnu": "4.35.0", "@rollup/rollup-linux-powerpc64le-gnu": "4.35.0", "@rollup/rollup-linux-riscv64-gnu": "4.35.0", "@rollup/rollup-linux-s390x-gnu": "4.35.0", "@rollup/rollup-linux-x64-gnu": "4.35.0", "@rollup/rollup-linux-x64-musl": "4.35.0", "@rollup/rollup-win32-arm64-msvc": "4.35.0", "@rollup/rollup-win32-ia32-msvc": "4.35.0", "@rollup/rollup-win32-x64-msvc": "4.35.0", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-kg6oI4g+vc41vePJyO6dHt/yl0Rz3Thv0kJeVQ3D1kS3E5XSuKbPc29G4IpT/Kv1KQwgHVcN+HtyS+HYLNSvQg=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
@@ -1007,6 +1199,8 @@
 
     "style-to-object": ["style-to-object@1.0.8", "", { "dependencies": { "inline-style-parser": "0.2.4" } }, "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g=="],
 
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
     "svgo": ["svgo@4.0.0", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.4.1" }, "bin": "./bin/svgo.js" }, "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
@@ -1028,6 +1222,8 @@
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
+
+    "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
 
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
 
@@ -1078,6 +1274,8 @@
     "unstorage": ["unstorage@1.17.4", "", { "dependencies": { "anymatch": "^3.1.3", "chokidar": "^5.0.0", "destr": "^2.0.5", "h3": "^1.15.5", "lru-cache": "^11.2.0", "node-fetch-native": "^1.6.7", "ofetch": "^1.5.1", "ufo": "^1.6.3" }, "peerDependencies": { "@azure/app-configuration": "^1.8.0", "@azure/cosmos": "^4.2.0", "@azure/data-tables": "^13.3.0", "@azure/identity": "^4.6.0", "@azure/keyvault-secrets": "^4.9.0", "@azure/storage-blob": "^12.26.0", "@capacitor/preferences": "^6 || ^7 || ^8", "@deno/kv": ">=0.9.0", "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0", "@planetscale/database": "^1.19.0", "@upstash/redis": "^1.34.3", "@vercel/blob": ">=0.27.1", "@vercel/functions": "^2.2.12 || ^3.0.0", "@vercel/kv": "^1 || ^2 || ^3", "aws4fetch": "^1.0.20", "db0": ">=0.2.1", "idb-keyval": "^6.2.1", "ioredis": "^5.4.2", "uploadthing": "^7.4.4" }, "optionalPeers": ["@azure/app-configuration", "@azure/cosmos", "@azure/data-tables", "@azure/identity", "@azure/keyvault-secrets", "@azure/storage-blob", "@capacitor/preferences", "@deno/kv", "@netlify/blobs", "@planetscale/database", "@upstash/redis", "@vercel/blob", "@vercel/functions", "@vercel/kv", "aws4fetch", "db0", "idb-keyval", "ioredis", "uploadthing"] }, "sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
@@ -1151,6 +1349,14 @@
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
     "esast-util-from-js/acorn": ["acorn@8.14.1", "", { "bin": "bin/acorn" }, "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg=="],
 
     "hast-util-to-parse5/property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
@@ -1158,6 +1364,8 @@
     "http-proxy-agent/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
     "https-proxy-agent/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
+
+    "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "make-fetch-happen/http-cache-semantics": ["http-cache-semantics@4.1.1", "", {}, "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="],
 
@@ -1224,6 +1432,12 @@
     "astro/sharp/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
     "minipass-flush/minipass/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 

--- a/website/package.json
+++ b/website/package.json
@@ -13,11 +13,13 @@
     "@astrojs/lit": "^4.3.0",
     "@astrojs/starlight": "^0.32.6",
     "astro": "^5.17.3",
+    "astro-mermaid": "^2.0.2",
+    "astro-vtbot": "^2.1.11",
     "gsap": "^3.14.2",
     "lit": "^3.3.2",
+    "mermaid": "^11.15.0",
     "node-gyp": "^12.2.0",
     "sharp": "^0.32.6",
-    "starlight-theme-flexoki": "^0.1.0",
-    "astro-vtbot": "^2.1.11"
+    "starlight-theme-flexoki": "^0.1.0"
   }
 }


### PR DESCRIPTION
Part of the functional-core / imperative-shell architecture. Builds on `arch/04-engine`.

Documentation only. Publishes the Internals handbook under `docs/internals/` with rendered diagrams and a design-decisions page that records what anchors each constant, refreshes the FAQ pages (degraded mode, window sensor, diagnostics, write budget), and updates the website navigation.

### Verification
- `ruff` and `pyrefly check`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded contributing guidance and README with links to the new internals architecture materials, highlighting “fail-soft and observable” behavior.
  * Updated FAQs with clearer explanations for TRV write delays (channel-spaced by at least 30 seconds), degraded mode (degradation ladder + timing + observable attributes), window sensor accepted states/debounce (including treating `unknown`/`unavailable` as closed), and step-by-step diagnostics downloads (including flight recorder details).
  * Added new internals docs covering architecture overview, calibration, design decisions, observability & testing, persistence, regions, safety & degradation, and writes/reconciliation mechanics. Also refined related configuration/window-delay references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->