### PR TITLE
fix: allow removing the cooler entity from the configuration

### DIFF
--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -548,9 +548,9 @@ def _normalize_user_submission(
             if isinstance(item, dict) and item.get("trv")
         ]
     normalized[CONF_HEATER] = list(heaters_list)
-    normalized[CONF_COOLER] = user_input.get(CONF_COOLER, normalized.get(CONF_COOLER))
 
     optional_keys = (
+        CONF_COOLER,
         CONF_SENSOR,
         CONF_SENSOR_WINDOW,
         CONF_HUMIDITY,

--- a/tests/unit/test_config_flow_normalize.py
+++ b/tests/unit/test_config_flow_normalize.py
@@ -1,0 +1,91 @@
+"""Tests for config_flow._normalize_user_submission.
+
+Focus on the optional entity selectors, which must be removable: when the
+user clears an optional entity in the options flow, the HA frontend omits
+the key from the submitted ``user_input``. The normalized result must then
+drop the previously stored value instead of silently keeping it.
+"""
+
+from homeassistant.const import CONF_NAME
+
+from custom_components.better_thermostat.config_flow import (
+    _normalize_user_submission,
+)
+from custom_components.better_thermostat.utils.const import (
+    CONF_COOLER,
+    CONF_HEATER,
+    CONF_SENSOR,
+)
+
+
+def _base_with_cooler():
+    return {
+        CONF_NAME: "Living Room",
+        CONF_HEATER: ["climate.trv"],
+        CONF_COOLER: "climate.ac",
+        CONF_SENSOR: "sensor.temp",
+    }
+
+
+def test_cooler_removed_when_key_absent_from_input():
+    """Clearing the cooler omits the key; the stored value must be dropped."""
+    user_input = {
+        CONF_NAME: "Living Room",
+        CONF_HEATER: ["climate.trv"],
+        CONF_SENSOR: "sensor.temp",
+    }
+
+    normalized = _normalize_user_submission(
+        user_input, mode="update", base=_base_with_cooler()
+    )
+
+    assert normalized[CONF_COOLER] is None
+
+
+def test_cooler_removed_when_input_empty():
+    """An explicit empty/None cooler value also clears the stored value."""
+    for empty in ("", None):
+        user_input = {
+            CONF_NAME: "Living Room",
+            CONF_HEATER: ["climate.trv"],
+            CONF_COOLER: empty,
+            CONF_SENSOR: "sensor.temp",
+        }
+
+        normalized = _normalize_user_submission(
+            user_input, mode="update", base=_base_with_cooler()
+        )
+
+        assert normalized[CONF_COOLER] is None
+
+
+def test_cooler_retained_when_present_in_input():
+    """A submitted cooler entity is kept."""
+    user_input = {
+        CONF_NAME: "Living Room",
+        CONF_HEATER: ["climate.trv"],
+        CONF_COOLER: "climate.ac",
+        CONF_SENSOR: "sensor.temp",
+    }
+
+    normalized = _normalize_user_submission(
+        user_input, mode="update", base={CONF_COOLER: "climate.old_ac"}
+    )
+
+    assert normalized[CONF_COOLER] == "climate.ac"
+
+
+def test_cooler_updated_to_different_entity():
+    """A changed cooler entity replaces the stored one."""
+    user_input = {
+        CONF_NAME: "Living Room",
+        CONF_HEATER: ["climate.trv"],
+        CONF_COOLER: "climate.new_ac",
+        CONF_SENSOR: "sensor.temp",
+    }
+
+    normalized = _normalize_user_submission(
+        user_input, mode="update", base=_base_with_cooler()
+    )
+
+    assert normalized[CONF_COOLER] == "climate.new_ac"

--- a/tests/unit/test_config_flow_normalize.py
+++ b/tests/unit/test_config_flow_normalize.py
@@ -8,9 +8,7 @@ drop the previously stored value instead of silently keeping it.
 
 from homeassistant.const import CONF_NAME
 
-from custom_components.better_thermostat.config_flow import (
-    _normalize_user_submission,
-)
+from custom_components.better_thermostat.config_flow import _normalize_user_submission
 from custom_components.better_thermostat.utils.const import (
     CONF_COOLER,
     CONF_HEATER,


### PR DESCRIPTION
## Problem

Reported in discussion #2069: the cooler / AC entity cannot be removed from a Better Thermostat configuration once set. Clearing the cooler selector in the options flow has no effect — the old entity stays configured.

## Cause

In `_normalize_user_submission` (`config_flow.py`), the cooler was the only optional entity normalized via a get-with-fallback chain:

```python
normalized[CONF_COOLER] = user_input.get(CONF_COOLER, normalized.get(CONF_COOLER))
```

The cooler selector is built as a `vol.Optional` field **without a real default** (only a `suggested_value`). When the user clears such a field, the HA frontend omits the key entirely from `user_input`. The fallback then resolves back to the previously stored cooler, so removal is impossible.

Every other optional entity (sensor, window, humidity, outdoor sensor, weather) is already handled correctly by the shared `optional_keys` loop, which maps an absent or empty value to `None`.

## Fix

Move `CONF_COOLER` into that shared `optional_keys` handling and drop the special-cased line. Behavior:

- key absent (selector cleared) → `None` ✅ (removal now works)
- empty string / `None` → `None` ✅
- entity set / changed → kept ✅

## Tests

Adds `tests/unit/test_config_flow_normalize.py` covering all four cases. Verified that the two removal cases fail without the fix. Full local suite: 1051 passed.

Fixes #2072 (duplicate report of the same problem).