### PR TITLE
test(benchmark): simulation core & scoring engine

### DIFF
--- a/tests/benchmark/__init__.py
+++ b/tests/benchmark/__init__.py
@@ -1,0 +1,6 @@
+"""Calibration controller benchmark suite.
+
+Pure-simulation comparison framework for Better Thermostat's calibration
+controllers (MPC, TPI, PID, …) against deterministic plant scenarios.
+Entry point: ``python -m tests.benchmark.runner --help``.
+"""

--- a/tests/benchmark/actuator.py
+++ b/tests/benchmark/actuator.py
@@ -1,0 +1,87 @@
+"""TRV actuator model with four valve-flow profiles.
+
+EQUAL_PERCENTAGE is the most realistic of the four for typical TRV
+hardware: a given fractional change in commanded valve position
+produces the same fractional change in delivered flow, which gives
+the controller a roughly constant loop gain across the operating
+range. See DESIGN.md §8 (actuator modelling; Karlsson 1980).
+
+flow = (pct/100)^alpha       (alpha ≈ 3 for typical residential TRVs)
+
+LINEAR remains the simplest reference profile and is still the default
+so existing tests keep their behaviour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class ActuatorProfile(StrEnum):
+    """Valve flow profile family."""
+
+    LINEAR = "linear"
+    THRESHOLD = "threshold"
+    EXPONENTIAL = "exponential"
+    EQUAL_PERCENTAGE = "equal_percentage"
+
+
+@dataclass
+class ActuatorParams:
+    """Parameters describing actuator behaviour."""
+
+    profile: ActuatorProfile = ActuatorProfile.LINEAR
+    dead_zone_pct: float = 0.0
+    hysteresis_pct: float = 0.0
+    quantize_pct: float = 0.0  # 0 = continuous, e.g. 1.0 = integer percent
+    # Exponent for equal-percentage profile; ignored by other profiles.
+    # Typical values for residential TRVs: 2.5 - 4.0.
+    equal_percentage_exponent: float = 3.0
+    # Generic deadband: commands strictly below this percent produce zero
+    # flow regardless of the profile. Distinct from ``dead_zone_pct``,
+    # which only applies inside the THRESHOLD profile.
+    deadband_pct: float = 0.0
+
+
+class Actuator:
+    """Maps a commanded valve percent to an effective flow in [0, 1]."""
+
+    def __init__(self, params: ActuatorParams) -> None:
+        self.params = params
+        self._last_applied_pct: float = 0.0
+
+    def apply(self, cmd_pct: float) -> float:
+        """Translate a commanded percent into an effective flow in [0, 1]."""
+        p = self.params
+        pct = max(0.0, min(100.0, cmd_pct))
+
+        if p.hysteresis_pct > 0.0:
+            if abs(pct - self._last_applied_pct) < p.hysteresis_pct:
+                pct = self._last_applied_pct
+
+        if p.quantize_pct > 0.0:
+            pct = round(pct / p.quantize_pct) * p.quantize_pct
+            pct = max(0.0, min(100.0, pct))
+
+        if p.deadband_pct > 0.0 and pct < p.deadband_pct:
+            self._last_applied_pct = pct
+            return 0.0
+
+        if p.profile == ActuatorProfile.THRESHOLD:
+            if pct < p.dead_zone_pct:
+                flow = 0.0
+            else:
+                span = 100.0 - p.dead_zone_pct
+                flow = (pct - p.dead_zone_pct) / span if span > 0.0 else 1.0
+        elif p.profile == ActuatorProfile.EXPONENTIAL:
+            flow = (pct / 100.0) ** 2
+        elif p.profile == ActuatorProfile.EQUAL_PERCENTAGE:
+            # Realistic TRV characteristic: equal-percentage curve.
+            exp = max(1.0, p.equal_percentage_exponent)
+            flow = (pct / 100.0) ** exp
+        else:  # LINEAR
+            flow = pct / 100.0
+
+        self._last_applied_pct = pct
+        return max(0.0, min(1.0, flow))

--- a/tests/benchmark/actuator.py
+++ b/tests/benchmark/actuator.py
@@ -8,14 +8,19 @@ range. See DESIGN.md §8 (actuator modelling; Karlsson 1980).
 
 flow = (pct/100)^alpha       (alpha ≈ 3 for typical residential TRVs)
 
-LINEAR remains the simplest reference profile and is still the default
-so existing tests keep their behaviour.
+EXPONENTIAL is a fixed quadratic curve, ``flow = (pct/100)^2`` — the
+alpha=2 special case of the power law, kept as a mild-curvature step
+between LINEAR and EQUAL_PERCENTAGE. It ignores
+``equal_percentage_exponent``.
+
+LINEAR is the simplest reference profile and the default.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
+import math
 
 
 class ActuatorProfile(StrEnum):
@@ -42,6 +47,37 @@ class ActuatorParams:
     # flow regardless of the profile. Distinct from ``dead_zone_pct``,
     # which only applies inside the THRESHOLD profile.
     deadband_pct: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Reject non-physical actuator parameters.
+
+        Raises
+        ------
+        ValueError
+            If a parameter is not finite, a percent-domain field is
+            outside [0, 100], or the equal-percentage exponent is < 1.
+        """
+        for name in (
+            "dead_zone_pct",
+            "hysteresis_pct",
+            "quantize_pct",
+            "equal_percentage_exponent",
+            "deadband_pct",
+        ):
+            value = getattr(self, name)
+            if not math.isfinite(value):
+                raise ValueError(f"ActuatorParams {name} must be finite, got {value}")
+        for name in ("dead_zone_pct", "hysteresis_pct", "quantize_pct", "deadband_pct"):
+            value = getattr(self, name)
+            if not (0.0 <= value <= 100.0):
+                raise ValueError(
+                    f"ActuatorParams {name} must be in [0, 100], got {value}"
+                )
+        if self.equal_percentage_exponent < 1.0:
+            raise ValueError(
+                "ActuatorParams equal_percentage_exponent must be >= 1, got "
+                f"{self.equal_percentage_exponent}"
+            )
 
 
 class Actuator:
@@ -75,11 +111,13 @@ class Actuator:
                 span = 100.0 - p.dead_zone_pct
                 flow = (pct - p.dead_zone_pct) / span if span > 0.0 else 1.0
         elif p.profile == ActuatorProfile.EXPONENTIAL:
+            # Fixed quadratic curve (power law with alpha = 2).
             flow = (pct / 100.0) ** 2
         elif p.profile == ActuatorProfile.EQUAL_PERCENTAGE:
-            # Realistic TRV characteristic: equal-percentage curve.
-            exp = max(1.0, p.equal_percentage_exponent)
-            flow = (pct / 100.0) ** exp
+            # Realistic TRV characteristic: equal-percentage curve
+            # (modified power-law approximation, exponent >= 1 enforced
+            # at construction).
+            flow = (pct / 100.0) ** p.equal_percentage_exponent
         else:  # LINEAR
             flow = pct / 100.0
 

--- a/tests/benchmark/actuator.py
+++ b/tests/benchmark/actuator.py
@@ -8,10 +8,9 @@ range. See DESIGN.md §8 (actuator modelling; Karlsson 1980).
 
 flow = (pct/100)^alpha       (alpha ≈ 3 for typical residential TRVs)
 
-EXPONENTIAL is a fixed quadratic curve, ``flow = (pct/100)^2`` — the
-alpha=2 special case of the power law, kept as a mild-curvature step
-between LINEAR and EQUAL_PERCENTAGE. It ignores
-``equal_percentage_exponent``.
+QUADRATIC is a fixed curve, ``flow = (pct/100)^2`` — the alpha=2
+special case of the power law, kept as a mild-curvature step between
+LINEAR and EQUAL_PERCENTAGE. It ignores ``equal_percentage_exponent``.
 
 LINEAR is the simplest reference profile and the default.
 """
@@ -28,7 +27,7 @@ class ActuatorProfile(StrEnum):
 
     LINEAR = "linear"
     THRESHOLD = "threshold"
-    EXPONENTIAL = "exponential"
+    QUADRATIC = "quadratic"
     EQUAL_PERCENTAGE = "equal_percentage"
 
 
@@ -110,7 +109,7 @@ class Actuator:
             else:
                 span = 100.0 - p.dead_zone_pct
                 flow = (pct - p.dead_zone_pct) / span if span > 0.0 else 1.0
-        elif p.profile == ActuatorProfile.EXPONENTIAL:
+        elif p.profile == ActuatorProfile.QUADRATIC:
             # Fixed quadratic curve (power law with alpha = 2).
             flow = (pct / 100.0) ** 2
         elif p.profile == ActuatorProfile.EQUAL_PERCENTAGE:

--- a/tests/benchmark/adapters/__init__.py
+++ b/tests/benchmark/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Per-controller adapters that bind benchmark inputs to controller-specific shapes."""

--- a/tests/benchmark/adapters/base.py
+++ b/tests/benchmark/adapters/base.py
@@ -10,6 +10,7 @@ the controller itself.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import math
 from typing import Any, Literal, Protocol
 
 
@@ -68,6 +69,17 @@ class BenchmarkOutput:
             raise ValueError(
                 "BenchmarkOutput allows only one output family "
                 f"(or duty_cycle_pct mirrored into valve_percent), got: {sorted(populated)}"
+            )
+        valve, duty = self.valve_percent, self.duty_cycle_pct
+        if (
+            populated == {"valve_percent", "duty_cycle_pct"}
+            and valve is not None
+            and duty is not None
+            and not math.isclose(valve, duty, abs_tol=1e-9)
+        ):
+            raise ValueError(
+                "BenchmarkOutput duty_cycle_pct must be mirrored into valve_percent "
+                f"(got valve_percent={valve}, duty_cycle_pct={duty})"
             )
 
 

--- a/tests/benchmark/adapters/base.py
+++ b/tests/benchmark/adapters/base.py
@@ -1,0 +1,93 @@
+"""Controller adapter protocol and shared dataclasses.
+
+Every calibration controller — existing or future — is wrapped by an adapter
+that conforms to :class:`ControllerAdapter`. The adapter's job is to translate
+between the benchmark's universal :class:`BenchmarkContext` / :class:`BenchmarkOutput`
+shape and the controller's native interface, with no behavior changes inside
+the controller itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+
+
+@dataclass(frozen=True)
+class BenchmarkContext:
+    """Read-only state visible to the controller at one simulation step."""
+
+    t: float  # seconds since scenario start
+    dt: float  # time since last step (seconds)
+    target_temp_C: float
+    current_temp_C: float  # measurement coming out of the sensor model
+    raw_room_temp_C: float  # plant-internal truth (for adapters that cheat-peek)
+    trv_temp_C: float | None  # radiator surface, if supported
+    outdoor_temp_C: float
+    window_open: bool = False
+    solar_intensity: float = 0.0  # 0.0 - 1.0
+    last_valve_percent: float = 0.0
+
+
+@dataclass(frozen=True)
+class BenchmarkOutput:
+    """What the controller produced at one step.
+
+    Exactly one of ``valve_percent`` / ``setpoint_offset_K`` / ``duty_cycle_pct``
+    should be set, matching the controller's :attr:`family`. The one exception:
+    duty-family controllers additionally mirror their duty cycle into
+    ``valve_percent``, because the plant is actuated through ``valve_percent``
+    regardless of family.
+    """
+
+    valve_percent: float | None = None
+    setpoint_offset_K: float | None = None
+    duty_cycle_pct: float | None = None
+    diagnostics: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate the one-output contract at the adapter boundary.
+
+        Raises
+        ------
+        ValueError
+            If no output field is populated, or if a combination other
+            than the documented duty+valve pairing is populated.
+        """
+        populated = {
+            name
+            for name in ("valve_percent", "setpoint_offset_K", "duty_cycle_pct")
+            if getattr(self, name) is not None
+        }
+        if not populated:
+            raise ValueError(
+                "BenchmarkOutput requires one of valve_percent, "
+                "setpoint_offset_K, duty_cycle_pct"
+            )
+        if len(populated) > 1 and populated != {"valve_percent", "duty_cycle_pct"}:
+            raise ValueError(
+                "BenchmarkOutput allows only one output family "
+                f"(or duty_cycle_pct mirrored into valve_percent), got: {sorted(populated)}"
+            )
+
+
+ControllerFamily = Literal["valve", "offset", "duty"]
+
+
+class ControllerAdapter(Protocol):
+    """Structural type every controller adapter must satisfy."""
+
+    name: str
+    family: ControllerFamily
+
+    def reset(self, prior: dict[str, Any] | None = None) -> None:
+        """Drop all learned state; optionally seed from ``prior``."""
+        ...
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        """Produce one control action for ``ctx``."""
+        ...
+
+    def export_state(self) -> dict[str, Any]:
+        """Return a serializable snapshot of current controller state."""
+        ...

--- a/tests/benchmark/metrics.py
+++ b/tests/benchmark/metrics.py
@@ -1,0 +1,232 @@
+"""Metric computations over a benchmark time-series.
+
+All metrics work on a :class:`TimeSeries` of parallel arrays. Time-series
+samples are assumed equally spaced in coarse steps; metrics that need
+specific resolution document their assumptions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+import math
+
+
+@dataclass(frozen=True)
+class TimeSeries:
+    """Parallel arrays of recorded simulator state at every step."""
+
+    t_s: Sequence[float]
+    T_room_C: Sequence[float]
+    T_setpoint_C: Sequence[float]
+    valve_pct: Sequence[float]
+
+    def __post_init__(self) -> None:
+        """Validate the parallel-array invariants every metric relies on.
+
+        Raises
+        ------
+        ValueError
+            If the four sequences differ in length or ``t_s`` is not
+            strictly increasing.
+        """
+        lengths = {
+            len(self.t_s),
+            len(self.T_room_C),
+            len(self.T_setpoint_C),
+            len(self.valve_pct),
+        }
+        if len(lengths) != 1:
+            raise ValueError("TimeSeries fields must have the same length")
+        if any(t2 <= t1 for t1, t2 in zip(self.t_s, self.t_s[1:])):
+            raise ValueError("TimeSeries.t_s must be strictly increasing")
+
+
+@dataclass(frozen=True)
+class MetricValues:
+    """Computed metrics for one (controller, scenario) run.
+
+    The metrics span four of the five user-priority dimensions described
+    in DESIGN.md §4 (the fifth — adaptation across runs — is a
+    benchmark-suite-level metric, not a per-run one):
+
+    * **Comfort**: max_overshoot_K, max_undershoot_K, rmse_tracking_K,
+      steady_state_error_K, settling_time_min
+    * **Actuator longevity**: valve_cycle_count, total_valve_travel_pct
+    * **Energy**: integral_valve_pct_min
+    * **Resilience**: implicit in failure-mode metrics (settling=inf etc.)
+    """
+
+    max_overshoot_K: float
+    max_undershoot_K: float
+    settling_time_min: float  # math.inf if not settled within run
+    steady_state_error_K: float
+    rmse_tracking_K: float
+    valve_cycle_count: int
+    integral_valve_pct_min: float
+    # Actuator-longevity proxy: Σ|Δu_pct| across the whole run, so small
+    # wiggles add up even if they never reverse direction.
+    total_valve_travel_pct: float
+    # Asymmetric comfort accounting in K·h (BOPTEST tdis_tot split), useful
+    # where overshoot and undershoot have different cost. Integrated over
+    # the transient phase only.
+    time_above_setpoint_K_h: float
+    time_below_setpoint_K_h: float
+    # Fraction of run time spent with the valve at 40–60 %. Heat-pump
+    # COP suffers at the extremes; the sweet spot is mid-range modulation.
+    valve_sweet_spot_residency_pct: float
+
+
+def _compute_overshoot(
+    series: TimeSeries, transient_start_s: float
+) -> tuple[float, float]:
+    over, under = 0.0, 0.0
+    for t, T, sp in zip(series.t_s, series.T_room_C, series.T_setpoint_C):
+        if t < transient_start_s:
+            continue
+        if T > sp + over:
+            over = T - sp
+        if T < sp - under:
+            under = sp - T
+    return over, under
+
+
+def _compute_settling(
+    series: TimeSeries,
+    transient_start_s: float,
+    band_K: float = 0.2,
+    min_dwell_s: float = 600.0,
+) -> float:
+    """Return settling time in minutes.
+
+    Minutes from the transient start until ``|T - setpoint| < band_K`` stays
+    true for at least ``min_dwell_s`` continuous seconds. Returns inf if the
+    settling never occurs within the run.
+    """
+    in_band_since: float | None = None
+    for t, T, sp in zip(series.t_s, series.T_room_C, series.T_setpoint_C):
+        if t < transient_start_s:
+            continue
+        if abs(T - sp) < band_K:
+            if in_band_since is None:
+                in_band_since = t
+            elif (t - in_band_since) >= min_dwell_s:
+                return (in_band_since - transient_start_s) / 60.0
+        else:
+            in_band_since = None
+    return math.inf
+
+
+def _compute_steady_state(series: TimeSeries, window_min: float = 30.0) -> float:
+    """Mean absolute tracking error over the final ``window_min`` minutes."""
+    if not series.t_s:
+        return 0.0
+    final_t = series.t_s[-1]
+    window_start = final_t - window_min * 60.0
+    errs = [
+        abs(T - sp)
+        for t, T, sp in zip(series.t_s, series.T_room_C, series.T_setpoint_C)
+        if t >= window_start
+    ]
+    if not errs:
+        return 0.0
+    return sum(errs) / len(errs)
+
+
+def _compute_rmse(series: TimeSeries, transient_start_s: float) -> float:
+    errs = [
+        (T - sp) ** 2
+        for t, T, sp in zip(series.t_s, series.T_room_C, series.T_setpoint_C)
+        if t >= transient_start_s
+    ]
+    if not errs:
+        return 0.0
+    return math.sqrt(sum(errs) / len(errs))
+
+
+def _compute_valve_cycles(series: TimeSeries) -> int:
+    """Count valve-direction reversals across the run."""
+    cycles = 0
+    last_direction = 0
+    for i in range(1, len(series.valve_pct)):
+        delta = series.valve_pct[i] - series.valve_pct[i - 1]
+        direction = 1 if delta > 0.5 else (-1 if delta < -0.5 else 0)
+        if direction != 0 and last_direction not in (0, direction):
+            cycles += 1
+        if direction != 0:
+            last_direction = direction
+    return cycles
+
+
+def _compute_integral_valve(series: TimeSeries) -> float:
+    """Trapezoidal integral of valve_pct over time (units: pct·min)."""
+    if len(series.t_s) < 2:
+        return 0.0
+    total = 0.0
+    for i in range(1, len(series.t_s)):
+        dt_min = (series.t_s[i] - series.t_s[i - 1]) / 60.0
+        avg_pct = (series.valve_pct[i] + series.valve_pct[i - 1]) / 2.0
+        total += avg_pct * dt_min
+    return total
+
+
+def _compute_setpoint_imbalance_K_h(
+    series: TimeSeries, transient_start_s: float
+) -> tuple[float, float]:
+    """Return (∫max(T-SP,0) dt, ∫max(SP-T,0) dt) in K·h over the transient phase."""
+    if len(series.t_s) < 2:
+        return 0.0, 0.0
+    above_K_h = 0.0
+    below_K_h = 0.0
+    for i in range(1, len(series.t_s)):
+        seg_end = series.t_s[i]
+        if seg_end <= transient_start_s:
+            continue
+        # Clip the first interval so pre-transient time is not charged.
+        seg_start = max(series.t_s[i - 1], transient_start_s)
+        dt_h = (seg_end - seg_start) / 3600.0
+        err = series.T_room_C[i] - series.T_setpoint_C[i]
+        if err > 0.0:
+            above_K_h += err * dt_h
+        else:
+            below_K_h += -err * dt_h
+    return above_K_h, below_K_h
+
+
+def _compute_valve_sweet_spot_residency(
+    series: TimeSeries, low_pct: float = 40.0, high_pct: float = 60.0
+) -> float:
+    """Fraction of run time the commanded valve sits inside [low, high] %."""
+    if not series.valve_pct:
+        return 0.0
+    inside = sum(1 for v in series.valve_pct if low_pct <= v <= high_pct)
+    return 100.0 * inside / len(series.valve_pct)
+
+
+def _compute_total_valve_travel(series: TimeSeries) -> float:
+    """Σ|Δu_pct| over the whole run — actuator-wear/battery proxy."""
+    if len(series.valve_pct) < 2:
+        return 0.0
+    return sum(
+        abs(series.valve_pct[i] - series.valve_pct[i - 1])
+        for i in range(1, len(series.valve_pct))
+    )
+
+
+def compute_metrics(series: TimeSeries, transient_start_s: float) -> MetricValues:
+    """Compute all defined metrics for a single time-series."""
+    over, under = _compute_overshoot(series, transient_start_s)
+    above_K_h, below_K_h = _compute_setpoint_imbalance_K_h(series, transient_start_s)
+    return MetricValues(
+        max_overshoot_K=over,
+        max_undershoot_K=under,
+        settling_time_min=_compute_settling(series, transient_start_s),
+        steady_state_error_K=_compute_steady_state(series),
+        rmse_tracking_K=_compute_rmse(series, transient_start_s),
+        valve_cycle_count=_compute_valve_cycles(series),
+        integral_valve_pct_min=_compute_integral_valve(series),
+        total_valve_travel_pct=_compute_total_valve_travel(series),
+        time_above_setpoint_K_h=above_K_h,
+        time_below_setpoint_K_h=below_K_h,
+        valve_sweet_spot_residency_pct=_compute_valve_sweet_spot_residency(series),
+    )

--- a/tests/benchmark/metrics.py
+++ b/tests/benchmark/metrics.py
@@ -27,8 +27,8 @@ class TimeSeries:
         Raises
         ------
         ValueError
-            If the four sequences differ in length or ``t_s`` is not
-            strictly increasing.
+            If the four sequences differ in length, contain non-finite
+            values, or ``t_s`` is not strictly increasing.
         """
         lengths = {
             len(self.t_s),
@@ -38,6 +38,9 @@ class TimeSeries:
         }
         if len(lengths) != 1:
             raise ValueError("TimeSeries fields must have the same length")
