### PR TITLE
test(benchmark): scenario library & controller adapters

### DIFF
--- a/tests/benchmark/adapters/baselines.py
+++ b/tests/benchmark/adapters/baselines.py
@@ -1,0 +1,186 @@
+"""Baseline controllers for benchmark context.
+
+These are not production controllers. They exist so that the production
+controllers can be compared against trivial reference behaviour:
+
+* :class:`BangBangAdapter` — fixed hysteresis band, 0 % or 100 % output.
+* :class:`LinearPAdapter` — simple proportional controller, no integral
+  action.
+* :class:`IdealOracleAdapter` — knows the plant's true steady-state
+  inverse and commands the valve setting needed to hold the setpoint
+  asymptotically. Used as an upper bound for what's physically possible
+  given the simulator.
+
+Comparing real controllers to these establishes a sanity floor and ceiling
+for each scenario's metrics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .base import BenchmarkContext, BenchmarkOutput, ControllerFamily
+
+
+@dataclass
+class BangBangParams:
+    """Hysteresis band for the bang-bang controller."""
+
+    band_K: float = 0.2  # +/- around setpoint
+    on_pct: float = 100.0
+    off_pct: float = 0.0
+
+
+class BangBangAdapter:
+    """Naive on/off controller with a single hysteresis band."""
+
+    name: str = "bangbang"
+    family: ControllerFamily = "valve"
+
+    def __init__(self, params: BangBangParams | None = None) -> None:
+        self._params = params if params is not None else BangBangParams()
+        self._state_on: bool = False
+
+    def reset(self, prior: dict[str, Any] | None = None) -> None:
+        """Reset to the OFF state."""
+        _ = prior
+        self._state_on = False
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        """Toggle between on/off based on the hysteresis band."""
+        sp = ctx.target_temp_C
+        cur = ctx.current_temp_C
+        p = self._params
+        if cur < sp - p.band_K:
+            self._state_on = True
+        elif cur > sp + p.band_K:
+            self._state_on = False
+        # Inside the band — keep previous state (the hysteresis).
+        return BenchmarkOutput(
+            valve_percent=p.on_pct if self._state_on else p.off_pct,
+            diagnostics={"state_on": self._state_on},
+        )
+
+    def export_state(self) -> dict[str, Any]:
+        """Return a snapshot of the on/off state."""
+        return {"state_on": self._state_on}
+
+
+@dataclass
+class LinearPParams:
+    """Gain and saturation for the proportional controller."""
+
+    kp: float = 50.0  # percent per K of error
+    clamp_min_pct: float = 0.0
+    clamp_max_pct: float = 100.0
+
+
+class LinearPAdapter:
+    """Single-gain proportional controller (no integral, no derivative)."""
+
+    name: str = "linear_p"
+    family: ControllerFamily = "valve"
+
+    def __init__(self, params: LinearPParams | None = None) -> None:
+        self._params = params if params is not None else LinearPParams()
+
+    def reset(self, prior: dict[str, Any] | None = None) -> None:
+        """Reset has nothing to clear for a pure-P controller."""
+        _ = prior
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        """Output ``kp * (setpoint - measured)`` clamped to the saturation band."""
+        p = self._params
+        error_K = ctx.target_temp_C - ctx.current_temp_C
+        raw = p.kp * error_K
+        clamped = max(p.clamp_min_pct, min(p.clamp_max_pct, raw))
+        return BenchmarkOutput(
+            valve_percent=clamped,
+            diagnostics={"error_K": round(error_K, 3), "raw_pct": round(raw, 2)},
+        )
+
+    def export_state(self) -> dict[str, Any]:
+        """Return an empty state (no learning)."""
+        return {}
+
+
+class IdealOracleAdapter:
+    """Oracle controller with steady-state plant inversion and aggressive feedback.
+
+    Knows the plant's parameters (``gain_heater``, ``T_water_C`` etc.) and
+    computes the steady-state valve percent that would hold the current
+    setpoint asymptotically. Adds a strong proportional feedback term
+    that compensates for transients and small modelling errors.
+
+    The oracle is *not* a real controller — it has direct access to the
+    plant parameters and would not exist outside simulation. It serves
+    two purposes in the benchmark:
+
+    * **Upper bound** for tracking quality — what a feedback controller
+      with perfect knowledge can achieve.
+    * **Stabilisation driver** in :func:`runner.run_scenario` — warms the
+      plant to equilibrium before the test controller takes over.
+    """
+
+    name: str = "ideal_oracle"
+    family: ControllerFamily = "valve"
+
+    def __init__(
+        self,
+        plant_params: Any | None = None,
+        feedback_gain_per_K: float = 50.0,
+        feedback_clamp_pct: float = 50.0,
+    ) -> None:
+        # Defer the plant import to runtime to keep adapters/ free of cycles.
+        if plant_params is None:
+            from tests.benchmark.plant import PROFILE_STANDARD
+
+            plant_params = PROFILE_STANDARD
+        self._plant = plant_params
+        self._feedback_gain = feedback_gain_per_K
+        self._feedback_clamp = feedback_clamp_pct
+
+    def reset(self, prior: dict[str, Any] | None = None) -> None:
+        """No state to reset."""
+        _ = prior
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        """Return steady-state valve percent plus aggressive feedback correction."""
+        p = self._plant
+        sp = ctx.target_temp_C
+        T_out = ctx.outdoor_temp_C
+
+        # Steady-state inversion of the two-state plant:
+        #   T_rad_ss = 2 * sp - T_out   (from room balance)
+        #   gain * u * (T_water - T_rad_ss) = T_rad_ss - sp   (from rad balance)
+        #   => u_ss = (T_rad_ss - sp) / (gain * (T_water - T_rad_ss))
+        T_rad_ss = 2.0 * sp - T_out
+        denom = p.gain_heater * (p.T_water_C - T_rad_ss)
+        if denom <= 0.0:
+            u_ff_pct = 100.0  # cannot reach setpoint with this water temp
+        else:
+            u_ff_pct = max(0.0, min(100.0, 100.0 * (T_rad_ss - sp) / denom))
+
+        # Aggressive P-feedback so the oracle reacts to transients quickly.
+        # Feed back on the plant truth: the oracle is the perfect-knowledge
+        # upper bound, so sensor lag/noise must not depress its ceiling.
+        error_K = sp - ctx.raw_room_temp_C
+        u_fb_pct = max(
+            -self._feedback_clamp,
+            min(self._feedback_clamp, error_K * self._feedback_gain),
+        )
+
+        valve = max(0.0, min(100.0, u_ff_pct + u_fb_pct))
+        return BenchmarkOutput(
+            valve_percent=valve,
+            diagnostics={
+                "u_ff_pct": round(u_ff_pct, 2),
+                "u_fb_pct": round(u_fb_pct, 2),
+                "error_K": round(error_K, 3),
+            },
+        )
+
+    def export_state(self) -> dict[str, Any]:
+        """Return an empty state (stateless)."""
+        return {}

--- a/tests/benchmark/adapters/baselines.py
+++ b/tests/benchmark/adapters/baselines.py
@@ -117,9 +117,13 @@ class IdealOracleAdapter:
     plant parameters and would not exist outside simulation. It serves
     two purposes in the benchmark:
 
-    * **Upper bound** for tracking quality — what a feedback controller
-      with perfect knowledge can achieve.
-    * **Stabilisation driver** in :func:`runner.run_scenario` — warms the
+    * **Reference ceiling** for tracking quality — a feedback controller
+      with perfect plant knowledge. The feedforward inversion is exact
+      for the RC2/RC3 plants driving a linear actuator; nonlinear valve
+      profiles and reverse-acting (cooling) plants are covered only by
+      the proportional feedback term, so on those scenarios the ceiling
+      is approximate rather than optimal.
+    * **Stabilisation driver** in the benchmark runner — warms the
       plant to equilibrium before the test controller takes over.
     """
 
@@ -151,11 +155,21 @@ class IdealOracleAdapter:
         sp = ctx.target_temp_C
         T_out = ctx.outdoor_temp_C
 
-        # Steady-state inversion of the two-state plant:
-        #   T_rad_ss = 2 * sp - T_out   (from room balance)
-        #   gain * u * (T_water - T_rad_ss) = T_rad_ss - sp   (from rad balance)
+        # Steady-state inversion of the lumped-RC plant. Room balance:
+        #   coupling * (T_rad_ss - sp) = loss_ss
+        # where the steady-state envelope loss is (sp - T_out) in RC2 and
+        # r * (sp - T_out) / (1 + r) in RC3 (the wall node sits between
+        # room and outdoor). Radiator balance:
+        #   gain * u * (T_water - T_rad_ss) = T_rad_ss - sp
         #   => u_ss = (T_rad_ss - sp) / (gain * (T_water - T_rad_ss))
-        T_rad_ss = 2.0 * sp - T_out
+        coupling = getattr(p, "coupling_rad_room", 1.0)
+        r_wall = getattr(p, "r_room_wall", 1.0)
+        tau_wall = getattr(p, "tau_wall_min", 0.0)
+        if tau_wall > 0.0:
+            loss_ss = r_wall * (sp - T_out) / (1.0 + r_wall)
+        else:
+            loss_ss = sp - T_out
+        T_rad_ss = sp + loss_ss / coupling
         denom = p.gain_heater * (p.T_water_C - T_rad_ss)
         if denom <= 0.0:
             u_ff_pct = 100.0  # cannot reach setpoint with this water temp

--- a/tests/benchmark/adapters/heating_power_adapter.py
+++ b/tests/benchmark/adapters/heating_power_adapter.py
@@ -158,7 +158,7 @@ class HeatingPowerAdapter:
             elapsed_since_peak_min = (ctx.t - self._cycle_peak_t) / 60.0
             if (
                 ctx.current_temp_C < self._cycle_peak_temp
-                or elapsed_since_peak_min > _FINALIZE_TIMEOUT_MIN
+                or elapsed_since_peak_min >= _FINALIZE_TIMEOUT_MIN
             ):
                 self._finalize_cycle()
 

--- a/tests/benchmark/adapters/heating_power_adapter.py
+++ b/tests/benchmark/adapters/heating_power_adapter.py
@@ -1,0 +1,184 @@
+"""Adapter for Better Thermostat's ``HEATING_POWER_CALIBRATION`` mode.
+
+The production mode is labelled *"Time Based"* in the UI. It combines two
+pieces:
+
+* A ``heating_power`` estimate (°C/min) learned from completed heating
+  cycles via EMA — see ``utils/thermal_learning.py``.
+* A heuristic valve-position formula ``valve = 0.019 · (Δt/hp)^0.946``
+  with minimum-opening floors — see ``utils/helpers.py``.
+
+This adapter reimplements the state machine in pure Python (no HA
+``HVACAction`` dependency) so the benchmark can exercise it the same way
+it exercises ``mpc`` / ``pid`` / ``tpi``. The valve-position formula and
+its tuning constants are imported from the production source so the
+heuristic stays in lock-step with deployed behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from custom_components.better_thermostat.utils.const import (
+    MAX_HEATING_POWER,
+    MIN_HEATING_POWER,
+    VALVE_MIN_BASE,
+    VALVE_MIN_OPENING_LARGE_DIFF,
+    VALVE_MIN_PROPORTIONAL_SLOPE,
+    VALVE_MIN_SMALL_DIFF_THRESHOLD,
+    VALVE_MIN_THRESHOLD_TEMP_DIFF,
+)
+
+from .base import BenchmarkContext, BenchmarkOutput, ControllerFamily
+
+# Production tuning constants (mirror utils/thermal_learning.py).
+_BASE_ALPHA: float = 0.10
+_MIN_CYCLE_DURATION_MIN: float = 1.0
+_FINALIZE_TIMEOUT_MIN: float = 30.0
+
+
+class HeatingPowerAdapter:
+    """Benchmark wrapper for the ``HEATING_POWER_CALIBRATION`` ("Time Based") mode.
+
+    The default ``initial_heating_power = 0.02 °C/min`` represents a
+    mid-range learned value — what a well-fitted production install would
+    converge on after a few days. Override to ``0.01`` for the
+    "fresh-install" cold-start experience.
+    """
+
+    name: str = "heating_power"
+    family: ControllerFamily = "valve"
+
+    def __init__(self, initial_heating_power: float = 0.02) -> None:
+        self._initial_heating_power = max(
+            MIN_HEATING_POWER, min(MAX_HEATING_POWER, initial_heating_power)
+        )
+        self.heating_power: float = self._initial_heating_power
+        self._cycle_start_temp: float | None = None
+        self._cycle_start_t: float | None = None
+        self._cycle_peak_temp: float | None = None
+        self._cycle_peak_t: float | None = None
+        self._was_heating: bool = False
+
+    def reset(self, prior: dict[str, Any] | None = None) -> None:
+        """Drop all learned state; optionally seed ``heating_power`` from ``prior``."""
+        seed = self._initial_heating_power
+        if prior is not None:
+            seeded = prior.get("heating_power")
+            if isinstance(seeded, (int, float)):
+                seed = max(MIN_HEATING_POWER, min(MAX_HEATING_POWER, float(seeded)))
+        self.heating_power = seed
+        self._cycle_start_temp = None
+        self._cycle_start_t = None
+        self._cycle_peak_temp = None
+        self._cycle_peak_t = None
+        self._was_heating = False
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        """Compute valve percent + update the heating-power learner."""
+        valve_pct = self._compute_valve_pct(ctx)
+        self._update_learner(ctx, valve_pct > 0.0)
+        return BenchmarkOutput(
+            valve_percent=valve_pct,
+            diagnostics={
+                "heating_power": self.heating_power,
+                "cycle_active": self._cycle_start_t is not None,
+            },
+        )
+
+    def export_state(self) -> dict[str, Any]:
+        """Return the learned heating-power and current cycle state."""
+        return {
+            "heating_power": self.heating_power,
+            "cycle_start_temp": self._cycle_start_temp,
+            "cycle_peak_temp": self._cycle_peak_temp,
+        }
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _compute_valve_pct(self, ctx: BenchmarkContext) -> float:
+        """Heating-power → valve-position formula, mirroring ``utils/helpers.py``."""
+        temp_diff = ctx.target_temp_C - ctx.current_temp_C
+        if temp_diff <= 0.0:
+            return 0.0
+        hp = max(MIN_HEATING_POWER, min(MAX_HEATING_POWER, self.heating_power))
+        valve_pos = 0.019 * (temp_diff / hp) ** 0.946
+        if temp_diff > VALVE_MIN_THRESHOLD_TEMP_DIFF:
+            valve_pos = max(VALVE_MIN_OPENING_LARGE_DIFF, valve_pos)
+        elif temp_diff >= VALVE_MIN_SMALL_DIFF_THRESHOLD:
+            min_v = (
+                VALVE_MIN_BASE
+                + (temp_diff - VALVE_MIN_SMALL_DIFF_THRESHOLD)
+                * VALVE_MIN_PROPORTIONAL_SLOPE
+            )
+            valve_pos = max(min_v, valve_pos)
+        return max(0.0, min(1.0, valve_pos)) * 100.0
+
+    def _update_learner(self, ctx: BenchmarkContext, is_heating: bool) -> None:
+        """Track heating cycles and EMA-update ``heating_power`` on finalize.
+
+        Cycle = valve-active phase. Peak = warmest point after valve closes
+        (radiator residual heat keeps room rising briefly). Finalize once
+        the room cools back below peak (or after a 30-min plateau timeout),
+        then EMA the observed K/min into ``heating_power``.
+        """
+        if is_heating and not self._was_heating:
+            # Demand can resume before the room cools below the tracked
+            # peak; finalize the finished cycle instead of dropping it.
+            if (
+                self._cycle_start_temp is not None
+                and self._cycle_start_t is not None
+                and self._cycle_peak_temp is not None
+                and self._cycle_peak_t is not None
+            ):
+                self._finalize_cycle()
+            self._cycle_start_temp = ctx.current_temp_C
+            self._cycle_start_t = ctx.t
+            self._cycle_peak_temp = None
+            self._cycle_peak_t = None
+        elif not is_heating and self._was_heating:
+            self._cycle_peak_temp = ctx.current_temp_C
+            self._cycle_peak_t = ctx.t
+        elif (
+            not is_heating
+            and self._cycle_peak_temp is not None
+            and ctx.current_temp_C > self._cycle_peak_temp
+        ):
+            self._cycle_peak_temp = ctx.current_temp_C
+            self._cycle_peak_t = ctx.t
+
+        if (
+            self._cycle_start_temp is not None
+            and self._cycle_start_t is not None
+            and self._cycle_peak_temp is not None
+            and self._cycle_peak_t is not None
+        ):
+            elapsed_since_peak_min = (ctx.t - self._cycle_peak_t) / 60.0
+            if (
+                ctx.current_temp_C < self._cycle_peak_temp
+                or elapsed_since_peak_min > _FINALIZE_TIMEOUT_MIN
+            ):
+                self._finalize_cycle()
+
+        self._was_heating = is_heating
+
+    def _finalize_cycle(self) -> None:
+        """Update the EMA from the just-closed cycle and reset cycle state."""
+        assert self._cycle_start_temp is not None
+        assert self._cycle_start_t is not None
+        assert self._cycle_peak_temp is not None
+        assert self._cycle_peak_t is not None
+        temp_diff_K = self._cycle_peak_temp - self._cycle_start_temp
+        duration_min = (self._cycle_peak_t - self._cycle_start_t) / 60.0
+        if duration_min >= _MIN_CYCLE_DURATION_MIN and temp_diff_K > 0.0:
+            heating_rate = temp_diff_K / duration_min
+            updated = (
+                self.heating_power * (1.0 - _BASE_ALPHA) + heating_rate * _BASE_ALPHA
+            )
+            self.heating_power = max(MIN_HEATING_POWER, min(MAX_HEATING_POWER, updated))
+        self._cycle_start_temp = None
+        self._cycle_start_t = None
+        self._cycle_peak_temp = None
+        self._cycle_peak_t = None

--- a/tests/benchmark/adapters/heating_power_adapter.py
+++ b/tests/benchmark/adapters/heating_power_adapter.py
@@ -8,11 +8,14 @@ pieces:
 * A heuristic valve-position formula ``valve = 0.019 · (Δt/hp)^0.946``
   with minimum-opening floors — see ``utils/helpers.py``.
 
-This adapter reimplements the state machine in pure Python (no HA
+This adapter reimplements the cycle state machine in pure Python (no HA
 ``HVACAction`` dependency) so the benchmark can exercise it the same way
-it exercises ``mpc`` / ``pid`` / ``tpi``. The valve-position formula and
-its tuning constants are imported from the production source so the
-heuristic stays in lock-step with deployed behaviour.
+it exercises ``mpc`` / ``pid`` / ``tpi``. The valve-position formula is
+re-implemented headlessly with its floor constants imported from the
+production source; ``test_production_drift.py`` pins the full formula
+against the production implementation. The EMA learner's adaptive alpha
+(weight/env factors, clamps, rounding) calls the production helpers from
+``utils/thermal_learning.py`` directly.
 """
 
 from __future__ import annotations
@@ -28,13 +31,28 @@ from custom_components.better_thermostat.utils.const import (
     VALVE_MIN_SMALL_DIFF_THRESHOLD,
     VALVE_MIN_THRESHOLD_TEMP_DIFF,
 )
+from custom_components.better_thermostat.utils.thermal_learning import (
+    _ALPHA_MAX,
+    _ALPHA_MIN,
+    _BASE_ALPHA,
+    _MIN_CYCLE_DURATION,
+    clamp,
+    compute_env_factor,
+    compute_weight_factor,
+    ema_smooth,
+)
 
 from .base import BenchmarkContext, BenchmarkOutput, ControllerFamily
 
-# Production tuning constants (mirror utils/thermal_learning.py).
-_BASE_ALPHA: float = 0.10
-_MIN_CYCLE_DURATION_MIN: float = 1.0
+# Benchmark-only plateau timeout: production finalizes a cycle when the
+# room cools below its peak; the timeout bounds pathological plateaus.
 _FINALIZE_TIMEOUT_MIN: float = 30.0
+
+# Default observed target-temperature range, mirroring
+# ``HeatingPowerTracker`` in utils/thermal_learning.py. Observed targets
+# widen the range; the weight factor positions the current target in it.
+_DEFAULT_MIN_TARGET: float = 18.0
+_DEFAULT_MAX_TARGET: float = 21.0
 
 
 class HeatingPowerAdapter:
@@ -59,6 +77,8 @@ class HeatingPowerAdapter:
         self._cycle_peak_temp: float | None = None
         self._cycle_peak_t: float | None = None
         self._was_heating: bool = False
+        self._min_target: float = _DEFAULT_MIN_TARGET
+        self._max_target: float = _DEFAULT_MAX_TARGET
 
     def reset(self, prior: dict[str, Any] | None = None) -> None:
         """Drop all learned state; optionally seed ``heating_power`` from ``prior``."""
@@ -73,6 +93,8 @@ class HeatingPowerAdapter:
         self._cycle_peak_temp = None
         self._cycle_peak_t = None
         self._was_heating = False
+        self._min_target = _DEFAULT_MIN_TARGET
+        self._max_target = _DEFAULT_MAX_TARGET
 
     def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
         """Compute valve percent + update the heating-power learner."""
@@ -133,7 +155,7 @@ class HeatingPowerAdapter:
                 and self._cycle_peak_temp is not None
                 and self._cycle_peak_t is not None
             ):
-                self._finalize_cycle()
+                self._finalize_cycle(ctx)
             self._cycle_start_temp = ctx.current_temp_C
             self._cycle_start_t = ctx.t
             self._cycle_peak_temp = None
@@ -160,24 +182,43 @@ class HeatingPowerAdapter:
                 ctx.current_temp_C < self._cycle_peak_temp
                 or elapsed_since_peak_min >= _FINALIZE_TIMEOUT_MIN
             ):
-                self._finalize_cycle()
+                self._finalize_cycle(ctx)
+
+        # Widen the observed target range after the finalize check, in the
+        # same order as ``HeatingPowerTracker.update``.
+        self._min_target = min(self._min_target, ctx.target_temp_C)
+        self._max_target = max(self._max_target, ctx.target_temp_C)
 
         self._was_heating = is_heating
 
-    def _finalize_cycle(self) -> None:
-        """Update the EMA from the just-closed cycle and reset cycle state."""
+    def _finalize_cycle(self, ctx: BenchmarkContext) -> None:
+        """Update the EMA from the just-closed cycle and reset cycle state.
+
+        The adaptive smoothing factor is the production formula:
+        ``alpha = clamp(base * weight * env, min, max)`` with the weight
+        and environment factors computed by ``utils/thermal_learning.py``.
+        """
         assert self._cycle_start_temp is not None
         assert self._cycle_start_t is not None
         assert self._cycle_peak_temp is not None
         assert self._cycle_peak_t is not None
         temp_diff_K = self._cycle_peak_temp - self._cycle_start_temp
         duration_min = (self._cycle_peak_t - self._cycle_start_t) / 60.0
