### PR TITLE
fix: retry critical entities at startup before raising repair issue

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1692,6 +1692,20 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
     async def _finalize_startup(self) -> None:
         """Run post-init tasks: triggers, listeners, periodic jobs."""
+        # Wait for critical entities (TRVs) with increasing retry delays before
+        # any startup path can raise a missing_entity repair issue.  Both
+        # _trigger_time and _trigger_check_weather below call
+        # check_critical_entities internally, so the retry must complete first.
+        # Cloud-backed valves (e.g. Tado) often initialise later than Home
+        # Assistant itself; without this wait a single immediate check reports a
+        # false-positive that lingers in the repair dashboard even after the
+        # valve comes online.
+        await await_critical_entities(self)
+        _LOGGER.debug(
+            "better_thermostat %s: checking critical entities...", self.device_name
+        )
+        await check_critical_entities(self)
+
         _LOGGER.debug("better_thermostat %s: triggering time...", self.device_name)
         await self._trigger_time(None)
         _LOGGER.debug(
@@ -1728,17 +1742,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             self.async_on_remove(
                 async_track_time_change(self.hass, self._trigger_time, 5, 0, 0)
             )
-
-        # Wait for critical entities (TRVs) with increasing retry delays before
-        # raising a missing_entity repair issue.  Cloud-backed valves (e.g.
-        # Tado) often initialise later than Home Assistant itself, so a single
-        # immediate check would report a false-positive that lingers in the
-        # repair dashboard even after the valve comes online.
-        await await_critical_entities(self)
-        _LOGGER.debug(
-            "better_thermostat %s: checking critical entities...", self.device_name
-        )
-        await check_critical_entities(self)
 
         # Wait for optional sensors with increasing retry delays before
         # entering degraded mode (see await_optional_sensors for details).

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -156,6 +156,7 @@ from .utils.valve_maintenance import (
 )
 from .utils.watcher import (
     STARTUP_DEGRADED_GRACE_PERIOD,
+    await_critical_entities,
     await_optional_sensors,
     check_and_update_degraded_mode,
     check_critical_entities,
@@ -1728,6 +1729,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 async_track_time_change(self.hass, self._trigger_time, 5, 0, 0)
             )
 
+        # Wait for critical entities (TRVs) with increasing retry delays before
+        # raising a missing_entity repair issue.  Cloud-backed valves (e.g.
+        # Tado) often initialise later than Home Assistant itself, so a single
+        # immediate check would report a false-positive that lingers in the
+        # repair dashboard even after the valve comes online.
+        await await_critical_entities(self)
         _LOGGER.debug(
             "better_thermostat %s: checking critical entities...", self.device_name
         )

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1701,6 +1701,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # false-positive that lingers in the repair dashboard even after the
         # valve comes online.
         await await_critical_entities(self)
+        if self.is_removed:
+            return
         _LOGGER.debug(
             "better_thermostat %s: checking critical entities...", self.device_name
         )

--- a/custom_components/better_thermostat/utils/watcher.py
+++ b/custom_components/better_thermostat/utils/watcher.py
@@ -310,6 +310,93 @@ async def await_optional_sensors(
     return pending
 
 
+# Default delays for the critical-entity startup retry loop.  Critical entities
+# are TRVs, which on cloud-backed integrations (e.g. Tado) can take noticeably
+# longer to initialise than local Zigbee valves, so the schedule is slightly
+# longer than the optional-sensor one.  Total ≈ 90 s.
+DEFAULT_CRITICAL_ENTITY_DELAYS: tuple[int, ...] = (3, 5, 10, 15, 25, 30)
+
+
+async def await_critical_entities(
+    self,
+    delays: tuple[int, ...] | list[int] = DEFAULT_CRITICAL_ENTITY_DELAYS,
+    _sleep=None,
+) -> list[str]:
+    """Wait for critical entities (TRVs) to become available with retry delays.
+
+    After a reboot, the underlying TRVs frequently need a few seconds to
+    initialise.  Cloud-backed integrations (e.g. Tado) load even later than
+    Home Assistant itself, so a single availability check at startup raises a
+    false-positive ``missing_entity`` repair issue before the valve is ready.
+    This helper retries with increasing intervals so that
+    ``check_critical_entities`` is not called while TRVs are still starting up.
+
+    Parameters
+    ----------
+    self :
+        BetterThermostat instance (must expose ``.hass`` and
+        ``.device_name``).
+    delays :
+        Sequence of sleep durations in seconds between retries.
+        Defaults to ``DEFAULT_CRITICAL_ENTITY_DELAYS`` (3/5/10/15/25/30 s).
+    _sleep :
+        Injectable sleep coroutine for testing.  Defaults to
+        ``asyncio.sleep``.
+
+    Returns
+    -------
+    list[str]
+        Entity IDs of critical entities that are still unavailable after all
+        retries have been exhausted (empty if all came online).
+    """
+    import asyncio
+
+    if _sleep is None:
+        _sleep = asyncio.sleep
+
+    elapsed = 0
+    pending: list[str] = []
+
+    for idx, delay in enumerate(delays):
+        pending = [
+            eid
+            for eid in get_critical_entities(self)
+            if not is_entity_available(self.hass, eid)
+        ]
+        if not pending:
+            _LOGGER.debug(
+                "better_thermostat %s: all critical entities available (after %d s)",
+                self.device_name,
+                elapsed,
+            )
+            return []
+        _LOGGER.debug(
+            "better_thermostat %s: waiting for critical entities "
+            "(attempt %d/%d, next check in %d s, pending: %s)",
+            self.device_name,
+            idx + 1,
+            len(delays),
+            delay,
+            ", ".join(pending),
+        )
+        await _sleep(delay)
+        elapsed += delay
+
+    # Final check after the last sleep
+    pending = [
+        eid
+        for eid in get_critical_entities(self)
+        if not is_entity_available(self.hass, eid)
+    ]
+    if not pending:
+        _LOGGER.debug(
+            "better_thermostat %s: all critical entities available (after %d s)",
+            self.device_name,
+            elapsed,
+        )
+    return pending
+
+
 async def check_and_update_degraded_mode(self) -> bool:
     """Check optional sensors and update degraded mode status.
 

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -920,6 +920,8 @@ class TestAwaitCriticalEntities:
             await_critical_entities,
         )
 
+        mock_bt_instance.real_trvs = {"climate.trv_1": {}, "climate.trv_2": {}}
+
         trv1_calls = 0
 
         def mock_get(entity_id):

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -773,6 +773,224 @@ class TestAwaitOptionalSensors:
         assert sleep_calls == [2, 4]
 
 
+class TestAwaitCriticalEntities:
+    """Tests for await_critical_entities retry logic.
+
+    Mirrors TestAwaitOptionalSensors but for critical entities (TRVs), which
+    on cloud-backed integrations (e.g. Tado) may take longer to initialise
+    than Home Assistant itself.
+    """
+
+    @staticmethod
+    def _run(coro):
+        """Run a coroutine in a fresh event loop (avoids HA plugin issues)."""
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def test_returns_empty_when_all_trvs_available_immediately(self, mock_bt_instance):
+        """All TRVs available on first check → no sleep, empty result."""
+        from custom_components.better_thermostat.utils.watcher import (
+            await_critical_entities,
+        )
+
+        mock_state = MagicMock()
+        mock_state.state = "heat"
+        mock_bt_instance.hass.states.get.return_value = mock_state
+
+        sleep_calls = []
+
+        async def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+
+        result = self._run(
+            await_critical_entities(
+                mock_bt_instance, delays=(3, 5, 10), _sleep=fake_sleep
+            )
+        )
+
+        assert result == []
+        assert sleep_calls == [], "Should not sleep when all TRVs are available"
+
+    def test_returns_empty_when_no_trvs_configured(self, mock_bt_instance):
+        """No critical entities configured → immediate empty result."""
+        from custom_components.better_thermostat.utils.watcher import (
+            await_critical_entities,
+        )
+
+        mock_bt_instance.real_trvs = {}
+
+        sleep_calls = []
+
+        async def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+
+        result = self._run(
+            await_critical_entities(mock_bt_instance, delays=(3, 5), _sleep=fake_sleep)
+        )
+
+        assert result == []
+        assert sleep_calls == []
+
+    def test_retries_until_trv_comes_online(self, mock_bt_instance):
+        """TRV unavailable on first check, available on second → one sleep."""
+        from custom_components.better_thermostat.utils.watcher import (
+            await_critical_entities,
+        )
+
+        # Single TRV configured
+        mock_bt_instance.real_trvs = {"climate.trv_1": {}}
+
+        call_count = 0
+
+        def mock_get(entity_id):
+            nonlocal call_count
+            state = MagicMock()
+            if entity_id == "climate.trv_1":
+                call_count += 1
+                # Unavailable on first call, available from second onwards
+                state.state = "unavailable" if call_count <= 1 else "heat"
+            else:
+                state.state = "heat"
+            return state
+
+        mock_bt_instance.hass.states.get.side_effect = mock_get
+
+        sleep_calls = []
+
+        async def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+
+        result = self._run(
+            await_critical_entities(
+                mock_bt_instance, delays=(3, 5, 10), _sleep=fake_sleep
+            )
+        )
+
+        assert result == []
+        assert sleep_calls == [3], "Should sleep once (3 s) before TRV comes online"
+
+    def test_returns_pending_after_all_retries_exhausted(self, mock_bt_instance):
+        """TRV stays unavailable through all retries → returned in pending list."""
+        from custom_components.better_thermostat.utils.watcher import (
+            await_critical_entities,
+        )
+
+        mock_bt_instance.real_trvs = {"climate.trv_1": {}}
+
+        mock_state = MagicMock()
+        mock_state.state = "unavailable"
+        mock_bt_instance.hass.states.get.return_value = mock_state
+
+        sleep_calls = []
+
+        async def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+
+        result = self._run(
+            await_critical_entities(
+                mock_bt_instance, delays=(2, 4, 8), _sleep=fake_sleep
+            )
+        )
+
+        assert result == ["climate.trv_1"]
+        assert sleep_calls == [2, 4, 8], "Should sleep through all delays"
+
+    def test_default_delays_increasing_and_total_roughly_90s(self):
+        """Default critical delays are increasing and sum to roughly 90 s."""
+        from custom_components.better_thermostat.utils.watcher import (
+            DEFAULT_CRITICAL_ENTITY_DELAYS,
+        )
+
+        total = sum(DEFAULT_CRITICAL_ENTITY_DELAYS)
+        assert 80 <= total <= 100, f"Expected ~90 s total, got {total} s"
+        for i in range(1, len(DEFAULT_CRITICAL_ENTITY_DELAYS)):
+            assert (
+                DEFAULT_CRITICAL_ENTITY_DELAYS[i]
+                > DEFAULT_CRITICAL_ENTITY_DELAYS[i - 1]
+            )
+
+    def test_partial_trvs_come_online(self, mock_bt_instance):
+        """One TRV comes online while another stays unavailable."""
+        from custom_components.better_thermostat.utils.watcher import (
+            await_critical_entities,
+        )
+
+        trv1_calls = 0
+
+        def mock_get(entity_id):
+            nonlocal trv1_calls
+            state = MagicMock()
+            if entity_id == "climate.trv_1":
+                trv1_calls += 1
+                # Comes online after first sleep
+                state.state = "unavailable" if trv1_calls <= 1 else "heat"
+            elif entity_id == "climate.trv_2":
+                # Stays unavailable forever
+                state.state = "unavailable"
+            else:
+                state.state = "heat"
+            return state
+
+        mock_bt_instance.hass.states.get.side_effect = mock_get
+
+        sleep_calls = []
+
+        async def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+
+        result = self._run(
+            await_critical_entities(
+                mock_bt_instance, delays=(2, 4, 8), _sleep=fake_sleep
+            )
+        )
+
+        assert result == ["climate.trv_2"]
+        assert sleep_calls == [2, 4, 8]
+
+    def test_final_check_after_last_sleep(self, mock_bt_instance):
+        """TRV comes online during the last sleep → caught by final check."""
+        from custom_components.better_thermostat.utils.watcher import (
+            await_critical_entities,
+        )
+
+        mock_bt_instance.real_trvs = {"climate.trv_1": {}}
+
+        get_count = 0
+
+        def mock_get(entity_id):
+            nonlocal get_count
+            state = MagicMock()
+            if entity_id == "climate.trv_1":
+                get_count += 1
+                # With delays=(2, 4): unavailable for the two loop checks,
+                # available on the final check.
+                state.state = "unavailable" if get_count <= 2 else "heat"
+            else:
+                state.state = "heat"
+            return state
+
+        mock_bt_instance.hass.states.get.side_effect = mock_get
+
+        sleep_calls = []
+
+        async def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+
+        result = self._run(
+            await_critical_entities(mock_bt_instance, delays=(2, 4), _sleep=fake_sleep)
+        )
+
+        assert result == [], (
+            "TRV came online during last sleep, final check should catch it"
+        )
+        assert sleep_calls == [2, 4]
+
+
 class TestBatteryStatusCalls:
     """Tests for battery status updates in entity checks."""
 


### PR DESCRIPTION
## Problem

Reported in #2090: on Home Assistant startup, Better Thermostat raises a false-positive `missing_entity` repair issue for TRVs that are simply slow to initialise. Cloud-backed integrations such as **Tado** load later than HA itself, so the TRV is briefly unavailable when BT checks it. The repair issue then lingers in the repair dashboard even after the valve comes online and has to be dismissed manually after every restart.

## Cause

At startup, `_finalize_startup` checked critical entities (TRVs) **exactly once**, immediately, via `check_critical_entities` — which raises the repair issue if a TRV is unavailable.

Optional sensors (outdoor/weather/window/humidity) already avoid this: `await_optional_sensors` retries on an increasing schedule plus a startup grace period before degraded mode is reported. Critical entities had no equivalent, so a slow TRV tripped the issue right away.

## Fix

Mirror the optional-sensor pattern for critical entities:

- New `await_critical_entities` in `utils/watcher.py` — retries on an increasing schedule (`DEFAULT_CRITICAL_ENTITY_DELAYS` = 3/5/10/15/25/30 s, ~90 s total; slightly longer than the optional schedule since cloud valves load latest) until all TRVs are available, returning any still-pending after the retries are exhausted.
- It runs **before** `check_critical_entities` in `_finalize_startup`, so slow valves get time to come online before any repair issue is raised. A genuinely missing TRV is still reported after the retries are exhausted.

## Tests

Adds `TestAwaitCriticalEntities` (7 cases) to `tests/unit/test_watcher.py`, mirroring the optional-sensor tests: immediate availability, retry-until-online, pending-after-exhaustion, partial recovery, final-check-after-last-sleep, custom delays, and the default-schedule shape. Uses an injectable `_sleep` so no real time passes.

Local run: `tests/unit/test_watcher.py` + `test_climate_startup.py` → 90 passed; full suite on the source branch → 1221 passed.

Fixes #2090.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Better Thermostat startup readiness checks for critical TRV entities by introducing a dedicated retry-based wait phase before the existing verification.
  * Consolidates critical-entity enforcement so readiness is checked in a single, consistent startup sequence.
* **Tests**
  * Added unit tests for the critical-entity waiting behavior, including immediate success, retry timing, partial success, pending results, and final-check handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->