+        for name in ("t_s", "T_room_C", "T_setpoint_C", "valve_pct"):
+            if any(not math.isfinite(v) for v in getattr(self, name)):
+                raise ValueError(f"TimeSeries.{name} must contain only finite values")
         if any(t2 <= t1 for t1, t2 in zip(self.t_s, self.t_s[1:])):
             raise ValueError("TimeSeries.t_s must be strictly increasing")
 

--- a/tests/benchmark/plant.py
+++ b/tests/benchmark/plant.py
@@ -73,6 +73,30 @@ class PlantParams:
     # at the radiator. ``0`` disables the delay.
     valve_command_delay_s: float = 0.0
 
+    def __post_init__(self) -> None:
+        """Reject non-physical parameters that would crash ``step``.
+
+        Raises
+        ------
+        ValueError
+            If a time constant that the integrator divides by is not
+            positive, or the wall layer / pipe delay is negative.
+        """
+        if self.tau_room_min <= 0.0 or self.tau_rad_min <= 0.0:
+            raise ValueError(
+                "PlantParams tau_room_min and tau_rad_min must be > 0, got "
+                f"tau_room_min={self.tau_room_min}, tau_rad_min={self.tau_rad_min}"
+            )
+        if self.tau_wall_min < 0.0:
+            raise ValueError(
+                f"PlantParams tau_wall_min must be >= 0, got {self.tau_wall_min}"
+            )
+        if self.valve_command_delay_s < 0.0:
+            raise ValueError(
+                "PlantParams valve_command_delay_s must be >= 0, got "
+                f"{self.valve_command_delay_s}"
+            )
+
 
 @dataclass
 class PlantState:

--- a/tests/benchmark/plant.py
+++ b/tests/benchmark/plant.py
@@ -1,0 +1,368 @@
+"""Lumped-RC thermal plant simulator (RC2 / RC3 + optional pipe transport delay).
+
+RC2 mode (``tau_wall_min == 0``):
+
+    dT_rad/dt  = (1 / tau_rad_min) * (
+        gain_heater * u * (T_water_C - T_rad)
+        - (T_rad - T_room)
+    )
+    dT_room/dt = (1 / tau_room_min) * (
+        coupling_rad_room * (T_rad - T_room)
+        - (T_room - T_outdoor)
+    ) + Q_K_per_min
+
+RC3 mode (``tau_wall_min > 0``):
+
+    dT_rad/dt  = (1 / tau_rad_min) * (
+        gain_heater * u * (T_water_C - T_rad)
+        - (T_rad - T_room)
+    )
+    dT_room/dt = (1 / tau_room_min) * (
+        coupling_rad_room * (T_rad - T_room)
+        - r_room_wall * (T_room - T_wall)
+    ) + Q_K_per_min
+    dT_wall/dt = (1 / tau_wall_min) * (
+        r_room_wall * (T_room - T_wall)
+        - (T_wall - T_outdoor)
+    )
+
+The RC3 mode introduces a slow wall thermal mass between the room and the
+outdoor. Heat now flows ``Room → Wall → Outdoor`` instead of directly to
+outdoor, giving the room a long-tail "thermal coast" after the heater
+stops — closer to real residential buildings (Bacher & Madsen 2011,
+ISO 52016-1).
+
+Pipe-transport delay: when ``valve_command_delay_s > 0`` the radiator
+does not see the *current* commanded ``u`` but the command from
+``valve_command_delay_s`` ago. Models the boiler → radiator transport
+lag (typically 30 s – 3 min; Burford & Madsen 2019).
+
+Integration uses explicit Euler with a step size that the caller chooses.
+For tau_rad_min >= 5 min and step sizes <= 60 s, this is comfortably stable
+in all modes.
+
+u is in [0, 1]; Q_K_per_min is an external disturbance heat-rate (K/min)
+that already includes the room thermal capacity.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+
+from .sensor import SensorParams
+
+
+@dataclass
+class PlantParams:
+    """Thermal parameters of a lumped-RC plant.
+
+    With ``tau_wall_min <= 0`` the plant is RC2 (room + radiator). Setting
+    ``tau_wall_min > 0`` enables the RC3 wall layer.
+    """
+
+    tau_room_min: float = 240.0
+    tau_rad_min: float = 15.0
+    gain_heater: float = 0.5
+    coupling_rad_room: float = 1.0
+    T_water_C: float = 65.0
+    # RC3 wall layer (opt-in via ``tau_wall_min > 0``).
+    tau_wall_min: float = 0.0
+    r_room_wall: float = 1.0
+    # Pipe transport delay (seconds) between commanded u and the u seen
+    # at the radiator. ``0`` disables the delay.
+    valve_command_delay_s: float = 0.0
+
+
+@dataclass
+class PlantState:
+    """Mutable simulator state.
+
+    ``T_wall_C`` is only meaningful in RC3 mode; in RC2 mode it stays at
+    whatever value it was initialised to. The plant initialises it to the
+    room temperature if the caller leaves it ``None``.
+    """
+
+    T_room_C: float
+    T_rad_C: float
+    T_wall_C: float | None = None
+
+
+# --- RC2 profiles ---
+
+PROFILE_FAST_SMALL = PlantParams(
+    tau_room_min=120.0,
+    tau_rad_min=8.0,
+    gain_heater=1.5,
+    coupling_rad_room=1.0,
+    T_water_C=65.0,
+)
+
+PROFILE_STANDARD = PlantParams(
+    tau_room_min=480.0,
+    tau_rad_min=15.0,
+    gain_heater=2.0,
+    coupling_rad_room=1.0,
+    T_water_C=65.0,
+)
+
+PROFILE_LARGE_SLOW = PlantParams(
+    tau_room_min=720.0,
+    tau_rad_min=25.0,
+    gain_heater=2.5,
+    coupling_rad_room=1.0,
+    T_water_C=65.0,
+)
+
+PROFILE_UNDERFLOOR = PlantParams(
+    tau_room_min=480.0,
+    tau_rad_min=60.0,
+    gain_heater=2.5,
+    coupling_rad_room=0.8,
+    T_water_C=45.0,
+)
+
+# Representative-residential profiles derived from cooling-window fits to
+# Home Assistant recorder data; see ``plant_fit/fit_plant.py`` for the
+# methodology and ``plant_fit/generate_synthetic_data.py`` for an
+# end-to-end synthetic equivalent.
+PROFILE_REAL_WOHNZIMMER = PlantParams(
+    tau_room_min=570.0,
+    tau_rad_min=15.0,
+    gain_heater=2.0,
+    coupling_rad_room=1.0,
+    T_water_C=65.0,
+)
+
+PROFILE_REAL_KUCHE = PlantParams(
+    tau_room_min=1011.0,
+    tau_rad_min=15.0,
+    gain_heater=2.0,
+    coupling_rad_room=1.0,
+    T_water_C=65.0,
+)
+
+
+# RC3 profiles split the lumped room time constant across the room-air
+# component (τ_room) and a wall mass (τ_wall). Air takes ≈ 1/8 of the
+# lumped τ, wall ≈ 7/8 — consistent with Bacher & Madsen 2011 and the
+# Modelica Buildings library ReducedOrder.RC reference.
+
+
+PROFILE_STANDARD_RC3 = PlantParams(
+    tau_room_min=60.0,
+    tau_rad_min=15.0,
+    gain_heater=2.0,
+    coupling_rad_room=1.0,
+    T_water_C=65.0,
+    tau_wall_min=900.0,
+    r_room_wall=1.0,
+)
+
+PROFILE_REAL_WOHNZIMMER_RC3 = PlantParams(
+    tau_room_min=70.0,
+    tau_rad_min=15.0,
+    gain_heater=2.0,
+    coupling_rad_room=1.0,
+    T_water_C=65.0,
+    tau_wall_min=1100.0,
+    r_room_wall=1.0,
+)
+
+
+# Realistic profile: RC3 wall mass, equal-percentage-friendly gains, and
+# a moderate pipe transport delay. To use the equal-percentage actuator
+# with this plant, pass
+# ``actuator_params=ActuatorParams(profile=EQUAL_PERCENTAGE)`` on the
+# scenario.
+
+# Heat-pump / low-temperature setup: supply ~42 °C instead of 65 °C.
+# Same loss and coupling parameters as STANDARD; only the driving water
+# temperature is reduced, which halves the effective heating-power gain
+# at full valve opening.
+PROFILE_BOILER_LIMITED = PlantParams(
+    tau_room_min=480.0,
+    tau_rad_min=15.0,
+    gain_heater=2.0,
+    coupling_rad_room=1.0,
+    T_water_C=42.0,
+)
+
+
+# DOE Reference Building–derived envelope classes.
+#
+# Lumped-parameter approximations of the three residential envelope
+# generations used by the US DOE Building Energy Codes Program prototype
+# buildings (energycodes.gov/prototype-building-models, IECC editions
+# 1980 / 2004-2009 / 2012-2021). Per-room values, not whole-building:
+# ~20 m² living room, ~50 m³ air volume, single external wall.
+#
+# Method (per generation):
+# * Wall + window + infiltration UA -> overall heat-loss coefficient.
+# * Effective room thermal capacity ~3× the dry-air mass, lumping
+#   furniture and partition walls into the air node (RC2) or splitting
+#   the slow mass into a wall node (RC3, tau_wall ≈ 5-10× tau_room).
+# * gain_heater scaled so a typical radiator delivers steady-state heat
+#   at u ≈ 0.3-0.5 with the envelope's design heat load at -5 °C outdoor.
+#
+# These profiles complement the existing PROFILE_STANDARD / _REAL_*
+# fits (which were tuned against measured BT installations) with
+# explicit DOE-codified envelope classes for cross-validation.
+
+PROFILE_DOE_SFD_PRE1980 = PlantParams(
+    # Single-family detached, uninsulated brick/wood-frame (pre-1980
+    # building stock, dominant in older European housing). High UA,
+    # low effective capacity -> short tau.
+    tau_room_min=240.0,
+    tau_rad_min=20.0,
+    gain_heater=2.5,
+    coupling_rad_room=1.0,
+    T_water_C=70.0,
+)
+
+PROFILE_DOE_SFD_2004 = PlantParams(
+    # Single-family detached at 2004-era IECC / EnEV 2002 envelope.
+    # Wall U ≈ 0.35 W/m²K, window U ≈ 1.6 W/m²K, ACH ≈ 0.5.
+    tau_room_min=480.0,
+    tau_rad_min=15.0,
+    gain_heater=2.0,
+    coupling_rad_room=1.0,
+    T_water_C=65.0,
+)
+
+PROFILE_DOE_SFD_2010 = PlantParams(
+    # Energy-efficient single-family at 2012+ IECC / EnEV 2009 envelope.
+    # Wall U ≈ 0.20 W/m²K, triple-pane windows, ACH ≈ 0.3, low-temp heating.
+    tau_room_min=720.0,
+    tau_rad_min=15.0,
+    gain_heater=1.8,
+    coupling_rad_room=1.0,
+    T_water_C=55.0,
+)
+
+PROFILE_DOE_MIDRISE_APT = PlantParams(
+    # Mid-rise apartment unit, 2010+ envelope. Adjacent units act as
+    # thermal buffers -> moderate tau but mild outdoor-coupling.
+    tau_room_min=600.0,
+    tau_rad_min=15.0,
+    gain_heater=2.0,
+    coupling_rad_room=1.0,
+    T_water_C=60.0,
+)
+
+
+# Reverse-acting "cooling" plant — same RC structure, but the radiator
+# circuit carries chilled water (≈ 15 °C). At u > 0 the radiator cools
+# the room instead of heating it. Used by S26 to expose how the BT/PID
+# controllers behave when the system's sign is flipped relative to their
+# design assumption (heating only).
+PROFILE_COOLING = PlantParams(
+    tau_room_min=480.0,
+    tau_rad_min=15.0,
+    gain_heater=2.0,
+    coupling_rad_room=1.0,
+    T_water_C=15.0,
+)
+
+
+PROFILE_REALISTIC = PlantParams(
+    tau_room_min=70.0,
+    tau_rad_min=15.0,
+    gain_heater=2.0,
+    coupling_rad_room=1.0,
+    T_water_C=65.0,
+    tau_wall_min=1100.0,
+    r_room_wall=1.0,
+    valve_command_delay_s=60.0,  # 1 min boiler→radiator transport
+)
+
+
+# Realistic sensor settings to combine with PROFILE_REALISTIC. Not used
+# automatically by any scenario; opt-in via ``scenario.sensor_params``.
+
+REALISTIC_SENSOR_PARAMS = SensorParams(
+    sample_interval_s=60.0,
+    ema_alpha=0.7,
+    noise_std_K=0.05,
+    thermal_lag_s=90.0,  # 1.5 min sensor thermal mass
+)
+
+
+class TwoStatePlant:
+    """Lumped-RC thermal plant.
+
+    Two internal states by default, three when the RC3 wall layer is
+    enabled via ``params.tau_wall_min > 0``. The plant owns its mutable
+    state. The caller drives it forward in time via :meth:`step`.
+    """
+
+    def __init__(self, params: PlantParams, initial: PlantState) -> None:
+        self.params = params
+        # Default T_wall to T_room when not provided. Important for RC3.
+        wall = initial.T_wall_C if initial.T_wall_C is not None else initial.T_room_C
+        self.state = PlantState(
+            T_room_C=initial.T_room_C, T_rad_C=initial.T_rad_C, T_wall_C=wall
+        )
+        # Pipe-delay buffer is allocated lazily on the first step() call,
+        # once we know the simulator's step size.
+        self._u_delay_buffer: deque[float] = deque()
+        self._u_buffer_target_len: int = 0
+
+    def step(
+        self, dt_s: float, u: float, T_outdoor_C: float, Q_K_per_min: float = 0.0
+    ) -> PlantState:
+        """Advance the plant by ``dt_s`` seconds. Returns the new state."""
+        if dt_s <= 0.0:
+            return self.state
+
+        dt_min = dt_s / 60.0
+        p = self.params
+        s = self.state
+        u_clamped = max(0.0, min(1.0, u))
+
+        # Apply pipe-transport delay: the radiator sees u from a few seconds
+        # ago, not the just-commanded value.
+        if p.valve_command_delay_s > 0.0:
+            if self._u_buffer_target_len == 0:
+                self._u_buffer_target_len = max(
+                    1, round(p.valve_command_delay_s / dt_s)
+                )
+                # Prime the buffer with the current u so the first
+                # ``delay`` steps are not artificially zero.
+                self._u_delay_buffer.extend([u_clamped] * self._u_buffer_target_len)
+            self._u_delay_buffer.append(u_clamped)
+            u_clamped = self._u_delay_buffer.popleft()
+
+        # Radiator dynamics — identical in RC2 and RC3.
+        dT_rad = (
+            p.gain_heater * u_clamped * (p.T_water_C - s.T_rad_C)
+            - (s.T_rad_C - s.T_room_C)
+        ) / p.tau_rad_min
+
+        if p.tau_wall_min > 0.0:
+            # RC3 dynamics: room exchanges with the wall instead of outdoor.
+            wall = s.T_wall_C if s.T_wall_C is not None else s.T_room_C
+
+            dT_room = (
+                p.coupling_rad_room * (s.T_rad_C - s.T_room_C)
+                - p.r_room_wall * (s.T_room_C - wall)
+            ) / p.tau_room_min
+
+            dT_wall = (
+                p.r_room_wall * (s.T_room_C - wall) - (wall - T_outdoor_C)
+            ) / p.tau_wall_min
+
+            s.T_rad_C += dT_rad * dt_min
+            s.T_room_C += (dT_room + Q_K_per_min) * dt_min
+            s.T_wall_C = wall + dT_wall * dt_min
+        else:
+            # RC2 dynamics: room exchanges directly with outdoor.
+            dT_room = (
+                p.coupling_rad_room * (s.T_rad_C - s.T_room_C)
+                - (s.T_room_C - T_outdoor_C)
+            ) / p.tau_room_min
+
+            s.T_rad_C += dT_rad * dt_min
+            s.T_room_C += (dT_room + Q_K_per_min) * dt_min
+
+        return s

--- a/tests/benchmark/plant.py
+++ b/tests/benchmark/plant.py
@@ -307,6 +307,9 @@ class TwoStatePlant:
         # once we know the simulator's step size.
         self._u_delay_buffer: deque[float] = deque()
         self._u_buffer_target_len: int = 0
+        # Step size captured when the delay buffer is sized; the modelled
+        # transport delay is only correct while dt_s stays constant.
+        self._delay_dt_s: float | None = None
 
     def step(
         self, dt_s: float, u: float, T_outdoor_C: float, Q_K_per_min: float = 0.0
@@ -324,12 +327,18 @@ class TwoStatePlant:
         # ago, not the just-commanded value.
         if p.valve_command_delay_s > 0.0:
             if self._u_buffer_target_len == 0:
+                self._delay_dt_s = dt_s
                 self._u_buffer_target_len = max(
                     1, round(p.valve_command_delay_s / dt_s)
                 )
                 # Prime the buffer with the current u so the first
                 # ``delay`` steps are not artificially zero.
                 self._u_delay_buffer.extend([u_clamped] * self._u_buffer_target_len)
+            elif self._delay_dt_s is not None and abs(dt_s - self._delay_dt_s) > 1e-9:
+                raise ValueError(
+                    "TwoStatePlant with valve_command_delay_s requires a constant "
+                    f"dt_s; buffer was sized for {self._delay_dt_s} s but got {dt_s} s"
+                )
             self._u_delay_buffer.append(u_clamped)
             u_clamped = self._u_delay_buffer.popleft()
 

--- a/tests/benchmark/plant.py
+++ b/tests/benchmark/plant.py
@@ -38,8 +38,12 @@ does not see the *current* commanded ``u`` but the command from
 lag (typically 30 s – 3 min; Burford & Madsen 2019).
 
 Integration uses explicit Euler with a step size that the caller chooses.
-For tau_rad_min >= 5 min and step sizes <= 60 s, this is comfortably stable
-in all modes.
+The stiffest node is the radiator, whose update rate is
+``(gain_heater * u + 1) / tau_rad_min``; explicit Euler requires
+``dt_min * (gain_heater * u + 1) / tau_rad_min < 2``. For the shipped
+profiles (gain_heater <= 2.5, tau_rad_min >= 5 min) and step sizes
+<= 60 s this is comfortably stable in all modes; much larger heater
+gains need a proportionally smaller step.
 
 u is in [0, 1]; Q_K_per_min is an external disturbance heat-rate (K/min)
 that already includes the room thermal capacity.
@@ -49,6 +53,7 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass
+import math
 
 from .sensor import SensorParams
 
@@ -79,17 +84,41 @@ class PlantParams:
         Raises
         ------
         ValueError
-            If a time constant that the integrator divides by is not
-            positive, or the wall layer / pipe delay is negative.
+            If a parameter is not finite, a time constant or gain that
+            the integrator relies on is not positive, or the wall layer
+            / pipe delay is negative.
         """