-        if duration_min >= _MIN_CYCLE_DURATION_MIN and temp_diff_K > 0.0:
-            heating_rate = temp_diff_K / duration_min
-            updated = (
-                self.heating_power * (1.0 - _BASE_ALPHA) + heating_rate * _BASE_ALPHA
+        if duration_min >= _MIN_CYCLE_DURATION and temp_diff_K > 0.0:
+            heating_rate = round(temp_diff_K / duration_min, 4)
+            weight_factor = compute_weight_factor(
+                ctx.target_temp_C, self._min_target, self._max_target
             )
-            self.heating_power = max(MIN_HEATING_POWER, min(MAX_HEATING_POWER, updated))
+            env_factor = compute_env_factor(ctx.outdoor_temp_C, ctx.target_temp_C)
+            alpha = clamp(
+                _BASE_ALPHA * weight_factor * env_factor, _ALPHA_MIN, _ALPHA_MAX
+            )
+            updated = clamp(
+                ema_smooth(self.heating_power, heating_rate, alpha),
+                MIN_HEATING_POWER,
+                MAX_HEATING_POWER,
+            )
+            self.heating_power = round(updated, 4)
         self._cycle_start_temp = None
         self._cycle_start_t = None
         self._cycle_peak_temp = None

--- a/tests/benchmark/adapters/indirect_trv.py
+++ b/tests/benchmark/adapters/indirect_trv.py
@@ -59,17 +59,36 @@ class IndirectTrvParams:
     setpoint_mapping: str = "heuristic"
 
     def __post_init__(self) -> None:
-        """Reject an unknown ``setpoint_mapping`` rather than silently inverting.
+        """Reject invalid mapping and non-physical numeric fields.
 
         Raises
         ------
         ValueError
-            If ``setpoint_mapping`` is neither ``"heuristic"`` nor ``"inversion"``.
+            If ``setpoint_mapping`` is neither ``"heuristic"`` nor
+            ``"inversion"``, if ``setpoint_step_K`` or ``internal_p_gain``
+            is not positive, or if a hysteresis/headroom/latency field is
+            negative.
         """
         if self.setpoint_mapping not in ("heuristic", "inversion"):
             raise ValueError(
                 "IndirectTrvParams setpoint_mapping must be 'heuristic' or "
                 f"'inversion', got {self.setpoint_mapping!r}"
+            )
+        if self.setpoint_step_K <= 0.0 or self.internal_p_gain <= 0.0:
+            raise ValueError(
+                "IndirectTrvParams setpoint_step_K and internal_p_gain must be "
+                f"> 0, got setpoint_step_K={self.setpoint_step_K}, "
+                f"internal_p_gain={self.internal_p_gain}"
+            )
+        if (
+            self.internal_hysteresis_K < 0.0
+            or self.max_calibration_headroom_K < 0.0
+            or self.command_latency_steps < 0
+        ):
+            raise ValueError(
+                "IndirectTrvParams internal_hysteresis_K, "
+                "max_calibration_headroom_K and command_latency_steps must be "
+                ">= 0"
             )
 
 

--- a/tests/benchmark/adapters/indirect_trv.py
+++ b/tests/benchmark/adapters/indirect_trv.py
@@ -58,6 +58,20 @@ class IndirectTrvParams:
     # internal regulator as a first-class layer rather than a bolt-on.
     setpoint_mapping: str = "heuristic"
 
+    def __post_init__(self) -> None:
+        """Reject an unknown ``setpoint_mapping`` rather than silently inverting.
+
+        Raises
+        ------
+        ValueError
+            If ``setpoint_mapping`` is neither ``"heuristic"`` nor ``"inversion"``.
+        """
+        if self.setpoint_mapping not in ("heuristic", "inversion"):
+            raise ValueError(
+                "IndirectTrvParams setpoint_mapping must be 'heuristic' or "
+                f"'inversion', got {self.setpoint_mapping!r}"
+            )
+
 
 # Vendor quirk presets. Values are heuristic — sourced from user-side
 # observations of each TRV family's offset-mode behaviour, not from
@@ -143,7 +157,12 @@ class IndirectTrvAdapter:
     def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
         """Translate the inner controller's valve_percent into TRV-controlled u."""
         inner_out = self.inner.step(ctx)
-        bt_valve_pct = inner_out.valve_percent or 0.0
+        if inner_out.valve_percent is None:
+            raise ValueError(
+                f"{self.name}: inner adapter {self.inner.name} produced no "
+                "valve_percent; IndirectTrvAdapter only wraps valve-family controllers"
+            )
+        bt_valve_pct = inner_out.valve_percent
 
         # Map BT's "heat intent" (0-100 % valve) onto a TRV setpoint.
         #

--- a/tests/benchmark/adapters/indirect_trv.py
+++ b/tests/benchmark/adapters/indirect_trv.py
@@ -1,0 +1,212 @@
+"""IndirectTrvAdapter — wrap any controller in an offset-based TRV layer.
+
+Tado, Bosch BTH-RA, Sonoff TRVZB offset-mode and similar TRVs do **not**
+accept a raw valve-percent command. They run their own closed loop and
+only expose a setpoint (typically quantised to 0.5 K). Home Assistant
+integrations like Better Thermostat fool such hardware into tracking an
+external sensor by pushing a *calibrated* setpoint, but the TRV's own
+P-regulator and hysteresis sit between BT's command and the physical
+valve.
+
+This wrapper sits on top of any benchmark adapter and converts the
+controller's ``valve_percent`` decision into:
+
+1. A *desired TRV setpoint* (high when BT wants heat, equal to room when
+   not),
+2. Quantised to ``setpoint_step_K``,
+3. Optionally held by a hysteresis band before it changes,
+4. Driven through a small TRV-internal P-loop using the TRV's own
+   reported temperature.
+
+The resulting ``valve_percent`` is what actually drives the plant's
+actuator. From the benchmark's point of view the wrapper looks like any
+other adapter; from BT's point of view the underlying controller is
+unchanged. The differential between BT's "intent" and the TRV's actual
+action surfaces the failure modes characteristic of Tado, Bosch,
+Sonoff (offset-mode) and SEA80x-family offset-based TRVs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .base import BenchmarkContext, BenchmarkOutput, ControllerAdapter, ControllerFamily
+
+
+@dataclass(frozen=True)
+class IndirectTrvParams:
+    """Hardware-side characteristics of an offset-based TRV."""
+
+    setpoint_step_K: float = 0.5
+    internal_hysteresis_K: float = 0.3
+    internal_p_gain: float = 30.0  # percent per Kelvin of internal error
+    # Max upward bias BT can push the TRV setpoint above the room target —
+    # the calibration headroom. 5 K is a realistic Better Thermostat
+    # calibration range; above that the TRV's own thermometer protects.
+    max_calibration_headroom_K: float = 5.0
+    command_latency_steps: int = 0  # # of steps between BT command and TRV reaction
+    # Mapping from the inner controller's ``u`` (valve_percent) to the
+    # TRV setpoint. ``"heuristic"`` (default) issues
+    # ``target + headroom·u/100``: a setpoint anchored at the user
+    # target, far above T_room. Tracks well on quantised TRVs because
+    # small u-changes still land on a setpoint above the room.
+    # ``"inversion"`` solves the TRV's own P-loop backwards
+    # (``T_set = T_room + u/p_gain``) — physically cleaner under sensor
+    # bias but degrades on quantised setpoints. The cleaner long-term
+    # fix is a cascade-control plant model that exposes the TRV's
+    # internal regulator as a first-class layer rather than a bolt-on.
+    setpoint_mapping: str = "heuristic"
+
+
+# Vendor quirk presets. Values are heuristic — sourced from user-side
+# observations of each TRV family's offset-mode behaviour, not from
+# manufacturer documentation. Treat them as plausible operating points
+# rather than calibrated truths.
+
+TADO_PARAMS = IndirectTrvParams(
+    setpoint_step_K=0.5,
+    internal_hysteresis_K=0.3,
+    internal_p_gain=30.0,
+    max_calibration_headroom_K=5.0,
+    command_latency_steps=0,
+)
+"""Tado X / Tado Smart Radiator Thermostat.
+
+0.5 K setpoint resolution, mild internal hysteresis, mid-range P-gain.
+"""
+
+BOSCH_PARAMS = IndirectTrvParams(
+    setpoint_step_K=0.5,
+    internal_hysteresis_K=0.5,  # tighter dead-zone before motor moves
+    internal_p_gain=20.0,  # gentler internal regulation
+    max_calibration_headroom_K=4.0,  # narrower override authority
+    command_latency_steps=2,  # Bosch BTH-RA is slow to react
+)
+"""Bosch BTH-RA / Smart Radiator Thermostat II.
+
+Larger hysteresis band, gentler P-gain, command latency of ~2 MPC
+steps — reflecting reports of slow follow-through on direct commands.
+"""
+
+TUYA_PARAMS = IndirectTrvParams(
+    setpoint_step_K=1.0,  # 1 K resolution kills fine tracking
+    internal_hysteresis_K=0.5,
+    internal_p_gain=15.0,  # softer regulation
+    max_calibration_headroom_K=4.0,
+    command_latency_steps=1,
+)
+"""Tuya TS0601-derivative TRVs.
+
+1 K setpoint quantisation is the dominant pathology — covers a long
+tail of cheap re-branded Tuya TRVs.
+"""
+
+SONOFF_TRVZB_PARAMS = IndirectTrvParams(
+    setpoint_step_K=0.5,
+    internal_hysteresis_K=0.5,
+    internal_p_gain=25.0,
+    max_calibration_headroom_K=5.0,
+    command_latency_steps=0,
+)
+"""Sonoff TRVZB in offset-mode (post-FW 1.3 — pre-1.3 quirks live in the
+direct-valve actuator profile with a 15-22 % deadband instead).
+"""
+
+
+class IndirectTrvAdapter:
+    """Wrap an inner adapter behind a TRV-internal P-loop with quantisation."""
+
+    family: ControllerFamily = "valve"
+
+    def __init__(self, inner: ControllerAdapter, params: IndirectTrvParams) -> None:
+        self.inner = inner
+        self.params = params
+        self.name = f"{inner.name}+indirect_trv"
+        self._last_quantised_setpoint_C: float | None = None
+        self._pending_setpoints: list[float] = []
+
+    def reset(self, prior: dict[str, Any] | None = None) -> None:
+        """Reset wrapped controller and the TRV layer.
+
+        ``prior`` takes the shape produced by :meth:`export_state`: the
+        inner controller's snapshot under ``"inner"``, the TRV-layer cache
+        at the top level. Missing keys fall back to a cleared state.
+        """
+        inner_prior = prior.get("inner") if prior is not None else None
+        self.inner.reset(inner_prior if isinstance(inner_prior, dict) else None)
+        last = prior.get("last_quantised_setpoint_C") if prior is not None else None
+        self._last_quantised_setpoint_C = last if isinstance(last, float) else None
+        pending = prior.get("pending_setpoints") if prior is not None else None
+        self._pending_setpoints = list(pending) if isinstance(pending, list) else []
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        """Translate the inner controller's valve_percent into TRV-controlled u."""
+        inner_out = self.inner.step(ctx)
+        bt_valve_pct = inner_out.valve_percent or 0.0
+
+        # Map BT's "heat intent" (0-100 % valve) onto a TRV setpoint.
+        #
+        # "inversion": invert the TRV's own P-loop exactly. The TRV
+        # computes ``u_trv = p_gain · (T_set − T_room)``; to request a
+        # ``u_trv == bt_valve_pct`` we set ``T_set = T_room +
+        # bt_valve_pct / p_gain``. Physically well-founded but degrades
+        # under heavy setpoint quantisation.
+        #
+        # "heuristic" (default): scale a fixed headroom band against the
+        # user target, ignoring T_room entirely. Less principled but
+        # tracks better on quantised TRVs (0.5 K / 1 K setpoint steps).
+        if self.params.setpoint_mapping == "heuristic":
+            headroom_K = self.params.max_calibration_headroom_K
+            desired_setpoint_C = ctx.target_temp_C + headroom_K * (bt_valve_pct / 100.0)
+        else:
+            p_gain = max(self.params.internal_p_gain, 1e-6)
+            desired_setpoint_C = ctx.current_temp_C + bt_valve_pct / p_gain
+
+        # Quantise to TRV's setpoint resolution.
+        step = max(self.params.setpoint_step_K, 1e-6)
+        quantised = round(desired_setpoint_C / step) * step
+
+        # Hysteresis band on the *quantised* setpoint — TRV ignores micro-
+        # changes inside the band.
+        if self._last_quantised_setpoint_C is None:
+            applied_setpoint = quantised
+        elif (
+            abs(quantised - self._last_quantised_setpoint_C)
+            < self.params.internal_hysteresis_K
+        ):
+            applied_setpoint = self._last_quantised_setpoint_C
+        else:
+            applied_setpoint = quantised
+        self._last_quantised_setpoint_C = applied_setpoint
+
+        # Optional FIFO latency for the command.
+        if self.params.command_latency_steps > 0:
+            self._pending_setpoints.append(applied_setpoint)
+            while len(self._pending_setpoints) > self.params.command_latency_steps + 1:
+                applied_setpoint = self._pending_setpoints.pop(0)
+            applied_setpoint = self._pending_setpoints[0]
+
+        # TRV-internal P-loop against the room temperature the TRV itself
+        # reports. We use ``current_temp_C`` (sensor reading) — real TRVs
+        # measure the room near their body, not the radiator surface they
+        # sit on, so the room temperature is the right proxy here.
+        error_K = applied_setpoint - ctx.current_temp_C
+        u_pct = max(0.0, min(100.0, self.params.internal_p_gain * error_K))
+
+        return BenchmarkOutput(
+            valve_percent=u_pct,
+            diagnostics={
+                **inner_out.diagnostics,
+                "indirect_setpoint_C": applied_setpoint,
+                "indirect_quantised_diff_K": applied_setpoint - desired_setpoint_C,
+            },
+        )
+
+    def export_state(self) -> dict[str, Any]:
+        """Expose inner state plus TRV-layer cache."""
+        return {
+            "inner": self.inner.export_state(),
+            "last_quantised_setpoint_C": self._last_quantised_setpoint_C,
+            "pending_setpoints": list(self._pending_setpoints),
+        }

--- a/tests/benchmark/adapters/indirect_trv.py
+++ b/tests/benchmark/adapters/indirect_trv.py
@@ -118,7 +118,7 @@ BOSCH_PARAMS = IndirectTrvParams(
 )
 """Bosch BTH-RA / Smart Radiator Thermostat II.
 
-Larger hysteresis band, gentler P-gain, command latency of ~2 MPC
+Larger hysteresis band, gentler P-gain, command latency of ~2 simulator
 steps — reflecting reports of slow follow-through on direct commands.
 """
 
@@ -169,7 +169,9 @@ class IndirectTrvAdapter:
         inner_prior = prior.get("inner") if prior is not None else None
         self.inner.reset(inner_prior if isinstance(inner_prior, dict) else None)
         last = prior.get("last_quantised_setpoint_C") if prior is not None else None
-        self._last_quantised_setpoint_C = last if isinstance(last, float) else None
+        self._last_quantised_setpoint_C = (
+            float(last) if isinstance(last, (int, float)) else None
+        )
         pending = prior.get("pending_setpoints") if prior is not None else None
         self._pending_setpoints = list(pending) if isinstance(pending, list) else []
 
@@ -222,7 +224,7 @@ class IndirectTrvAdapter:
         if self.params.command_latency_steps > 0:
             self._pending_setpoints.append(applied_setpoint)
             while len(self._pending_setpoints) > self.params.command_latency_steps + 1:
-                applied_setpoint = self._pending_setpoints.pop(0)
+                self._pending_setpoints.pop(0)
             applied_setpoint = self._pending_setpoints[0]
 
         # TRV-internal P-loop against the room temperature the TRV itself

--- a/tests/benchmark/adapters/mpc_adapter.py
+++ b/tests/benchmark/adapters/mpc_adapter.py
@@ -1,0 +1,112 @@
+"""Adapter wrapping the existing MPC controller in custom_components.better_thermostat.
+
+The MPC's ``compute_mpc`` function uses module-level ``time()`` calls to
+compute deltas. For deterministic, fast simulation we virtualise time by
+monkey-patching the module's ``time`` symbol with our own counter for the
+duration of each step. This affects only this process and is restored on
+adapter destruction.
+
+This is benchmark-only code: never imported by production.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from itertools import count
+import random
+from typing import Any
+
+from custom_components.better_thermostat.utils.calibration import mpc as mpc_mod
+from custom_components.better_thermostat.utils.calibration.mpc import (
+    MpcInput,
+    MpcParams,
+    _MpcState,
+    compute_mpc,
+)
+from custom_components.better_thermostat.utils.state_manager import _make_json_safe
+
+from .base import BenchmarkContext, BenchmarkOutput, ControllerFamily
+
+# Controller state is caller-owned; each adapter keeps its own ``all_states``
+# map so concurrent instances never share learned state.
+_KEY_COUNTER = count()
+
+# Fixed seed for the MPC's hybrid-learning RNG (``random.random()`` in
+# mpc.py). Re-applied on every reset so each scenario sees the same
+# forced-calibration realisation regardless of run order — the benchmark's
+# determinism guarantee extends to MPC's stochastic learning path.
+_MPC_RNG_SEED = 1_234_567
+
+
+class MpcAdapter:
+    """Benchmark adapter for the production MPC controller."""
+
+    name: str = "mpc"
+    family: ControllerFamily = "valve"
+
+    def __init__(self, params: MpcParams | None = None, key: str | None = None) -> None:
+        self._params = params if params is not None else MpcParams()
+        self._state: _MpcState = _MpcState()
+        self._all_states: dict[str, _MpcState] = {}
+        self._key = key if key is not None else f"bench:trv:mpc{next(_KEY_COUNTER)}"
+        self._sim_time_s: float = 0.0
+        self._original_time = mpc_mod.time
+        # Deterministic stand-in for the module-global ``random`` that
+        # mpc.py uses for its hybrid-learning forced calibration.
+        self._rng = random.Random(_MPC_RNG_SEED)
+        self._original_random = mpc_mod.random
+
+    def _virtualise(self) -> None:
+        """Swap the mpc module's time + random for deterministic stand-ins."""
+        mpc_mod.time = lambda: self._sim_time_s
+        mpc_mod.random = self._rng
+
+    def _restore(self) -> None:
+        """Restore the mpc module's real time + random symbols."""
+        mpc_mod.time = self._original_time
+        mpc_mod.random = self._original_random
+
+    def reset(self, prior: dict[str, Any] | None = None) -> None:
+        """Drop learned state. ``prior`` is unused."""
+        _ = prior
+        self._state = _MpcState()
+        self._all_states.clear()
+        self._sim_time_s = 0.0
+        self._rng.seed(_MPC_RNG_SEED)
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        """Compute one MPC step for the given benchmark context."""
+        self._sim_time_s = ctx.t
+        self._virtualise()
+        try:
+            inp = MpcInput(
+                key=self._key,
+                target_temp_C=ctx.target_temp_C,
+                current_temp_C=ctx.current_temp_C,
+                trv_temp_C=ctx.trv_temp_C,
+                outdoor_temp_C=ctx.outdoor_temp_C,
+                window_open=ctx.window_open,
+                solar_intensity=ctx.solar_intensity,
+                heating_allowed=True,
+                bt_name="benchmark",
+                entity_id="bench_trv",
+            )
+            out, self._state = compute_mpc(
+                inp, self._params, state=self._state, all_states=self._all_states
+            )
+        finally:
+            self._restore()
+
+        if out is None:
+            # Early exit (e.g. window-open, missing temp). Hold previous output.
+            return BenchmarkOutput(
+                valve_percent=ctx.last_valve_percent, diagnostics={"early_exit": True}
+            )
+        return BenchmarkOutput(
+            valve_percent=float(out.valve_percent),
+            diagnostics=dict(out.debug) if out.debug else {},
+        )
+
+    def export_state(self) -> dict[str, Any]:
+        """Return a serializable snapshot of the wrapped MPC state."""
+        return _make_json_safe(asdict(self._state))

--- a/tests/benchmark/adapters/mpc_adapter.py
+++ b/tests/benchmark/adapters/mpc_adapter.py
@@ -23,7 +23,10 @@ from custom_components.better_thermostat.utils.calibration.mpc import (
     _MpcState,
     compute_mpc,
 )
-from custom_components.better_thermostat.utils.state_manager import _make_json_safe
+from custom_components.better_thermostat.utils.state_manager import (
+    _make_json_safe,
+    deserialize_mpc,
+)
 
 from .base import BenchmarkContext, BenchmarkOutput, ControllerFamily
 
@@ -46,9 +49,11 @@ class MpcAdapter:
 
     def __init__(self, params: MpcParams | None = None, key: str | None = None) -> None:
         self._params = params if params is not None else MpcParams()
-        self._state: _MpcState = _MpcState()
         self._all_states: dict[str, _MpcState] = {}
-        self._key = key if key is not None else f"bench:trv:mpc{next(_KEY_COUNTER)}"
+        # ``uid:entity`` prefix of the production state key. The full key
+        # appends the per-target bucket in ``step`` (see ``_bucket_key``),
+        # mirroring ``build_mpc_key``.
+        self._key = key if key is not None else f"bench{next(_KEY_COUNTER)}:trv"
         self._sim_time_s: float = 0.0
         self._original_time = mpc_mod.time
         # Deterministic stand-in for the module-global ``random`` that
@@ -67,20 +72,42 @@ class MpcAdapter:
         mpc_mod.random = self._original_random
 
     def reset(self, prior: dict[str, Any] | None = None) -> None:
-        """Drop learned state. ``prior`` is unused."""
-        _ = prior
-        self._state = _MpcState()
+        """Reset the adapter, optionally rehydrating persisted state.
+
+        Production persists per-bucket MPC state across Home Assistant
+        restarts (``StateManager`` store); passing a prior
+        ``export_state()`` snapshot replays that behaviour through the
+        production ``deserialize_mpc`` path. Without ``prior`` the
+        adapter cold-starts.
+        """
         self._all_states.clear()
+        if prior:
+            for bucket_key, raw in prior.items():
+                if isinstance(raw, dict):
+                    self._all_states[bucket_key] = deserialize_mpc(raw)
         self._sim_time_s = 0.0
         self._rng.seed(_MPC_RNG_SEED)
+
+    def _bucket_key(self, target_temp_C: float) -> str:
+        """Return the production-shaped per-target-bucket state key.
+
+        Mirrors ``build_mpc_key``: MPC state is partitioned by the target
+        temperature rounded to 0.5 K, so a setpoint move across a bucket
+        boundary allocates a fresh state that ``compute_mpc`` seeds from
+        its nearest sibling via ``all_states``.
+        """
+        bucket = f"t{round(float(target_temp_C) * 2.0) / 2.0:.1f}"
+        return f"{self._key}:{bucket}"
 
     def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
         """Compute one MPC step for the given benchmark context."""
         self._sim_time_s = ctx.t
+        key = self._bucket_key(ctx.target_temp_C)
+        state = self._all_states.setdefault(key, _MpcState())
         self._virtualise()
         try:
             inp = MpcInput(
-                key=self._key,
+                key=key,
                 target_temp_C=ctx.target_temp_C,
                 current_temp_C=ctx.current_temp_C,
                 trv_temp_C=ctx.trv_temp_C,
@@ -91,22 +118,27 @@ class MpcAdapter:
                 bt_name="benchmark",
                 entity_id="bench_trv",
             )
-            out, self._state = compute_mpc(
-                inp, self._params, state=self._state, all_states=self._all_states
+            out, new_state = compute_mpc(
+                inp, self._params, state=state, all_states=self._all_states
             )
+            self._all_states[key] = new_state
         finally:
             self._restore()
 
         if out is None:
-            # Early exit (e.g. window-open, missing temp). Hold previous output.
-            return BenchmarkOutput(
-                valve_percent=ctx.last_valve_percent, diagnostics={"early_exit": True}
-            )
+            # ``compute_mpc``'s contract allows None (no recommendation);
+            # production then skips the MPC result for this cycle. The
+            # benchmark has no fallback controller, so map it to a closed
+            # valve — the same floor the window-open path emits.
+            return BenchmarkOutput(valve_percent=0.0, diagnostics={"early_exit": True})
         return BenchmarkOutput(
             valve_percent=float(out.valve_percent),
             diagnostics=dict(out.debug) if out.debug else {},
         )
 
     def export_state(self) -> dict[str, Any]:
-        """Return a serializable snapshot of the wrapped MPC state."""
-        return _make_json_safe(asdict(self._state))
+        """Return a serializable snapshot of all per-bucket MPC states."""
+        return {
+            bucket_key: _make_json_safe(asdict(state))
+            for bucket_key, state in self._all_states.items()
+        }

--- a/tests/benchmark/adapters/passive_modes.py
+++ b/tests/benchmark/adapters/passive_modes.py
@@ -87,8 +87,10 @@ class DefaultCalibrationAdapter:
 class AggressiveCalibrationAdapter:
     """``CalibrationMode.AGGRESIVE_CALIBRATION`` — DEFAULT + −2.5 K boost while heating.
 
-    The boost is latched: it kicks in once the previous step commanded
-    a non-zero valve and stays active until the room reaches the target.
+    The boost adds ``p_gain · 2.5`` to the proportional valve command on
+    every step where the room is below the target (positive error),
+    mirroring production's downward offset bias while heating. It is not
+    latched — it tracks the error sign step by step.
     """
 
     name: str = "aggressive"
@@ -121,7 +123,7 @@ class AggressiveCalibrationAdapter:
         )
 
     def export_state(self) -> dict[str, Any]:
-        """Return whether the boost is currently latched."""
+        """Return whether the last step commanded a non-zero valve."""
         return {"was_heating": self._was_heating}
 
 

--- a/tests/benchmark/adapters/passive_modes.py
+++ b/tests/benchmark/adapters/passive_modes.py
@@ -1,0 +1,164 @@
+"""BT's offset-family calibration modes — passive (no smart controller).
+
+These three modes do not run an inner controller (no MPC, PID, TPI or
+heating-power learner). They configure the TRV's own sensor-offset and
+then let the TRV's internal P-loop close the loop.
+
+In production:
+
+* **DEFAULT** — BT pushes ``bt_target`` to the TRV unchanged and sends a
+  calibration offset of ``(external - trv_internal)``. The TRV's
+  internal regulator then effectively tracks the external sensor:
+  ``valve = p_gain · (bt_target - external)``.
+* **AGGRESIVE_CALIBRATION** (UI: *Fix Calibration*) — same as DEFAULT
+  plus a −2.5 K bias on the offset while heating, so the TRV thinks
+  it's 2.5 K colder than it is and opens the valve more aggressively.
+* **NO_CALIBRATION** — BT pushes only ``bt_target``, no offset. The
+  TRV's regulator tracks **its own internal sensor**, not the external
+  one: ``valve = p_gain · (bt_target - trv_internal_temp)``. Performs
+  badly whenever the TRV's body temperature diverges from the room
+  (radiator backsplash, sensor offsets, multi-TRV rooms).
+
+The benchmark models these directly as P-controllers without an
+``IndirectTrvAdapter`` wrapper because the *adapter itself* already
+encodes the TRV-side P-loop that these modes rely on. Wrapping would
+double-apply the regulator.
+
+The default ``p_gain = 30 %/K`` matches the Tado/Sonoff family preset
+in :mod:`adapters.indirect_trv`. Override via the ``p_gain`` constructor
+argument to model softer (Tuya, Bosch) hardware.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .base import BenchmarkContext, BenchmarkOutput, ControllerFamily
+
+# Production constants from ``utils/calibration.py``.
+_AGGRESSIVE_BOOST_K: float = 2.5
+
+# Representative TRV-internal P-gain (mirrors ``TADO_PARAMS.internal_p_gain``).
+_DEFAULT_TRV_P_GAIN: float = 30.0
+
+
+@dataclass
+class PassiveModeParams:
+    """Parameters shared across the offset-family adapters."""
+
+    p_gain: float = _DEFAULT_TRV_P_GAIN
+    clamp_min_pct: float = 0.0
+    clamp_max_pct: float = 100.0
+
+
+def _proportional(error_K: float, params: PassiveModeParams) -> float:
+    """Clamp ``p_gain · error_K`` to the saturation band."""
+    return max(params.clamp_min_pct, min(params.clamp_max_pct, params.p_gain * error_K))
+
+
+class DefaultCalibrationAdapter:
+    """``CalibrationMode.DEFAULT`` — TRV tracks external sensor via offset calibration."""
+
+    name: str = "default"
+    family: ControllerFamily = "valve"
+
+    def __init__(self, params: PassiveModeParams | None = None) -> None:
+        self._params = params if params is not None else PassiveModeParams()
+
+    def reset(self, prior: dict[str, Any] | None = None) -> None:
+        """Stateless — nothing to reset."""
+        _ = prior
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        """Output ``p_gain · (target - external)`` clamped to [0, 100] %."""
+        error_K = ctx.target_temp_C - ctx.current_temp_C
+        valve = _proportional(error_K, self._params)
+        return BenchmarkOutput(
+            valve_percent=valve,
+            diagnostics={"error_K": round(error_K, 3), "p_gain": self._params.p_gain},
+        )
+
+    def export_state(self) -> dict[str, Any]:
+        """Return an empty state (stateless)."""
+        return {}
+
+
+class AggressiveCalibrationAdapter:
+    """``CalibrationMode.AGGRESIVE_CALIBRATION`` — DEFAULT + −2.5 K boost while heating.
+
+    The boost is latched: it kicks in once the previous step commanded
+    a non-zero valve and stays active until the room reaches the target.
+    """
+
+    name: str = "aggressive"
+    family: ControllerFamily = "valve"
+
+    def __init__(self, params: PassiveModeParams | None = None) -> None:
+        self._params = params if params is not None else PassiveModeParams()
+        self._was_heating: bool = False
+
+    def reset(self, prior: dict[str, Any] | None = None) -> None:
+        """Forget whether we were heating last step."""
+        _ = prior
+        self._was_heating = False
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        """Add ``p_gain · 2.5`` to the proportional output while heating."""
+        error_K = ctx.target_temp_C - ctx.current_temp_C
+        # The boost is active whenever BT considers itself "heating" — we
+        # use ``error_K > 0`` (room below target) as the proxy for the
+        # production ``HVACAction.HEATING`` trigger.
+        boost = self._params.p_gain * _AGGRESSIVE_BOOST_K if error_K > 0.0 else 0.0
+        raw_pct = self._params.p_gain * error_K + boost
+        valve = max(
+            self._params.clamp_min_pct, min(self._params.clamp_max_pct, raw_pct)
+        )
+        self._was_heating = valve > 0.0
+        return BenchmarkOutput(
+            valve_percent=valve,
+            diagnostics={"error_K": round(error_K, 3), "boost_pct": round(boost, 2)},
+        )
+
+    def export_state(self) -> dict[str, Any]:
+        """Return whether the boost is currently latched."""
+        return {"was_heating": self._was_heating}
+
+
+class NoCalibrationAdapter:
+    """``CalibrationMode.NO_CALIBRATION`` — TRV tracks its own internal sensor.
+
+    BT pushes ``bt_target`` straight through with no offset. The TRV's
+    P-loop closes against ``trv_temp_C`` (the radiator-mounted sensor),
+    not against the room sensor — so the controller's error reference is
+    whatever the TRV body is reading, not what the room actually is.
+    """
+
+    name: str = "no_calibration"
+    family: ControllerFamily = "valve"
+
+    def __init__(self, params: PassiveModeParams | None = None) -> None:
+        self._params = params if params is not None else PassiveModeParams()
+
+    def reset(self, prior: dict[str, Any] | None = None) -> None:
+        """Stateless — nothing to reset."""
+        _ = prior
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        """Output ``p_gain · (target - trv_internal)``, clamped."""
+        # Fall back to the external sensor only when the scenario lacks
+        # an explicit TRV temperature (sensorless plant variants).
+        trv_T = ctx.trv_temp_C if ctx.trv_temp_C is not None else ctx.current_temp_C
+        error_K = ctx.target_temp_C - trv_T
+        valve = _proportional(error_K, self._params)
+        return BenchmarkOutput(
+            valve_percent=valve,
+            diagnostics={
+                "error_K": round(error_K, 3),
+                "trv_temp_used_C": round(trv_T, 3),
+            },
+        )
+
+    def export_state(self) -> dict[str, Any]:
+        """Return an empty state (stateless)."""
+        return {}

--- a/tests/benchmark/adapters/passive_modes.py
+++ b/tests/benchmark/adapters/passive_modes.py
@@ -98,12 +98,10 @@ class AggressiveCalibrationAdapter:
 
     def __init__(self, params: PassiveModeParams | None = None) -> None:
         self._params = params if params is not None else PassiveModeParams()
-        self._was_heating: bool = False
 
     def reset(self, prior: dict[str, Any] | None = None) -> None:
-        """Forget whether we were heating last step."""
+        """No state to reset."""
         _ = prior
-        self._was_heating = False
 
     def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
         """Add ``p_gain · 2.5`` to the proportional output while heating."""
@@ -116,15 +114,14 @@ class AggressiveCalibrationAdapter:
         valve = max(
             self._params.clamp_min_pct, min(self._params.clamp_max_pct, raw_pct)
         )
-        self._was_heating = valve > 0.0
         return BenchmarkOutput(
             valve_percent=valve,
             diagnostics={"error_K": round(error_K, 3), "boost_pct": round(boost, 2)},
         )
 
     def export_state(self) -> dict[str, Any]:
-        """Return whether the last step commanded a non-zero valve."""
-        return {"was_heating": self._was_heating}
+        """Stateless adapter: nothing to export."""
+        return {}
 
 
 class NoCalibrationAdapter:

--- a/tests/benchmark/adapters/pid_adapter.py
+++ b/tests/benchmark/adapters/pid_adapter.py
@@ -1,0 +1,99 @@
+"""Adapter wrapping the existing PID controller.
+
+PID's signature differs from the others (positional args, no Input dataclass).
+This adapter normalises it to the common protocol shape.
+"""
+
+from __future__ import annotations
+
+from itertools import count
+from typing import Any
+
+from custom_components.better_thermostat.utils.calibration import pid as pid_mod
+from custom_components.better_thermostat.utils.calibration.pid import (
+    PIDParams,
+    PIDState,
+    compute_pid,
+)
+
+from .base import BenchmarkContext, BenchmarkOutput, ControllerFamily
+
+# Controller state is caller-owned; the adapter threads its own ``_state``
+# through compute_pid, so instances never share learned state.
+_KEY_COUNTER = count()
+
+
+class PidAdapter:
+    """Benchmark adapter for the production PID controller."""
+
+    name: str = "pid"
+    family: ControllerFamily = "valve"
+
+    def __init__(self, params: PIDParams | None = None, key: str | None = None) -> None:
+        self._params = params if params is not None else PIDParams()
+        self._state: PIDState = PIDState()
+        self._key = key if key is not None else f"bench:trv:pid{next(_KEY_COUNTER)}"
+        self._sim_time_s: float = 0.0
+        self._original_monotonic = pid_mod.monotonic
+        self._prev_temp: float | None = None
+        self._prev_t: float | None = None
+
+    def _virtualise_time(self) -> None:
+        pid_mod.monotonic = lambda: self._sim_time_s
+
+    def _restore_time(self) -> None:
+        pid_mod.monotonic = self._original_monotonic
+
+    def reset(self, prior: dict[str, Any] | None = None) -> None:
+        """Drop learned state. ``prior`` is unused."""
+        _ = prior
+        self._state = PIDState()
+        self._sim_time_s = 0.0
+        self._prev_temp = None
+        self._prev_t = None
+
+    def _estimate_slope(self, ctx: BenchmarkContext) -> float | None:
+        if self._prev_temp is None or self._prev_t is None:
+            self._prev_temp = ctx.current_temp_C
+            self._prev_t = ctx.t
+            return None
+        dt_min = (ctx.t - self._prev_t) / 60.0
+        slope: float | None = None
+        if dt_min > 0.0:
+            slope = (ctx.current_temp_C - self._prev_temp) / dt_min
+        self._prev_temp = ctx.current_temp_C
+        self._prev_t = ctx.t
+        return slope
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        """Compute one PID step for the given benchmark context."""
+        self._sim_time_s = ctx.t
+        self._virtualise_time()
+        slope = self._estimate_slope(ctx)
+        try:
+            percent, debug, self._state = compute_pid(
+                params=self._params,
+                inp_target_temp_C=ctx.target_temp_C,
+                inp_current_temp_C=ctx.current_temp_C,
+                inp_trv_temp_C=ctx.trv_temp_C,
+                inp_temp_slope_K_per_min=slope,
+                key=self._key,
+                inp_current_temp_ema_C=ctx.current_temp_C,
+                state=self._state,
+            )
+        finally:
+            self._restore_time()
+
+        return BenchmarkOutput(
+            valve_percent=float(percent), diagnostics=dict(debug) if debug else {}
+        )
+
+    def export_state(self) -> dict[str, Any]:
+        """Return a snapshot of PID internals as a dict."""
+        return {
+            "pid_integral": self._state.pid_integral,
+            "pid_kp": self._state.pid_kp,
+            "pid_ki": self._state.pid_ki,
+            "pid_kd": self._state.pid_kd,
+            "last_percent": self._state.last_percent,
+        }

--- a/tests/benchmark/adapters/pid_adapter.py
+++ b/tests/benchmark/adapters/pid_adapter.py
@@ -2,10 +2,18 @@
 
 PID's signature differs from the others (positional args, no Input dataclass).
 This adapter normalises it to the common protocol shape.
+
+Deliberate simplifications relative to the production call site: the raw
+sensor reading is passed as ``inp_current_temp_ema_C`` (production feeds
+its maintained EMA ``cur_temp_filtered``), and the temperature slope is a
+two-point finite difference (production passes its own ``temp_slope``).
+Both stand-ins converge on the production values for the noise-free,
+fixed-step scenarios the benchmark runs.
 """
 
 from __future__ import annotations
 
+from dataclasses import asdict
 from itertools import count
 from typing import Any
 
@@ -14,6 +22,10 @@ from custom_components.better_thermostat.utils.calibration.pid import (
     PIDParams,
     PIDState,
     compute_pid,
+)
+from custom_components.better_thermostat.utils.state_manager import (
+    _make_json_safe,
+    deserialize_pid,
 )
 
 from .base import BenchmarkContext, BenchmarkOutput, ControllerFamily
@@ -45,9 +57,15 @@ class PidAdapter:
         pid_mod.monotonic = self._original_monotonic
 
     def reset(self, prior: dict[str, Any] | None = None) -> None:
-        """Drop learned state. ``prior`` is unused."""
-        _ = prior
-        self._state = PIDState()
+        """Reset the adapter, optionally rehydrating persisted state.
+
+        Production persists PID state across Home Assistant restarts
+        (``StateManager`` store); passing a prior ``export_state()``
+        snapshot replays that behaviour through the production
+        ``deserialize_pid`` path. Without ``prior`` the adapter
+        cold-starts.
+        """
+        self._state = deserialize_pid(prior) if prior else PIDState()
         self._sim_time_s = 0.0
         self._prev_temp = None
         self._prev_t = None
@@ -89,11 +107,5 @@ class PidAdapter:
         )
 
     def export_state(self) -> dict[str, Any]:
-        """Return a snapshot of PID internals as a dict."""
-        return {
-            "pid_integral": self._state.pid_integral,
-            "pid_kp": self._state.pid_kp,
-            "pid_ki": self._state.pid_ki,
-            "pid_kd": self._state.pid_kd,
-            "last_percent": self._state.last_percent,
-        }
+        """Return a serializable snapshot of the wrapped PID state."""
+        return _make_json_safe(asdict(self._state))

--- a/tests/benchmark/adapters/tpi_adapter.py
+++ b/tests/benchmark/adapters/tpi_adapter.py
@@ -1,0 +1,88 @@
+"""Adapter wrapping the existing TPI controller.
+
+TPI emits a duty cycle. For the benchmark, the duty cycle is interpreted
+as an equivalent steady-state valve fraction over the simulator step —
+i.e. ``duty_cycle_pct`` is fed directly to the plant as ``valve_percent``.
+This is the standard interpretation when the duty cycle's period is short
+relative to the simulator step.
+"""
+
+from __future__ import annotations
+
+from itertools import count
+from typing import Any
+
+from custom_components.better_thermostat.utils.calibration import tpi as tpi_mod
+from custom_components.better_thermostat.utils.calibration.tpi import (
+    TpiInput,
+    TpiParams,
+    _TpiState,
+    compute_tpi,
+)
+
+from .base import BenchmarkContext, BenchmarkOutput, ControllerFamily
+
+# Controller state is caller-owned; the adapter threads its own ``_state``
+# through compute_tpi, so instances never share learned state.
+_KEY_COUNTER = count()
+
+
+class TpiAdapter:
+    """Benchmark adapter for the production TPI controller."""
+
+    name: str = "tpi"
+    family: ControllerFamily = "duty"
+
+    def __init__(self, params: TpiParams | None = None, key: str | None = None) -> None:
+        self._params = params if params is not None else TpiParams()
+        self._state: _TpiState = _TpiState()
+        self._key = key if key is not None else f"bench:trv:tpi{next(_KEY_COUNTER)}"
+        self._sim_time_s: float = 0.0
+        self._original_monotonic = tpi_mod.monotonic
+
+    def _virtualise_time(self) -> None:
+        tpi_mod.monotonic = lambda: self._sim_time_s
+
+    def _restore_time(self) -> None:
+        tpi_mod.monotonic = self._original_monotonic
+
+    def reset(self, prior: dict[str, Any] | None = None) -> None:
+        """Drop learned state. ``prior`` is unused."""
+        _ = prior
+        self._state = _TpiState()
+        self._sim_time_s = 0.0
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        """Compute one TPI step for the given benchmark context."""
+        self._sim_time_s = ctx.t
+        self._virtualise_time()
+        try:
+            inp = TpiInput(
+                key=self._key,
+                target_temp_C=ctx.target_temp_C,
+                current_temp_C=ctx.current_temp_C,
+                outdoor_temp_C=ctx.outdoor_temp_C,
+                window_open=ctx.window_open,
+                heating_allowed=True,
+                bt_name="benchmark",
+                entity_id="bench_trv",
+            )
+            out, self._state = compute_tpi(inp, self._params, state=self._state)
+        finally:
+            self._restore_time()
+
+        if out is None:
+            return BenchmarkOutput(
+                duty_cycle_pct=ctx.last_valve_percent,
+                valve_percent=ctx.last_valve_percent,
+                diagnostics={"early_exit": True},
+            )
+        return BenchmarkOutput(
+            duty_cycle_pct=float(out.duty_cycle_pct),
+            valve_percent=float(out.duty_cycle_pct),
+            diagnostics=dict(out.debug) if out.debug else {},
+        )
+
+    def export_state(self) -> dict[str, Any]:
+        """Return the (small) TPI state as a serialisable dict."""
+        return {"last_percent": self._state.last_percent}

--- a/tests/benchmark/adapters/tpi_adapter.py
+++ b/tests/benchmark/adapters/tpi_adapter.py
@@ -9,6 +9,7 @@ relative to the simulator step.
 
 from __future__ import annotations
 
+from dataclasses import asdict
 from itertools import count
 from typing import Any
 
@@ -18,6 +19,10 @@ from custom_components.better_thermostat.utils.calibration.tpi import (
     TpiParams,
     _TpiState,
     compute_tpi,
+)
+from custom_components.better_thermostat.utils.state_manager import (
+    _make_json_safe,
+    deserialize_tpi,
 )
 
 from .base import BenchmarkContext, BenchmarkOutput, ControllerFamily
@@ -47,9 +52,15 @@ class TpiAdapter:
         tpi_mod.monotonic = self._original_monotonic
 
     def reset(self, prior: dict[str, Any] | None = None) -> None:
-        """Drop learned state. ``prior`` is unused."""
-        _ = prior
-        self._state = _TpiState()
+        """Reset the adapter, optionally rehydrating persisted state.
+
+        Production persists TPI state across Home Assistant restarts
+        (``StateManager`` store); passing a prior ``export_state()``
+        snapshot replays that behaviour through the production
+        ``deserialize_tpi`` path. Without ``prior`` the adapter
+        cold-starts.
+        """
+        self._state = deserialize_tpi(prior) if prior else _TpiState()
         self._sim_time_s = 0.0
 
     def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
@@ -72,10 +83,12 @@ class TpiAdapter:
             self._restore_time()
 
         if out is None:
+            # ``compute_tpi``'s contract allows None (no recommendation);
+            # production then skips the TPI result for this cycle. The
+            # benchmark has no fallback controller, so map it to a zero
+            # duty cycle — the same floor the window-open path emits.
             return BenchmarkOutput(
-                duty_cycle_pct=ctx.last_valve_percent,
-                valve_percent=ctx.last_valve_percent,
-                diagnostics={"early_exit": True},
+                duty_cycle_pct=0.0, valve_percent=0.0, diagnostics={"early_exit": True}
             )
         return BenchmarkOutput(
             duty_cycle_pct=float(out.duty_cycle_pct),
@@ -84,5 +97,5 @@ class TpiAdapter:
         )
 
     def export_state(self) -> dict[str, Any]:
-        """Return the (small) TPI state as a serialisable dict."""
-        return {"last_percent": self._state.last_percent}
+        """Return a serializable snapshot of the wrapped TPI state."""
+        return _make_json_safe(asdict(self._state))

