### PR TITLE
fix: correct inital_tweak typo to initial_tweak

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -66,7 +66,7 @@ from .events.cooler import trigger_cooler_change
 from .events.temperature import trigger_temperature_change
 from .events.trv import trigger_trv_change
 from .events.window import trigger_window_change, window_queue
-from .model_fixes.model_quirks import inital_tweak, load_model_quirks
+from .model_fixes.model_quirks import initial_tweak, load_model_quirks
 from .trv import Trv
 from .utils.calibration.pid import (
     PIDParams,
@@ -1550,7 +1550,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 )
 
             try:
-                await inital_tweak(self, trv)
+                await initial_tweak(self, trv)
             except Exception as exc:
                 _LOGGER.error(
                     "better_thermostat %s: Error running initial tweak for TRV %s: %s",

--- a/custom_components/better_thermostat/model_fixes/SPZB0001.py
+++ b/custom_components/better_thermostat/model_fixes/SPZB0001.py
@@ -72,7 +72,7 @@ async def check_operation_mode(self, entity_id, goal: str = "1"):
     return True
 
 
-async def inital_tweak(self, entity_id):
+async def initial_tweak(self, entity_id):
     """Run initial tweaks for the device."""
     _calibration_type = self.real_trvs[entity_id].advanced.get(
         "calibration", CalibrationType.TARGET_TEMP_BASED

--- a/custom_components/better_thermostat/model_fixes/default.py
+++ b/custom_components/better_thermostat/model_fixes/default.py
@@ -45,7 +45,7 @@ async def override_set_valve(self, entity_id, percent: int):
     return False
 
 
-async def inital_tweak(self, entity_id):
+async def initial_tweak(self, entity_id):
     """Run initial tweaks for the device."""
     entity_registry = er.async_get(self.hass)
     reg_entity = entity_registry.async_get(entity_id)

--- a/custom_components/better_thermostat/model_fixes/model_quirks.py
+++ b/custom_components/better_thermostat/model_fixes/model_quirks.py
@@ -159,8 +159,8 @@ async def override_set_temperature(self, entity_id, temperature):
     )
 
 
-async def inital_tweak(self, entity_id):
+async def initial_tweak(self, entity_id):
     """Run initial tweaks for the device."""
     quirks = self.real_trvs[entity_id].model_quirks
-    if hasattr(quirks, "inital_tweak"):
-        await quirks.inital_tweak(self, entity_id)
+    if hasattr(quirks, "initial_tweak"):
+        await quirks.initial_tweak(self, entity_id)

--- a/custom_components/better_thermostat/model_fixes/model_quirks.py
+++ b/custom_components/better_thermostat/model_fixes/model_quirks.py
@@ -15,8 +15,7 @@ _LOGGER = logging.getLogger(__name__)
 async def load_model_quirks(self, model, entity_id):
     """Load model quirks module for a given TRV model, falling back to default.
 
-    Adds explicit debug logs for both success and fallback paths to make it
-    visible why nothing appeared previously.
+    Emits debug logs for both the success and the fallback path.
     """
 
     # Normalize model to a safe module suffix

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -389,7 +389,7 @@ class TestInitializeTrvCurrentTemperature:
         with (
             patch("custom_components.better_thermostat.climate.init", AsyncMock()),
             patch(
-                "custom_components.better_thermostat.climate.inital_tweak", AsyncMock()
+                "custom_components.better_thermostat.climate.initial_tweak", AsyncMock()
             ),
             patch(
                 "custom_components.better_thermostat.climate.control_trv",


### PR DESCRIPTION
Corrects the model-quirk hook name `inital_tweak` to `initial_tweak`. The name is a hook contract, so every site is updated together:

- the dispatcher definition and its `hasattr`/`getattr` lookup string in `model_fixes/model_quirks.py`,
- the implementations in `model_fixes/default.py` and `model_fixes/SPZB0001.py`,
- the import and call site in `climate.py`,
- the patch target in `tests/unit/test_climate_startup.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the thermostat startup flow so device-specific “initial tweak” actions now run properly.
  * Fixed the matching device hooks to use the same corrected name, improving compatibility during initialization.
  * Updated startup tests to cover the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->