### PR TITLE
chore: trivial hygiene fixes (docstring, dead comment, boolean)

### DIFF
--- a/custom_components/better_thermostat/diagnostics.py
+++ b/custom_components/better_thermostat/diagnostics.py
@@ -1,4 +1,4 @@
-"""Diagnostics support for Brother."""
+"""Diagnostics support for Better Thermostat."""
 
 from __future__ import annotations
 

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -67,7 +67,6 @@ async def trigger_trv_change(self, event):
             entity_id,
         )
         return
-    # set context HACK TO FIND OUT IF AN EVENT WAS SEND BY BT
 
     # Check if the update is coming from the code
     if self.context == event.context:

--- a/custom_components/better_thermostat/utils/weather.py
+++ b/custom_components/better_thermostat/utils/weather.py
@@ -52,7 +52,6 @@ async def check_weather(self) -> bool:
 
     if self.outdoor_sensor is not None:
         if None in (self.last_avg_outdoor_temp, self.off_temperature):
-            # TODO: add condition if heating period (oct-mar) then set it to true?
             # Check if sensor is currently unavailable (expected during startup)
             _outdoor_state = self.hass.states.get(self.outdoor_sensor)
             _sensor_unavailable = _outdoor_state is None or _outdoor_state.state in (

--- a/custom_components/better_thermostat/utils/weather.py
+++ b/custom_components/better_thermostat/utils/weather.py
@@ -83,10 +83,7 @@ async def check_weather(self) -> bool:
         self.call_for_heat = True
         return True
 
-    if old_call_for_heat != self.call_for_heat:
-        return True
-    else:
-        return False
+    return old_call_for_heat != self.call_for_heat
 
 
 async def check_weather_prediction(self) -> bool | None:


### PR DESCRIPTION
- `diagnostics.py`: the module docstring read `"""Diagnostics support for Brother."""` (from the Brother integration template); corrected to Better Thermostat.
- `events/trv.py`: removed a comment above the context check that duplicated the line below it.
- `utils/weather.py`: collapsed `if a != b: return True else: return False` into `return a != b`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected an inaccurate diagnostic description.
* **Refactor**
  * Cleaned up internal comments and simplified a weather-state comparison for clearer logic.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->