--- a/tests/benchmark/scenarios.py
+++ b/tests/benchmark/scenarios.py
@@ -1,0 +1,734 @@
+"""Scenario library.
+
+A scenario is an immutable description of one benchmark run: initial
+conditions, plant parameters, input schedules, disturbance schedules
+and acceptance criteria.
+
+DESIGN.md §7.1 enumerates 16 scenarios; this module ships the
+``setpoint``-, ``disturbance``- and ``cold-start`` families. The
+multi-TRV variant (S14) is deferred until the simulator supports
+multiple actuators.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from . import schedules
+from .actuator import ActuatorParams, ActuatorProfile
+from .plant import (
+    PROFILE_BOILER_LIMITED,
+    PROFILE_COOLING,
+    PROFILE_STANDARD,
+    PROFILE_UNDERFLOOR,
+    PlantParams,
+)
+from .sensor import SensorParams
+
+
+@dataclass(frozen=True)
+class InitialConditions:
+    """Plant state at scenario start.
+
+    Attributes
+    ----------
+    T_room_C : float
+        Room air temperature in °C.
+    T_rad_C : float
+        Radiator surface temperature in °C.
+    """
+
+    T_room_C: float
+    T_rad_C: float
+
+
+@dataclass(frozen=True)
+class ScenarioConfig:
+    """Immutable description of one benchmark scenario.
+
+    Attributes
+    ----------
+    name : str
+        Registry key and report label.
+    description : str
+        Human-readable one-line summary.
+    duration_min : int
+        Nominal scenario duration in minutes (scaled for slow plants).
+    initial : InitialConditions
+        Plant state at scenario start.
+    plant : PlantParams
+        Thermal plant the scenario runs against.
+    setpoint_schedule : Callable[[float], float]
+        ``t_s -> T_setpoint_C``.
+    outdoor_schedule : Callable[[float], float]
+        ``t_s -> T_outdoor_C``.
+    transient_start_s : float
+        Time from which transient metrics are evaluated.
+    """
+
+    name: str
+    description: str
+    duration_min: int
+    initial: InitialConditions
+    plant: PlantParams
+    setpoint_schedule: Callable[[float], float]  # t_s → T_setpoint
+    outdoor_schedule: Callable[[float], float]  # t_s → T_outdoor
+    transient_start_s: float = 0.0
+
+    # --- Optional disturbance and sensor schedules ---
+    # If None, the runner treats the channel as inactive (no window event,
+    # no solar gain, default sensor).
+    window_open_schedule: Callable[[float], bool] | None = None
+    solar_intensity_schedule: Callable[[float], float] | None = None
+    # Independent solar signal *seen* by the controller. When ``None`` the
+    # controller sees the same value as the plant; setting it to a
+    # different schedule models a wrong weather forecast.
+    controller_solar_schedule: Callable[[float], float] | None = None
+    window_loss_K_per_min: float = 0.5  # heat lost per minute while window is open
+    solar_max_K_per_min: float = 0.03  # plant-side heat gain at full solar (1.0)
+    sensor_params: SensorParams | None = None
+    actuator_params: ActuatorParams | None = None
+    # Per-scenario override for the stabilisation phase. ``None`` defers
+    # to the CLI default.
+    stabilisation_min: float | None = None
+    # If set, the runner calls ``adapter.reset()`` once when ``t`` first
+    # reaches this value — models an HA restart that wipes integrator
+    # state mid-flight.
+    controller_restart_t_s: float | None = None
+
+
+# --- Schedule helpers ---
+
+
+# --- Scenarios ---
+
+
+S01_SETPOINT_STEP_SMALL = ScenarioConfig(
+    name="S01_setpoint_step_small",
+    description="Setpoint step 20.0 → 21.0 °C after 30 min stabilization",
+    duration_min=180,
+    initial=InitialConditions(T_room_C=20.0, T_rad_C=20.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.step(30 * 60.0, 20.0, 21.0),
+    outdoor_schedule=schedules.constant(5.0),
+    transient_start_s=30 * 60.0,
+)
+
+
+S02_SETPOINT_STEP_LARGE = ScenarioConfig(
+    name="S02_setpoint_step_large",
+    description="Setpoint step 19.0 → 23.0 °C after 30 min stabilization",
+    duration_min=300,
+    initial=InitialConditions(T_room_C=19.0, T_rad_C=19.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.step(30 * 60.0, 19.0, 23.0),
+    outdoor_schedule=schedules.constant(5.0),
+    transient_start_s=30 * 60.0,
+)
+
+
+S03_FROST_TO_COMFORT = ScenarioConfig(
+    name="S03_frost_to_comfort",
+    description="Cold home: 12 → 21 °C with cold outdoor (-2 °C)",
+    duration_min=720,  # 12 h: large jump on cold start
+    initial=InitialConditions(T_room_C=12.0, T_rad_C=12.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.step(30 * 60.0, 12.0, 21.0),
+    outdoor_schedule=schedules.constant(-2.0),
+    transient_start_s=30 * 60.0,
+    # Vacation-mode arrival: cold radiator, no prior controller state.
+    stabilisation_min=10.0,
+)
+
+
+S04_SETPOINT_DROP = ScenarioConfig(
+    name="S04_setpoint_drop",
+    description="Downward setpoint step 22 → 19 °C — heat-off recovery",
+    duration_min=300,
+    initial=InitialConditions(T_room_C=22.0, T_rad_C=35.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.step(30 * 60.0, 22.0, 19.0),
+    outdoor_schedule=schedules.constant(5.0),
+    transient_start_s=30 * 60.0,
+)
+
+
+S06_SETPOINT_DURING_HEATING = ScenarioConfig(
+    name="S06_setpoint_during_heating",
+    description="Multi-step setpoint: 20 → 22 → 21 °C while controller is active",
+    duration_min=360,
+    initial=InitialConditions(T_room_C=20.0, T_rad_C=20.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.piecewise_step(
+        [(60 * 60.0, 22.0), (180 * 60.0, 21.0)], initial=20.0
+    ),
+    outdoor_schedule=schedules.constant(5.0),
+    transient_start_s=60 * 60.0,
+)
+
+
+S07_OUTDOOR_STEP_COLD = ScenarioConfig(
+    name="S07_outdoor_step_cold",
+    description="Outdoor temperature step 5 → -10 °C while holding setpoint 21",
+    duration_min=300,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=37.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.step(60 * 60.0, 5.0, -10.0),
+    transient_start_s=60 * 60.0,
+)
+
+
+S08_OUTDOOR_RAMP_WARM = ScenarioConfig(
+    name="S08_outdoor_ramp_warm",
+    description="Outdoor warms slowly from 5 to 12 °C over 6 h, setpoint constant 21",
+    duration_min=420,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=37.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.ramp(60 * 60.0, 60 * 60.0 + 6 * 3600.0, 5.0, 12.0),
+    transient_start_s=60 * 60.0,
+)
+
+
+S09_WINDOW_OPEN_SHORT = ScenarioConfig(
+    name="S09_window_open_short",
+    description="5-minute window-open event at t=60 min, setpoint 21",
+    duration_min=240,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=37.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.constant(5.0),
+    window_open_schedule=schedules.pulse_bool(60 * 60.0, 65 * 60.0),
+    transient_start_s=60 * 60.0,
+)
+
+
+S10_WINDOW_OPEN_LONG = ScenarioConfig(
+    name="S10_window_open_long",
+    description="20-minute window-open event at t=60 min, setpoint 21",
+    duration_min=360,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=37.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.constant(5.0),
+    window_open_schedule=schedules.pulse_bool(60 * 60.0, 80 * 60.0),
+    transient_start_s=60 * 60.0,
+)
+
+
+S11_SOLAR_GAIN_MORNING = ScenarioConfig(
+    name="S11_solar_gain_morning",
+    description="Solar trapezoid (rise 60 min, plateau 60 min, fall 60 min) at full intensity",
+    duration_min=300,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=37.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.constant(8.0),
+    solar_intensity_schedule=schedules.solar_trapezoid(
+        60 * 60.0, 120 * 60.0, 180 * 60.0, 240 * 60.0, peak=1.0
+    ),
+    transient_start_s=60 * 60.0,
+)
+
+
+S12_SENSOR_DROPOUT = ScenarioConfig(
+    name="S12_sensor_dropout",
+    description="10-minute sensor dropout at t=60-70 min, setpoint 21",
+    duration_min=240,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=37.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.constant(5.0),
+    transient_start_s=60 * 60.0,
+    sensor_params=SensorParams(
+        sample_interval_s=60.0, dropout_from_t_s=60 * 60.0, dropout_until_t_s=70 * 60.0
+    ),
+)
+
+
+S13_COLD_START = ScenarioConfig(
+    name="S13_cold_start",
+    description="Cold start: T_room=15, no prior controller state, setpoint 20",
+    duration_min=360,
+    initial=InitialConditions(T_room_C=15.0, T_rad_C=15.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(20.0),
+    outdoor_schedule=schedules.constant(5.0),
+    transient_start_s=0.0,
+    # Forced cold-start: no pre-warm via oracle.
+    stabilisation_min=0.0,
+)
+
+
+S05_SLOW_RADIATOR = ScenarioConfig(
+    name="S05_slow_radiator",
+    description="Setpoint step 20 → 21 °C on an underfloor heating plant",
+    duration_min=480,
+    initial=InitialConditions(T_room_C=20.0, T_rad_C=20.0),
+    plant=PROFILE_UNDERFLOOR,
+    setpoint_schedule=schedules.step(30 * 60.0, 20.0, 21.0),
+    outdoor_schedule=schedules.constant(5.0),
+    transient_start_s=30 * 60.0,
+)
+
+
+S14_NIGHTLY_SETBACK = ScenarioConfig(
+    name="S14_nightly_setback",
+    description="Setback 18 °C → wake-up 21 °C @ 06:30 → setback 18 °C @ 16:30",
+    duration_min=12 * 60,
+    initial=InitialConditions(T_room_C=18.0, T_rad_C=18.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.piecewise_step(
+        [(30 * 60.0, 21.0), (10 * 3600.0, 18.0)], initial=18.0
+    ),
+    outdoor_schedule=schedules.constant(-2.0),
+    transient_start_s=30 * 60.0,
+)
+
+
+S15_DAILY_CYCLE = ScenarioConfig(
+    name="S15_daily_cycle",
+    description="24 h day: morning warmup, daytime away, evening, night setback",
+    duration_min=24 * 60,
+    initial=InitialConditions(T_room_C=19.0, T_rad_C=22.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.piecewise_step(
+        [
+            (2 * 3600.0, 19.0),  # 08:00 daytime away
+            (11 * 3600.0, 21.0),  # 17:00 evening occupied
+            (16 * 3600.0, 18.0),  # 22:00 night setback
+        ],
+        initial=21.0,  # 06:00 morning, already on the wakeup setpoint
+    ),
+    outdoor_schedule=schedules.sinus_diurnal(
+        min_value=1.0, max_value=8.0, phase_min_h=0.0
+    ),
+    transient_start_s=0.0,
+)
+
+
+S17_SENSOR_BIAS = ScenarioConfig(
+    name="S17_sensor_bias",
+    description="Steady-state with constant sensor bias +0.5 K (room ends 0.5 K below SP)",
+    duration_min=8 * 60,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=33.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.constant(5.0),
+    sensor_params=SensorParams(sample_interval_s=60.0, bias_K=0.5),
+    transient_start_s=30 * 60.0,
+)
+
+
+S18_SENSOR_DRIFT = ScenarioConfig(
+    name="S18_sensor_drift",
+    description="Slow sensor drift +0.05 K/h over 12 h (alters perceived ss_err)",
+    duration_min=12 * 60,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=33.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.constant(5.0),
+    sensor_params=SensorParams(sample_interval_s=60.0, drift_K_per_h=0.05),
+    transient_start_s=30 * 60.0,
+)
+
+
+S19_VALVE_STICTION = ScenarioConfig(
+    name="S19_valve_stiction",
+    description="Steady-state under 5 % valve stiction (stick-slip hysteresis)",
+    duration_min=6 * 60,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=33.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.constant(5.0),
+    actuator_params=ActuatorParams(
+        profile=ActuatorProfile.EQUAL_PERCENTAGE,
+        equal_percentage_exponent=3.0,
+        hysteresis_pct=5.0,
+    ),
+    transient_start_s=30 * 60.0,
+)
+
+
+S20_VALVE_DEADBAND = ScenarioConfig(
+    name="S20_valve_deadband",
+    description="Small setpoint step (20 → 21) on a valve with 3 % deadband",
+    duration_min=180,
+    initial=InitialConditions(T_room_C=20.0, T_rad_C=20.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.step(30 * 60.0, 20.0, 21.0),
+    outdoor_schedule=schedules.constant(5.0),
+    actuator_params=ActuatorParams(
+        profile=ActuatorProfile.EQUAL_PERCENTAGE,
+        equal_percentage_exponent=3.0,
+        deadband_pct=3.0,
+    ),
+    transient_start_s=30 * 60.0,
+)
+
+
+S23_BOILER_LIMITED = ScenarioConfig(
+    name="S23_boiler_limited",
+    description="Cold start (15 → 21 °C) on a 42 °C heat-pump supply at +8 °C outdoor",
+    duration_min=720,  # 12 h — heat pump warmup is slower
+    initial=InitialConditions(T_room_C=15.0, T_rad_C=15.0),
+    plant=PROFILE_BOILER_LIMITED,
+    setpoint_schedule=schedules.step(30 * 60.0, 15.0, 21.0),
+    outdoor_schedule=schedules.constant(8.0),
+    transient_start_s=30 * 60.0,
+    stabilisation_min=10.0,
+)
+
+
+S21_STOCHASTIC_WINDOWS = ScenarioConfig(
+    name="S21_stochastic_windows",
+    description="12 h with 3 randomised window-open events (Annex-79-style)",
+    duration_min=12 * 60,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=33.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.constant(0.0),
+    window_open_schedule=schedules.stochastic_windows(
+        seed=42,
+        count=3,
+        duration_s=12 * 3600.0,
+        min_duration_s=3 * 60.0,
+        max_duration_s=8 * 60.0,
+    ),
+    window_loss_K_per_min=0.3,
+    transient_start_s=30 * 60.0,
+)
+
+
+S24_CONTROLLER_RESTART = ScenarioConfig(
+    name="S24_controller_restart",
+    description="Steady-state, then controller reset() at t=2h (HA restart sim)",
+    duration_min=4 * 60,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=35.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.constant(0.0),
+    transient_start_s=120 * 60.0,
+    controller_restart_t_s=120 * 60.0,
+)
+
+
+S25_DEMAND_RESPONSE = ScenarioConfig(
+    name="S25_demand_response",
+    description="Grid demand-response: pre-heat +2 K, then setback -1 K, back to normal",
+    duration_min=8 * 60,
+    initial=InitialConditions(T_room_C=20.0, T_rad_C=30.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.piecewise_step(
+        [
+            (2 * 3600.0, 22.0),  # DR pre-heat
+            (4 * 3600.0, 19.0),  # DR peak setback
+            (6 * 3600.0, 20.0),  # back to normal
+        ],
+        initial=20.0,
+    ),
+    outdoor_schedule=schedules.constant(0.0),
+    transient_start_s=2 * 3600.0,
+)
+
+
+S16_VACATION = ScenarioConfig(
+    name="S16_vacation",
+    description="6 d vacation: 20 °C → 8 °C frost-protect (5 d) → 20 °C return",
+    duration_min=6 * 24 * 60,  # 144 h
+    initial=InitialConditions(T_room_C=20.0, T_rad_C=25.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.piecewise_step(
+        [
+            (2 * 3600.0, 8.0),  # vacation setback after 2 h
+            (5 * 24 * 3600.0, 20.0),  # return after 5 d
+        ],
+        initial=20.0,
+    ),
+    outdoor_schedule=schedules.constant(-5.0),
+    transient_start_s=5 * 24 * 3600.0,  # measure the return transient
+)
+
+
+def _build_synthetic_weather_scenario(
+    name: str,
+    climate: ClimateParams,
+    seed: int,
+    start_day_of_year: int = 14,
+    duration_h: int = 168,
+    setpoint_C: float = 21.0,
+) -> ScenarioConfig:
+    """Build a constant-setpoint, weather-driven scenario.
+
+    The outdoor and solar schedules are generated by
+    :mod:`weather.synthetic` from the supplied ``climate`` preset plus a
+    seed — fully reproducible, no external data.
+
+    Parameters
+    ----------
+    name : str
+        Scenario registry key.
+    climate : ClimateParams
+        Climate preset for the synthetic weather generator.
+    seed : int
+        RNG seed for the weather generator.
+    start_day_of_year : int
+        Day of year at which the weather slice starts.
+    duration_h : int
+        Scenario length in hours.
+    setpoint_C : float
+        Constant setpoint in °C.
+
+    Returns
+    -------
+    ScenarioConfig
+        Fully-populated weather-driven scenario.
+    """
+    from .weather.synthetic import make_schedules
+
+    outdoor, solar = make_schedules(
+        climate, start_day_of_year=start_day_of_year, duration_h=duration_h, seed=seed
+    )
+    return ScenarioConfig(
+        name=name,
+        description=(
+            f"{duration_h // 24} d {climate.name} winter slice "
+            f"(seed={seed}), setpoint {setpoint_C} °C"
+        ),
+        duration_min=duration_h * 60,
+        initial=InitialConditions(T_room_C=setpoint_C, T_rad_C=setpoint_C + 8.0),
+        plant=PROFILE_STANDARD,
+        setpoint_schedule=schedules.constant(setpoint_C),
+        outdoor_schedule=outdoor,
+        solar_intensity_schedule=solar,
+        transient_start_s=0.0,
+        # Permanent outdoor variability — settling is not a meaningful
+        # metric and overshoot tolerates the diurnal swing.
+    )
+
+
+# Lazy import so the dataclass is reachable from the type annotation.
+from .weather.synthetic import CHICAGO_LIKE, DENVER_LIKE, ClimateParams  # noqa: E402
+
+S37_WINTER_WEEK_HUMID_CONT = _build_synthetic_weather_scenario(
+    name="S37_winter_week_humid_continental",
+    climate=CHICAGO_LIKE,
+    seed=37,
+    start_day_of_year=14,  # mid-January
+)
+
+
+S38_WINTER_WEEK_SEMI_ARID = _build_synthetic_weather_scenario(
+    name="S38_winter_week_semi_arid", climate=DENVER_LIKE, seed=38, start_day_of_year=14
+)
+
+
+S28_INDIRECT_TRV_TADO = ScenarioConfig(
+    name="S28_indirect_trv_tado",
+    description="SP step 19 → 21 on a Tado-style indirect TRV (0.5 K steps, internal P-loop)",
+    duration_min=4 * 60,
+    initial=InitialConditions(T_room_C=19.0, T_rad_C=19.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.step(30 * 60.0, 19.0, 21.0),
+    outdoor_schedule=schedules.constant(5.0),
+    transient_start_s=30 * 60.0,
+)
+
+
+S30_FROST_DRIFT_RECOVERY = ScenarioConfig(
+    name="S30_frost_drift_recovery",
+    description="7 d frost-protection at 12 °C, then 8 h recovery to 21 °C — only recovery is scored",
+    duration_min=7 * 24 * 60 + 8 * 60,
+    initial=InitialConditions(T_room_C=12.0, T_rad_C=15.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.piecewise_step([(7 * 24 * 3600.0, 21.0)], initial=12.0),
+    outdoor_schedule=schedules.constant(-5.0),
+    transient_start_s=7 * 24 * 3600.0,
+    stabilisation_min=0.0,
+)
+
+
+S32_FORECAST_MISMATCH_SOLAR = ScenarioConfig(
+    name="S32_forecast_mismatch_solar",
+    description="Controller sees solar=1.0 (wrong forecast) while plant gets solar=0.0",
+    duration_min=8 * 60,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=33.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.constant(-5.0),
+    solar_intensity_schedule=schedules.constant(0.0),  # plant truth: no sun
+    controller_solar_schedule=schedules.constant(1.0),  # controller lie: full sun
+    transient_start_s=30 * 60.0,
+)
+
+
+S29_HEATPUMP_STEADY_STATE = ScenarioConfig(
+    name="S29_heatpump_steady_state",
+    description="24 h on PROFILE_BOILER_LIMITED with diurnal outdoor; evaluate valve sweet-spot residency",
+    duration_min=24 * 60,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=33.0),
+    plant=PROFILE_BOILER_LIMITED,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.sinus_diurnal(
+        min_value=4.0, max_value=12.0, phase_min_h=6.0
+    ),
+    transient_start_s=0.0,
+)
+
+
+S33_UFH_ASYMMETRIC = ScenarioConfig(
+    name="S33_ufh_asymmetric",
+    description="Underfloor SP step 20 → 21; asymmetric overshoot/undershoot accounting",
+    duration_min=16 * 60,
+    initial=InitialConditions(T_room_C=20.0, T_rad_C=28.0),
+    plant=PROFILE_UNDERFLOOR,
+    setpoint_schedule=schedules.step(30 * 60.0, 20.0, 21.0),
+    outdoor_schedule=schedules.constant(10.0),
+    transient_start_s=30 * 60.0,
+)
+
+
+S31_BOILER_CYCLE_STRESS = ScenarioConfig(
+    name="S31_boiler_cycle_stress",
+    description="Multi-step SP wobble on a 20 % deadband valve — boiler cycle stress",
+    duration_min=6 * 60,
+    initial=InitialConditions(T_room_C=20.5, T_rad_C=30.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.piecewise_step(
+        [(60 * 60.0, 21.0), (120 * 60.0, 20.8), (180 * 60.0, 21.2), (240 * 60.0, 21.0)],
+        initial=21.0,
+    ),
+    outdoor_schedule=schedules.constant(5.0),
+    actuator_params=ActuatorParams(
+        profile=ActuatorProfile.EQUAL_PERCENTAGE,
+        equal_percentage_exponent=3.0,
+        deadband_pct=20.0,
+        hysteresis_pct=3.0,
+    ),
+    transient_start_s=0.0,
+)
+
+
+S35_SAMPLE_JITTER = ScenarioConfig(
+    name="S35_sample_jitter",
+    description="SP step 20 → 21 with sensor sample interval jittering ±45 s around 120 s",
+    duration_min=4 * 60,
+    initial=InitialConditions(T_room_C=20.0, T_rad_C=20.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.step(30 * 60.0, 20.0, 21.0),
+    outdoor_schedule=schedules.constant(5.0),
+    sensor_params=SensorParams(sample_interval_s=120.0, jitter_std_s=45.0),
+    transient_start_s=30 * 60.0,
+)
+
+
+S36_USER_OVERRIDE = ScenarioConfig(
+    name="S36_user_override",
+    description="SP whipped via API every 8 minutes — controller must not drop updates",
+    duration_min=2 * 60,
+    initial=InitialConditions(T_room_C=20.0, T_rad_C=30.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.piecewise_step(
+        [
+            (8 * 60.0, 22.0),
+            (16 * 60.0, 19.5),
+            (24 * 60.0, 21.0),
+            (32 * 60.0, 20.0),
+            (40 * 60.0, 22.5),
+            (48 * 60.0, 19.0),
+            (56 * 60.0, 21.0),
+        ],
+        initial=20.0,
+    ),
+    outdoor_schedule=schedules.constant(5.0),
+    transient_start_s=0.0,
+)
+
+
+S27_PIPE_FILL_AFTER_IDLE = ScenarioConfig(
+    name="S27_pipe_fill_after_idle",
+    description="Long idle then SP step 20 → 22 with 120 s pipe-transport delay",
+    duration_min=4 * 60,
+    initial=InitialConditions(T_room_C=20.0, T_rad_C=20.0),
+    plant=PlantParams(
+        tau_room_min=480.0,
+        tau_rad_min=15.0,
+        gain_heater=2.0,
+        coupling_rad_room=1.0,
+        T_water_C=65.0,
+        valve_command_delay_s=120.0,
+    ),
+    setpoint_schedule=schedules.step(120 * 60.0, 20.0, 22.0),
+    outdoor_schedule=schedules.constant(2.0),
+    transient_start_s=120 * 60.0,
+    stabilisation_min=0.0,
+)
+
+
+S26_COOLING_MODE = ScenarioConfig(
+    name="S26_cooling_mode",
+    description="Hot day (outdoor 28 °C) on a reverse-acting chilled-water plant",
+    duration_min=8 * 60,
+    initial=InitialConditions(T_room_C=22.0, T_rad_C=22.0),
+    plant=PROFILE_COOLING,
+    setpoint_schedule=schedules.constant(22.0),
+    outdoor_schedule=schedules.constant(28.0),
+    transient_start_s=30 * 60.0,
+)
+
+
+S22_DIURNAL_OUTDOOR = ScenarioConfig(
+    name="S22_diurnal_outdoor",
+    description="Constant 21 °C setpoint under a 24 h diurnal outdoor cycle (-5..+3 °C)",
+    duration_min=24 * 60,
+    initial=InitialConditions(T_room_C=21.0, T_rad_C=31.0),
+    plant=PROFILE_STANDARD,
+    setpoint_schedule=schedules.constant(21.0),
+    outdoor_schedule=schedules.sinus_diurnal(
+        min_value=-5.0, max_value=3.0, phase_min_h=0.0
+    ),
+    transient_start_s=0.0,
+)
+
+
+ALL_SCENARIOS: dict[str, ScenarioConfig] = {
+    S01_SETPOINT_STEP_SMALL.name: S01_SETPOINT_STEP_SMALL,
+    S02_SETPOINT_STEP_LARGE.name: S02_SETPOINT_STEP_LARGE,
+    S03_FROST_TO_COMFORT.name: S03_FROST_TO_COMFORT,
+    S04_SETPOINT_DROP.name: S04_SETPOINT_DROP,
+    S05_SLOW_RADIATOR.name: S05_SLOW_RADIATOR,
+    S06_SETPOINT_DURING_HEATING.name: S06_SETPOINT_DURING_HEATING,
+    S07_OUTDOOR_STEP_COLD.name: S07_OUTDOOR_STEP_COLD,
+    S08_OUTDOOR_RAMP_WARM.name: S08_OUTDOOR_RAMP_WARM,
+    S09_WINDOW_OPEN_SHORT.name: S09_WINDOW_OPEN_SHORT,
+    S10_WINDOW_OPEN_LONG.name: S10_WINDOW_OPEN_LONG,
+    S11_SOLAR_GAIN_MORNING.name: S11_SOLAR_GAIN_MORNING,
+    S12_SENSOR_DROPOUT.name: S12_SENSOR_DROPOUT,
+    S13_COLD_START.name: S13_COLD_START,
+    S14_NIGHTLY_SETBACK.name: S14_NIGHTLY_SETBACK,
+    S15_DAILY_CYCLE.name: S15_DAILY_CYCLE,
+    S16_VACATION.name: S16_VACATION,
+    S17_SENSOR_BIAS.name: S17_SENSOR_BIAS,
+    S18_SENSOR_DRIFT.name: S18_SENSOR_DRIFT,
+    S19_VALVE_STICTION.name: S19_VALVE_STICTION,
+    S20_VALVE_DEADBAND.name: S20_VALVE_DEADBAND,
+    S21_STOCHASTIC_WINDOWS.name: S21_STOCHASTIC_WINDOWS,
+    S22_DIURNAL_OUTDOOR.name: S22_DIURNAL_OUTDOOR,
+    S23_BOILER_LIMITED.name: S23_BOILER_LIMITED,
+    S24_CONTROLLER_RESTART.name: S24_CONTROLLER_RESTART,
+    S25_DEMAND_RESPONSE.name: S25_DEMAND_RESPONSE,
+    S26_COOLING_MODE.name: S26_COOLING_MODE,
+    S27_PIPE_FILL_AFTER_IDLE.name: S27_PIPE_FILL_AFTER_IDLE,
+    S31_BOILER_CYCLE_STRESS.name: S31_BOILER_CYCLE_STRESS,
+    S35_SAMPLE_JITTER.name: S35_SAMPLE_JITTER,
+    S36_USER_OVERRIDE.name: S36_USER_OVERRIDE,
+    S33_UFH_ASYMMETRIC.name: S33_UFH_ASYMMETRIC,
+    S29_HEATPUMP_STEADY_STATE.name: S29_HEATPUMP_STEADY_STATE,
+    S32_FORECAST_MISMATCH_SOLAR.name: S32_FORECAST_MISMATCH_SOLAR,
+    S30_FROST_DRIFT_RECOVERY.name: S30_FROST_DRIFT_RECOVERY,
+    S28_INDIRECT_TRV_TADO.name: S28_INDIRECT_TRV_TADO,
+    S37_WINTER_WEEK_HUMID_CONT.name: S37_WINTER_WEEK_HUMID_CONT,
+    S38_WINTER_WEEK_SEMI_ARID.name: S38_WINTER_WEEK_SEMI_ARID,
+}

--- a/tests/benchmark/scenarios.py
+++ b/tests/benchmark/scenarios.py
@@ -276,7 +276,7 @@ S05_SLOW_RADIATOR = ScenarioConfig(
 
 S14_NIGHTLY_SETBACK = ScenarioConfig(
     name="S14_nightly_setback",
-    description="Setback 18 °C → wake-up 21 °C @ 06:30 → setback 18 °C @ 16:30",
+    description="Setback 18 °C → wake-up 21 °C after 30 min → setback 18 °C at 10 h",
     duration_min=12 * 60,
     initial=InitialConditions(T_room_C=18.0, T_rad_C=18.0),
     plant=PROFILE_STANDARD,

--- a/tests/benchmark/scenarios.py
+++ b/tests/benchmark/scenarios.py
@@ -4,10 +4,10 @@ A scenario is an immutable description of one benchmark run: initial
 conditions, plant parameters, input schedules, disturbance schedules
 and acceptance criteria.
 
-DESIGN.md §7.1 enumerates 16 scenarios; this module ships the
-``setpoint``-, ``disturbance``- and ``cold-start`` families. The
-multi-TRV variant (S14) is deferred until the simulator supports
-multiple actuators.
+The library covers setpoint dynamics, outdoor/load disturbances, cold
+starts, sensor and actuator faults, HVAC topologies, schedule-driven
+weeks and synthetic-weather weeks; ``ALL_SCENARIOS`` at the bottom of
+the module is the authoritative registry.
 """
 
 from __future__ import annotations
