### PR TITLE
refactor: extract shared find_device_entity helper

### DIFF
--- a/custom_components/better_thermostat/model_fixes/default.py
+++ b/custom_components/better_thermostat/model_fixes/default.py
@@ -10,6 +10,8 @@ from homeassistant.components.lock import LockState
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers import entity_registry as er
 
+from ..utils.helpers import find_device_entity
+
 _LOGGER = logging.getLogger(__name__)
 
 VALVE_MAINTENANCE_INTERVAL_HOURS = 168  # Default: 7 days
@@ -54,20 +56,9 @@ async def inital_tweak(self, entity_id):
         device_id = reg_entity.device_id
 
         def find_entity(domains, keywords):
-            for ent in entity_registry.entities.values():
-                if ent.device_id != device_id or ent.domain not in domains:
-                    continue
-                name = (getattr(ent, "original_name", "") or "").lower()
-                uid = (ent.unique_id or "").lower()
-                eid = (ent.entity_id or "").lower()
-
-                if (
-                    any(k in name for k in keywords)
-                    or any(k in uid for k in keywords)
-                    or any(k in eid for k in keywords)
-                ):
-                    return ent.entity_id
-            return None
+            return find_device_entity(
+                entity_registry, device_id, domains, keywords
+            )
 
         # 1. Local calibration -> 0
         cal_entity = find_entity(

--- a/custom_components/better_thermostat/switch.py
+++ b/custom_components/better_thermostat/switch.py
@@ -18,6 +18,7 @@ from .utils.calibration.pid import (
     resolve_unique_id,
 )
 from .utils.const import CONF_CALIBRATION_MODE, CalibrationMode
+from .utils.helpers import find_device_entity
 
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = "better_thermostat"
@@ -221,25 +222,12 @@ class BetterThermostatChildLockSwitch(SwitchEntity, RestoreEntity):
 
         device_id = reg_entity.device_id
 
-        def find_entity(domains, keywords):
-            for ent in entity_registry.entities.values():
-                if ent.device_id != device_id or ent.domain not in domains:
-                    continue
-                name = (getattr(ent, "original_name", "") or "").lower()
-                uid = (ent.unique_id or "").lower()
-                eid = (ent.entity_id or "").lower()
-
-                if (
-                    any(k in name for k in keywords)
-                    or any(k in uid for k in keywords)
-                    or any(k in eid for k in keywords)
-                ):
-                    return ent.entity_id
-            return None
-
         # Look for switch (Z2M) or lock
-        cl_entity = find_entity(
-            ["switch", "lock"], ["child_lock", "child lock", "lock"]
+        cl_entity = find_device_entity(
+            entity_registry,
+            device_id,
+            ["switch", "lock"],
+            ["child_lock", "child lock", "lock"],
         )
 
         if cl_entity:

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -44,6 +44,8 @@ def find_device_entity(
     ``domains`` and whose name, unique_id or entity_id contains any of
     ``keywords`` (case-insensitive). Returns ``None`` if nothing matches.
     """
+    domains = tuple(domains)
+    keywords = tuple(k.lower() for k in keywords)
     for ent in entity_registry.entities.values():
         if ent.device_id != device_id or ent.domain not in domains:
             continue

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -354,8 +354,8 @@ def convert_to_float(
         return None
     try:
         # Use 0.01 step (2 decimal places) to preserve sensor precision.
-        # Rounding to 0.1 caused issues where 19.97 became 20.0, leading to
-        # incorrect HVAC action decisions (see issues #1792, #1789, #1785).
+        # Rounding to 0.1 can turn 19.97 into 20.0, leading to incorrect
+        # HVAC action decisions.
         return round_by_step(float(value), 0.01)
     except ValueError, TypeError, AttributeError, KeyError:
         _LOGGER.debug(

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -1,6 +1,6 @@
 """Helper functions for the Better Thermostat component."""
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from datetime import datetime
 import logging
 import math
@@ -30,6 +30,34 @@ from custom_components.better_thermostat.utils.const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def find_device_entity(
+    entity_registry: er.EntityRegistry,
+    device_id: str,
+    domains: Iterable[str],
+    keywords: Iterable[str],
+) -> str | None:
+    """Return the entity_id of the first matching entity on a device.
+
+    A match is any entity belonging to ``device_id`` whose domain is in
+    ``domains`` and whose name, unique_id or entity_id contains any of
+    ``keywords`` (case-insensitive). Returns ``None`` if nothing matches.
+    """
+    for ent in entity_registry.entities.values():
+        if ent.device_id != device_id or ent.domain not in domains:
+            continue
+        name = (getattr(ent, "original_name", "") or "").lower()
+        uid = (ent.unique_id or "").lower()
+        eid = (ent.entity_id or "").lower()
+
+        if (
+            any(k in name for k in keywords)
+            or any(k in uid for k in keywords)
+            or any(k in eid for k in keywords)
+        ):
+            return ent.entity_id
+    return None
 
 
 def normalize_calibration_mode(


### PR DESCRIPTION
An identical nested `find_entity(domains, keywords)` closure existed in two places:

- `switch.py` — child-lock entity lookup,
- `model_fixes/default.py` — initial-tweak lookups (4 call sites).

Both iterate the entity registry for a device and match domain + keyword against name/unique_id/entity_id. Extracted into `find_device_entity(entity_registry, device_id, domains, keywords)` in `utils/helpers.py`; `switch.py` calls it directly, `default.py` keeps a thin local `find_entity` shim. The helper materializes its iterable arguments and lower-cases keywords, so it accepts generators and matches case-insensitively.

`_get_active_algorithms()` in `sensor.py` and `config_flow.py` is similar but consumes different inputs (typed `Trv` objects vs raw config dicts), sits in a different layer, and only the sensor variant logs a per-TRV warning; it stays separate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the thermostat finds related controls and entities, making child lock and calibration-related actions more reliable.
  * Reduced the chance of incorrect device matching when applying thermostat settings.
* **Refactor**
  * Consolidated entity lookup logic to make behavior more consistent across thermostat features.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->