+        for name in (
+            "tau_room_min",
+            "tau_rad_min",
+            "gain_heater",
+            "coupling_rad_room",
+            "T_water_C",
+            "tau_wall_min",
+            "r_room_wall",
+            "valve_command_delay_s",
+        ):
+            value = getattr(self, name)
+            if not math.isfinite(value):
+                raise ValueError(f"PlantParams {name} must be finite, got {value}")
         if self.tau_room_min <= 0.0 or self.tau_rad_min <= 0.0:
             raise ValueError(
                 "PlantParams tau_room_min and tau_rad_min must be > 0, got "
                 f"tau_room_min={self.tau_room_min}, tau_rad_min={self.tau_rad_min}"
             )
+        if self.gain_heater <= 0.0 or self.coupling_rad_room <= 0.0:
+            raise ValueError(
+                "PlantParams gain_heater and coupling_rad_room must be > 0, got "
+                f"gain_heater={self.gain_heater}, "
+                f"coupling_rad_room={self.coupling_rad_room}"
+            )
         if self.tau_wall_min < 0.0:
             raise ValueError(
                 f"PlantParams tau_wall_min must be >= 0, got {self.tau_wall_min}"
+            )
+        if self.tau_wall_min > 0.0 and self.r_room_wall <= 0.0:
+            raise ValueError(
+                f"PlantParams r_room_wall must be > 0 in RC3 mode, got {self.r_room_wall}"
             )
         if self.valve_command_delay_s < 0.0:
             raise ValueError(
@@ -150,7 +179,7 @@ PROFILE_UNDERFLOOR = PlantParams(
 # Home Assistant recorder data; see ``plant_fit/fit_plant.py`` for the
 # methodology and ``plant_fit/generate_synthetic_data.py`` for an
 # end-to-end synthetic equivalent.
-PROFILE_REAL_WOHNZIMMER = PlantParams(
+PROFILE_REAL_LIVING_ROOM = PlantParams(
     tau_room_min=570.0,
     tau_rad_min=15.0,
     gain_heater=2.0,
@@ -158,7 +187,7 @@ PROFILE_REAL_WOHNZIMMER = PlantParams(
     T_water_C=65.0,
 )
 
-PROFILE_REAL_KUCHE = PlantParams(
+PROFILE_REAL_KITCHEN = PlantParams(
     tau_room_min=1011.0,
     tau_rad_min=15.0,
     gain_heater=2.0,
@@ -183,7 +212,7 @@ PROFILE_STANDARD_RC3 = PlantParams(
     r_room_wall=1.0,
 )
 
-PROFILE_REAL_WOHNZIMMER_RC3 = PlantParams(
+PROFILE_REAL_LIVING_ROOM_RC3 = PlantParams(
     tau_room_min=70.0,
     tau_rad_min=15.0,
     gain_heater=2.0,
@@ -193,12 +222,6 @@ PROFILE_REAL_WOHNZIMMER_RC3 = PlantParams(
     r_room_wall=1.0,
 )
 
-
-# Realistic profile: RC3 wall mass, equal-percentage-friendly gains, and
-# a moderate pipe transport delay. To use the equal-percentage actuator
-# with this plant, pass
-# ``actuator_params=ActuatorParams(profile=EQUAL_PERCENTAGE)`` on the
-# scenario.
 
 # Heat-pump / low-temperature setup: supply ~42 °C instead of 65 °C.
 # Same loss and coupling parameters as STANDARD; only the driving water
@@ -289,6 +312,11 @@ PROFILE_COOLING = PlantParams(
 )
 
 
+# Realistic profile: RC3 wall mass, equal-percentage-friendly gains, and
+# a moderate pipe transport delay. To use the equal-percentage actuator
+# with this plant, pass
+# ``actuator_params=ActuatorParams(profile=EQUAL_PERCENTAGE)`` on the
+# scenario.
 PROFILE_REALISTIC = PlantParams(
     tau_room_min=70.0,
     tau_rad_min=15.0,

--- a/tests/benchmark/reporter.py
+++ b/tests/benchmark/reporter.py
@@ -1,0 +1,259 @@
+"""Console reporting for benchmark runs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import math
+import statistics
+
+from .metrics import MetricValues
+from .scoring import DimensionScores, UserProfile, compute_scores
+
+
+@dataclass(frozen=True)
+class ScenarioResult:
+    """Outcome of one (controller, scenario) benchmark run."""
+
+    controller: str
+    scenario: str
+    metrics: MetricValues
+
+
+def format_metric(val: float, decimals: int = 2) -> str:
+    """Format a metric value for human-readable output."""
+    if math.isinf(val):
+        return "  inf"
+    if math.isnan(val):
+        return "  NaN"
+    return f"{val:.{decimals}f}"
+
+
+# -----------------------------------------------------------------------------
+# Score-matrix reporting (continuous, oracle-normalised)
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScoredResult:
+    """A :class:`ScenarioResult` enriched with oracle-relative scores.
+
+    ``block_label`` carries the plant-override block the result came
+    from; the same scenario name can exist under several blocks, so the
+    pair (``block_label``, ``scenario``) is the full scenario identity.
+    """
+
+    controller: str
+    scenario: str
+    metrics: MetricValues
+    scores: DimensionScores
+    block_label: str = ""
+
+
+def score_results(
+    results: Mapping[str, list[ScenarioResult]],
+    oracle_per_scenario: Mapping[tuple[str, str], MetricValues],
+    profile: UserProfile,
+) -> list[ScoredResult]:
+    """Compute per-(controller, scenario) scores against the Oracle baseline.
+
+    ``oracle_per_scenario`` is keyed by ``(block_label, scenario_name)`` so
+    the same physical scenario evaluated under multiple plant overrides
+    gets its own Oracle reference.
+    """
+    out: list[ScoredResult] = []
+    for label, block in results.items():
+        for r in block:
+            oracle_m = oracle_per_scenario.get((label, r.scenario))
+            if oracle_m is None:
+                continue
+            s = compute_scores(r.metrics, oracle_m, profile)
+            out.append(
+                ScoredResult(
+                    controller=r.controller,
+                    scenario=r.scenario,
+                    metrics=r.metrics,
+                    scores=s,
+                    block_label=label,
+                )
+            )
+    return out
+
+
+def _mean(values: list[float]) -> float:
+    finite = [v for v in values if not math.isnan(v)]
+    return statistics.mean(finite) if finite else 0.0
+
+
+def _stdev(values: list[float]) -> float:
+    """Compute population stdev; return 0 for fewer than two finite samples."""
+    finite = [v for v in values if not math.isnan(v)]
+    return statistics.pstdev(finite) if len(finite) >= 2 else 0.0
+
+
+def render_score_matrix(scored: list[ScoredResult], profile: UserProfile) -> str:
+    """Per-controller mean (comfort, actuator, energy, overall) ranking.
+
+    Each metric column is followed by a ``σ`` column — the population
+    standard deviation of that metric across the controller's scenarios.
+    High σ means the mean hides big per-scenario swings (one bad
+    scenario dragging the row down, or vice versa).
+    """
+    by_ctrl: dict[str, list[ScoredResult]] = {}
+    for sr in scored:
+        by_ctrl.setdefault(sr.controller, []).append(sr)
+
+    rows: list[
+        tuple[str, float, float, float, float, float, float, float, float, int]
+    ] = []
+    for ctrl, items in by_ctrl.items():
+        overalls = [i.scores.overall for i in items]
+        comforts = [i.scores.comfort for i in items]
+        actuators = [i.scores.actuator for i in items]
+        energies = [i.scores.energy for i in items]
+        rows.append(
+            (
+                ctrl,
+                _mean(overalls),
+                _stdev(overalls),
+                _mean(comforts),
+                _stdev(comforts),
+                _mean(actuators),
+                _stdev(actuators),
+                _mean(energies),
+                _stdev(energies),
+                len(items),
+            )
+        )
+    rows.sort(key=lambda r: -r[1])
+
+    lines: list[str] = []
+    width = 92
+    lines.append("=" * width)
+    lines.append(
+        f"Score matrix — user profile: {profile.name} "
+        f"(w_c={profile.w_comfort}, w_a={profile.w_actuator}, w_e={profile.w_energy})"
+    )
+    lines.append("Scores are 0..1, oracle-normalised; 1.0 = oracle-equivalent.")
+    lines.append(
+        "σ = population stdev across scenarios (lower = steadier per dimension)."
+    )
+    lines.append("=" * width)
+    lines.append(
+        f"  {'controller':<18}"
+        f"{'overall':>9}{'σ':>7}"
+        f"{'comfort':>9}{'σ':>7}"
+        f"{'actuator':>10}{'σ':>7}"
+        f"{'energy':>9}{'σ':>7}"
+        f"{'n':>5}"
+    )
+    lines.append("  " + "-" * (width - 4))
+    for ctrl, ov, ov_s, c, c_s, a, a_s, e, e_s, n in rows:
+        marker = " *" if (rows and ctrl == rows[0][0]) else "  "
+        lines.append(
+            f"{marker}{ctrl:<18}"
+            f"{ov:>9.3f}{ov_s:>7.3f}"
+            f"{c:>9.3f}{c_s:>7.3f}"
+            f"{a:>10.3f}{a_s:>7.3f}"
+            f"{e:>9.3f}{e_s:>7.3f}"
+            f"{n:>5d}"
+        )
+    lines.append("=" * width)
+    return "\n".join(lines)
+
+
+def render_plant_sweep(
+    scored_per_plant: Mapping[str, list[ScoredResult]], profile: UserProfile
+) -> str:
+    """Cross-plant overall-score matrix — one column per plant.
+
+    Each cell is the controller's mean overall score on that plant.
+    Rows are sorted by the mean across all plants.
+    """
+    plant_names = list(scored_per_plant.keys())
+    controllers: list[str] = []
+    seen: set[str] = set()
+    for label in plant_names:
+        for sr in scored_per_plant[label]:
+            if sr.controller not in seen:
+                controllers.append(sr.controller)
+                seen.add(sr.controller)
+
+    # mean(overall) per (controller, plant)
+    cell: dict[tuple[str, str], float] = {}
+    for label, items in scored_per_plant.items():
+        per_ctrl: dict[str, list[float]] = {}
+        for sr in items:
+            per_ctrl.setdefault(sr.controller, []).append(sr.scores.overall)
+        for ctrl, vs in per_ctrl.items():
+            cell[(ctrl, label)] = _mean(vs)
+
+    # mean + cross-plant stdev + plant coverage. Controllers with results
+    # on only a subset of plants must not outrank full-sweep controllers
+    # on an inflated mean, so coverage sorts first.
+    cross_mean: dict[str, float] = {}
+    cross_std: dict[str, float] = {}
+    cross_cov: dict[str, int] = {}
+    for ctrl in controllers:
+        vals = [cell.get((ctrl, p), float("nan")) for p in plant_names]
+        cross_cov[ctrl] = sum(1 for v in vals if not math.isnan(v))
+        cross_mean[ctrl] = _mean(vals)
+        cross_std[ctrl] = _stdev(vals)
+    controllers.sort(key=lambda c: (-cross_cov[c], -cross_mean[c]))
+
+    lines: list[str] = []
+    lines.append("")
+    header_cells = "".join(f"{p[:13]:>14}" for p in plant_names)
+    lines.append(
+        f"Cross-plant overall — profile: {profile.name}  "
+        f"({len(plant_names)} plants × {len({sr.scenario for items in scored_per_plant.values() for sr in items})} scenarios)"
+    )
+    lines.append(
+        "±σ = population stdev of mean overall across plants. "
+        "cov = plants with results; incomplete rows rank below complete ones."
+    )
+    header = f"  {'controller':<18}{header_cells}{'mean':>10}{'±σ':>8}{'cov':>8}"
+    lines.append(header)
+    lines.append("  " + "-" * (len(header) - 2))
+    for ctrl in controllers:
+        row = f"  {ctrl:<18}"
+        for p in plant_names:
+            v = cell.get((ctrl, p), float("nan"))
+            row += f"{v:>14.3f}"
+        cov = f"{cross_cov[ctrl]}/{len(plant_names)}"
+        row += f"{cross_mean[ctrl]:>10.3f}{cross_std[ctrl]:>8.3f}{cov:>8}"
+        lines.append(row)
+    return "\n".join(lines)
+
+
+def render_per_scenario(scored: list[ScoredResult], profile: UserProfile) -> str:
+    """Render the controller × scenario matrix (one row per scenario, overall score per cell).
+
+    When the results span more than one block label, rows are keyed by
+    ``scenario [block]`` so same-named scenarios from different plant
+    overrides do not overwrite each other.
+    """
+    labels = {sr.block_label for sr in scored}
+    qualify = len(labels) > 1
+    by_scen: dict[str, dict[str, float]] = {}
+    controllers: list[str] = []
+    seen: set[str] = set()
+    for sr in scored:
+        row_key = f"{sr.scenario} [{sr.block_label}]" if qualify else sr.scenario
+        by_scen.setdefault(row_key, {})[sr.controller] = sr.scores.overall
+        if sr.controller not in seen:
+            controllers.append(sr.controller)
+            seen.add(sr.controller)
+
+    lines: list[str] = []
+    lines.append("")
+    lines.append(f"Per-scenario overall scores — profile: {profile.name}")
+    header = f"  {'scenario':<34}" + "".join(f"{c[:9]:>10}" for c in controllers)
+    lines.append(header)
+    lines.append("  " + "-" * (len(header) - 2))
+    for scen in sorted(by_scen):
+        cells = "".join(
+            f"{by_scen[scen].get(c, float('nan')):>10.3f}" for c in controllers
+        )
+        lines.append(f"  {scen:<34}{cells}")
+    return "\n".join(lines)

--- a/tests/benchmark/scoring.py
+++ b/tests/benchmark/scoring.py
@@ -1,0 +1,273 @@
+"""Weighted scoring across the user-priority dimensions.
+
+Each (controller, scenario) pair produces a continuous 0..1 score per
+dimension (comfort, actuator longevity, energy) and a weighted aggregate
+under a chosen ``UserProfile``.
+
+Each dimension is normalised against the IdealOracle:
+
+* Oracle's value → ``1.0`` (best physically reachable)
+* Controller value ≥ "failure" threshold → ``0.0``
+* Linear interpolation in between
+
+Failure thresholds are chosen so the score scale is interpretable:
+
+* Comfort: a controller with ≥ 1 K extra overshoot, ≥ 5× oracle settling
+  or ≥ 0.5 K extra steady-state error scores ≤ 0
+* Actuator: a controller with ≥ 5× oracle's total valve travel scores ≤ 0
+* Energy: symmetric — ≥ 2× oracle's integral is over-heating,
+  ≤ 0× is under-heating; both directions score ≤ 0
+
+Resilience is not a continuous per-run dimension — it shows up as
+catastrophic comfort/actuator scores in the edge-case scenarios
+(sensor dropout, large outdoor steps, etc.). It is captured implicitly
+by averaging across all scenarios.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+from .metrics import MetricValues
+
+
+@dataclass(frozen=True)
+class DimensionScores:
+    """Sub-scores per dimension, plus the weighted overall score.
+
+    Attributes
+    ----------
+    comfort : float
+        Comfort sub-score in 0..1.
+    actuator : float
+        Actuator-longevity sub-score in 0..1.
+    energy : float
+        Energy sub-score in 0..1.
+    overall : float
+        Profile-weighted aggregate of the three sub-scores.
+    """
+
+    comfort: float
+    actuator: float
+    energy: float
+    overall: float
+
+
+@dataclass(frozen=True)
+class UserProfile:
+    """Weights expressing the user's relative priorities.
+
+    The three weights must sum to 1. ``balanced`` is the safe default;
+    the other profiles bias the score toward a specific axis.
+
+    Attributes
+    ----------
+    name : str
+        Profile identifier used in reports and the CLI.
+    w_comfort : float
+        Weight of the comfort dimension.
+    w_actuator : float
+        Weight of the actuator-longevity dimension.
+    w_energy : float
+        Weight of the energy dimension.
+    """
+
+    name: str
+    w_comfort: float
+    w_actuator: float
+    w_energy: float
+
+    def __post_init__(self) -> None:
+        """Validate that the three weights sum to 1.0.
+
+        Raises
+        ------
+        ValueError
+            If the weights do not sum to 1.0 within tolerance.
+        """
+        s = self.w_comfort + self.w_actuator + self.w_energy
+        if not math.isclose(s, 1.0, abs_tol=1e-3):
+            raise ValueError(
+                f"UserProfile weights must sum to 1.0, got {s:.4f} for {self.name}"
+            )
+
+
+PROFILES: dict[str, UserProfile] = {
+    "balanced": UserProfile("balanced", 0.50, 0.30, 0.20),
+    "comfort_first": UserProfile("comfort_first", 0.75, 0.15, 0.10),
+    "longevity_first": UserProfile("longevity_first", 0.30, 0.55, 0.15),
+    "energy_first": UserProfile("energy_first", 0.30, 0.15, 0.55),
+}
+
+
+# --- Sub-score helpers ---
+
+
+def _clamp_01(x: float) -> float:
+    return max(0.0, min(1.0, x))
+
+
+# When the oracle settles instantly there is no transient to normalise
+# against; a candidate consuming this many minutes still earns the full
+# settling penalty.
+_ABS_SETTLING_FAILURE_MIN = 5.0
+
+
+def _settling_ratio(metric: float, oracle: float) -> float:
+    """Settling-time ratio with sensible inf handling.
+
+    Parameters
+    ----------
+    metric : float
+        Candidate controller's settling time in minutes (may be inf).
+    oracle : float
+        Oracle's settling time in minutes (may be inf).
+
+    Returns
+    -------
+    float
+        Ratio ``metric / oracle``; capped at 10 when only the candidate
+        never settles, and computed against an absolute scale when the
+        oracle settled instantly.
+    """
+    if math.isinf(metric) and math.isinf(oracle):
+        return 1.0
+    if math.isinf(metric):
+        return 10.0
+    if math.isinf(oracle):
+        return 1.0
+    if oracle <= 0.0:
+        # Zero-settling oracle: score the candidate on an absolute scale
+        # instead of treating every settling time as oracle-equivalent.
+        return 1.0 + _clamp_01(metric / _ABS_SETTLING_FAILURE_MIN) * 4.0
+    return metric / oracle
+
+
+def comfort_score(metrics: MetricValues, oracle: MetricValues) -> float:
+    """Score comfort across overshoot, settling and steady-state error.
+
+    Weights inside comfort: 0.4 overshoot, 0.4 settling, 0.2 ss_error.
+    Failure thresholds: +1 K overshoot, 5× oracle settling, +0.5 K ss_error.
+
+    Parameters
+    ----------
+    metrics : MetricValues
+        Candidate controller's metrics.
+    oracle : MetricValues
+        Oracle baseline metrics for the same scenario.
+
+    Returns
+    -------
+    float
+        Comfort score; 1.0 is oracle-equivalent, 0.0 is at/beyond the
+        failure thresholds.
+    """
+    overshoot_excess = max(0.0, metrics.max_overshoot_K - oracle.max_overshoot_K)
+    overshoot_pen = _clamp_01(overshoot_excess / 1.0)
+
+    settling_ratio = _settling_ratio(
+        metrics.settling_time_min, oracle.settling_time_min
+    )
+    settling_pen = _clamp_01((settling_ratio - 1.0) / 4.0)  # 1× → 0, 5× → 1
+
+    ss_excess = max(0.0, metrics.steady_state_error_K - oracle.steady_state_error_K)
+    ss_pen = _clamp_01(ss_excess / 0.5)
+
+    penalty = 0.4 * overshoot_pen + 0.4 * settling_pen + 0.2 * ss_pen
+    return 1.0 - penalty
+
+
+def actuator_score(metrics: MetricValues, oracle: MetricValues) -> float:
+    """Score total valve travel relative to the oracle.
+
+    Failure threshold: 5× oracle's total travel. Cycle count is *not*
+    used directly — see DESIGN.md §5 (actuator metric): tracking-precise
+    controllers (oracle) cycle many small times; total travel is the
+    honest wear/battery proxy.
+
+    Parameters
+    ----------
+    metrics : MetricValues
+        Candidate controller's metrics.
+    oracle : MetricValues
+        Oracle baseline metrics for the same scenario.
+
+    Returns
+    -------
+    float
+        Actuator score in 0..1.
+    """
+    if oracle.total_valve_travel_pct < 1.0:
+        # Oracle barely moved. Compare against a floor so a low-activity
+        # controller still scores around 1.0.
+        return _clamp_01(1.0 - metrics.total_valve_travel_pct / 500.0)
+    ratio = metrics.total_valve_travel_pct / oracle.total_valve_travel_pct
+    penalty = max(0.0, (ratio - 1.0) / 4.0)  # 1× → 0, 5× → 1
+    return _clamp_01(1.0 - penalty)
+
+
+#: Below this oracle integral the ratio is ill-conditioned (the scenario
+#: barely heated/cooled), so excess usage is scored against this absolute
+#: floor instead. A candidate that over-uses by a full floor scores 0.
+_ENERGY_FLOOR_PCT_MIN = 100.0
+
+
+def energy_score(metrics: MetricValues, oracle: MetricValues) -> float:
+    """Score integral valve usage relative to the oracle (symmetric).
+
+    The oracle delivers exactly the heat required to track the setpoint, so
+    any deviation is waste: ≥ 2× the oracle's integral is over-heating
+    (overshoot losses), ≤ 0 is under-heating (setpoint missed — the same
+    logic applies in cooling). Both directions are penalised equally.
+
+    Parameters
+    ----------
+    metrics : MetricValues
+        Candidate controller's metrics.
+    oracle : MetricValues
+        Oracle baseline metrics for the same scenario.
+
+    Returns
+    -------
+    float
+        Energy score in 0..1.
+    """
+    if oracle.integral_valve_pct_min < _ENERGY_FLOOR_PCT_MIN:
+        # Oracle barely moved, so the ratio is ill-conditioned. Score the
+        # candidate's *excess* usage over the oracle against the floor
+        # rather than treating every candidate as oracle-equivalent —
+        # otherwise a grossly over-heating controller escapes scoring here.
+        excess = max(
+            0.0, metrics.integral_valve_pct_min - oracle.integral_valve_pct_min
+        )
+        return _clamp_01(1.0 - excess / _ENERGY_FLOOR_PCT_MIN)
+    ratio = metrics.integral_valve_pct_min / oracle.integral_valve_pct_min
+    deviation = abs(ratio - 1.0)
+    return _clamp_01(1.0 - deviation)
+
+
+def compute_scores(
+    metrics: MetricValues, oracle: MetricValues, profile: UserProfile
+) -> DimensionScores:
+    """Compute all three sub-scores plus the profile-weighted overall.
+
+    Parameters
+    ----------
+    metrics : MetricValues
+        Candidate controller's metrics.
+    oracle : MetricValues
+        Oracle baseline metrics for the same scenario.
+    profile : UserProfile
+        Weighting profile for the overall aggregate.
+
+    Returns
+    -------
+    DimensionScores
+        Sub-scores and the weighted overall score.
+    """
+    c = comfort_score(metrics, oracle)
+    a = actuator_score(metrics, oracle)
+    e = energy_score(metrics, oracle)
+    overall = profile.w_comfort * c + profile.w_actuator * a + profile.w_energy * e
+    return DimensionScores(comfort=c, actuator=a, energy=e, overall=overall)

--- a/tests/benchmark/scoring.py
+++ b/tests/benchmark/scoring.py
@@ -245,9 +245,7 @@ def energy_score(metrics: MetricValues, oracle: MetricValues) -> float:
         # rather than treating every candidate as oracle-equivalent. The
         # deviation is symmetric (matching the main branch): both gross
         # over-heating and under-heating are penalised here.
-        deviation = abs(
-            metrics.integral_valve_pct_min - oracle.integral_valve_pct_min
-        )
+        deviation = abs(metrics.integral_valve_pct_min - oracle.integral_valve_pct_min)
         return _clamp_01(1.0 - deviation / _ENERGY_FLOOR_PCT_MIN)
     ratio = metrics.integral_valve_pct_min / oracle.integral_valve_pct_min
     deviation = abs(ratio - 1.0)

--- a/tests/benchmark/scoring.py
+++ b/tests/benchmark/scoring.py
@@ -79,14 +79,20 @@ class UserProfile:
     w_energy: float
 
     def __post_init__(self) -> None:
-        """Validate that the three weights sum to 1.0.
+        """Validate that each weight is in [0, 1] and the three sum to 1.0.
 
         Raises
         ------
         ValueError
-            If the weights do not sum to 1.0 within tolerance.
+            If any weight falls outside [0, 1], or the weights do not sum
+            to 1.0 within tolerance.
         """
-        s = self.w_comfort + self.w_actuator + self.w_energy
+        weights = (self.w_comfort, self.w_actuator, self.w_energy)
+        if any(w < 0.0 or w > 1.0 for w in weights):
+            raise ValueError(
+                f"UserProfile weights must each be in [0, 1], got {weights} for {self.name}"
+            )
+        s = sum(weights)
         if not math.isclose(s, 1.0, abs_tol=1e-3):
             raise ValueError(
                 f"UserProfile weights must sum to 1.0, got {s:.4f} for {self.name}"
@@ -235,13 +241,14 @@ def energy_score(metrics: MetricValues, oracle: MetricValues) -> float:
     """
     if oracle.integral_valve_pct_min < _ENERGY_FLOOR_PCT_MIN:
         # Oracle barely moved, so the ratio is ill-conditioned. Score the
-        # candidate's *excess* usage over the oracle against the floor
-        # rather than treating every candidate as oracle-equivalent —
-        # otherwise a grossly over-heating controller escapes scoring here.
-        excess = max(
-            0.0, metrics.integral_valve_pct_min - oracle.integral_valve_pct_min
+        # candidate's absolute deviation from the oracle against the floor
+        # rather than treating every candidate as oracle-equivalent. The
+        # deviation is symmetric (matching the main branch): both gross
+        # over-heating and under-heating are penalised here.
+        deviation = abs(
+            metrics.integral_valve_pct_min - oracle.integral_valve_pct_min
         )
-        return _clamp_01(1.0 - excess / _ENERGY_FLOOR_PCT_MIN)
+        return _clamp_01(1.0 - deviation / _ENERGY_FLOOR_PCT_MIN)
     ratio = metrics.integral_valve_pct_min / oracle.integral_valve_pct_min
     deviation = abs(ratio - 1.0)
     return _clamp_01(1.0 - deviation)

--- a/tests/benchmark/scoring.py
+++ b/tests/benchmark/scoring.py
@@ -12,8 +12,12 @@ Each dimension is normalised against the IdealOracle:
 
 Failure thresholds are chosen so the score scale is interpretable:
 
-* Comfort: a controller with ≥ 1 K extra overshoot, ≥ 5× oracle settling
-  or ≥ 0.5 K extra steady-state error scores ≤ 0
+* Comfort: weighted penalty of overshoot (0.4), settling (0.4) and
+  steady-state error (0.2). Each component saturates at 1 K extra
+  overshoot, 5× oracle settling and 0.5 K extra steady-state error
+  respectively — a single saturated component costs its weight
+  (e.g. 1 K extra overshoot alone scores 0.6); comfort reaches 0 only
+  when all three saturate
 * Actuator: a controller with ≥ 5× oracle's total valve travel scores ≤ 0
 * Energy: symmetric — ≥ 2× oracle's integral is over-heating,
   ≤ 0× is under-heating; both directions score ≤ 0
@@ -243,8 +247,8 @@ def energy_score(metrics: MetricValues, oracle: MetricValues) -> float:
         # Oracle barely moved, so the ratio is ill-conditioned. Score the
         # candidate's absolute deviation from the oracle against the floor
         # rather than treating every candidate as oracle-equivalent. The
-        # deviation is symmetric (matching the main branch): both gross
-        # over-heating and under-heating are penalised here.
+        # deviation is symmetric, matching the ratio path below: both
+        # gross over-heating and under-heating are penalised here.
         deviation = abs(metrics.integral_valve_pct_min - oracle.integral_valve_pct_min)
         return _clamp_01(1.0 - deviation / _ENERGY_FLOOR_PCT_MIN)
     ratio = metrics.integral_valve_pct_min / oracle.integral_valve_pct_min

--- a/tests/benchmark/sensor.py
+++ b/tests/benchmark/sensor.py
@@ -54,7 +54,7 @@ class SensorParams:
         Raises
         ------
         ValueError
-            If the sampling interval is not positive, the EMA factor is
+            If the sampling interval is negative, the EMA factor is
             outside (0, 1], or a noise/lag/jitter magnitude is negative.
         """
         # 0 is valid and means "sample on every step"; only negatives are rejected.

--- a/tests/benchmark/sensor.py
+++ b/tests/benchmark/sensor.py
@@ -1,0 +1,131 @@
+"""Sensor model: thermal lag + sampling + EMA filter + optional noise/dropout.
+
+Two distinct time-domain effects are modelled here:
+
+1. **Thermal lag** — the sensor body has its own thermal mass, so its
+   reading approaches the air temperature with a first-order continuous
+   filter (time constant ``thermal_lag_s``). This is the dominant
+   physical lag in residential temperature sensors (typ. 30 s – 3 min,
+   see DESIGN.md §8 (sensor modelling)).
+
+2. **Sampling** — sensors only emit values every ``sample_interval_s``
+   (typical 1–5 min for Zigbee). Between samples the previous reading
+   is returned. An optional EMA filter smooths the sample stream
+   (matches BT's own periodic EMA in `events/temperature.py`).
+
+Noise is deterministic (LCG seeded fixed) for reproducible benchmarks.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+
+@dataclass
+class SensorParams:
+    """Parameters describing the sampled-temperature sensor."""
+
+    sample_interval_s: float = 60.0
+    ema_alpha: float = 1.0  # 1.0 = no EMA filter; <1.0 = smoothed toward filtered
+    noise_std_K: float = 0.0
+    # Dropout window: the sensor returns None while
+    # ``dropout_from_t_s <= t_s < dropout_until_t_s``. The defaults
+    # (0.0 / -1.0) describe an empty window, i.e. no dropout.
+    dropout_from_t_s: float = 0.0
+    dropout_until_t_s: float = -1.0
+    # Sensor's own thermal time constant. ``0`` disables the lag;
+    # typical residential values are 60–180 s.
+    thermal_lag_s: float = 0.0
+    # Calibration faults: constant bias plus a linear drift against the
+    # true room temperature. The reported value at time ``t`` is
+    # ``T_true + bias_K + drift_K_per_h * t / 3600``.
+    bias_K: float = 0.0
+    drift_K_per_h: float = 0.0
+    # Sample-jitter: when ``> 0``, the effective time between samples is
+    # drawn from a deterministic LCG with mean ``sample_interval_s`` and
+    # standard deviation ``jitter_std_s`` (clipped to ≥ 5 s). Models the
+    # async sensor-report behaviour of Zigbee TRVs that report on change.
+    jitter_std_s: float = 0.0
+
+
+class Sensor:
+    """Sampled-output sensor with optional thermal lag and EMA filtering.
+
+    The lag is applied continuously (every call), the sampling and EMA
+    operate on the lagged value.
+    """
+
+    def __init__(self, params: SensorParams, seed: int = 12345) -> None:
+        self.params = params
+        self._filtered: float | None = None
+        self._last_sample_t: float = -1.0
+        # Noise/jitter RNG seed. Defaults to a fixed value for standalone
+        # use; the runner derives a per-scenario seed so noise realisations
+        # are decorrelated across scenarios rather than identical.
+        self._rng_state: int = seed & 0x7FFFFFFF
+        # Thermal-lag state: continuously updated regardless of sampling.
+        self._lag_state: float | None = None
+        self._last_lag_update_t: float = -1.0
+        # Next sample's effective interval (jitter mode).
+        self._next_sample_interval_s: float = params.sample_interval_s
+
+    def _noise(self) -> float:
+        if self.params.noise_std_K <= 0.0:
+            return 0.0
+        self._rng_state = (self._rng_state * 1103515245 + 12345) & 0x7FFFFFFF
+        u = (self._rng_state / 0x7FFFFFFF) * 2.0 - 1.0  # [-1, 1]
+        return u * u * u * self.params.noise_std_K
+
+    def _apply_thermal_lag(self, t_s: float, T_true_C: float) -> float:
+        """Return the lagged sensor temperature for the current step.
+
+        Advances the sensor's internal thermal state.
+        """
+        if self.params.thermal_lag_s <= 0.0:
+            return T_true_C
+
+        if self._lag_state is None or self._last_lag_update_t < 0.0:
+            self._lag_state = T_true_C
+            self._last_lag_update_t = t_s
+            return T_true_C
+
+        dt = t_s - self._last_lag_update_t
+        if dt > 0.0:
+            alpha = 1.0 - math.exp(-dt / self.params.thermal_lag_s)
+            self._lag_state += alpha * (T_true_C - self._lag_state)
+            self._last_lag_update_t = t_s
+        return self._lag_state
+
+    def read(self, t_s: float, T_true_C: float) -> float | None:
+        """Return the currently observed temperature, or None on dropout."""
+        # The sensor body keeps tracking the room even while reporting is
+        # down, so the lag state must advance through the outage.
+        T_lagged = self._apply_thermal_lag(t_s, T_true_C)
+        if self.params.dropout_from_t_s <= t_s < self.params.dropout_until_t_s:
+            return None
+
+        T_lagged += self.params.bias_K + self.params.drift_K_per_h * (t_s / 3600.0)
+
+        should_sample = (
+            self._last_sample_t < 0.0
+            or (t_s - self._last_sample_t) >= self._next_sample_interval_s
+        )
+        if should_sample:
+            raw = T_lagged + self._noise()
+            if self.params.jitter_std_s > 0.0:
+                # Roll a new effective interval using a Gaussian-ish kick
+                # from the cubic-noise generator (same RNG as _noise).
+                self._rng_state = (self._rng_state * 1103515245 + 12345) & 0x7FFFFFFF
+                u = (self._rng_state / 0x7FFFFFFF) * 2.0 - 1.0
+                kick = u * u * u * self.params.jitter_std_s
+                self._next_sample_interval_s = max(
+                    5.0, self.params.sample_interval_s + kick
+                )
+            if self._filtered is None:
+                self._filtered = raw
+            else:
+                a = self.params.ema_alpha
+                self._filtered = a * raw + (1.0 - a) * self._filtered
+            self._last_sample_t = t_s
+        return self._filtered

--- a/tests/benchmark/sensor.py
+++ b/tests/benchmark/sensor.py
@@ -48,6 +48,31 @@ class SensorParams:
     # async sensor-report behaviour of Zigbee TRVs that report on change.
     jitter_std_s: float = 0.0
 
+    def __post_init__(self) -> None:
+        """Reject physically invalid sensor parameters.
+
+        Raises
+        ------
+        ValueError
+            If the sampling interval is not positive, the EMA factor is
+            outside (0, 1], or a noise/lag/jitter magnitude is negative.
+        """
+        # 0 is valid and means "sample on every step"; only negatives are rejected.
+        if self.sample_interval_s < 0.0:
+            raise ValueError(
+                f"SensorParams sample_interval_s must be >= 0, got {self.sample_interval_s}"
+            )
+        if not (0.0 < self.ema_alpha <= 1.0):
+            raise ValueError(
+                f"SensorParams ema_alpha must be in (0, 1], got {self.ema_alpha}"
+            )
+        if self.noise_std_K < 0.0 or self.thermal_lag_s < 0.0 or self.jitter_std_s < 0.0:
+            raise ValueError(
+                "SensorParams noise_std_K, thermal_lag_s and jitter_std_s must be "
+                f">= 0, got noise_std_K={self.noise_std_K}, "
+                f"thermal_lag_s={self.thermal_lag_s}, jitter_std_s={self.jitter_std_s}"
+            )
+
 
 class Sensor:
     """Sampled-output sensor with optional thermal lag and EMA filtering.

--- a/tests/benchmark/sensor.py
+++ b/tests/benchmark/sensor.py
@@ -66,7 +66,11 @@ class SensorParams:
             raise ValueError(
                 f"SensorParams ema_alpha must be in (0, 1], got {self.ema_alpha}"
             )
-        if self.noise_std_K < 0.0 or self.thermal_lag_s < 0.0 or self.jitter_std_s < 0.0:
+        if (
+            self.noise_std_K < 0.0
+            or self.thermal_lag_s < 0.0
+            or self.jitter_std_s < 0.0
+        ):
             raise ValueError(
                 "SensorParams noise_std_K, thermal_lag_s and jitter_std_s must be "
                 f">= 0, got noise_std_K={self.noise_std_K}, "

--- a/tests/benchmark/sensor.py
+++ b/tests/benchmark/sensor.py
@@ -28,6 +28,9 @@ class SensorParams:
 
     sample_interval_s: float = 60.0
     ema_alpha: float = 1.0  # 1.0 = no EMA filter; <1.0 = smoothed toward filtered
+    # Noise scale in Kelvin. The generator cubes a uniform [-1, 1] draw,
+    # so samples cluster near zero and the effective standard deviation
+    # is ~0.38 * noise_std_K (sqrt(1/7)), with |noise| <= noise_std_K.
     noise_std_K: float = 0.0
     # Dropout window: the sensor returns None while
     # ``dropout_from_t_s <= t_s < dropout_until_t_s``. The defaults
@@ -43,9 +46,10 @@ class SensorParams:
     bias_K: float = 0.0
     drift_K_per_h: float = 0.0
     # Sample-jitter: when ``> 0``, the effective time between samples is
-    # drawn from a deterministic LCG with mean ``sample_interval_s`` and
-    # standard deviation ``jitter_std_s`` (clipped to ≥ 5 s). Models the
-    # async sensor-report behaviour of Zigbee TRVs that report on change.
+    # ``sample_interval_s`` plus a deterministic LCG kick bounded by
+    # ``±jitter_std_s`` (cubic-shaped, effective stdev ~0.38 * jitter_std_s;
+    # clipped to ≥ 5 s). Models the async sensor-report behaviour of
+    # Zigbee TRVs that report on change.
     jitter_std_s: float = 0.0
 
     def __post_init__(self) -> None:

--- a/tests/benchmark/sensor.py
+++ b/tests/benchmark/sensor.py
@@ -21,6 +21,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 import math
 
+# A cubed uniform [-1, 1] draw has standard deviation sqrt(1/7); this
+# factor rescales the cubic-shaped kick so its standard deviation equals
+# the nominal noise/jitter parameter.
+_CUBIC_STD_CORRECTION = math.sqrt(7.0)
+
 
 @dataclass
 class SensorParams:
@@ -28,9 +33,10 @@ class SensorParams:
 
     sample_interval_s: float = 60.0
     ema_alpha: float = 1.0  # 1.0 = no EMA filter; <1.0 = smoothed toward filtered
-    # Noise scale in Kelvin. The generator cubes a uniform [-1, 1] draw,
-    # so samples cluster near zero and the effective standard deviation
-    # is ~0.38 * noise_std_K (sqrt(1/7)), with |noise| <= noise_std_K.
+    # Noise standard deviation in Kelvin. The generator cubes a uniform
+    # [-1, 1] draw and rescales it, so samples cluster near zero
+    # (Gaussian-ish) while the distribution's standard deviation equals
+    # this parameter exactly; |noise| is bounded at sqrt(7) * noise_std_K.
     noise_std_K: float = 0.0
     # Dropout window: the sensor returns None while
     # ``dropout_from_t_s <= t_s < dropout_until_t_s``. The defaults
@@ -46,10 +52,10 @@ class SensorParams:
     bias_K: float = 0.0
     drift_K_per_h: float = 0.0
     # Sample-jitter: when ``> 0``, the effective time between samples is
-    # ``sample_interval_s`` plus a deterministic LCG kick bounded by
-    # ``±jitter_std_s`` (cubic-shaped, effective stdev ~0.38 * jitter_std_s;
-    # clipped to ≥ 5 s). Models the async sensor-report behaviour of
-    # Zigbee TRVs that report on change.
+    # drawn from a deterministic LCG with mean ``sample_interval_s`` and
+    # standard deviation ``jitter_std_s`` (cubic-shaped, bounded at
+    # sqrt(7) * jitter_std_s; the result is clipped to >= 5 s). Models the
+    # async sensor-report behaviour of Zigbee TRVs that report on change.
     jitter_std_s: float = 0.0
 
     def __post_init__(self) -> None:
@@ -108,7 +114,7 @@ class Sensor:
             return 0.0
         self._rng_state = (self._rng_state * 1103515245 + 12345) & 0x7FFFFFFF
         u = (self._rng_state / 0x7FFFFFFF) * 2.0 - 1.0  # [-1, 1]
-        return u * u * u * self.params.noise_std_K
+        return u * u * u * _CUBIC_STD_CORRECTION * self.params.noise_std_K
 
     def _apply_thermal_lag(self, t_s: float, T_true_C: float) -> float:
         """Return the lagged sensor temperature for the current step.
@@ -151,7 +157,7 @@ class Sensor:
                 # from the cubic-noise generator (same RNG as _noise).
                 self._rng_state = (self._rng_state * 1103515245 + 12345) & 0x7FFFFFFF
                 u = (self._rng_state / 0x7FFFFFFF) * 2.0 - 1.0
-                kick = u * u * u * self.params.jitter_std_s
+                kick = u * u * u * _CUBIC_STD_CORRECTION * self.params.jitter_std_s
                 self._next_sample_interval_s = max(
                     5.0, self.params.sample_interval_s + kick
                 )

--- a/tests/benchmark/tests/__init__.py
+++ b/tests/benchmark/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the benchmark infrastructure itself."""

--- a/tests/benchmark/tests/test_actuator_and_sensor.py
+++ b/tests/benchmark/tests/test_actuator_and_sensor.py
@@ -1,0 +1,183 @@
+"""Actuator profile + sensor edge-case tests.
+
+The single-TRV scenarios exercise most actuator/sensor paths implicitly,
+but several branches (deadband, threshold profile, jitter, dropout) are
+only hit under specific param combinations these unit tests pin down.
+"""
+
+from __future__ import annotations
+
+from tests.benchmark.actuator import Actuator, ActuatorParams, ActuatorProfile
+from tests.benchmark.sensor import Sensor, SensorParams
+
+
+def test_actuator_linear_default():
+    """Actuator linear default."""
+    a = Actuator(ActuatorParams())
+    assert a.apply(0.0) == 0.0
+    assert a.apply(50.0) == 0.5
+    assert a.apply(100.0) == 1.0
+
+
+def test_actuator_clamps_input_range():
+    """Actuator clamps input range."""
+    a = Actuator(ActuatorParams())
+    assert a.apply(-10.0) == 0.0
+    assert a.apply(110.0) == 1.0
+
+
+def test_actuator_threshold_profile():
+    """Actuator threshold profile."""
+    a = Actuator(ActuatorParams(profile=ActuatorProfile.THRESHOLD, dead_zone_pct=20.0))
+    assert a.apply(10.0) == 0.0  # inside dead zone → zero flow
+    # Just above dead zone: small but nonzero.
+    out = a.apply(25.0)
+    assert 0.0 < out < 0.1
+    # Full open.
+    assert abs(a.apply(100.0) - 1.0) < 1e-6
+
+
+def test_actuator_exponential_profile():
+    """Actuator exponential profile."""
+    a = Actuator(ActuatorParams(profile=ActuatorProfile.EXPONENTIAL))
+    assert abs(a.apply(50.0) - 0.25) < 1e-9
+    assert a.apply(100.0) == 1.0
+
+
+def test_actuator_equal_percentage_curve():
+    """Actuator equal percentage curve."""
+    a = Actuator(
+        ActuatorParams(
+            profile=ActuatorProfile.EQUAL_PERCENTAGE, equal_percentage_exponent=3.0
+        )
+    )
+    assert abs(a.apply(50.0) - 0.125) < 1e-9
+    assert a.apply(100.0) == 1.0
+
+
+def test_actuator_deadband_zeroes_low_commands():
+    """Actuator deadband zeroes low commands."""
+    a = Actuator(ActuatorParams(deadband_pct=10.0))
+    assert a.apply(5.0) == 0.0
+    assert a.apply(9.99) == 0.0
+    assert a.apply(10.0) > 0.0
+
+
+def test_actuator_hysteresis_holds_last_value():
+    """Actuator hysteresis holds last value."""
+    a = Actuator(ActuatorParams(hysteresis_pct=5.0))
+    a.apply(50.0)  # set baseline
+    # Small wiggle inside the band → no movement.
+    out_inside = a.apply(52.0)
+    assert out_inside == 0.5
+    # Step outside the band → moves.
+    out_outside = a.apply(60.0)
+    assert out_outside == 0.6
+
+
+def test_actuator_quantize_snaps_to_grid():
+    """Actuator quantize snaps to grid."""
+    a = Actuator(ActuatorParams(quantize_pct=10.0))
+    # 12 → 10, 17 → 20.
+    assert a.apply(12.0) == 0.1
+    assert a.apply(17.0) == 0.2
+
+
+def test_sensor_noise_path_is_deterministic():
+    """Two fresh Sensor instances with identical params produce identical reads."""
+    p = SensorParams(noise_std_K=0.5, sample_interval_s=30.0)
+    s1 = Sensor(p)
+    s2 = Sensor(p)
+    a = [s1.read(t * 30.0, 20.0) for t in range(5)]
+    b = [s2.read(t * 30.0, 20.0) for t in range(5)]
+    assert a == b
+    assert any(v != 20.0 for v in a)  # noise actually fires
+
+
+def test_sensor_seed_is_deterministic_and_decorrelating():
+    """Same seed → identical noise; different seeds → different realisations."""
+    p = SensorParams(noise_std_K=0.5, sample_interval_s=30.0)
+    same_a = [Sensor(p, seed=7).read(t * 30.0, 20.0) for t in range(5)]
+    same_b = [Sensor(p, seed=7).read(t * 30.0, 20.0) for t in range(5)]
+    assert same_a == same_b  # reproducible
+    other = [Sensor(p, seed=99).read(t * 30.0, 20.0) for t in range(5)]
+    assert other != same_a  # decorrelated across seeds
+
+
+def test_sensor_dropout_returns_none():
+    """Sensor dropout returns none."""
+    p = SensorParams(dropout_until_t_s=600.0)
+    s = Sensor(p)
+    assert s.read(0.0, 20.0) is None
+    assert s.read(599.999, 20.0) is None
+    assert s.read(600.0, 20.0) is not None  # past dropout window
+
+
+def test_sensor_jitter_changes_next_interval():
+    """Sensor jitter changes next interval."""
+    p = SensorParams(sample_interval_s=30.0, jitter_std_s=10.0)
+    s = Sensor(p)
+    # Force the first sample so the jitter recomputation runs. The RNG is
+    # deterministic, so the rolled interval must differ from the nominal.
+    s.read(0.0, 20.0)
+    assert s._next_sample_interval_s != 30.0
+    # Drive several reads.
+    for t in range(1, 20):
+        s.read(t * 30.0, 20.0)
+
+
+def test_sensor_thermal_lag_smooths_step():
+    """Sensor thermal lag smooths step."""
+    p = SensorParams(thermal_lag_s=120.0, sample_interval_s=30.0)
+    s = Sensor(p)
+    # Initial reading equals the true value (state init).
+    first = s.read(0.0, 20.0)
+    assert first == 20.0
+    # Step the world to 22 — the sensor lags behind.
+    second = s.read(30.0, 22.0)
+    assert second is not None
+    assert 20.0 < second < 22.0
+
+
+def test_sensor_bias_and_drift_apply():
+    """Sensor bias and drift apply."""
+    p = SensorParams(bias_K=0.5, drift_K_per_h=0.1, sample_interval_s=30.0)
+    s = Sensor(p)
+    # At t=0: bias only.
+    first = s.read(0.0, 20.0)
+    assert first is not None
+    assert abs(first - 20.5) < 1e-6
+    # At t=1h: bias + 0.1 K drift.
+    later = s.read(3600.0, 20.0)
+    assert later is not None
+    assert abs(later - 20.6) < 1e-6
+
+
+def test_sensor_dropout_window_with_start():
+    """The dropout honours its start timestamp, not just the end."""
+    p = SensorParams(dropout_from_t_s=600.0, dropout_until_t_s=1200.0)
+    s = Sensor(p)
+    assert s.read(0.0, 20.0) is not None  # before the outage
+    assert s.read(600.0, 20.0) is None
+    assert s.read(1199.0, 20.0) is None
+    assert s.read(1200.0, 20.0) is not None  # after the outage
+
+
+def test_thermal_lag_advances_through_dropout():
+    """The sensor body keeps tracking the room during the outage."""
+    p = SensorParams(
+        sample_interval_s=0.0,
+        thermal_lag_s=60.0,
+        dropout_from_t_s=10.0,
+        dropout_until_t_s=600.0,
+    )
+    s = Sensor(p)
+    s.read(0.0, 20.0)  # initialise the lag state at 20 °C
+    # Room steps to 25 °C during the outage.
+    for t in range(10, 600, 30):
+        assert s.read(float(t), 25.0) is None
+    after = s.read(600.0, 25.0)
+    # ~10 lag time-constants passed → the first post-outage reading must
+    # reflect the new room temperature, not the pre-outage state.
+    assert after is not None
+    assert after > 24.0

--- a/tests/benchmark/tests/test_actuator_and_sensor.py
+++ b/tests/benchmark/tests/test_actuator_and_sensor.py
@@ -7,6 +7,9 @@ only hit under specific param combinations these unit tests pin down.
 
 from __future__ import annotations
 
+import math
+from statistics import pstdev
+
 import pytest
 
 from tests.benchmark.actuator import Actuator, ActuatorParams, ActuatorProfile
@@ -39,9 +42,9 @@ def test_actuator_threshold_profile():
     assert abs(a.apply(100.0) - 1.0) < 1e-6
 
 
-def test_actuator_exponential_profile():
-    """Actuator exponential profile."""
-    a = Actuator(ActuatorParams(profile=ActuatorProfile.EXPONENTIAL))
+def test_actuator_quadratic_profile():
+    """Actuator quadratic profile."""
+    a = Actuator(ActuatorParams(profile=ActuatorProfile.QUADRATIC))
     assert abs(a.apply(50.0) - 0.25) < 1e-9
     assert a.apply(100.0) == 1.0
 
@@ -208,3 +211,27 @@ def test_actuator_params_reject_non_finite_values():
     """NaN or infinite parameters fail at construction."""
     with pytest.raises(ValueError):
         ActuatorParams(hysteresis_pct=float("nan"))
+
+
+def test_sensor_noise_std_matches_parameter():
+    """The empirical noise standard deviation equals ``noise_std_K``.
+
+    The cubic-shaped LCG kick is rescaled by sqrt(7) so the parameter is
+    a true standard deviation; samples stay bounded at sqrt(7) * std.
+    """
+    std_K = 0.5
+    p = SensorParams(noise_std_K=std_K, sample_interval_s=0.0)
+    s = Sensor(p, seed=3)
+    samples = [s.read(float(t), 20.0) - 20.0 for t in range(1, 20001)]
+    assert abs(pstdev(samples) - std_K) < 0.02
+    assert max(abs(x) for x in samples) <= std_K * math.sqrt(7.0) + 1e-9
+
+
+def test_sensor_jitter_kick_is_bounded():
+    """Rolled sample intervals stay within sqrt(7) * jitter_std_s of nominal."""
+    p = SensorParams(sample_interval_s=60.0, jitter_std_s=10.0)
+    s = Sensor(p)
+    bound = 10.0 * math.sqrt(7.0) + 1e-9
+    for t in range(200):
+        s.read(t * 60.0, 20.0)
+        assert abs(s._next_sample_interval_s - 60.0) <= bound

--- a/tests/benchmark/tests/test_actuator_and_sensor.py
+++ b/tests/benchmark/tests/test_actuator_and_sensor.py
@@ -7,6 +7,8 @@ only hit under specific param combinations these unit tests pin down.
 
 from __future__ import annotations
 
+import pytest
+
 from tests.benchmark.actuator import Actuator, ActuatorParams, ActuatorProfile
 from tests.benchmark.sensor import Sensor, SensorParams
 
@@ -121,9 +123,14 @@ def test_sensor_jitter_changes_next_interval():
     # deterministic, so the rolled interval must differ from the nominal.
     s.read(0.0, 20.0)
     assert s._next_sample_interval_s != 30.0
-    # Drive several reads.
+    # Each subsequent sample re-rolls the interval; across several reads
+    # the effective interval must keep varying, never collapsing to one
+    # fixed value.
+    intervals = {s._next_sample_interval_s}
     for t in range(1, 20):
         s.read(t * 30.0, 20.0)
+        intervals.add(s._next_sample_interval_s)
+    assert len(intervals) > 2
 
 
 def test_sensor_thermal_lag_smooths_step():
@@ -181,3 +188,23 @@ def test_thermal_lag_advances_through_dropout():
     # reflect the new room temperature, not the pre-outage state.
     assert after is not None
     assert after > 24.0
+
+
+def test_actuator_params_reject_out_of_range_percent_fields():
+    """Percent-domain fields outside [0, 100] fail at construction."""
+    with pytest.raises(ValueError):
+        ActuatorParams(deadband_pct=-1.0)
+    with pytest.raises(ValueError):
+        ActuatorParams(dead_zone_pct=150.0)
+
+
+def test_actuator_params_reject_exponent_below_one():
+    """An equal-percentage exponent below 1 fails at construction."""
+    with pytest.raises(ValueError):
+        ActuatorParams(equal_percentage_exponent=0.5)
+
+
+def test_actuator_params_reject_non_finite_values():
+    """NaN or infinite parameters fail at construction."""
+    with pytest.raises(ValueError):
+        ActuatorParams(hysteresis_pct=float("nan"))

--- a/tests/benchmark/tests/test_metrics.py
+++ b/tests/benchmark/tests/test_metrics.py
@@ -1,0 +1,129 @@
+"""Tests for metric computations on synthetic time series."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from tests.benchmark.metrics import TimeSeries, compute_metrics
+
+
+def _flat_series(
+    value: float, setpoint: float, n: int = 100, dt_s: float = 60.0
+) -> TimeSeries:
+    t = [i * dt_s for i in range(n)]
+    return TimeSeries(
+        t_s=t, T_room_C=[value] * n, T_setpoint_C=[setpoint] * n, valve_pct=[0.0] * n
+    )
+
+
+def test_zero_error_no_overshoot():
+    """A constant series at setpoint yields zero error metrics."""
+    series = _flat_series(20.0, 20.0)
+    m = compute_metrics(series, transient_start_s=0.0)
+    assert m.max_overshoot_K == 0.0
+    assert m.max_undershoot_K == 0.0
+    assert m.rmse_tracking_K == 0.0
+
+
+def test_overshoot_detected():
+    """A single positive spike is recorded as overshoot."""
+    n = 100
+    t = [i * 60.0 for i in range(n)]
+    T_room = [20.0 + (0.5 if i == 50 else 0.0) for i in range(n)]
+    series = TimeSeries(
+        t_s=t, T_room_C=T_room, T_setpoint_C=[20.0] * n, valve_pct=[0.0] * n
+    )
+    m = compute_metrics(series, transient_start_s=0.0)
+    assert abs(m.max_overshoot_K - 0.5) < 1e-9
+
+
+def test_settling_time_detected():
+    """Settling is reported once the band is held continuously for the dwell."""
+    n = 50
+    dt_s = 60.0
+    t = [i * dt_s for i in range(n)]
+    T_setpoint = [21.0] * n
+    T_room = [20.0 if i < 5 else 21.0 for i in range(n)]
+    series = TimeSeries(
+        t_s=t, T_room_C=T_room, T_setpoint_C=T_setpoint, valve_pct=[0.0] * n
+    )
+    m = compute_metrics(series, transient_start_s=0.0)
+    # Enters band at t=5min, dwell requirement is 10min, so settling
+    # reported as "entered band at minute 5".
+    assert m.settling_time_min == 5.0
+
+
+def test_settling_inf_when_never_in_band():
+    """If the band is never reached the settling time is +inf."""
+    n = 100
+    t = [i * 60.0 for i in range(n)]
+    series = TimeSeries(
+        t_s=t, T_room_C=[20.0] * n, T_setpoint_C=[22.0] * n, valve_pct=[0.0] * n
+    )
+    m = compute_metrics(series, transient_start_s=0.0)
+    assert math.isinf(m.settling_time_min)
+
+
+def test_valve_cycle_count():
+    """Direction reversals in a synthetic valve trajectory are counted correctly."""
+    n = 10
+    series = TimeSeries(
+        t_s=[i * 60.0 for i in range(n)],
+        T_room_C=[20.0] * n,
+        T_setpoint_C=[20.0] * n,
+        # 0 -> 50 (up) -> 50 -> 0 (down) -> 0 -> 50 (up) -> 50 -> 0 (down)
+        valve_pct=[0.0, 50.0, 50.0, 0.0, 0.0, 50.0, 50.0, 0.0, 0.0, 0.0],
+    )
+    m = compute_metrics(series, transient_start_s=0.0)
+    # Direction reversals: up->down, down->up, up->down  = 3
+    assert m.valve_cycle_count == 3
+
+
+def test_integral_valve_pct_min():
+    """A 60-minute window at 50 percent yields 3000 pct·min by trapezoidal integration."""
+    n = 61  # samples
+    series = TimeSeries(
+        t_s=[i * 60.0 for i in range(n)],
+        T_room_C=[20.0] * n,
+        T_setpoint_C=[20.0] * n,
+        valve_pct=[50.0] * n,
+    )
+    m = compute_metrics(series, transient_start_s=0.0)
+    assert abs(m.integral_valve_pct_min - 3000.0) < 1e-6
+
+
+def test_timeseries_rejects_mismatched_lengths():
+    """Parallel arrays of different length fail at construction."""
+    with pytest.raises(ValueError):
+        TimeSeries(
+            t_s=[0.0, 30.0],
+            T_room_C=[20.0],
+            T_setpoint_C=[21.0, 21.0],
+            valve_pct=[0.0, 0.0],
+        )
+
+
+def test_timeseries_rejects_non_monotonic_time():
+    """Non-increasing timestamps fail at construction."""
+    with pytest.raises(ValueError):
+        TimeSeries(
+            t_s=[0.0, 30.0, 30.0],
+            T_room_C=[20.0, 20.0, 20.0],
+            T_setpoint_C=[21.0, 21.0, 21.0],
+            valve_pct=[0.0, 0.0, 0.0],
+        )
+
+
+def test_imbalance_clips_interval_straddling_transient_start():
+    """Only the post-transient portion of a straddling interval is charged."""
+    series = TimeSeries(
+        t_s=[0.0, 3600.0],
+        T_room_C=[22.0, 22.0],
+        T_setpoint_C=[21.0, 21.0],
+        valve_pct=[0.0, 0.0],
+    )
+    m = compute_metrics(series, transient_start_s=1800.0)
+    # 1 K error over the half hour after the transient start → 0.5 K·h.
+    assert m.time_above_setpoint_K_h == pytest.approx(0.5)

--- a/tests/benchmark/tests/test_metrics.py
+++ b/tests/benchmark/tests/test_metrics.py
@@ -127,3 +127,21 @@ def test_imbalance_clips_interval_straddling_transient_start():
     m = compute_metrics(series, transient_start_s=1800.0)
     # 1 K error over the half hour after the transient start → 0.5 K·h.
     assert m.time_above_setpoint_K_h == pytest.approx(0.5)
+
+
+def test_timeseries_rejects_non_finite_values():
+    """NaN or infinite samples fail at construction."""
+    with pytest.raises(ValueError):
+        TimeSeries(
+            t_s=[0.0, float("nan")],
+            T_room_C=[20.0, 20.0],
+            T_setpoint_C=[21.0, 21.0],
+            valve_pct=[0.0, 0.0],
+        )
+    with pytest.raises(ValueError):
+        TimeSeries(
+            t_s=[0.0, 30.0],
+            T_room_C=[20.0, float("inf")],
+            T_setpoint_C=[21.0, 21.0],
+            valve_pct=[0.0, 0.0],
+        )

--- a/tests/benchmark/tests/test_plant.py
+++ b/tests/benchmark/tests/test_plant.py
@@ -1,0 +1,49 @@
+"""Sanity tests for the plant model."""
+
+from __future__ import annotations
+
+from tests.benchmark.plant import PROFILE_STANDARD, PlantState, TwoStatePlant
+
+
+def test_plant_warms_with_full_valve():
+    """A fully open valve heats both radiator and room over 30 min."""
+    plant = TwoStatePlant(PROFILE_STANDARD, PlantState(T_room_C=18.0, T_rad_C=18.0))
+    # Run 30 minutes at fully open valve, mild outdoor.
+    for _ in range(60):
+        plant.step(dt_s=30.0, u=1.0, T_outdoor_C=5.0)
+    assert plant.state.T_room_C > 18.5, (
+        f"Room should warm with full valve, got {plant.state.T_room_C:.3f}"
+    )
+    assert plant.state.T_rad_C > plant.state.T_room_C, (
+        "Radiator should be hotter than room when heating"
+    )
+
+
+def test_plant_cools_without_heat():
+    """Without heat input the room cools toward the outdoor temperature."""
+    plant = TwoStatePlant(PROFILE_STANDARD, PlantState(T_room_C=22.0, T_rad_C=22.0))
+    for _ in range(120):  # 1 h
+        plant.step(dt_s=30.0, u=0.0, T_outdoor_C=0.0)
+    assert plant.state.T_room_C < 22.0, (
+        f"Room should cool without heat input, got {plant.state.T_room_C:.3f}"
+    )
+
+
+def test_plant_settles_at_outdoor_without_heat():
+    """After many time constants, the room equilibrates to outdoor."""
+    plant = TwoStatePlant(PROFILE_STANDARD, PlantState(T_room_C=22.0, T_rad_C=22.0))
+    # Run many time constants without heat — should approach outdoor.
+    # PROFILE_STANDARD has tau_room=480min, so ~5 e-folds in 40h to be safe.
+    for _ in range(5000):  # ~42 h with 30s steps
+        plant.step(dt_s=30.0, u=0.0, T_outdoor_C=5.0)
+    assert abs(plant.state.T_room_C - 5.0) < 1.0, (
+        f"After long cooling room should approach outdoor=5C, got {plant.state.T_room_C:.3f}"
+    )
+
+
+def test_plant_zero_dt_is_noop():
+    """A step with ``dt_s == 0`` must leave state unchanged."""
+    plant = TwoStatePlant(PROFILE_STANDARD, PlantState(T_room_C=20.0, T_rad_C=20.0))
+    before = (plant.state.T_room_C, plant.state.T_rad_C)
+    plant.step(dt_s=0.0, u=1.0, T_outdoor_C=0.0)
+    assert (plant.state.T_room_C, plant.state.T_rad_C) == before

--- a/tests/benchmark/tests/test_plant.py
+++ b/tests/benchmark/tests/test_plant.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from tests.benchmark.plant import PROFILE_STANDARD, PlantState, TwoStatePlant
+import pytest
+
+from tests.benchmark.plant import (
+    PROFILE_STANDARD,
+    PlantParams,
+    PlantState,
+    TwoStatePlant,
+)
 
 
 def test_plant_warms_with_full_valve():
@@ -47,3 +54,25 @@ def test_plant_zero_dt_is_noop():
     before = (plant.state.T_room_C, plant.state.T_rad_C)
     plant.step(dt_s=0.0, u=1.0, T_outdoor_C=0.0)
     assert (plant.state.T_room_C, plant.state.T_rad_C) == before
+
+
+def test_plant_params_reject_non_positive_gain_and_coupling():
+    """Zero or negative heater gain / radiator coupling fail at construction."""
+    with pytest.raises(ValueError):
+        PlantParams(gain_heater=0.0)
+    with pytest.raises(ValueError):
+        PlantParams(coupling_rad_room=-1.0)
+
+
+def test_plant_params_reject_non_finite_values():
+    """NaN or infinite parameters fail at construction."""
+    with pytest.raises(ValueError):
+        PlantParams(gain_heater=float("nan"))
+    with pytest.raises(ValueError):
+        PlantParams(tau_room_min=float("inf"))
+
+
+def test_plant_params_reject_non_positive_wall_coupling_in_rc3():
+    """RC3 mode requires a positive room-wall coupling."""
+    with pytest.raises(ValueError):
+        PlantParams(tau_wall_min=900.0, r_room_wall=0.0)

--- a/tests/benchmark/tests/test_rc3_and_equal_percentage.py
+++ b/tests/benchmark/tests/test_rc3_and_equal_percentage.py
@@ -1,0 +1,180 @@
+"""Tests for the RC3 plant extension and the EQUAL_PERCENTAGE actuator profile (Phase D.1)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from tests.benchmark.actuator import Actuator, ActuatorParams, ActuatorProfile
+from tests.benchmark.plant import (
+    PROFILE_STANDARD,
+    PROFILE_STANDARD_RC3,
+    PlantParams,
+    PlantState,
+    TwoStatePlant,
+)
+
+# ---------- RC3 plant ----------
+
+
+def test_rc3_plant_initialises_wall_to_room_when_unset():
+    """When PlantState.T_wall_C is None, the plant copies T_room_C onto the wall."""
+    plant = TwoStatePlant(
+        PROFILE_STANDARD_RC3, PlantState(T_room_C=20.0, T_rad_C=20.0, T_wall_C=None)
+    )
+    assert plant.state.T_wall_C == 20.0
+
+
+def test_rc3_plant_warms_with_full_valve():
+    """A full-valve RC3 plant heats both radiator and room over 60 min."""
+    plant = TwoStatePlant(PROFILE_STANDARD_RC3, PlantState(T_room_C=18.0, T_rad_C=18.0))
+    for _ in range(120):  # 60 min at 30s steps
+        plant.step(30.0, 1.0, 5.0)
+    assert plant.state.T_room_C > 18.5
+    assert plant.state.T_rad_C > plant.state.T_room_C
+
+
+def test_rc3_wall_lags_room_during_heating():
+    """During heating, the wall warms much more slowly than the room.
+
+    Sanity for the RC3 splitting: the wall is between room and outdoor,
+    and starts at room temp here. Because the wall→outdoor gradient is
+    initially much bigger than the room→wall gradient, the wall actually
+    drifts toward outdoor while the room warms. The key sanity check is
+    that the room is always warmer than the wall (otherwise the room→wall
+    heat flow has the wrong sign for our physical model).
+    """
+    plant = TwoStatePlant(PROFILE_STANDARD_RC3, PlantState(T_room_C=18.0, T_rad_C=18.0))
+    for _ in range(40):  # 20 min at 30s
+        plant.step(30.0, 1.0, 5.0)
+    assert plant.state.T_room_C is not None
+    assert plant.state.T_wall_C is not None
+    # Room is heating fast, wall lags far behind.
+    assert plant.state.T_room_C > plant.state.T_wall_C
+    # Room has warmed measurably.
+    assert plant.state.T_room_C > 19.0
+
+
+def test_rc3_room_cools_slower_than_rc2_with_same_lumped_tau():
+    """RC3 with a heat-loaded wall holds the room longer than the equivalent RC2 plant.
+
+    Construct an RC3 plant whose total room+wall thermal mass is roughly
+    comparable to an RC2 plant with tau_room=600. After full warming, cut
+    the heater off and compare the room temperatures after 2 hours. RC3
+    should still be warmer because the wall is acting as a battery.
+    """
+    rc2 = PlantParams(
+        tau_room_min=600.0,
+        tau_rad_min=15.0,
+        gain_heater=2.0,
+        coupling_rad_room=1.0,
+        T_water_C=65.0,
+    )
+    rc3 = PlantParams(
+        tau_room_min=60.0,
+        tau_rad_min=15.0,
+        gain_heater=2.0,
+        coupling_rad_room=1.0,
+        T_water_C=65.0,
+        tau_wall_min=900.0,
+        r_room_wall=1.0,
+    )
+
+    plant_rc2 = TwoStatePlant(rc2, PlantState(T_room_C=22.0, T_rad_C=35.0))
+    plant_rc3 = TwoStatePlant(
+        rc3, PlantState(T_room_C=22.0, T_rad_C=35.0, T_wall_C=22.0)
+    )
+
+    # Pre-warm wall in RC3 so it really acts like a battery — heat for 4 h
+    # against a steady setpoint by injecting some heater command.
+    for _ in range(8 * 60 * 2):  # 4 h at 30 s
+        plant_rc3.step(30.0, 0.25, 5.0)
+    for _ in range(8 * 60 * 2):
+        plant_rc2.step(30.0, 0.25, 5.0)
+
+    # Now switch heater off and let both cool for 2 h.
+    for _ in range(4 * 60 * 2):  # 2 h
+        plant_rc2.step(30.0, 0.0, 5.0)
+        plant_rc3.step(30.0, 0.0, 5.0)
+
+    # RC3 should retain more heat thanks to the wall capacitance.
+    assert plant_rc3.state.T_room_C > plant_rc2.state.T_room_C
+
+
+def test_rc2_path_unchanged_when_tau_wall_zero():
+    """``tau_wall_min == 0`` follows the RC2 reference exactly.
+
+    Non-default wall parameters must have no effect while the wall layer
+    is disabled, so both plants must produce bit-identical trajectories.
+    """
+    reference = TwoStatePlant(
+        PROFILE_STANDARD,  # RC2 default (tau_wall_min == 0)
+        PlantState(T_room_C=20.0, T_rad_C=20.0),
+    )
+    tau_zero = TwoStatePlant(
+        replace(PROFILE_STANDARD, tau_wall_min=0.0, r_room_wall=3.7),
+        PlantState(T_room_C=20.0, T_rad_C=20.0),
+    )
+    for _ in range(60):
+        reference.step(30.0, 0.5, 5.0)
+        tau_zero.step(30.0, 0.5, 5.0)
+        assert tau_zero.state.T_room_C == reference.state.T_room_C
+        assert tau_zero.state.T_rad_C == reference.state.T_rad_C
+    # Sanity check that RC2 still warms.
+    assert 20.0 < reference.state.T_room_C < 35.0
+
+
+# ---------- EQUAL_PERCENTAGE actuator ----------
+
+
+def test_equal_percentage_low_pct_gives_small_flow():
+    """At 10% command, equal-percentage flow is much less than linear."""
+    actuator = Actuator(
+        ActuatorParams(
+            profile=ActuatorProfile.EQUAL_PERCENTAGE, equal_percentage_exponent=3.0
+        )
+    )
+    flow = actuator.apply(10.0)
+    # 0.1^3 = 0.001 — three orders of magnitude smaller than the 0.1 linear case.
+    assert flow < 0.05
+
+
+def test_equal_percentage_high_pct_approaches_full_flow():
+    """At 90% command, equal-percentage gives roughly 0.7 flow."""
+    actuator = Actuator(
+        ActuatorParams(
+            profile=ActuatorProfile.EQUAL_PERCENTAGE, equal_percentage_exponent=3.0
+        )
+    )
+    flow = actuator.apply(90.0)
+    # 0.9^3 = 0.729
+    assert 0.6 < flow < 0.8
+
+
+def test_equal_percentage_full_command_full_flow():
+    """At 100% command, equal-percentage delivers full flow."""
+    actuator = Actuator(ActuatorParams(profile=ActuatorProfile.EQUAL_PERCENTAGE))
+    flow = actuator.apply(100.0)
+    assert flow == 1.0
+
+
+def test_equal_percentage_zero_command_zero_flow():
+    """At 0% command, equal-percentage delivers no flow."""
+    actuator = Actuator(ActuatorParams(profile=ActuatorProfile.EQUAL_PERCENTAGE))
+    flow = actuator.apply(0.0)
+    assert flow == 0.0
+
+
+def test_equal_percentage_exponent_changes_curve():
+    """A higher exponent makes the curve more aggressive at the low end."""
+    flow_low = Actuator(
+        ActuatorParams(
+            profile=ActuatorProfile.EQUAL_PERCENTAGE, equal_percentage_exponent=2.0
+        )
+    ).apply(50.0)
+    flow_high = Actuator(
+        ActuatorParams(
+            profile=ActuatorProfile.EQUAL_PERCENTAGE, equal_percentage_exponent=4.0
+        )
+    ).apply(50.0)
+    # At 50%: 0.5^2 = 0.25 vs 0.5^4 = 0.0625 → higher exponent gives lower flow.
+    assert flow_low > flow_high

--- a/tests/benchmark/tests/test_rc3_and_equal_percentage.py
+++ b/tests/benchmark/tests/test_rc3_and_equal_percentage.py
@@ -86,13 +86,13 @@ def test_rc3_room_cools_slower_than_rc2_with_same_lumped_tau():
 
     # Pre-warm wall in RC3 so it really acts like a battery — heat for 4 h
     # against a steady setpoint by injecting some heater command.
-    for _ in range(8 * 60 * 2):  # 4 h at 30 s
+    for _ in range(4 * 60 * 2):  # 4 h at 30 s
         plant_rc3.step(30.0, 0.25, 5.0)
-    for _ in range(8 * 60 * 2):
+    for _ in range(4 * 60 * 2):
         plant_rc2.step(30.0, 0.25, 5.0)
 
     # Now switch heater off and let both cool for 2 h.
-    for _ in range(4 * 60 * 2):  # 2 h
+    for _ in range(2 * 60 * 2):  # 2 h
         plant_rc2.step(30.0, 0.0, 5.0)
         plant_rc3.step(30.0, 0.0, 5.0)
 

--- a/tests/benchmark/tests/test_rc3_and_equal_percentage.py
+++ b/tests/benchmark/tests/test_rc3_and_equal_percentage.py
@@ -1,4 +1,4 @@
-"""Tests for the RC3 plant extension and the EQUAL_PERCENTAGE actuator profile (Phase D.1)."""
+"""Tests for the RC3 plant extension and the EQUAL_PERCENTAGE actuator profile."""
 
 from __future__ import annotations
 

--- a/tests/benchmark/tests/test_reporter.py
+++ b/tests/benchmark/tests/test_reporter.py
@@ -1,0 +1,225 @@
+"""Reporter rendering tests."""
+
+from __future__ import annotations
+
+from tests.benchmark.metrics import MetricValues
+from tests.benchmark.reporter import (
+    ScenarioResult,
+    ScoredResult,
+    _mean,
+    _stdev,
+    format_metric,
+    render_per_scenario,
+    render_plant_sweep,
+    render_score_matrix,
+    score_results,
+)
+from tests.benchmark.scoring import PROFILES, DimensionScores
+
+
+def _m(rmse: float = 0.1, integral: float = 100.0, cycles: int = 10) -> MetricValues:
+    return MetricValues(
+        max_overshoot_K=0.2,
+        max_undershoot_K=0.1,
+        settling_time_min=10.0,
+        steady_state_error_K=0.05,
+        rmse_tracking_K=rmse,
+        valve_cycle_count=cycles,
+        integral_valve_pct_min=integral,
+        total_valve_travel_pct=500.0,
+        time_above_setpoint_K_h=0.1,
+        time_below_setpoint_K_h=0.1,
+        valve_sweet_spot_residency_pct=50.0,
+    )
+
+
+def _scored(
+    controller: str,
+    scenario: str,
+    overall: float,
+    comfort: float = 0.9,
+    actuator: float = 0.7,
+    energy: float = 0.85,
+    block_label: str = "",
+) -> ScoredResult:
+    return ScoredResult(
+        controller=controller,
+        scenario=scenario,
+        metrics=_m(),
+        scores=DimensionScores(
+            overall=overall, comfort=comfort, actuator=actuator, energy=energy
+        ),
+        block_label=block_label,
+    )
+
+
+def test_format_metric_renders_finite():
+    """Format metric renders finite."""
+    assert format_metric(1.234567, decimals=2) == "1.23"
+    assert format_metric(0.0, decimals=3) == "0.000"
+
+
+def test_format_metric_handles_inf_and_nan():
+    """Format metric handles inf and nan."""
+    assert format_metric(float("inf"), 2).strip() == "inf"
+    assert format_metric(float("nan"), 2).strip() == "NaN"
+
+
+def test_mean_empty_is_zero():
+    """Mean empty is zero."""
+    assert _mean([]) == 0.0
+
+
+def test_mean_filters_nan():
+    """Mean filters nan."""
+    assert _mean([1.0, float("nan"), 3.0]) == 2.0
+
+
+def test_stdev_one_value_is_zero():
+    """Stdev one value is zero."""
+    assert _stdev([0.5]) == 0.0
+
+
+def test_stdev_empty_is_zero():
+    """Stdev empty is zero."""
+    assert _stdev([]) == 0.0
+
+
+def test_stdev_two_values():
+    """Stdev two values."""
+    # pstdev of [1, 2] is 0.5 (population).
+    assert abs(_stdev([1.0, 2.0]) - 0.5) < 1e-9
+
+
+def test_score_results_joins_on_block_label():
+    """Score results joins on block label."""
+    results = {
+        "block_a": [
+            ScenarioResult(controller="pid", scenario="S01", metrics=_m()),
+            ScenarioResult(controller="pid", scenario="S02", metrics=_m()),
+        ]
+    }
+    oracle = {("block_a", "S01"): _m(), ("block_a", "S02"): _m()}
+    scored = score_results(results, oracle, PROFILES["balanced"])
+    assert len(scored) == 2
+    assert {s.scenario for s in scored} == {"S01", "S02"}
+
+
+def test_score_results_skips_when_oracle_missing():
+    """Score results skips when oracle missing."""
+    results = {
+        "block_a": [
+            ScenarioResult(controller="pid", scenario="S01", metrics=_m()),
+            ScenarioResult(controller="pid", scenario="missing", metrics=_m()),
+        ]
+    }
+    oracle = {("block_a", "S01"): _m()}  # no entry for "missing"
+    scored = score_results(results, oracle, PROFILES["balanced"])
+    assert len(scored) == 1
+    assert scored[0].scenario == "S01"
+
+
+def test_render_score_matrix_orders_by_overall_descending():
+    """Render score matrix orders by overall descending."""
+    items = [
+        _scored("a", "S01", overall=0.7),
+        _scored("a", "S02", overall=0.9),
+        _scored("b", "S01", overall=0.95),
+        _scored("b", "S02", overall=0.85),
+    ]
+    out = render_score_matrix(items, PROFILES["balanced"])
+    # Header bits.
+    assert "Score matrix" in out
+    assert "comfort" in out
+    assert "σ" in out
+    # The higher-mean controller (b, mean 0.9) outranks a (mean 0.8) and gets the * marker.
+    a_line = [line for line in out.splitlines() if "a " in line and "b " not in line][
+        -1
+    ]
+    b_line = [line for line in out.splitlines() if "b " in line][-1]
+    # b appears above a in the body.
+    assert out.index(b_line) < out.index(a_line)
+    assert b_line.startswith(" *")
+
+
+def test_render_score_matrix_handles_single_run():
+    """Render score matrix handles single run."""
+    items = [_scored("only", "S01", overall=0.8)]
+    out = render_score_matrix(items, PROFILES["balanced"])
+    assert "only" in out
+    # σ = 0 for n = 1
+    assert "0.000" in out
+
+
+def test_render_per_scenario_lists_each_scenario_row():
+    """Render per scenario lists each scenario row."""
+    items = [
+        _scored("pid", "S01", overall=0.8),
+        _scored("pid", "S02", overall=0.7),
+        _scored("mpc", "S01", overall=0.9),
+        _scored("mpc", "S02", overall=0.6),
+    ]
+    out = render_per_scenario(items, PROFILES["balanced"])
+    assert "S01" in out and "S02" in out
+    assert "pid" in out and "mpc" in out
+
+
+def test_render_plant_sweep_columns_and_cross_mean():
+    """Render plant sweep columns and cross mean."""
+    block_a = [_scored("pid", "S01", 0.8), _scored("pid", "S02", 0.7)]
+    block_b = [_scored("pid", "S01", 0.85), _scored("pid", "S02", 0.75)]
+    out = render_plant_sweep(
+        {"plant=alpha": block_a, "plant=beta": block_b}, PROFILES["balanced"]
+    )
+    assert "Cross-plant" in out
+    assert "plant=alpha" in out or "alpha" in out
+    assert "plant=beta" in out or "beta" in out
+    assert "mean" in out
+    assert "±σ" in out
+
+
+def test_render_plant_sweep_sorts_controllers_by_cross_mean():
+    """Render plant sweep sorts controllers by cross mean."""
+    block_a = [_scored("strong", "S01", 0.95), _scored("weak", "S01", 0.40)]
+    block_b = [_scored("strong", "S01", 0.90), _scored("weak", "S01", 0.50)]
+    out = render_plant_sweep(
+        {"plant=a": block_a, "plant=b": block_b}, PROFILES["balanced"]
+    )
+    assert out.index("strong") < out.index("weak")
+
+
+def test_score_results_threads_block_label():
+    """score_results carries the block label into ScoredResult."""
+    results = {"plant=a": [ScenarioResult("pid", "S01", _m())]}
+    oracle = {("plant=a", "S01"): _m()}
+    scored = score_results(results, oracle, PROFILES["balanced"])
+    assert scored[0].block_label == "plant=a"
+
+
+def test_per_scenario_qualifies_rows_per_block_label():
+    """Same-named scenarios from different blocks render as separate rows."""
+    scored = [
+        _scored("pid", "S01", 0.9, block_label="plant=a"),
+        _scored("pid", "S01", 0.5, block_label="plant=b"),
+    ]
+    out = render_per_scenario(scored, PROFILES["balanced"])
+    assert "S01 [plant=a]" in out
+    assert "S01 [plant=b]" in out
+
+
+def test_plant_sweep_ranks_full_coverage_first():
+    """A partially-covered controller sorts below full-sweep controllers."""
+    scored_per_plant = {
+        "plant=a": [
+            _scored("low_full", "S01", 0.2),
+            _scored("high_partial", "S01", 0.99),
+        ],
+        "plant=b": [_scored("low_full", "S01", 0.2)],
+    }
+    out = render_plant_sweep(scored_per_plant, PROFILES["balanced"])
+    lines = out.splitlines()
+    row_low = next(i for i, line in enumerate(lines) if "low_full" in line)
+    row_high = next(i for i, line in enumerate(lines) if "high_partial" in line)
+    assert row_low < row_high
+    assert "2/2" in lines[row_low]
+    assert "1/2" in lines[row_high]

--- a/tests/benchmark/tests/test_reporter.py
+++ b/tests/benchmark/tests/test_reporter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from tests.benchmark.metrics import MetricValues
 from tests.benchmark.reporter import (
     ScenarioResult,
@@ -132,14 +134,14 @@ def test_render_score_matrix_orders_by_overall_descending():
     assert "Score matrix" in out
     assert "comfort" in out
     assert "σ" in out
-    # The higher-mean controller (b, mean 0.9) outranks a (mean 0.8) and gets the * marker.
-    a_line = [line for line in out.splitlines() if "a " in line and "b " not in line][
-        -1
-    ]
-    b_line = [line for line in out.splitlines() if "b " in line][-1]
-    # b appears above a in the body.
-    assert out.index(b_line) < out.index(a_line)
-    assert b_line.startswith(" *")
+    # The higher-mean controller (b, mean 0.9) outranks a (mean 0.8) and
+    # gets the * marker. Body rows start with a two-character marker
+    # column followed by the controller name.
+    lines = out.splitlines()
+    a_idx = next(i for i, line in enumerate(lines) if re.match(r"^(  | \*)a\s", line))
+    b_idx = next(i for i, line in enumerate(lines) if re.match(r"^(  | \*)b\s", line))
+    assert b_idx < a_idx
+    assert lines[b_idx].startswith(" *")
 
 
 def test_render_score_matrix_handles_single_run():

--- a/tests/benchmark/tests/test_scoring.py
+++ b/tests/benchmark/tests/test_scoring.py
@@ -1,0 +1,205 @@
+"""Tests for the weighted scoring system (Phase F)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import math
+
+import pytest
+
+from tests.benchmark.metrics import MetricValues
+from tests.benchmark.scoring import (
+    PROFILES,
+    UserProfile,
+    actuator_score,
+    comfort_score,
+    compute_scores,
+    energy_score,
+)
+
+
+def _zero_metrics(**overrides) -> MetricValues:
+    base = MetricValues(
+        max_overshoot_K=0.0,
+        max_undershoot_K=0.0,
+        settling_time_min=10.0,
+        steady_state_error_K=0.0,
+        rmse_tracking_K=0.0,
+        valve_cycle_count=0,
+        integral_valve_pct_min=1000.0,
+        total_valve_travel_pct=100.0,
+        time_above_setpoint_K_h=0.0,
+        time_below_setpoint_K_h=0.0,
+        valve_sweet_spot_residency_pct=0.0,
+    )
+    return replace(base, **overrides)
+
+
+# ---------- Profile invariants ----------
+
+
+def test_profiles_weights_sum_to_one():
+    """Every UserProfile's weights sum to 1.0 (constructor invariant)."""
+    for p in PROFILES.values():
+        assert math.isclose(p.w_comfort + p.w_actuator + p.w_energy, 1.0, abs_tol=1e-6)
+
+
+def test_profile_rejects_invalid_weights():
+    """Constructor refuses weights that don't sum to 1."""
+    with pytest.raises(ValueError):
+        UserProfile("bad", 0.5, 0.5, 0.5)
+
+
+# ---------- Comfort score ----------
+
+
+def test_comfort_score_matches_oracle_returns_one():
+    """A controller matching the oracle exactly scores 1.0 on comfort."""
+    oracle = _zero_metrics()
+    candidate = _zero_metrics()
+    assert comfort_score(candidate, oracle) == pytest.approx(1.0)
+
+
+def test_comfort_score_overshoot_penalty():
+    """Extra overshoot drops the comfort score proportionally."""
+    oracle = _zero_metrics()
+    candidate = _zero_metrics(max_overshoot_K=1.0)
+    # 1 K excess overshoot → comfort drops by 0.4 (weight in comfort)
+    assert comfort_score(candidate, oracle) == pytest.approx(0.6, abs=0.01)
+
+
+def test_comfort_score_inf_settling_penalised():
+    """Inf settling drives comfort below 0.6 (most of the 0.4 settling penalty)."""
+    oracle = _zero_metrics()
+    candidate = _zero_metrics(settling_time_min=math.inf)
+    assert comfort_score(candidate, oracle) < 0.7
+
+
+def test_comfort_score_clamps_to_zero():
+    """Catastrophic comfort fails (overshoot + settling + ss_err) clamp at 0."""
+    oracle = _zero_metrics()
+    candidate = _zero_metrics(
+        max_overshoot_K=10.0, settling_time_min=math.inf, steady_state_error_K=5.0
+    )
+    assert comfort_score(candidate, oracle) == pytest.approx(0.0)
+
+
+# ---------- Actuator score ----------
+
+
+def test_actuator_score_matches_oracle_returns_one():
+    """Matching the oracle's travel scores 1.0."""
+    oracle = _zero_metrics(total_valve_travel_pct=500.0)
+    candidate = _zero_metrics(total_valve_travel_pct=500.0)
+    assert actuator_score(candidate, oracle) == pytest.approx(1.0)
+
+
+def test_actuator_score_5x_travel_scores_zero():
+    """5× the oracle's travel scores 0."""
+    oracle = _zero_metrics(total_valve_travel_pct=500.0)
+    candidate = _zero_metrics(total_valve_travel_pct=2500.0)
+    assert actuator_score(candidate, oracle) == pytest.approx(0.0)
+
+
+def test_actuator_score_less_travel_than_oracle_scores_one():
+    """Using *less* travel than the oracle still caps at 1.0."""
+    oracle = _zero_metrics(total_valve_travel_pct=500.0)
+    candidate = _zero_metrics(total_valve_travel_pct=100.0)
+    assert actuator_score(candidate, oracle) == pytest.approx(1.0)
+
+
+def test_actuator_score_handles_low_oracle_travel():
+    """When the oracle barely moved, the candidate is compared against a floor."""
+    oracle = _zero_metrics(total_valve_travel_pct=0.5)
+    candidate = _zero_metrics(total_valve_travel_pct=250.0)
+    # Floor of 500 → 250/500 = 0.5 penalty → score 0.5
+    assert 0.4 < actuator_score(candidate, oracle) < 0.6
+
+
+# ---------- Energy score ----------
+
+
+def test_energy_score_matches_oracle_returns_one():
+    """Matching the oracle's integral flow scores 1.0."""
+    oracle = _zero_metrics(integral_valve_pct_min=5000.0)
+    candidate = _zero_metrics(integral_valve_pct_min=5000.0)
+    assert energy_score(candidate, oracle) == pytest.approx(1.0)
+
+
+def test_energy_score_double_oracle_scores_zero():
+    """Using 2× the oracle's integral flow scores 0."""
+    oracle = _zero_metrics(integral_valve_pct_min=5000.0)
+    candidate = _zero_metrics(integral_valve_pct_min=10000.0)
+    assert energy_score(candidate, oracle) == pytest.approx(0.0)
+
+
+def test_energy_score_low_oracle_neutral_for_matching_candidate():
+    """When the oracle barely heated, a candidate near it still scores ~1.0."""
+    oracle = _zero_metrics(integral_valve_pct_min=20.0)
+    candidate = _zero_metrics(integral_valve_pct_min=25.0)
+    assert energy_score(candidate, oracle) == pytest.approx(1.0 - 5.0 / 100.0)
+
+
+def test_energy_score_low_oracle_penalises_gross_overuse():
+    """A grossly over-heating candidate must not escape via the low-oracle path."""
+    oracle = _zero_metrics(integral_valve_pct_min=20.0)
+    candidate = _zero_metrics(integral_valve_pct_min=2000.0)
+    # Excess of ~1980 pct·min against the 100 floor → fully penalised.
+    assert energy_score(candidate, oracle) == pytest.approx(0.0)
+
+
+def test_energy_score_undershoot_penalised_symmetrically():
+    """Heating *less* than the oracle is under-heating, not legitimate saving."""
+    oracle = _zero_metrics(integral_valve_pct_min=5000.0)
+    candidate = _zero_metrics(integral_valve_pct_min=3000.0)
+    # ratio = 0.6 → |0.6 - 1| = 0.4 → score 0.6
+    assert energy_score(candidate, oracle) == pytest.approx(0.6)
+
+
+def test_energy_score_zero_integral_scores_zero():
+    """Not heating at all when oracle would heat scores 0."""
+    oracle = _zero_metrics(integral_valve_pct_min=5000.0)
+    candidate = _zero_metrics(integral_valve_pct_min=0.0)
+    assert energy_score(candidate, oracle) == pytest.approx(0.0)
+
+
+# ---------- compute_scores integration ----------
+
+
+def test_compute_scores_returns_all_dimensions():
+    """The aggregate function returns comfort, actuator, energy, overall."""
+    oracle = _zero_metrics(total_valve_travel_pct=500.0, integral_valve_pct_min=5000.0)
+    candidate = _zero_metrics(
+        max_overshoot_K=0.5, total_valve_travel_pct=750.0, integral_valve_pct_min=5500.0
+    )
+    profile = PROFILES["balanced"]
+    s = compute_scores(candidate, oracle, profile)
+    assert 0.0 <= s.comfort <= 1.0
+    assert 0.0 <= s.actuator <= 1.0
+    assert 0.0 <= s.energy <= 1.0
+    assert 0.0 <= s.overall <= 1.0
+
+
+def test_overall_score_respects_profile_weights():
+    """Same dimension scores under different profiles give different overalls."""
+    oracle = _zero_metrics(total_valve_travel_pct=500.0)
+    # Candidate: perfect comfort, terrible actuator
+    candidate = _zero_metrics(total_valve_travel_pct=2500.0)
+    score_balanced = compute_scores(candidate, oracle, PROFILES["balanced"]).overall
+    score_comfort_first = compute_scores(
+        candidate, oracle, PROFILES["comfort_first"]
+    ).overall
+    score_longevity_first = compute_scores(
+        candidate, oracle, PROFILES["longevity_first"]
+    ).overall
+    # comfort_first should rate this candidate higher (good comfort dominates),
+    # longevity_first should rate it lower (bad actuator dominates).
+    assert score_comfort_first > score_balanced > score_longevity_first
+
+
+def test_zero_settling_oracle_still_penalises_slow_candidates():
+    """An instantly-settled oracle must not mask slow candidate settling."""
+    oracle = _zero_metrics(settling_time_min=0.0)
+    slow = _zero_metrics(settling_time_min=10.0)
+    instant = _zero_metrics(settling_time_min=0.0)
+    assert comfort_score(slow, oracle) < comfort_score(instant, oracle)

--- a/tests/benchmark/tests/test_scoring.py
+++ b/tests/benchmark/tests/test_scoring.py
@@ -50,6 +50,14 @@ def test_profile_rejects_invalid_weights():
         UserProfile("bad", 0.5, 0.5, 0.5)
 
 
+def test_profile_rejects_out_of_range_weights():
+    """Weights summing to 1 but outside [0, 1] are rejected (no inverted priorities)."""
+    with pytest.raises(ValueError):
+        UserProfile("neg", 1.2, -0.1, -0.1)
+    with pytest.raises(ValueError):
+        UserProfile("over", 1.5, 0.5, -1.0)
+
+
 # ---------- Comfort score ----------
 
 
@@ -146,6 +154,14 @@ def test_energy_score_low_oracle_penalises_gross_overuse():
     candidate = _zero_metrics(integral_valve_pct_min=2000.0)
     # Excess of ~1980 pct·min against the 100 floor → fully penalised.
     assert energy_score(candidate, oracle) == pytest.approx(0.0)
+
+
+def test_energy_score_low_oracle_penalises_underheating():
+    """Under-heating in the low-oracle path is penalised symmetrically (not 1.0)."""
+    oracle = _zero_metrics(integral_valve_pct_min=80.0)
+    candidate = _zero_metrics(integral_valve_pct_min=0.0)
+    # Deviation of 80 pct·min against the 100 floor → score 0.2.
+    assert energy_score(candidate, oracle) == pytest.approx(1.0 - 80.0 / 100.0)
 
 
 def test_energy_score_undershoot_penalised_symmetrically():

--- a/tests/benchmark/tests/test_scoring.py
+++ b/tests/benchmark/tests/test_scoring.py
@@ -1,4 +1,4 @@
-"""Tests for the weighted scoring system (Phase F)."""
+"""Tests for the weighted scoring system."""
 
 from __future__ import annotations
 

--- a/tests/benchmark/tests/test_sensor_lag_and_pipe_delay.py
+++ b/tests/benchmark/tests/test_sensor_lag_and_pipe_delay.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+import pytest
+
 from tests.benchmark.plant import (
     PROFILE_STANDARD,
     PlantParams,
@@ -102,3 +104,12 @@ def test_realistic_profile_has_both_features():
 
     assert PROFILE_REALISTIC.tau_wall_min > 0.0
     assert PROFILE_REALISTIC.valve_command_delay_s > 0.0
+
+
+def test_pipe_delay_rejects_changed_dt_s():
+    """Changing dt_s after the delay buffer is sized fails fast."""
+    params = replace(PROFILE_STANDARD, valve_command_delay_s=60.0)
+    plant = TwoStatePlant(params, PlantState(T_room_C=20.0, T_rad_C=20.0))
+    plant.step(30.0, 1.0, 5.0)  # sizes the buffer for dt_s=30
+    with pytest.raises(ValueError):
+        plant.step(60.0, 1.0, 5.0)  # different dt_s → reject

--- a/tests/benchmark/tests/test_sensor_lag_and_pipe_delay.py
+++ b/tests/benchmark/tests/test_sensor_lag_and_pipe_delay.py
@@ -1,0 +1,104 @@
+"""Tests for sensor thermal lag and pipe-transport delay (Phase D.2)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from tests.benchmark.plant import (
+    PROFILE_STANDARD,
+    PlantParams,
+    PlantState,
+    TwoStatePlant,
+)
+from tests.benchmark.sensor import Sensor, SensorParams
+
+# ---------- Sensor thermal lag ----------
+
+
+def test_sensor_thermal_lag_zero_passes_temperature_through():
+    """With thermal_lag_s = 0, the sensor returns T_true (modulo sampling)."""
+    sensor = Sensor(SensorParams(sample_interval_s=0.0, thermal_lag_s=0.0))
+    reading = sensor.read(0.0, 20.0)
+    assert reading == 20.0
+
+
+def test_sensor_thermal_lag_settles_to_steady_input():
+    """With a steady input and enough time, the lagged reading equals T_true."""
+    sensor = Sensor(SensorParams(sample_interval_s=0.0, thermal_lag_s=60.0))
+    sensor.read(0.0, 20.0)  # initialise
+    for t in range(1, 600):  # 10 min
+        reading = sensor.read(float(t), 20.0)
+    assert abs(reading - 20.0) < 1e-3
+
+
+def test_sensor_thermal_lag_first_order_response_to_step():
+    """A step in T_true takes about ``thermal_lag_s`` to reach 63 % of the new value."""
+    tau_s = 120.0
+    sensor = Sensor(SensorParams(sample_interval_s=0.0, thermal_lag_s=tau_s))
+    sensor.read(0.0, 20.0)
+    sensor.read(0.001, 20.0)  # ensure lag-state is fully initialised at 20.0
+    # Apply a step to 22.0 and check the reading at one time constant.
+    final = sensor.read(tau_s, 22.0)
+    # After one tau, first-order response reaches ≈63 % of step = 20 + 0.63*2 ≈ 21.26
+    assert 21.10 < final < 21.45
+
+
+def test_sensor_thermal_lag_lags_step():
+    """Immediately after a step, the reading should still be near the old value."""
+    sensor = Sensor(SensorParams(sample_interval_s=0.0, thermal_lag_s=180.0))
+    sensor.read(0.0, 20.0)
+    sensor.read(0.1, 20.0)
+    # 1 second after a 5 K step the reading must still be close to the old value
+    reading = sensor.read(1.1, 25.0)
+    assert reading < 20.2  # large lag → barely moved
+
+
+# ---------- Pipe-transport delay ----------
+
+
+def test_pipe_delay_zero_disables_buffer():
+    """With valve_command_delay_s = 0 the plant behaves exactly as before."""
+    plant = TwoStatePlant(PROFILE_STANDARD, PlantState(T_room_C=18.0, T_rad_C=18.0))
+    for _ in range(60):
+        plant.step(30.0, 1.0, 5.0)
+    # No assertion on absolute value — sanity check it warmed.
+    assert plant.state.T_room_C > 18.5
+
+
+def test_pipe_delay_buffer_serves_old_value():
+    """The radiator sees the buffered (old) u until the delay window passes.
+
+    Setup: prime the buffer with u=0, then command u=1.
+    """
+    delayed = PlantParams(
+        tau_room_min=60.0,
+        tau_rad_min=10.0,
+        gain_heater=2.0,
+        T_water_C=65.0,
+        valve_command_delay_s=120.0,
+    )
+    # Identical thermal constants — only the delay differs, so the
+    # comparison isolates the pipe-delay behaviour.
+    no_delay = replace(delayed, valve_command_delay_s=0.0)
+    plant_a = TwoStatePlant(no_delay, PlantState(T_room_C=18.0, T_rad_C=18.0))
+    plant_b = TwoStatePlant(delayed, PlantState(T_room_C=18.0, T_rad_C=18.0))
+
+    # Prime both plants with u=0 so they share the same pre-state.
+    for _ in range(4):  # 2 min of u=0
+        plant_a.step(30.0, 0.0, 5.0)
+        plant_b.step(30.0, 0.0, 5.0)
+    # Now command u=1.0. The next 2 minutes (4 steps of 30 s) the
+    # radiator should still see u=0 from the buffer; only after that
+    # the u=1.0 starts arriving.
+    plant_a.step(30.0, 1.0, 5.0)  # plant_a sees u=1.0 immediately
+    plant_b.step(30.0, 1.0, 5.0)  # plant_b serves the head of the buffer (=0)
+    # plant_a's radiator should have warmed, plant_b's not at all yet.
+    assert plant_a.state.T_rad_C > plant_b.state.T_rad_C
+
+
+def test_realistic_profile_has_both_features():
+    """PROFILE_REALISTIC ships with RC3 wall + pipe delay enabled."""
+    from tests.benchmark.plant import PROFILE_REALISTIC
+
+    assert PROFILE_REALISTIC.tau_wall_min > 0.0
+    assert PROFILE_REALISTIC.valve_command_delay_s > 0.0

--- a/tests/benchmark/tests/test_sensor_lag_and_pipe_delay.py
+++ b/tests/benchmark/tests/test_sensor_lag_and_pipe_delay.py
@@ -1,4 +1,4 @@
-"""Tests for sensor thermal lag and pipe-transport delay (Phase D.2)."""
+"""Tests for sensor thermal lag and pipe-transport delay."""
 
 from __future__ import annotations
 
@@ -59,11 +59,12 @@ def test_sensor_thermal_lag_lags_step():
 
 
 def test_pipe_delay_zero_disables_buffer():
-    """With valve_command_delay_s = 0 the plant behaves exactly as before."""
+    """With valve_command_delay_s = 0 the delay buffer is never engaged."""
     plant = TwoStatePlant(PROFILE_STANDARD, PlantState(T_room_C=18.0, T_rad_C=18.0))
     for _ in range(60):
         plant.step(30.0, 1.0, 5.0)
-    # No assertion on absolute value — sanity check it warmed.
+    assert len(plant._u_delay_buffer) == 0
+    assert plant._u_buffer_target_len == 0
     assert plant.state.T_room_C > 18.5
 
 

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -1417,22 +1417,14 @@ class TestEdgeCasesAndPotentialBugs:
         # dt = max(0, now - future) = 0 → alpha = 0 → EMA stays at 20
         assert sensor._ema_value == 20.0
 
-    def test_cleanup_stale_empty_entry_removed(self):
+    @pytest.mark.asyncio
+    async def test_cleanup_stale_empty_entry_removed(self):
         """After all algorithms removed, the entry_id key should be deleted."""
         _ACTIVE_ALGORITHM_ENTITIES["entry_1"] = {}
         # empty dict → should be cleaned up
         hass = MagicMock()
         bt = _make_bt_climate()
-        import asyncio
-
-        # Fresh event loop avoids HA pytest plugin issues with the current loop.
-        loop = asyncio.new_event_loop()
-        try:
-            loop.run_until_complete(
-                _cleanup_stale_algorithm_entities(hass, "entry_1", bt, set())
-            )
-        finally:
-            loop.close()
+        await _cleanup_stale_algorithm_entities(hass, "entry_1", bt, set())
         # The function checks `if not _ACTIVE_ALGORITHM_ENTITIES[entry_id]`
         # and deletes it → entry should be gone
         assert "entry_1" not in _ACTIVE_ALGORITHM_ENTITIES


### PR DESCRIPTION
## Calibration benchmark — simulation core & scoring

Pure-simulation foundation of the calibration benchmark, under `tests/benchmark/`. No Home Assistant runtime, no production code touched.

**Contents**
- **Thermal plant** (`plant.py`) — RC2/RC3 lumped-parameter models, explicit-Euler integration, optional pipe-transport delay
- **Sensor** (`sensor.py`) — sampling, thermal lag, EMA, plus noise/bias/drift/dropout/jitter fault injection
- **Actuator** (`actuator.py`) — linear/threshold/exponential/equal-percentage valve-flow profiles, deadband, hysteresis, quantisation
- **Adapter protocol** (`adapters/base.py`) — `BenchmarkContext` / `BenchmarkOutput` contract
- **Metrics & scoring** (`metrics.py`, `scoring.py`, `reporter.py`) — comfort/actuator/energy metrics, oracle-normalised 0..1 scoring, matrix reporter

`tests/unit/test_sensor.py` uses the `@pytest.mark.asyncio` idiom instead of `get_event_loop().run_until_complete()`, which raises on Python 3.13+ depending on collection order.

Tests: `uv run pytest tests/benchmark -p no:homeassistant` + `tests/unit/test_sensor.py`; `ruff check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a thermal control benchmark suite with a simulated plant (wall effects and optional valve transport delay), a calibrated sensor with sampling/lag/dropout behavior, actuator valve profile mapping, metric computation, and weighted oracle-normalized scoring.
  * Added console reporting to render score matrices, per-scenario views, and plant sweep summaries.
* **Tests**
  * Added comprehensive unit and sanity tests for plant, actuator, sensor, metrics, scoring, and reporter rendering.
  * Updated an async unit test to use `pytest.mark.asyncio`.
* **Documentation**
  * Added module-level docs explaining the benchmark framework and how to run the runner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> **Stack note:** a few docstrings reference `DESIGN.md`, `tests.benchmark.runner` and `plant_fit/` — those files land in the follow-up PRs of this stack (#2088, #2089). The references resolve once the stack merges in order.


---
**Update 2026-07-03:** rebased onto current `develop` (74185870) and extended with two review-fix commits:
- Validation hardening — `PlantParams`/`ActuatorParams`/`TimeSeries` reject non-finite and non-physical values at construction; the Euler stability claim now states the gain-dependent bound; comfort-threshold and noise docstrings match the implementation; English profile identifiers (`PROFILE_REAL_LIVING_ROOM`/`_KITCHEN`).
- `noise_std_K` / `jitter_std_s` are now **true standard deviations** (the cubic LCG kick is rescaled by `sqrt(7)`, pinned by an empirical-std test); the fixed quadratic valve profile is named `QUADRATIC` instead of `EXPONENTIAL`.

Tests at this layer: 94 benchmark tests + `tests/unit/test_sensor.py`; `ruff check`/`format` clean.