@@ -25,6 +25,7 @@ from .plant import (
     PlantParams,
 )
 from .sensor import SensorParams
+from .weather.synthetic import CHICAGO_LIKE, DENVER_LIKE, ClimateParams, make_schedules
 
 
 @dataclass(frozen=True)
@@ -486,8 +487,6 @@ def _build_synthetic_weather_scenario(
     ScenarioConfig
         Fully-populated weather-driven scenario.
     """
-    from .weather.synthetic import make_schedules
-
     outdoor, solar = make_schedules(
         climate, start_day_of_year=start_day_of_year, duration_h=duration_h, seed=seed
     )
@@ -509,9 +508,6 @@ def _build_synthetic_weather_scenario(
     )
 
 
-# Lazy import so the dataclass is reachable from the type annotation.
-from .weather.synthetic import CHICAGO_LIKE, DENVER_LIKE, ClimateParams  # noqa: E402
-
 S37_WINTER_WEEK_HUMID_CONT = _build_synthetic_weather_scenario(
     name="S37_winter_week_humid_continental",
     climate=CHICAGO_LIKE,
@@ -527,7 +523,12 @@ S38_WINTER_WEEK_SEMI_ARID = _build_synthetic_weather_scenario(
 
 S28_INDIRECT_TRV_TADO = ScenarioConfig(
     name="S28_indirect_trv_tado",
-    description="SP step 19 → 21 on a Tado-style indirect TRV (0.5 K steps, internal P-loop)",
+    description=(
+        "SP step 19 → 21 as the nominal pairing scenario for the "
+        "indirect-TRV wrapper controllers (Tado-style 0.5 K steps, "
+        "internal P-loop); the wrapping itself is selected by the "
+        "controller registry, not by this config"
+    ),
     duration_min=4 * 60,
     initial=InitialConditions(T_room_C=19.0, T_rad_C=19.0),
     plant=PROFILE_STANDARD,

--- a/tests/benchmark/schedules.py
+++ b/tests/benchmark/schedules.py
@@ -245,6 +245,8 @@ def stochastic_windows(
     """
     if count <= 0:
         raise ValueError("count must be greater than 0")
+    if duration_s <= 0.0:
+        raise ValueError("duration_s must be greater than 0")
     if min_duration_s < 0.0 or max_duration_s < min_duration_s:
         raise ValueError(
             "duration bounds must satisfy 0 <= min_duration_s <= max_duration_s"

--- a/tests/benchmark/schedules.py
+++ b/tests/benchmark/schedules.py
@@ -301,7 +301,20 @@ def solar_trapezoid(
     -------
     Callable[[float], float]
         Schedule function ``t -> intensity``.
+
+    Raises
+    ------
+    ValueError
+        If the edges are not strictly ordered
+        ``t_rise_start < t_rise_end <= t_fall_start < t_fall_end`` (a
+        zero-width rising or falling edge would divide by zero).
     """
+    if not (t_rise_start < t_rise_end <= t_fall_start < t_fall_end):
+        raise ValueError(
+            "solar_trapezoid requires t_rise_start < t_rise_end <= "
+            "t_fall_start < t_fall_end, got "
+            f"({t_rise_start}, {t_rise_end}, {t_fall_start}, {t_fall_end})"
+        )
 
     def _f(t: float) -> float:
         if t < t_rise_start or t >= t_fall_end:

--- a/tests/benchmark/schedules.py
+++ b/tests/benchmark/schedules.py
@@ -1,0 +1,313 @@
+"""Reusable setpoint / outdoor / disturbance schedule builders.
+
+Every helper returns a function ``t -> value`` (or ``t -> bool``) that the
+scenario runner samples at each simulation tick. Keeping them in their own
+module lets ``scenarios.py`` stay a pure registry of ``ScenarioConfig``
+literals.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import math
+import random
+
+
+def step(t_threshold_s: float, before: float, after: float) -> Callable[[float], float]:
+    """Build a single-step schedule.
+
+    Parameters
+    ----------
+    t_threshold_s : float
+        Time of the step in seconds.
+    before : float
+        Value returned for ``t < t_threshold_s``.
+    after : float
+        Value returned for ``t >= t_threshold_s``.
+
+    Returns
+    -------
+    Callable[[float], float]
+        Schedule function ``t -> value``.
+    """
+    return lambda t: after if t >= t_threshold_s else before
+
+
+def constant(value: float) -> Callable[[float], float]:
+    """Build a time-independent constant schedule.
+
+    Parameters
+    ----------
+    value : float
+        Value returned for every ``t``.
+
+    Returns
+    -------
+    Callable[[float], float]
+        Schedule function ``t -> value``.
+    """
+    return lambda _t: value
+
+
+def pulse(
+    t_start_s: float, t_end_s: float, value: float, default: float = 0.0
+) -> Callable[[float], float]:
+    """Build a rectangular pulse schedule.
+
+    Parameters
+    ----------
+    t_start_s : float
+        Pulse start in seconds (inclusive).
+    t_end_s : float
+        Pulse end in seconds (exclusive).
+    value : float
+        Value returned inside ``[t_start_s, t_end_s)``.
+    default : float
+        Value returned outside the pulse.
+
+    Returns
+    -------
+    Callable[[float], float]
+        Schedule function ``t -> value``.
+    """
+    return lambda t: value if t_start_s <= t < t_end_s else default
+
+
+def pulse_bool(t_start_s: float, t_end_s: float) -> Callable[[float], bool]:
+    """Build a boolean pulse schedule.
+
+    Parameters
+    ----------
+    t_start_s : float
+        Pulse start in seconds (inclusive).
+    t_end_s : float
+        Pulse end in seconds (exclusive).
+
+    Returns
+    -------
+    Callable[[float], bool]
+        Schedule function returning True inside ``[t_start_s, t_end_s)``.
+    """
+    return lambda t: t_start_s <= t < t_end_s
+
+
+def ramp(
+    t_start_s: float,
+    t_end_s: float,
+    start_value: float,
+    end_value: float,
+    after: float | None = None,
+) -> Callable[[float], float]:
+    """Build a piecewise linear ramp schedule.
+
+    Constant ``start_value`` before ``t_start_s``, linear ramp to
+    ``end_value``, constant ``after`` (or ``end_value`` if unspecified)
+    afterwards.
+
+    Parameters
+    ----------
+    t_start_s : float
+        Ramp start in seconds. Must be strictly less than ``t_end_s``.
+    t_end_s : float
+        Ramp end in seconds.
+    start_value : float
+        Value before and at the start of the ramp.
+    end_value : float
+        Value at the end of the ramp.
+    after : float or None
+        Value after the ramp; defaults to ``end_value``.
+
+    Returns
+    -------
+    Callable[[float], float]
+        Schedule function ``t -> value``.
+
+    Raises
+    ------
+    ValueError
+        If ``t_end_s <= t_start_s``.
+    """
+    if t_end_s <= t_start_s:
+        raise ValueError("t_end_s must be greater than t_start_s")
+
+    final = after if after is not None else end_value
+
+    def _f(t: float) -> float:
+        if t < t_start_s:
+            return start_value
+        if t >= t_end_s:
+            return final
+        frac = (t - t_start_s) / (t_end_s - t_start_s)
+        return start_value + frac * (end_value - start_value)
+
+    return _f
+
+
+def piecewise_step(
+    pairs: list[tuple[float, float]], initial: float
+) -> Callable[[float], float]:
+    """Build a multi-step schedule from threshold/value pairs.
+
+    Parameters
+    ----------
+    pairs : list of tuple of float
+        ``(t_threshold_s, value)`` pairs; sorted internally.
+    initial : float
+        Value before the first threshold.
+
+    Returns
+    -------
+    Callable[[float], float]
+        Schedule function ``t -> value``.
+    """
+    sorted_pairs = sorted(pairs)
+
+    def _f(t: float) -> float:
+        value = initial
+        for t_thresh, v in sorted_pairs:
+            if t >= t_thresh:
+                value = v
+            else:
+                break
+        return value
+
+    return _f
+
+
+def sinus_diurnal(
+    min_value: float, max_value: float, period_h: float = 24.0, phase_min_h: float = 6.0
+) -> Callable[[float], float]:
+    """Build a sinusoidal diurnal schedule.
+
+    Minimum at simulation hour ``phase_min_h``; maximum ``period_h/2``
+    later. Used for BOPTEST/Sinergym-style outdoor diurnal cycles.
+
+    Parameters
+    ----------
+    min_value : float
+        Minimum of the sinusoid.
+    max_value : float
+        Maximum of the sinusoid.
+    period_h : float
+        Period in hours.
+    phase_min_h : float
+        Simulation hour at which the minimum occurs.
+
+    Returns
+    -------
+    Callable[[float], float]
+        Schedule function ``t -> value``.
+    """
+    period_s = period_h * 3600.0
+    offset_s = phase_min_h * 3600.0
+    amp = (max_value - min_value) / 2.0
+    mid = (max_value + min_value) / 2.0
+    return lambda t: mid - amp * math.cos(2.0 * math.pi * (t - offset_s) / period_s)
+
+
+def stochastic_windows(
+    seed: int,
+    count: int,
+    duration_s: float,
+    min_duration_s: float = 5 * 60.0,
+    max_duration_s: float = 30 * 60.0,
+) -> Callable[[float], bool]:
+    """Build a deterministic stochastic window-open schedule.
+
+    ``count`` non-overlapping events distributed roughly evenly over
+    ``duration_s`` — each event stays inside its own ``duration_s/count``
+    slot. Reproducible for a given ``seed`` (IEA Annex 79 residential
+    window-opening pattern, simplified).
+
+    Parameters
+    ----------
+    seed : int
+        RNG seed; identical seeds produce identical schedules.
+    count : int
+        Number of window-open events. Must be positive.
+    duration_s : float
+        Total schedule horizon in seconds.
+    min_duration_s : float
+        Lower bound of one event's duration in seconds.
+    max_duration_s : float
+        Upper bound of one event's duration in seconds.
+
+    Returns
+    -------
+    Callable[[float], bool]
+        Schedule function returning True while a window is open.
+
+    Raises
+    ------
+    ValueError
+        If ``count`` is not positive or the duration bounds are
+        inconsistent.
+    """
+    if count <= 0:
+        raise ValueError("count must be greater than 0")
+    if min_duration_s < 0.0 or max_duration_s < min_duration_s:
+        raise ValueError(
+            "duration bounds must satisfy 0 <= min_duration_s <= max_duration_s"
+        )
+
+    rng = random.Random(seed)
+    slot_s = duration_s / count
+    events: list[tuple[float, float]] = []
+    for i in range(count):
+        latest_start = slot_s - max_duration_s
+        if latest_start <= 0.0:
+            t_start = i * slot_s
+        else:
+            t_start = i * slot_s + rng.uniform(0.0, latest_start)
+        # Clamp the duration to the remaining slot budget so short slots
+        # cannot spill an event into the next slot.
+        slot_remaining = (i + 1) * slot_s - t_start
+        max_dur = min(max_duration_s, slot_remaining)
+        min_dur = min(min_duration_s, max_dur)
+        dur = rng.uniform(min_dur, max_dur)
+        events.append((t_start, t_start + dur))
+
+    def schedule(t: float) -> bool:
+        return any(start <= t < end for start, end in events)
+
+    return schedule
+
+
+def solar_trapezoid(
+    t_rise_start: float,
+    t_rise_end: float,
+    t_fall_start: float,
+    t_fall_end: float,
+    peak: float = 1.0,
+) -> Callable[[float], float]:
+    """Build a trapezoidal solar schedule: ramp up, plateau, ramp down.
+
+    Parameters
+    ----------
+    t_rise_start : float
+        Start of the rising edge in seconds.
+    t_rise_end : float
+        End of the rising edge / start of the plateau in seconds.
+    t_fall_start : float
+        End of the plateau / start of the falling edge in seconds.
+    t_fall_end : float
+        End of the falling edge in seconds.
+    peak : float
+        Plateau intensity (0.0 - 1.0).
+
+    Returns
+    -------
+    Callable[[float], float]
+        Schedule function ``t -> intensity``.
+    """
+
+    def _f(t: float) -> float:
+        if t < t_rise_start or t >= t_fall_end:
+            return 0.0
+        if t < t_rise_end:
+            return peak * (t - t_rise_start) / (t_rise_end - t_rise_start)
+        if t < t_fall_start:
+            return peak
+        return peak * (t_fall_end - t) / (t_fall_end - t_fall_start)
+
+    return _f

--- a/tests/benchmark/schedules.py
+++ b/tests/benchmark/schedules.py
@@ -197,7 +197,14 @@ def sinus_diurnal(
     -------
     Callable[[float], float]
         Schedule function ``t -> value``.
+
+    Raises
+    ------
+    ValueError
+        If ``period_h`` is not positive (the cosine argument divides by it).
     """
+    if period_h <= 0.0:
+        raise ValueError(f"sinus_diurnal period_h must be > 0, got {period_h}")
     period_s = period_h * 3600.0
     offset_s = phase_min_h * 3600.0
     amp = (max_value - min_value) / 2.0

--- a/tests/benchmark/tests/test_adapters.py
+++ b/tests/benchmark/tests/test_adapters.py
@@ -134,3 +134,10 @@ def test_oracle_feedback_uses_plant_truth():
     )
     out = adapter.step(ctx)
     assert out.diagnostics["error_K"] == pytest.approx(0.0)
+
+
+def test_benchmark_output_rejects_mismatched_duty_valve_mirror():
+    """duty_cycle_pct paired with a non-matching valve_percent is rejected."""
+    BenchmarkOutput(valve_percent=30.0, duty_cycle_pct=30.0)  # mirror OK
+    with pytest.raises(ValueError):
+        BenchmarkOutput(valve_percent=50.0, duty_cycle_pct=30.0)

--- a/tests/benchmark/tests/test_adapters.py
+++ b/tests/benchmark/tests/test_adapters.py
@@ -1,0 +1,136 @@
+"""Smoke tests for every controller adapter.
+
+These verify that each adapter:
+  - constructs cleanly with default params
+  - returns a sensible BenchmarkOutput on first step
+  - resets state without throwing
+  - exports state as a dict
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.benchmark.adapters.base import BenchmarkContext, BenchmarkOutput
+from tests.benchmark.adapters.baselines import (
+    BangBangAdapter,
+    IdealOracleAdapter,
+    LinearPAdapter,
+)
+from tests.benchmark.adapters.heating_power_adapter import HeatingPowerAdapter
+from tests.benchmark.adapters.mpc_adapter import MpcAdapter
+from tests.benchmark.adapters.passive_modes import (
+    AggressiveCalibrationAdapter,
+    DefaultCalibrationAdapter,
+    NoCalibrationAdapter,
+)
+from tests.benchmark.adapters.pid_adapter import PidAdapter
+from tests.benchmark.adapters.tpi_adapter import TpiAdapter
+
+_ADAPTERS = [
+    pytest.param(MpcAdapter, id="mpc"),
+    pytest.param(TpiAdapter, id="tpi"),
+    pytest.param(PidAdapter, id="pid"),
+    pytest.param(HeatingPowerAdapter, id="heating_power"),
+    pytest.param(DefaultCalibrationAdapter, id="default"),
+    pytest.param(AggressiveCalibrationAdapter, id="aggressive"),
+    pytest.param(NoCalibrationAdapter, id="no_calibration"),
+    pytest.param(BangBangAdapter, id="bangbang"),
+    pytest.param(LinearPAdapter, id="linear_p"),
+    pytest.param(IdealOracleAdapter, id="ideal_oracle"),
+]
+
+
+def _ctx(target: float = 21.0, current: float = 20.0) -> BenchmarkContext:
+    return BenchmarkContext(
+        t=0.0,
+        dt=30.0,
+        target_temp_C=target,
+        current_temp_C=current,
+        raw_room_temp_C=current,
+        trv_temp_C=current,
+        outdoor_temp_C=5.0,
+    )
+
+
+@pytest.mark.parametrize("adapter_cls", _ADAPTERS)
+def test_adapter_constructs_with_defaults(adapter_cls):
+    """Every adapter constructs cleanly with no arguments."""
+    adapter = adapter_cls()
+    assert adapter.name
+    assert adapter.family in ("valve", "offset", "duty")
+
+
+@pytest.mark.parametrize("adapter_cls", _ADAPTERS)
+def test_adapter_step_returns_output(adapter_cls):
+    """Calling step() returns a BenchmarkOutput with at least one populated field."""
+    adapter = adapter_cls()
+    out = adapter.step(_ctx())
+    populated = (
+        out.valve_percent is not None
+        or out.setpoint_offset_K is not None
+        or out.duty_cycle_pct is not None
+    )
+    assert populated, f"{adapter.name} produced an output with no populated field"
+
+
+@pytest.mark.parametrize("adapter_cls", _ADAPTERS)
+def test_adapter_reset_does_not_throw(adapter_cls):
+    """reset() must not raise even when called repeatedly."""
+    adapter = adapter_cls()
+    adapter.reset()
+    adapter.reset()
+    adapter.reset()
+
+
+@pytest.mark.parametrize("adapter_cls", _ADAPTERS)
+def test_adapter_export_state_is_dict(adapter_cls):
+    """export_state() returns a dict (possibly empty)."""
+    adapter = adapter_cls()
+    adapter.step(_ctx())
+    snapshot = adapter.export_state()
+    assert isinstance(snapshot, dict)
+
+
+def test_error_drives_demand_for_feedback_controllers():
+    """When current < setpoint, a P-controller and bang-bang command non-zero output."""
+    for adapter_cls in (LinearPAdapter, BangBangAdapter):
+        adapter = adapter_cls()
+        out = adapter.step(_ctx(target=22.0, current=18.0))
+        valve = out.valve_percent or 0.0
+        assert valve > 0.0, f"{adapter_cls.__name__} should command heat when cold"
+
+
+def test_benchmark_output_requires_exactly_one_family_field():
+    """The output contract rejects empty and mixed-family outputs."""
+    with pytest.raises(ValueError):
+        BenchmarkOutput()
+    with pytest.raises(ValueError):
+        BenchmarkOutput(valve_percent=50.0, setpoint_offset_K=1.0)
+    # The documented duty controllers' pairing stays allowed.
+    out = BenchmarkOutput(duty_cycle_pct=40.0, valve_percent=40.0)
+    assert out.duty_cycle_pct == 40.0
+
+
+def test_state_backed_adapters_use_unique_default_keys():
+    """Two default-keyed instances must not share controller state entries."""
+    for cls in (PidAdapter, TpiAdapter, MpcAdapter):
+        a, b = cls(), cls()
+        assert a._key != b._key
+    assert PidAdapter(key="shared")._key == "shared"
+
+
+def test_oracle_feedback_uses_plant_truth():
+    """The oracle's P-term reads the plant truth, not the lagged sensor."""
+    adapter = IdealOracleAdapter()
+    ctx = BenchmarkContext(
+        t=0.0,
+        dt=30.0,
+        target_temp_C=21.0,
+        current_temp_C=18.0,  # lagged/noisy sensor reading
+        raw_room_temp_C=21.0,  # plant truth already at setpoint
+        trv_temp_C=None,
+        outdoor_temp_C=5.0,
+    )
+    out = adapter.step(ctx)
+    assert out.diagnostics["error_K"] == pytest.approx(0.0)

--- a/tests/benchmark/tests/test_adapters.py
+++ b/tests/benchmark/tests/test_adapters.py
@@ -63,15 +63,15 @@ def test_adapter_constructs_with_defaults(adapter_cls):
 
 @pytest.mark.parametrize("adapter_cls", _ADAPTERS)
 def test_adapter_step_returns_output(adapter_cls):
-    """Calling step() returns a BenchmarkOutput with at least one populated field."""
+    """Calling step() succeeds and yields a BenchmarkOutput.
+
+    The one-populated-field contract itself is enforced (and separately
+    tested) in ``BenchmarkOutput.__post_init__``; this test pins that
+    every adapter's happy path gets through it without raising.
+    """
     adapter = adapter_cls()
     out = adapter.step(_ctx())
-    populated = (
-        out.valve_percent is not None
-        or out.setpoint_offset_K is not None
-        or out.duty_cycle_pct is not None
-    )
-    assert populated, f"{adapter.name} produced an output with no populated field"
+    assert isinstance(out, BenchmarkOutput)
 
 
 @pytest.mark.parametrize("adapter_cls", _ADAPTERS)
@@ -141,3 +141,68 @@ def test_benchmark_output_rejects_mismatched_duty_valve_mirror():
     BenchmarkOutput(valve_percent=30.0, duty_cycle_pct=30.0)  # mirror OK
     with pytest.raises(ValueError):
         BenchmarkOutput(valve_percent=50.0, duty_cycle_pct=30.0)
+
+
+def _ctx_at(t: float, target: float = 21.0, current: float = 20.0) -> BenchmarkContext:
+    return BenchmarkContext(
+        t=t,
+        dt=30.0,
+        target_temp_C=target,
+        current_temp_C=current,
+        raw_room_temp_C=current,
+        trv_temp_C=current,
+        outdoor_temp_C=5.0,
+    )
+
+
+def test_mpc_adapter_partitions_state_by_target_bucket():
+    """A setpoint move across a 0.5 K boundary allocates a new bucket state.
+
+    Mirrors production's ``build_mpc_key`` partitioning: one state per
+    0.5-K-rounded target, all buckets visible to ``compute_mpc`` for
+    sibling seeding.
+    """
+    adapter = MpcAdapter()
+    adapter.step(_ctx_at(0.0, target=21.0))
+    adapter.step(_ctx_at(30.0, target=22.3))  # rounds to bucket t22.5
+    keys = sorted(adapter._all_states)
+    assert len(keys) == 2
+    assert keys[0].endswith(":t21.0")
+    assert keys[1].endswith(":t22.5")
+
+
+def test_mpc_adapter_rehydrates_bucket_states_from_prior():
+    """reset(prior=export_state()) restores the per-bucket state map."""
+    adapter = MpcAdapter()
+    for i in range(5):
+        adapter.step(_ctx_at(i * 30.0))
+    snapshot = adapter.export_state()
+    assert snapshot  # at least one bucket learned
+    adapter.reset(prior=snapshot)
+    assert set(adapter._all_states) == set(snapshot)
+    adapter.reset()
+    assert adapter._all_states == {}
+
+
+def test_pid_adapter_rehydrates_from_prior():
+    """reset(prior=export_state()) restores PID internals."""
+    adapter = PidAdapter()
+    for i in range(5):
+        adapter.step(_ctx_at(i * 30.0))
+    snapshot = adapter.export_state()
+    integral = adapter._state.pid_integral
+    last_percent = adapter._state.last_percent
+    adapter.reset(prior=snapshot)
+    assert adapter._state.pid_integral == integral
+    assert adapter._state.last_percent == last_percent
+
+
+def test_tpi_adapter_rehydrates_from_prior():
+    """reset(prior=export_state()) restores TPI internals."""
+    adapter = TpiAdapter()
+    for i in range(5):
+        adapter.step(_ctx_at(i * 30.0))
+    snapshot = adapter.export_state()
+    last_percent = adapter._state.last_percent
+    adapter.reset(prior=snapshot)
+    assert adapter._state.last_percent == last_percent

--- a/tests/benchmark/tests/test_heating_power_adapter.py
+++ b/tests/benchmark/tests/test_heating_power_adapter.py
@@ -1,0 +1,183 @@
+"""HeatingPower adapter tests."""
+
+from __future__ import annotations
+
+from custom_components.better_thermostat.utils.const import (
+    MAX_HEATING_POWER,
+    MIN_HEATING_POWER,
+    VALVE_MIN_OPENING_LARGE_DIFF,
+)
+from tests.benchmark.adapters.base import BenchmarkContext
+from tests.benchmark.adapters.heating_power_adapter import HeatingPowerAdapter
+
+
+def _ctx(
+    t: float = 0.0, target: float = 21.0, current: float = 20.0
+) -> BenchmarkContext:
+    return BenchmarkContext(
+        t=t,
+        dt=30.0,
+        target_temp_C=target,
+        current_temp_C=current,
+        raw_room_temp_C=current,
+        trv_temp_C=current,
+        outdoor_temp_C=5.0,
+    )
+
+
+def test_name_and_family():
+    """Name and family."""
+    adapter = HeatingPowerAdapter()
+    assert adapter.name == "heating_power"
+    assert adapter.family == "valve"
+
+
+def test_initial_heating_power_is_clamped_to_realistic_range():
+    """Initial heating power is clamped to realistic range."""
+    too_low = HeatingPowerAdapter(initial_heating_power=0.0001)
+    too_high = HeatingPowerAdapter(initial_heating_power=10.0)
+    assert too_low.heating_power == MIN_HEATING_POWER
+    assert too_high.heating_power == MAX_HEATING_POWER
+
+
+def test_zero_demand_produces_zero_valve():
+    """At-target or over-target → zero valve."""
+    adapter = HeatingPowerAdapter()
+    assert adapter.step(_ctx(target=20.0, current=20.0)).valve_percent == 0.0
+    assert adapter.step(_ctx(target=20.0, current=22.0)).valve_percent == 0.0
+
+
+def test_positive_demand_produces_positive_valve():
+    """Positive demand produces positive valve."""
+    adapter = HeatingPowerAdapter()
+    out = adapter.step(_ctx(target=21.0, current=20.0))
+    assert out.valve_percent is not None
+    assert out.valve_percent > 0.0
+
+
+def test_large_diff_enforces_min_opening():
+    """Large diff enforces min opening."""
+    # With a fast heating_power the formula would underestimate; the
+    # minimum-opening floor for diff > 0.3 K kicks in regardless.
+    adapter = HeatingPowerAdapter(initial_heating_power=MAX_HEATING_POWER)
+    out = adapter.step(_ctx(target=22.0, current=20.0))
+    assert out.valve_percent is not None
+    assert out.valve_percent >= VALVE_MIN_OPENING_LARGE_DIFF * 100.0
+
+
+def test_valve_clamps_to_100_when_demand_is_extreme():
+    """Valve clamps to 100 when demand is extreme."""
+    adapter = HeatingPowerAdapter(initial_heating_power=MIN_HEATING_POWER)
+    out = adapter.step(_ctx(target=22.0, current=18.0))
+    assert out.valve_percent is not None
+    assert out.valve_percent == 100.0
+
+
+def test_reset_clears_cycle_and_restores_initial_power():
+    """Reset clears cycle and restores initial power."""
+    adapter = HeatingPowerAdapter(initial_heating_power=0.02)
+    # Drive a heating cycle so internal state populates.
+    for t in range(30):
+        adapter.step(_ctx(t=t * 30.0, target=21.0, current=20.0))
+    adapter.heating_power = 0.05  # mutate to verify reset path
+    adapter.reset()
+    assert adapter.heating_power == 0.02
+    assert adapter._cycle_start_temp is None
+
+
+def test_reset_seeds_from_prior():
+    """Reset seeds from prior."""
+    adapter = HeatingPowerAdapter(initial_heating_power=0.02)
+    adapter.reset(prior={"heating_power": 0.05})
+    assert adapter.heating_power == 0.05
+
+
+def test_reset_ignores_non_numeric_prior():
+    """Reset ignores non numeric prior."""
+    adapter = HeatingPowerAdapter(initial_heating_power=0.02)
+    adapter.reset(prior={"heating_power": "garbage"})
+    assert adapter.heating_power == 0.02
+
+
+def test_reset_clamps_seeded_power():
+    """Reset clamps seeded power."""
+    adapter = HeatingPowerAdapter()
+    adapter.reset(prior={"heating_power": 5.0})
+    assert adapter.heating_power == MAX_HEATING_POWER
+
+
+def test_export_state_includes_heating_power():
+    """Export state includes heating power."""
+    adapter = HeatingPowerAdapter(initial_heating_power=0.03)
+    snapshot = adapter.export_state()
+    assert snapshot["heating_power"] == 0.03
+
+
+def test_diagnostics_expose_heating_power():
+    """Diagnostics expose heating power."""
+    adapter = HeatingPowerAdapter()
+    out = adapter.step(_ctx(target=21.0, current=20.0))
+    assert out.diagnostics["heating_power"] == adapter.heating_power
+
+
+def test_cycle_finalizes_when_room_cools_after_peak():
+    """Cycle finalizes when room cools after peak."""
+    adapter = HeatingPowerAdapter(initial_heating_power=0.02)
+    # Phase 1: warm valve-open phase for 10 minutes, room rises 20 → 21.
+    for i in range(20):
+        cur = 20.0 + 0.05 * i
+        adapter.step(_ctx(t=i * 30.0, target=22.0, current=cur))
+    # Phase 2: target reached → valve closes. Room peaks at 21.2 then falls.
+    adapter.step(_ctx(t=20 * 30.0, target=20.5, current=21.2))  # cycle end (valve = 0)
+    adapter.step(_ctx(t=21 * 30.0, target=20.5, current=21.0))  # cooling → finalize
+    # heating_power should have moved off its initial value.
+    assert adapter.heating_power != 0.02
+    # And cycle state has been cleared.
+    assert adapter._cycle_start_temp is None
+
+
+def test_cycle_finalize_clamps_to_max():
+    """Cycle finalize clamps to max."""
+    adapter = HeatingPowerAdapter(initial_heating_power=MAX_HEATING_POWER)
+    # Implausibly fast heating: 5 K in 5 minutes = 1 K/min, way above MAX.
+    for i in range(10):
+        adapter.step(_ctx(t=i * 30.0, target=25.0, current=20.0 + 0.5 * i))
+    adapter.step(_ctx(t=10 * 30.0, target=22.0, current=25.0))  # cycle end
+    adapter.step(_ctx(t=11 * 30.0, target=22.0, current=24.0))  # cooling → finalize
+    assert adapter.heating_power <= MAX_HEATING_POWER
+
+
+def test_short_cycle_does_not_update_heating_power():
+    """Cycles shorter than 1 minute are discarded."""
+    adapter = HeatingPowerAdapter(initial_heating_power=0.02)
+    # Open valve for one 30 s step, then close.
+    adapter.step(_ctx(t=0.0, target=21.0, current=20.0))  # heating starts
+    adapter.step(_ctx(t=20.0, target=20.0, current=20.5))  # valve = 0, peak
+    adapter.step(_ctx(t=40.0, target=20.0, current=20.3))  # cooling → finalize
+    # Duration was well below _MIN_CYCLE_DURATION (1 min) → no update.
+    assert adapter.heating_power == 0.02
+
+
+def test_repeated_steps_are_deterministic():
+    """Repeated steps are deterministic."""
+    a = HeatingPowerAdapter()
+    b = HeatingPowerAdapter()
+    for t in range(50):
+        out_a = a.step(_ctx(t=t * 30.0, target=21.0, current=20.0 + 0.01 * t))
+        out_b = b.step(_ctx(t=t * 30.0, target=21.0, current=20.0 + 0.01 * t))
+        assert out_a.valve_percent == out_b.valve_percent
+    assert a.heating_power == b.heating_power
+
+
+def test_cycle_finalizes_when_heating_resumes_before_cooldown():
+    """Demand resuming above the tracked peak still finalizes the cycle."""
+    adapter = HeatingPowerAdapter(initial_heating_power=0.02)
+    # Heating phase: room 20 → 21 over 10 minutes.
+    for i in range(20):
+        adapter.step(_ctx(t=i * 30.0, target=22.0, current=20.0 + 0.05 * i))
+    # Valve closes and the post-heat peak is tracked, but demand resumes
+    # before the room ever cools below that peak.
+    adapter.step(_ctx(t=20 * 30.0, target=20.5, current=21.2))  # valve = 0, peak
+    adapter.step(_ctx(t=21 * 30.0, target=23.0, current=21.2))  # heating resumes
+    # The finished cycle updated the learner instead of being dropped.
+    assert adapter.heating_power != 0.02

--- a/tests/benchmark/tests/test_heating_power_adapter.py
+++ b/tests/benchmark/tests/test_heating_power_adapter.py
@@ -181,3 +181,27 @@ def test_cycle_finalizes_when_heating_resumes_before_cooldown():
     adapter.step(_ctx(t=21 * 30.0, target=23.0, current=21.2))  # heating resumes
     # The finished cycle updated the learner instead of being dropped.
     assert adapter.heating_power != 0.02
+
+
+def test_finalize_uses_production_adaptive_alpha():
+    """The EMA smoothing factor follows the production weight/env formula.
+
+    Hand-computed: rate = 0.5 K / 10 min = 0.05; weight factor 1.1
+    (target 20.4 in the observed 18..22 range), env factor 0.77
+    (outdoor 5 C), alpha = 0.1 * 1.1 * 0.77 = 0.0847;
+    ema(0.02, 0.05, 0.0847) rounded to 4 decimals = 0.0225.
+    """
+    adapter = HeatingPowerAdapter(initial_heating_power=0.02)
+    adapter.step(_ctx(t=0.0, target=22.0, current=20.0))  # heating starts
+    adapter.step(_ctx(t=600.0, target=20.4, current=20.5))  # valve closes, peak
+    adapter.step(_ctx(t=630.0, target=20.4, current=20.3))  # cooling -> finalize
+    assert abs(adapter.heating_power - 0.0225) < 1e-9
+
+
+def test_observed_targets_widen_the_weight_range():
+    """Observed setpoints expand the production-mirrored target range."""
+    adapter = HeatingPowerAdapter()
+    adapter.step(_ctx(t=0.0, target=25.0, current=20.0))
+    adapter.step(_ctx(t=30.0, target=16.0, current=20.0))
+    assert adapter._min_target == 16.0
+    assert adapter._max_target == 25.0

--- a/tests/benchmark/tests/test_indirect_trv.py
+++ b/tests/benchmark/tests/test_indirect_trv.py
@@ -230,3 +230,33 @@ def test_reset_restores_exported_state():
     adapter.reset()
     assert adapter._last_quantised_setpoint_C is None
     assert adapter._pending_setpoints == []
+
+
+class _FakeOffsetAdapter:
+    """Inner adapter that emits a non-valve (offset) output."""
+
+    name = "fake_offset"
+    family = "offset"
+
+    def reset(self, prior=None) -> None:
+        _ = prior
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        _ = ctx
+        return BenchmarkOutput(setpoint_offset_K=1.0)
+
+    def export_state(self) -> dict:
+        return {}
+
+
+def test_indirect_params_rejects_invalid_mapping():
+    """An unknown setpoint_mapping is rejected at construction."""
+    with pytest.raises(ValueError):
+        IndirectTrvParams(setpoint_mapping="bogus")
+
+
+def test_indirect_rejects_missing_inner_valve():
+    """Wrapping a non-valve inner controller fails fast instead of coercing to 0%."""
+    wrapper = IndirectTrvAdapter(_FakeOffsetAdapter(), TADO_PARAMS)
+    with pytest.raises(ValueError):
+        wrapper.step(_ctx())

--- a/tests/benchmark/tests/test_indirect_trv.py
+++ b/tests/benchmark/tests/test_indirect_trv.py
@@ -1,0 +1,232 @@
+"""Indirect-TRV wrapper tests.
+
+The wrapper translates an inner controller's valve-% intent through an
+offset-mode TRV's own setpoint-quantisation + internal P-loop. These
+tests verify each of those stages in isolation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.benchmark.adapters.base import BenchmarkContext, BenchmarkOutput
+from tests.benchmark.adapters.indirect_trv import (
+    BOSCH_PARAMS,
+    SONOFF_TRVZB_PARAMS,
+    TADO_PARAMS,
+    TUYA_PARAMS,
+    IndirectTrvAdapter,
+    IndirectTrvParams,
+)
+from tests.benchmark.adapters.pid_adapter import PidAdapter
+
+
+class _FakeValveAdapter:
+    """Inner adapter whose valve demand is controlled by the test."""
+
+    name = "fake"
+    family = "valve"
+
+    def __init__(self, pct: float) -> None:
+        self.pct = pct
+
+    def reset(self, prior=None) -> None:
+        _ = prior
+
+    def step(self, ctx: BenchmarkContext) -> BenchmarkOutput:
+        _ = ctx
+        return BenchmarkOutput(valve_percent=self.pct)
+
+    def export_state(self) -> dict:
+        return {}
+
+
+def _ctx(target: float = 21.0, current: float = 20.0) -> BenchmarkContext:
+    return BenchmarkContext(
+        t=0.0,
+        dt=30.0,
+        target_temp_C=target,
+        current_temp_C=current,
+        raw_room_temp_C=current,
+        trv_temp_C=current,
+        outdoor_temp_C=5.0,
+    )
+
+
+def test_name_inherits_from_inner_with_suffix():
+    """Name inherits from inner with suffix."""
+    adapter = IndirectTrvAdapter(PidAdapter(), TADO_PARAMS)
+    assert adapter.name == "pid+indirect_trv"
+
+
+def test_reset_clears_internal_caches():
+    """Reset clears internal caches."""
+    adapter = IndirectTrvAdapter(PidAdapter(), TADO_PARAMS)
+    adapter.step(_ctx(target=22.0, current=18.0))
+    assert adapter._last_quantised_setpoint_C is not None
+    adapter.reset()
+    assert adapter._last_quantised_setpoint_C is None
+    assert adapter._pending_setpoints == []
+
+
+def test_step_returns_valve_in_range():
+    """Step returns valve in range."""
+    adapter = IndirectTrvAdapter(PidAdapter(), TADO_PARAMS)
+    out = adapter.step(_ctx(target=22.0, current=18.0))
+    assert out.valve_percent is not None
+    assert 0.0 <= out.valve_percent <= 100.0
+
+
+def test_diagnostics_include_indirect_keys():
+    """Diagnostics include indirect keys."""
+    adapter = IndirectTrvAdapter(PidAdapter(), TADO_PARAMS)
+    out = adapter.step(_ctx(target=21.0, current=20.0))
+    assert "indirect_setpoint_C" in out.diagnostics
+    assert "indirect_quantised_diff_K" in out.diagnostics
+
+
+def test_export_state_includes_inner_and_setpoint():
+    """Export state includes inner and setpoint."""
+    adapter = IndirectTrvAdapter(PidAdapter(), TADO_PARAMS)
+    adapter.step(_ctx(target=22.0, current=18.0))
+    snapshot = adapter.export_state()
+    assert "inner" in snapshot
+    assert "last_quantised_setpoint_C" in snapshot
+    assert snapshot["last_quantised_setpoint_C"] is not None
+
+
+def test_quantisation_to_setpoint_step():
+    """Tuya params (1 K step) should produce integer-K setpoints."""
+    adapter = IndirectTrvAdapter(PidAdapter(), TUYA_PARAMS)
+    out = adapter.step(_ctx(target=21.0, current=18.0))
+    sp = out.diagnostics["indirect_setpoint_C"]
+    # 1 K quantisation → setpoint is an integer.
+    assert abs(sp - round(sp)) < 1e-6
+
+
+def test_hysteresis_holds_old_setpoint_inside_band():
+    """Hysteresis holds old setpoint inside band."""
+    # Tight hysteresis on a 0.5 K step: a tiny u-change inside the
+    # hysteresis band must hold the previous setpoint.
+    params = IndirectTrvParams(
+        setpoint_step_K=0.5, internal_hysteresis_K=2.0, internal_p_gain=30.0
+    )
+    adapter = IndirectTrvAdapter(PidAdapter(), params)
+    adapter.step(_ctx(target=22.0, current=18.0))  # big jump first
+    first_sp = adapter._last_quantised_setpoint_C
+    # Same call → setpoint must stay (within hysteresis).
+    adapter.step(_ctx(target=22.0, current=18.0))
+    assert adapter._last_quantised_setpoint_C == first_sp
+
+
+def test_command_latency_delays_setpoint_change():
+    """A setpoint change reaches the TRV only after command_latency_steps."""
+    params = IndirectTrvParams(
+        setpoint_step_K=0.5,
+        internal_hysteresis_K=0.0,
+        internal_p_gain=30.0,
+        command_latency_steps=3,
+    )
+    inner = _FakeValveAdapter(0.0)
+    adapter = IndirectTrvAdapter(inner, params)
+    # Saturate the FIFO with the all-closed command (setpoint == target).
+    out = adapter.step(_ctx(target=22.0, current=18.0))
+    for _ in range(4):
+        out = adapter.step(_ctx(target=22.0, current=18.0))
+    old_sp = out.diagnostics["indirect_setpoint_C"]
+    assert old_sp == pytest.approx(22.0)
+
+    # Inner controller now demands full heat → new setpoint target+headroom.
+    inner.pct = 100.0
+    for _ in range(params.command_latency_steps):
+        out = adapter.step(_ctx(target=22.0, current=18.0))
+        assert out.diagnostics["indirect_setpoint_C"] == pytest.approx(old_sp)
+    out = adapter.step(_ctx(target=22.0, current=18.0))
+    assert out.diagnostics["indirect_setpoint_C"] == pytest.approx(
+        22.0 + params.max_calibration_headroom_K
+    )
+    assert len(adapter._pending_setpoints) <= params.command_latency_steps + 1
+
+
+def test_inversion_mapping_uses_current_temp():
+    """Inversion mapping uses current temp."""
+    params = IndirectTrvParams(
+        setpoint_step_K=0.5,
+        internal_hysteresis_K=0.0,
+        internal_p_gain=30.0,
+        setpoint_mapping="inversion",
+    )
+    adapter = IndirectTrvAdapter(PidAdapter(), params)
+    out = adapter.step(_ctx(target=21.0, current=19.0))
+    # Inversion ⇒ setpoint = current + bt_u/p_gain. Should be in a
+    # plausible range above current_temp.
+    sp = out.diagnostics["indirect_setpoint_C"]
+    assert sp >= 19.0
+
+
+def test_heuristic_mapping_uses_target_temp():
+    """Heuristic mapping uses target temp."""
+    params = IndirectTrvParams(
+        setpoint_step_K=0.5,
+        internal_hysteresis_K=0.0,
+        internal_p_gain=30.0,
+        setpoint_mapping="heuristic",
+        max_calibration_headroom_K=5.0,
+    )
+    adapter = IndirectTrvAdapter(PidAdapter(), params)
+    out = adapter.step(_ctx(target=21.0, current=19.0))
+    sp = out.diagnostics["indirect_setpoint_C"]
+    # Heuristic ⇒ setpoint = target + headroom · u/100 ∈ [target, target+headroom].
+    assert 21.0 - 0.5 <= sp <= 21.0 + 5.0 + 0.5
+
+
+def test_p_gain_clamps_internal_command_to_0_to_100():
+    """Very high error must clamp the internal valve command to 100 %."""
+    adapter = IndirectTrvAdapter(PidAdapter(), TADO_PARAMS)
+    out = adapter.step(_ctx(target=30.0, current=10.0))  # 20 K error
+    assert out.valve_percent is not None
+    assert out.valve_percent == 100.0
+
+
+def test_zero_error_yields_zero_valve():
+    """Zero error yields zero valve."""
+    adapter = IndirectTrvAdapter(PidAdapter(), TADO_PARAMS)
+    # Inner PID with target == current → zero demand; quantised setpoint
+    # lands at/near room temp, so internal P-loop produces ~0 %.
+    out = adapter.step(_ctx(target=20.0, current=20.0))
+    assert out.valve_percent is not None
+    assert out.valve_percent == pytest.approx(0.0, abs=1e-6)
+
+
+@pytest.mark.parametrize(
+    "preset", [TADO_PARAMS, BOSCH_PARAMS, TUYA_PARAMS, SONOFF_TRVZB_PARAMS]
+)
+def test_every_vendor_preset_drives_a_full_step_cleanly(preset):
+    """Every vendor preset drives a full step cleanly."""
+    adapter = IndirectTrvAdapter(PidAdapter(), preset)
+    out = adapter.step(_ctx(target=22.0, current=19.0))
+    assert out.valve_percent is not None
+    assert 0.0 <= out.valve_percent <= 100.0
+
+
+def test_reset_restores_exported_state():
+    """``reset(export_state())`` restores the wrapper's TRV-layer cache."""
+    params = IndirectTrvParams(
+        setpoint_step_K=0.5,
+        internal_hysteresis_K=0.0,
+        internal_p_gain=30.0,
+        command_latency_steps=2,
+    )
+    adapter = IndirectTrvAdapter(_FakeValveAdapter(100.0), params)
+    for _ in range(3):
+        adapter.step(_ctx(target=22.0, current=18.0))
+    snapshot = adapter.export_state()
+    assert snapshot["pending_setpoints"]
+
+    adapter.reset(snapshot)
+    assert adapter._last_quantised_setpoint_C == snapshot["last_quantised_setpoint_C"]
+    assert adapter._pending_setpoints == snapshot["pending_setpoints"]
+
+    adapter.reset()
+    assert adapter._last_quantised_setpoint_C is None
+    assert adapter._pending_setpoints == []

--- a/tests/benchmark/tests/test_passive_modes.py
+++ b/tests/benchmark/tests/test_passive_modes.py
@@ -1,0 +1,177 @@
+"""Tests for BT's offset-family calibration modes."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.benchmark.adapters.base import BenchmarkContext
+from tests.benchmark.adapters.passive_modes import (
+    AggressiveCalibrationAdapter,
+    DefaultCalibrationAdapter,
+    NoCalibrationAdapter,
+    PassiveModeParams,
+)
+
+
+def _ctx(
+    target: float = 21.0, current: float = 20.0, trv: float | None = 20.0
+) -> BenchmarkContext:
+    return BenchmarkContext(
+        t=0.0,
+        dt=30.0,
+        target_temp_C=target,
+        current_temp_C=current,
+        raw_room_temp_C=current,
+        trv_temp_C=trv,
+        outdoor_temp_C=5.0,
+    )
+
+
+# -- DefaultCalibrationAdapter ------------------------------------------------
+
+
+def test_default_zero_demand_yields_zero_valve():
+    """At-target → zero valve."""
+    out = DefaultCalibrationAdapter().step(_ctx(target=20.0, current=20.0))
+    assert out.valve_percent == 0.0
+
+
+def test_default_negative_error_clamps_to_zero():
+    """Room warmer than target → clamped to zero."""
+    out = DefaultCalibrationAdapter().step(_ctx(target=20.0, current=22.0))
+    assert out.valve_percent == 0.0
+
+
+def test_default_proportional_to_error():
+    """Valve = 30 %/K · error, e.g. 1 K → 30 %."""
+    out = DefaultCalibrationAdapter().step(_ctx(target=21.0, current=20.0))
+    assert out.valve_percent == pytest.approx(30.0)
+
+
+def test_default_saturates_at_100():
+    """Large error clamps to 100 %."""
+    out = DefaultCalibrationAdapter().step(_ctx(target=25.0, current=20.0))
+    assert out.valve_percent == 100.0
+
+
+def test_default_ignores_trv_temp():
+    """DEFAULT regulates against the external sensor, not the TRV body."""
+    # External says 20, TRV body says 25. DEFAULT must use the external value.
+    out = DefaultCalibrationAdapter().step(_ctx(target=21.0, current=20.0, trv=25.0))
+    assert out.valve_percent == pytest.approx(30.0)
+
+
+def test_default_custom_gain():
+    """Custom p_gain overrides the default 30 %/K."""
+    adapter = DefaultCalibrationAdapter(PassiveModeParams(p_gain=15.0))
+    out = adapter.step(_ctx(target=21.0, current=20.0))
+    assert out.valve_percent == pytest.approx(15.0)
+
+
+# -- AggressiveCalibrationAdapter --------------------------------------------
+
+
+def test_aggressive_zero_error_yields_zero_valve():
+    """At-target → no boost, valve = 0."""
+    out = AggressiveCalibrationAdapter().step(_ctx(target=20.0, current=20.0))
+    assert out.valve_percent == 0.0
+
+
+def test_aggressive_negative_error_clamps_to_zero():
+    """Above target → clamped to 0 (no boost when not heating)."""
+    out = AggressiveCalibrationAdapter().step(_ctx(target=20.0, current=22.0))
+    assert out.valve_percent == 0.0
+
+
+def test_aggressive_adds_2_5_K_boost_while_heating():
+    """1 K error + 2.5 K boost = 30 + 75 = 105 → clamped to 100."""
+    out = AggressiveCalibrationAdapter().step(_ctx(target=21.0, current=20.0))
+    assert out.valve_percent == 100.0
+
+
+def test_aggressive_small_error_with_boost_still_in_range():
+    """Even a tiny error gets the boost: 0.1 K → 3 + 75 = 78 %."""
+    out = AggressiveCalibrationAdapter().step(_ctx(target=20.1, current=20.0))
+    assert out.valve_percent == pytest.approx(78.0)
+
+
+def test_aggressive_diagnostics_expose_boost_amount():
+    """Diagnostics include the boost contribution."""
+    out = AggressiveCalibrationAdapter().step(_ctx(target=21.0, current=20.0))
+    assert out.diagnostics["boost_pct"] == pytest.approx(75.0)
+    out_off = AggressiveCalibrationAdapter().step(_ctx(target=20.0, current=22.0))
+    assert out_off.diagnostics["boost_pct"] == 0.0
+
+
+def test_aggressive_reset_clears_was_heating():
+    """Reset flips the latched ``was_heating`` flag back off."""
+    adapter = AggressiveCalibrationAdapter()
+    adapter.step(_ctx(target=21.0, current=20.0))
+    assert adapter.export_state()["was_heating"]
+    adapter.reset()
+    assert not adapter.export_state()["was_heating"]
+
+
+# -- NoCalibrationAdapter ----------------------------------------------------
+
+
+def test_no_calibration_uses_trv_internal_sensor():
+    """NO_CALIBRATION regulates against ``trv_temp_C``, not the room sensor."""
+    # Room says 20 (cold), TRV body says 22 (warm radiator backsplash).
+    # The TRV's P-loop sees target − trv = 21 − 22 = −1 → clamped to 0 %.
+    out = NoCalibrationAdapter().step(_ctx(target=21.0, current=20.0, trv=22.0))
+    assert out.valve_percent == 0.0
+
+
+def test_no_calibration_falls_back_to_external_when_trv_missing():
+    """Sensorless plant variant: fall back to room reading."""
+    out = NoCalibrationAdapter().step(_ctx(target=21.0, current=20.0, trv=None))
+    assert out.valve_percent == pytest.approx(30.0)
+
+
+def test_no_calibration_proportional_to_trv_error():
+    """1 K of TRV-internal error → 30 %."""
+    out = NoCalibrationAdapter().step(_ctx(target=21.0, current=20.0, trv=20.0))
+    assert out.valve_percent == pytest.approx(30.0)
+
+
+def test_no_calibration_diagnostics_show_which_temp_was_used():
+    """``trv_temp_used_C`` reflects the actual reference temperature."""
+    out = NoCalibrationAdapter().step(_ctx(target=21.0, current=20.0, trv=20.5))
+    assert out.diagnostics["trv_temp_used_C"] == 20.5
+
+
+# -- Cross-cutting -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "adapter_cls",
+    [DefaultCalibrationAdapter, AggressiveCalibrationAdapter, NoCalibrationAdapter],
+)
+def test_all_passive_adapters_have_valve_family(adapter_cls):
+    """All three modes are valve-family controllers."""
+    assert adapter_cls().family == "valve"
+
+
+@pytest.mark.parametrize(
+    "adapter_cls,expected_name",
+    [
+        (DefaultCalibrationAdapter, "default"),
+        (AggressiveCalibrationAdapter, "aggressive"),
+        (NoCalibrationAdapter, "no_calibration"),
+    ],
+)
+def test_adapter_names_match_calibration_mode(adapter_cls, expected_name):
+    """Adapter name matches its production CalibrationMode key."""
+    assert adapter_cls().name == expected_name
+
+
+@pytest.mark.parametrize(
+    "adapter_cls",
+    [DefaultCalibrationAdapter, AggressiveCalibrationAdapter, NoCalibrationAdapter],
+)
+def test_export_state_is_dict(adapter_cls):
+    """``export_state`` returns a serializable dict."""
+    adapter = adapter_cls()
+    adapter.step(_ctx())
+    assert isinstance(adapter.export_state(), dict)

--- a/tests/benchmark/tests/test_passive_modes.py
+++ b/tests/benchmark/tests/test_passive_modes.py
@@ -103,13 +103,13 @@ def test_aggressive_diagnostics_expose_boost_amount():
     assert out_off.diagnostics["boost_pct"] == 0.0
 
 
-def test_aggressive_reset_clears_was_heating():
-    """Reset flips the latched ``was_heating`` flag back off."""
+def test_aggressive_is_stateless():
+    """The adapter carries no state across steps or resets."""
     adapter = AggressiveCalibrationAdapter()
     adapter.step(_ctx(target=21.0, current=20.0))
-    assert adapter.export_state()["was_heating"]
+    assert adapter.export_state() == {}
     adapter.reset()
-    assert not adapter.export_state()["was_heating"]
+    assert adapter.export_state() == {}
 
 
 # -- NoCalibrationAdapter ----------------------------------------------------

--- a/tests/benchmark/tests/test_production_drift.py
+++ b/tests/benchmark/tests/test_production_drift.py
@@ -1,0 +1,89 @@
+"""Drift guards binding benchmark adapters to their production sources.
+
+The benchmark is only meaningful if its adapters reproduce the deployed
+calibration logic. Most adapters call the production functions directly
+(``compute_mpc`` / ``compute_pid`` / ``compute_tpi``) and cannot drift.
+The heating-power adapter is the exception: it re-implements the
+valve-position state machine in pure Python (production's
+``heating_power_valve_position`` is bolted onto the HA entity and cannot
+be called headless). That re-implementation duplicates the production
+formula and its tuning constants, so it can silently drift when the
+production heuristic changes.
+
+This test pins the duplication: it drives the *real* production function
+through a fake entity across a grid of ``(temp_diff, heating_power)`` and
+asserts the benchmark adapter produces the identical valve position. If
+anyone retunes ``heating_power_valve_position`` (coefficients, floors,
+clamping) without updating the adapter, this fails.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.better_thermostat.utils.helpers import (
+    heating_power_valve_position,
+)
+from tests.benchmark.adapters.base import BenchmarkContext
+from tests.benchmark.adapters.heating_power_adapter import HeatingPowerAdapter
+
+# Cover the full heating regime: tiny error (minimum-opening floors),
+# mid-range, and saturation, across the learned heating-power band.
+_TEMP_DIFFS_K = [0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 2.0, 3.5, 5.0]
+_HEATING_POWERS = [0.005, 0.01, 0.02, 0.035, 0.05]
+
+
+def _production_valve_pct(temp_diff_K: float, heating_power: float) -> float:
+    """Run the real production formula and return valve percent (0..100)."""
+    fake_entity = SimpleNamespace(
+        bt_target_temp=20.0 + temp_diff_K,
+        cur_temp=20.0,
+        heating_power=heating_power,
+        device_name="drift-guard",
+    )
+    valve_fraction = heating_power_valve_position(fake_entity, "drift_guard_trv")
+    return valve_fraction * 100.0
+
+
+def _adapter_valve_pct(temp_diff_K: float, heating_power: float) -> float:
+    """Run the benchmark adapter's formula and return valve percent (0..100)."""
+    adapter = HeatingPowerAdapter(initial_heating_power=heating_power)
+    adapter.heating_power = heating_power
+    ctx = BenchmarkContext(
+        t=0.0,
+        dt=30.0,
+        target_temp_C=20.0 + temp_diff_K,
+        current_temp_C=20.0,
+        raw_room_temp_C=20.0,
+        trv_temp_C=None,
+        outdoor_temp_C=5.0,
+    )
+    return adapter._compute_valve_pct(ctx)
+
+
+@pytest.mark.parametrize("temp_diff_K", _TEMP_DIFFS_K)
+@pytest.mark.parametrize("heating_power", _HEATING_POWERS)
+def test_heating_power_adapter_matches_production(
+    temp_diff_K: float, heating_power: float
+) -> None:
+    """Adapter valve position equals the production heuristic across the grid."""
+    expected = _production_valve_pct(temp_diff_K, heating_power)
+    actual = _adapter_valve_pct(temp_diff_K, heating_power)
+    assert actual == pytest.approx(expected, abs=1e-9), (
+        f"heating-power adapter drifted from production at "
+        f"temp_diff={temp_diff_K} K, heating_power={heating_power}: "
+        f"adapter={actual:.6f}%, production={expected:.6f}%"
+    )
+
+
+def test_non_heating_returns_zero_in_both() -> None:
+    """Room at/above target → both production and adapter command 0 %."""
+    assert _production_valve_pct(0.0, 0.02) == 0.0
+    assert _adapter_valve_pct(0.0, 0.02) == 0.0
+    # Room above target (negative diff): production short-circuits to 0.
+    fake_entity = SimpleNamespace(
+        bt_target_temp=19.5, cur_temp=20.0, heating_power=0.02, device_name="drift"
+    )
+    assert heating_power_valve_position(fake_entity, "trv") == 0.0

--- a/tests/benchmark/tests/test_schedules.py
+++ b/tests/benchmark/tests/test_schedules.py
@@ -204,3 +204,15 @@ def test_stochastic_windows_do_not_spill_into_next_slot():
         t += 1.0
     # Spilling events would merge with their successors → fewer edges.
     assert edges == count
+
+
+def test_stochastic_windows_rejects_nonpositive_duration():
+    """A non-positive duration_s is rejected before slot computation."""
+    with pytest.raises(ValueError):
+        schedules.stochastic_windows(seed=0, count=3, duration_s=0.0)
+
+
+def test_solar_trapezoid_rejects_unordered_edges():
+    """Zero-width or misordered edges are rejected (no divide-by-zero)."""
+    with pytest.raises(ValueError):
+        schedules.solar_trapezoid(100.0, 100.0, 200.0, 300.0)  # zero-width rise

--- a/tests/benchmark/tests/test_schedules.py
+++ b/tests/benchmark/tests/test_schedules.py
@@ -1,0 +1,206 @@
+"""Schedule-builder unit tests."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from tests.benchmark import schedules
+
+
+def test_step_switches_at_threshold():
+    """Step switches at threshold."""
+    f = schedules.step(t_threshold_s=100.0, before=18.0, after=21.0)
+    assert f(0.0) == 18.0
+    assert f(99.999) == 18.0
+    assert f(100.0) == 21.0
+    assert f(1000.0) == 21.0
+
+
+def test_constant_is_time_independent():
+    """Constant is time independent."""
+    f = schedules.constant(5.5)
+    for t in (0.0, 60.0, 3600.0, 86400.0):
+        assert f(t) == 5.5
+
+
+def test_pulse_returns_value_inside_window_and_default_outside():
+    """Pulse returns value inside window and default outside."""
+    f = schedules.pulse(t_start_s=100.0, t_end_s=200.0, value=1.0, default=-0.5)
+    assert f(0.0) == -0.5
+    assert f(99.9) == -0.5
+    assert f(100.0) == 1.0
+    assert f(150.0) == 1.0
+    assert f(199.9) == 1.0
+    assert f(200.0) == -0.5  # half-open right
+    assert f(1000.0) == -0.5
+
+
+def test_pulse_bool_returns_bool():
+    """Pulse bool returns bool."""
+    f = schedules.pulse_bool(t_start_s=10.0, t_end_s=20.0)
+    assert f(0.0) is False
+    assert f(10.0) is True
+    assert f(15.0) is True
+    assert f(20.0) is False
+
+
+def test_ramp_interpolates_between_endpoints_and_holds_after():
+    """Ramp interpolates between endpoints and holds after."""
+    f = schedules.ramp(t_start_s=0.0, t_end_s=100.0, start_value=10.0, end_value=20.0)
+    assert f(-1.0) == 10.0
+    assert f(0.0) == 10.0
+    assert math.isclose(f(50.0), 15.0)
+    assert f(100.0) == 20.0
+    assert f(1000.0) == 20.0
+
+
+def test_ramp_after_override():
+    """Ramp after override."""
+    f = schedules.ramp(
+        t_start_s=0.0, t_end_s=100.0, start_value=10.0, end_value=20.0, after=5.0
+    )
+    assert f(50.0) == 15.0
+    assert f(100.0) == 5.0
+    assert f(1000.0) == 5.0
+
+
+def test_piecewise_step_walks_thresholds_in_order():
+    """Piecewise step walks thresholds in order."""
+    f = schedules.piecewise_step(
+        pairs=[(100.0, 18.0), (200.0, 22.0), (300.0, 20.0)], initial=16.0
+    )
+    assert f(0.0) == 16.0
+    assert f(99.9) == 16.0
+    assert f(100.0) == 18.0
+    assert f(199.9) == 18.0
+    assert f(200.0) == 22.0
+    assert f(300.0) == 20.0
+    assert f(10000.0) == 20.0
+
+
+def test_piecewise_step_sorts_unsorted_input():
+    """Piecewise step sorts unsorted input."""
+    f = schedules.piecewise_step(
+        pairs=[(300.0, 20.0), (100.0, 18.0), (200.0, 22.0)], initial=16.0
+    )
+    assert f(150.0) == 18.0
+    assert f(250.0) == 22.0
+    assert f(350.0) == 20.0
+
+
+def test_sinus_diurnal_reaches_min_and_max():
+    """Sinus diurnal reaches min and max."""
+    f = schedules.sinus_diurnal(
+        min_value=-5.0, max_value=5.0, period_h=24.0, phase_min_h=6.0
+    )
+    # Minimum at simulation hour 6.
+    assert math.isclose(f(6.0 * 3600.0), -5.0, abs_tol=1e-9)
+    # Maximum 12 h later.
+    assert math.isclose(f(18.0 * 3600.0), 5.0, abs_tol=1e-9)
+    # Mid value at the transition quarter-points.
+    assert math.isclose(f(0.0 * 3600.0), 0.0, abs_tol=1e-9)
+
+
+def test_stochastic_windows_deterministic_and_within_duration():
+    """Stochastic windows deterministic and within duration."""
+    f = schedules.stochastic_windows(
+        seed=42,
+        count=5,
+        duration_s=10 * 3600.0,
+        min_duration_s=300.0,
+        max_duration_s=600.0,
+    )
+    # Determinism — same seed → identical schedule.
+    g = schedules.stochastic_windows(
+        seed=42,
+        count=5,
+        duration_s=10 * 3600.0,
+        min_duration_s=300.0,
+        max_duration_s=600.0,
+    )
+    samples_f = [f(t * 60.0) for t in range(600)]
+    samples_g = [g(t * 60.0) for t in range(600)]
+    assert samples_f == samples_g
+    # At least one window must actually open and at least one moment must be closed.
+    assert any(samples_f)
+    assert not all(samples_f)
+
+
+def test_stochastic_windows_handles_short_slots_gracefully():
+    """Stochastic windows handles short slots gracefully."""
+    # max_duration_s > slot_s → fallback path: t_start = i * slot_s, dur clipped by sampling.
+    f = schedules.stochastic_windows(
+        seed=1, count=10, duration_s=100.0, min_duration_s=20.0, max_duration_s=50.0
+    )
+    # At least one tick is True somewhere in the window.
+    assert any(f(t) for t in range(0, 100))
+
+
+def test_solar_trapezoid_envelope():
+    """Solar trapezoid envelope."""
+    f = schedules.solar_trapezoid(
+        t_rise_start=100.0,
+        t_rise_end=200.0,
+        t_fall_start=300.0,
+        t_fall_end=400.0,
+        peak=2.0,
+    )
+    assert f(50.0) == 0.0  # before rise
+    assert math.isclose(f(150.0), 1.0)  # half-rise
+    assert f(200.0) == 2.0  # plateau start
+    assert f(250.0) == 2.0  # mid-plateau
+    assert math.isclose(f(350.0), 1.0)  # half-fall
+    assert f(400.0) == 0.0  # past fall
+    assert f(1000.0) == 0.0  # well past
+
+
+def test_ramp_rejects_non_positive_span():
+    """A zero- or negative-length ramp window is rejected."""
+    with pytest.raises(ValueError):
+        schedules.ramp(100.0, 100.0, 0.0, 1.0)
+    with pytest.raises(ValueError):
+        schedules.ramp(200.0, 100.0, 0.0, 1.0)
+
+
+def test_stochastic_windows_rejects_non_positive_count():
+    """Count <= 0 is rejected instead of dividing by zero."""
+    with pytest.raises(ValueError):
+        schedules.stochastic_windows(seed=1, count=0, duration_s=3600.0)
+
+
+def test_stochastic_windows_rejects_inconsistent_duration_bounds():
+    """min_duration_s > max_duration_s is rejected."""
+    with pytest.raises(ValueError):
+        schedules.stochastic_windows(
+            seed=1,
+            count=2,
+            duration_s=3600.0,
+            min_duration_s=600.0,
+            max_duration_s=300.0,
+        )
+
+
+def test_stochastic_windows_do_not_spill_into_next_slot():
+    """Short slots clamp event durations so events stay non-overlapping."""
+    count = 6
+    slot_s = 600.0
+    sched = schedules.stochastic_windows(
+        seed=7,
+        count=count,
+        duration_s=count * slot_s,
+        min_duration_s=300.0,
+        max_duration_s=1800.0,  # far longer than one slot
+    )
+    edges = 0
+    prev = False
+    t = 0.0
+    while t < count * slot_s:
+        cur = sched(t)
+        if cur and not prev:
+            edges += 1
+        prev = cur
+        t += 1.0
+    # Spilling events would merge with their successors → fewer edges.
+    assert edges == count

--- a/tests/benchmark/tests/test_weather_synthetic.py
+++ b/tests/benchmark/tests/test_weather_synthetic.py
@@ -1,0 +1,126 @@
+"""Synthetic weather generator unit tests."""
+
+from __future__ import annotations
+
+from tests.benchmark.weather.synthetic import (
+    CHICAGO_LIKE,
+    DENVER_LIKE,
+    ClimateParams,
+    _ar1_path,
+    _daylight_hours,
+    _seasonal_mean,
+    _solar_peak,
+    make_schedules,
+)
+
+
+def test_ar1_path_is_deterministic_for_given_seed():
+    """Ar1 path is deterministic for given seed."""
+    import random
+
+    rng1 = random.Random(7)
+    rng2 = random.Random(7)
+    p1 = _ar1_path(n=100, alpha=0.9, sigma=2.0, mean=0.0, rng=rng1)
+    p2 = _ar1_path(n=100, alpha=0.9, sigma=2.0, mean=0.0, rng=rng2)
+    assert p1 == p2
+    assert len(p1) == 100
+
+
+def test_ar1_path_approximates_target_statistics():
+    """Ar1 path approximates target statistics."""
+    import random
+
+    rng = random.Random(0)
+    n = 20000
+    path = _ar1_path(n=n, alpha=0.85, sigma=3.0, mean=5.0, rng=rng)
+    mean = sum(path) / n
+    var = sum((x - mean) ** 2 for x in path) / n
+    # 5 % tolerance — generous, but enough to catch a regression.
+    assert abs(mean - 5.0) < 0.2
+    assert abs(var - 9.0) < 1.5  # sigma² = 9
+
+
+def test_daylight_hours_within_bracketed_range():
+    """Daylight hours within bracketed range."""
+    p = CHICAGO_LIKE
+    # Day 14 → winter min, day 14+183 → summer max
+    winter = _daylight_hours(p.seasonal_min_day, p)
+    summer = _daylight_hours(p.seasonal_min_day + 183, p)
+    assert abs(winter - p.daylight_winter_h) < 0.5
+    assert abs(summer - p.daylight_summer_h) < 0.5
+    # Equinox is roughly in the middle.
+    mid = _daylight_hours(p.seasonal_min_day + 91, p)
+    assert p.daylight_winter_h < mid < p.daylight_summer_h
+
+
+def test_solar_peak_winter_minimum():
+    """Solar peak winter minimum."""
+    p = CHICAGO_LIKE
+    w = _solar_peak(p.seasonal_min_day, p)
+    s = _solar_peak(p.seasonal_min_day + 183, p)
+    assert abs(w - p.solar_peak_winter_W_m2) < 1.0
+    assert abs(s - p.solar_peak_summer_W_m2) < 1.0
+
+
+def test_seasonal_mean_extremes():
+    """Seasonal mean extremes."""
+    p = CHICAGO_LIKE
+    cold = _seasonal_mean(p.seasonal_min_day, p)
+    warm = _seasonal_mean(p.seasonal_min_day + 183, p)
+    # Cold end is annual_mean − annual_amp, warm end is annual_mean + annual_amp.
+    assert abs(cold - (p.annual_mean_C - p.annual_amp_C)) < 0.5
+    assert abs(warm - (p.annual_mean_C + p.annual_amp_C)) < 0.5
+
+
+def test_make_schedules_returns_pure_functions_of_time():
+    """Make schedules returns pure functions of time."""
+    outdoor, solar = make_schedules(CHICAGO_LIKE, duration_h=72, seed=1)
+    assert outdoor(0.0) == outdoor(0.0)  # repeated call same result
+    # Hour-by-hour outdoor values in a sensible winter range.
+    for h in range(72):
+        T = outdoor(h * 3600.0)
+        assert -30.0 < T < 30.0, f"outdoor at h={h} out of range: {T}"
+        s = solar(h * 3600.0)
+        assert 0.0 <= s <= 1.0, f"solar at h={h} out of [0,1]: {s}"
+
+
+def test_make_schedules_deterministic_for_seed():
+    """Make schedules deterministic for seed."""
+    o1, s1 = make_schedules(DENVER_LIKE, duration_h=24, seed=42)
+    o2, s2 = make_schedules(DENVER_LIKE, duration_h=24, seed=42)
+    samples1 = [(o1(t * 3600.0), s1(t * 3600.0)) for t in range(24)]
+    samples2 = [(o2(t * 3600.0), s2(t * 3600.0)) for t in range(24)]
+    assert samples1 == samples2
+
+
+def test_solar_zero_outside_daylight():
+    """Solar zero outside daylight."""
+    _outdoor, solar = make_schedules(CHICAGO_LIKE, duration_h=48, seed=0)
+    # Midnight: definitely no sun.
+    assert solar(0.0 * 3600.0) == 0.0
+    assert solar(2.0 * 3600.0) == 0.0
+    # Noon: positive (cloud-modulated, so we only check >0 in principle).
+    noon = solar(12.0 * 3600.0)
+    assert 0.0 <= noon <= 1.0
+
+
+def test_climate_preset_overrides_carry():
+    """Climate preset overrides carry."""
+    assert CHICAGO_LIKE.name == "cold_humid_continental"
+    assert DENVER_LIKE.name == "cold_semi_arid"
+    # Denver has lower cloud_mean than Chicago.
+    assert DENVER_LIKE.cloud_mean < CHICAGO_LIKE.cloud_mean
+
+
+def test_default_climate_params_constructible():
+    """Default climate params constructible."""
+    p = ClimateParams()
+    assert p.annual_mean_C > 0
+    assert p.synoptic_alpha < 1.0
+
+
+def test_diurnal_cycle_peaks_mid_afternoon():
+    """With synoptics muted, 15:00 must be warmer than the small hours."""
+    calm = ClimateParams(name="calm", synoptic_sigma_C=0.0)
+    outdoor, _solar = make_schedules(calm, start_day_of_year=14, duration_h=24, seed=1)
+    assert outdoor(15 * 3600.0) > outdoor(3 * 3600.0)

--- a/tests/benchmark/tests/test_weather_synthetic.py
+++ b/tests/benchmark/tests/test_weather_synthetic.py
@@ -99,9 +99,11 @@ def test_solar_zero_outside_daylight():
     # Midnight: definitely no sun.
     assert solar(0.0 * 3600.0) == 0.0
     assert solar(2.0 * 3600.0) == 0.0
-    # Noon: positive (cloud-modulated, so we only check >0 in principle).
+    # Noon: the sun is up, so even under cloud modulation the intensity
+    # must be strictly positive (deterministic for this seed) and stay
+    # inside the generator's [0, 1] clamp.
     noon = solar(12.0 * 3600.0)
-    assert 0.0 <= noon <= 1.0
+    assert 0.0 < noon <= 1.0
 
 
 def test_climate_preset_overrides_carry():

--- a/tests/benchmark/weather/__init__.py
+++ b/tests/benchmark/weather/__init__.py
@@ -1,0 +1,5 @@
+"""Synthetic weather generation for the calibration benchmark."""
+
+from .synthetic import CHICAGO_LIKE, DENVER_LIKE, ClimateParams, make_schedules
+
+__all__ = ["CHICAGO_LIKE", "DENVER_LIKE", "ClimateParams", "make_schedules"]

--- a/tests/benchmark/weather/synthetic.py
+++ b/tests/benchmark/weather/synthetic.py
@@ -1,0 +1,214 @@
+"""Synthetic outdoor-temperature and solar generator.
+
+Weather-driven scenarios expose controllers to *synoptic variability*
+(multi-day weather fronts) layered on a *diurnal cycle* and a slow
+*seasonal mean*. A short statistical model produces exactly that,
+fully reproducible from a seed and parameter set, with no external
+data dependency.
+
+The model:
+
+* Seasonal mean: cosine over the year, minimum at day 14 (mid-January).
+* Diurnal cycle: cosine over the day, maximum at 15:00 and minimum
+  12 hours earlier.
+* Synoptic anomaly: AR(1) process on a 1-hour grid; lag-1
+  autocorrelation around 0.9 (~24 h decorrelation timescale, matching
+  observed mid-latitude winter synoptics).
+* Solar: astronomical clear-sky envelope (parabolic between sunrise
+  and sunset, scaled by season) × ``(1 − cloud_fraction)``. Cloud
+  fraction is itself an AR(1) process clipped to ``[0, 1]``.
+
+Two climate presets ship with the module — humid-continental and
+semi-arid — bracketing the dynamics weather-driven scenarios probe.
+Other presets can be added by copying the dataclass.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import math
+import random
+
+
+@dataclass(frozen=True)
+class ClimateParams:
+    """Statistical descriptors of a winter-week weather pattern.
+
+    All temperatures in °C, all times in hours, irradiance in W/m².
+    Defaults give a Chicago-like cold-humid-continental winter; the
+    factory presets below override fields that differ.
+    """
+
+    name: str = "cold_humid_continental"
+    # Climatological mean and seasonal swing (year-cycle amplitude).
+    annual_mean_C: float = 9.0
+    annual_amp_C: float = 13.0
+    # Day-of-year at which the seasonal mean reaches its minimum.
+    seasonal_min_day: int = 14
+    # Diurnal swing (amplitude of the day-night cycle).
+    diurnal_amp_C: float = 5.0
+    # AR(1) synoptic anomaly: lag-1 autocorrelation and standard deviation
+    # at steady state. ``alpha`` = e^(−1/tau_h) where tau_h is the
+    # autocorrelation timescale in hours.
+    synoptic_alpha: float = 0.92
+    synoptic_sigma_C: float = 3.5
+    # Solar: clear-sky peak irradiance (W/m²) at the winter solstice and
+    # peak day length in hours. Both scale linearly with the cosine of
+    # the season — summer peaks higher and lasts longer.
+    solar_peak_winter_W_m2: float = 350.0
+    solar_peak_summer_W_m2: float = 1000.0
+    daylight_winter_h: float = 9.0
+    daylight_summer_h: float = 15.0
+    # Cloud fraction AR(1): mean, std, autocorrelation.
+    cloud_mean: float = 0.5
+    cloud_sigma: float = 0.3
+    cloud_alpha: float = 0.85
+
+
+CHICAGO_LIKE = ClimateParams(
+    name="cold_humid_continental",
+    annual_mean_C=9.0,
+    annual_amp_C=13.0,
+    diurnal_amp_C=5.0,
+    synoptic_alpha=0.92,
+    synoptic_sigma_C=3.5,
+    cloud_mean=0.55,  # more overcast on average
+    cloud_sigma=0.30,
+)
+
+DENVER_LIKE = ClimateParams(
+    name="cold_semi_arid",
+    annual_mean_C=10.0,
+    annual_amp_C=12.0,
+    diurnal_amp_C=8.0,  # high-altitude → sharper diurnal swing
+    synoptic_alpha=0.94,  # weather fronts less frequent
+    synoptic_sigma_C=4.5,  # but stronger when they arrive
+    solar_peak_winter_W_m2=450.0,  # less cloud → more incoming solar
+    cloud_mean=0.30,
+    cloud_sigma=0.25,
+)
+
+
+# --- AR(1) sample generator (one path, hourly) ------------------------------
+
+
+def _ar1_path(
+    n: int, alpha: float, sigma: float, mean: float, rng: random.Random
+) -> list[float]:
+    """Generate one AR(1) path of length ``n`` with the requested moments.
+
+    ``x[k] = mean + alpha · (x[k-1] − mean) + ε`` where ``ε`` is white
+    noise sized so the stationary variance matches ``sigma²``.
+    """
+    # Drive the AR(1) at its stationary variance.
+    inno_sigma = sigma * math.sqrt(1.0 - alpha * alpha)
+    x = mean + rng.gauss(0.0, sigma)
+    out: list[float] = [x]
+    for _ in range(1, n):
+        x = mean + alpha * (x - mean) + rng.gauss(0.0, inno_sigma)
+        out.append(x)
+    return out
+
+
+# --- Astronomical helpers ---------------------------------------------------
+
+
+def _daylight_hours(day_of_year: int, params: ClimateParams) -> float:
+    """Length of day in hours, linearly interpolated between solstices."""
+    # Cosine with min at day 14 (winter solstice analogue, matching seasonal_min_day).
+    cycle = math.cos(2.0 * math.pi * (day_of_year - params.seasonal_min_day) / 365.0)
+    mid = (params.daylight_summer_h + params.daylight_winter_h) / 2.0
+    amp = (params.daylight_summer_h - params.daylight_winter_h) / 2.0
+    return mid - amp * cycle
+
+
+def _solar_peak(day_of_year: int, params: ClimateParams) -> float:
+    """Clear-sky peak irradiance for the day (W/m²)."""
+    cycle = math.cos(2.0 * math.pi * (day_of_year - params.seasonal_min_day) / 365.0)
+    mid = (params.solar_peak_summer_W_m2 + params.solar_peak_winter_W_m2) / 2.0
+    amp = (params.solar_peak_summer_W_m2 - params.solar_peak_winter_W_m2) / 2.0
+    return mid - amp * cycle
+
+
+def _seasonal_mean(day_of_year: int, params: ClimateParams) -> float:
+    return params.annual_mean_C - params.annual_amp_C * math.cos(
+        2.0 * math.pi * (day_of_year - params.seasonal_min_day) / 365.0
+    )
+
+
+# --- Public builders --------------------------------------------------------
+
+
+def make_schedules(
+    params: ClimateParams,
+    start_day_of_year: int = 14,
+    duration_h: int = 168,
+    seed: int = 0,
+) -> tuple[Callable[[float], float], Callable[[float], float]]:
+    """Return ``(outdoor_schedule, solar_schedule)`` for the requested slice.
+
+    The schedules are pure functions of ``t`` (seconds) but reference
+    pre-generated AR(1) paths internally — they are deterministic for a
+    given ``(params, start_day_of_year, duration_h, seed)`` triple.
+    """
+    rng = random.Random(seed)
+    # Hourly grid plus one wrap entry so linear interpolation between
+    # samples is well-defined at the end of the slice.
+    n_hours = duration_h + 1
+
+    synoptic = _ar1_path(
+        n_hours,
+        alpha=params.synoptic_alpha,
+        sigma=params.synoptic_sigma_C,
+        mean=0.0,
+        rng=rng,
+    )
+    cloud_raw = _ar1_path(
+        n_hours,
+        alpha=params.cloud_alpha,
+        sigma=params.cloud_sigma,
+        mean=params.cloud_mean,
+        rng=rng,
+    )
+    cloud = [max(0.0, min(1.0, c)) for c in cloud_raw]
+
+    def outdoor(t_s: float) -> float:
+        hours_in = t_s / 3600.0
+        i = int(hours_in)
+        frac = hours_in - i
+        day = start_day_of_year + hours_in / 24.0
+        hour_of_day = (hours_in + 0.0) % 24.0
+        seasonal = _seasonal_mean(int(day), params)
+        diurnal = params.diurnal_amp_C * math.cos(
+            2.0 * math.pi * (hour_of_day - 15.0) / 24.0
+        )
+        # Linear interp the synoptic anomaly between hourly samples.
+        s0 = synoptic[min(i, len(synoptic) - 1)]
+        s1 = synoptic[min(i + 1, len(synoptic) - 1)]
+        return seasonal + diurnal + s0 + frac * (s1 - s0)
+
+    def solar(t_s: float) -> float:
+        hours_in = t_s / 3600.0
+        i = int(hours_in)
+        frac = hours_in - i
+        day = int(start_day_of_year + hours_in / 24.0)
+        hour_of_day = hours_in % 24.0
+        daylen = _daylight_hours(day, params)
+        sunrise = 12.0 - daylen / 2.0
+        sunset = 12.0 + daylen / 2.0
+        if hour_of_day < sunrise or hour_of_day > sunset:
+            return 0.0
+        # Parabolic clear-sky envelope, 0 at sunrise/sunset, peak at noon.
+        x = (hour_of_day - sunrise) / (sunset - sunrise)
+        envelope = 4.0 * x * (1.0 - x)
+        peak = _solar_peak(day, params)
+        # Linear interp the cloud fraction between hourly samples.
+        c0 = cloud[min(i, len(cloud) - 1)]
+        c1 = cloud[min(i + 1, len(cloud) - 1)]
+        clouds = c0 + frac * (c1 - c0)
+        w_per_m2 = peak * envelope * (1.0 - clouds)
+        # Normalise to [0..1] against a 1000 W/m² clear-sky reference.
+        return max(0.0, min(1.0, w_per_m2 / 1000.0))
+
+    return outdoor, solar

--- a/tests/benchmark/weather/synthetic.py
+++ b/tests/benchmark/weather/synthetic.py
@@ -100,7 +100,21 @@ def _ar1_path(
 
     ``x[k] = mean + alpha · (x[k-1] − mean) + ε`` where ``ε`` is white
     noise sized so the stationary variance matches ``sigma²``.
+
+    Raises
+    ------
+    ValueError
+        If ``n < 1``, ``|alpha| >= 1`` (non-stationary; the innovation
+        variance would go negative), or ``sigma < 0``.
     """
+    if n < 1:
+        raise ValueError(f"_ar1_path n must be >= 1, got {n}")
+    if not -1.0 < alpha < 1.0:
+        raise ValueError(
+            f"_ar1_path requires |alpha| < 1 for a stationary process, got {alpha}"
+        )
+    if sigma < 0.0:
+        raise ValueError(f"_ar1_path sigma must be >= 0, got {sigma}")
     # Drive the AR(1) at its stationary variance.
     inno_sigma = sigma * math.sqrt(1.0 - alpha * alpha)
     x = mean + rng.gauss(0.0, sigma)

--- a/tests/benchmark/weather/synthetic.py
+++ b/tests/benchmark/weather/synthetic.py
@@ -198,8 +198,10 @@ def make_schedules(
             2.0 * math.pi * (hour_of_day - 15.0) / 24.0
         )
         # Linear interp the synoptic anomaly between hourly samples.
-        s0 = synoptic[min(i, len(synoptic) - 1)]
-        s1 = synoptic[min(i + 1, len(synoptic) - 1)]
+        # Clamp both ends so a negative t (or t past the path) cannot wrap
+        # around via negative indexing.
+        s0 = synoptic[max(0, min(i, len(synoptic) - 1))]
+        s1 = synoptic[max(0, min(i + 1, len(synoptic) - 1))]
         return seasonal + diurnal + s0 + frac * (s1 - s0)
 
     def solar(t_s: float) -> float:

--- a/tests/benchmark/weather/synthetic.py
+++ b/tests/benchmark/weather/synthetic.py
@@ -220,8 +220,9 @@ def make_schedules(
         envelope = 4.0 * x * (1.0 - x)
         peak = _solar_peak(day, params)
         # Linear interp the cloud fraction between hourly samples.
-        c0 = cloud[min(i, len(cloud) - 1)]
-        c1 = cloud[min(i + 1, len(cloud) - 1)]
+        # Clamp both ends so a negative t cannot wrap via negative indexing.
+        c0 = cloud[max(0, min(i, len(cloud) - 1))]
+        c1 = cloud[max(0, min(i + 1, len(cloud) - 1))]
         clouds = c0 + frac * (c1 - c0)
         w_per_m2 = peak * envelope * (1.0 - clouds)
         # Normalise to [0..1] against a 1000 W/m² clear-sky reference.

--- a/tests/benchmark/weather/synthetic.py
+++ b/tests/benchmark/weather/synthetic.py
@@ -192,7 +192,7 @@ def make_schedules(
         i = int(hours_in)
         frac = hours_in - i
         day = start_day_of_year + hours_in / 24.0
-        hour_of_day = (hours_in + 0.0) % 24.0
+        hour_of_day = hours_in % 24.0
         seasonal = _seasonal_mean(int(day), params)
         diurnal = params.diurnal_amp_C * math.cos(
             2.0 * math.pi * (hour_of_day - 15.0) / 24.0


### PR DESCRIPTION
## Calibration benchmark — scenario library & controller adapters

Additive under `tests/benchmark/`.

**Contents**
- **Scenario library** (`scenarios.py`, `schedules.py`, `weather/`) — 37 reproducible scenarios: setpoint dynamics, outdoor/load disturbances, the window problem, solar & forecast, sensor faults, actuator faults, HVAC topologies, schedules, and synthetic-weather weeks
- **Controller adapters** (`adapters/`) — `mpc`/`pid`/`tpi` call the production `compute_*` functions directly; baselines (BangBang/LinearP/IdealOracle), the offset family (`default`/`aggressive`/`no_calibration`), and the indirect-TRV wrapper round out the field
- **Drift guard** (`test_production_drift.py`) — pins the `heating_power` adapter's valve formula to its production source so the headless re-implementation cannot silently diverge

Tests: `uv run pytest tests/benchmark -p no:homeassistant`; `ruff check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added benchmark-only controller adapters for standardized algorithm comparison, including heating-power learning, passive calibration modes, an offset-mode TRV wrapper, and oracle/baseline controllers, plus wrappers for production PID/TPI/MPC.
* **Tests**
  * Expanded benchmark smoke/contract tests and added focused coverage for adapter validation, heating-power learning and production drift parity, TRV wrapper behavior, schedule generation, and synthetic weather determinism.
* **Chores**
  * Introduced a reproducible synthetic weather, schedules, and scenario framework for easier benchmark extension.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
**Update 2026-07-03:** rebased onto the updated base (stack now sits on `develop`@74185870) and extended with a review-fix commit closing two production-fidelity gaps:
- The **MPC adapter replicates production's per-target-bucket state keying** (`build_mpc_key` semantics): one state per 0.5-K-rounded target, all buckets passed as `all_states` so `compute_mpc`'s sibling seeding fires on setpoint moves — the setpoint-dynamics scenarios now exercise the same learning regime as deployed code.
- The **heating-power learner uses the production adaptive-alpha helpers** from `utils/thermal_learning.py` directly (weight/env factors, clamps, 4-decimal rounding) instead of a fixed base alpha, and tracks the observed target range like `HeatingPowerTracker`.

Also: `reset(prior)` on mpc/pid/tpi rehydrates persisted state through the production `deserialize_*` path (matching the `StateManager` restore across HA restarts); the ideal oracle's steady-state inversion is generalised to non-unit radiator coupling and the RC3 wall topology; assorted comment/scenario-description cleanups. New tests pin bucket partitioning, `reset(prior)` rehydration and the adaptive alpha against hand-computed values.

Tests at this layer: 281; `ruff check`/`format` clean.
