### PR TITLE
fix: compare group member setpoints in Celsius in group_all_members_off

### DIFF
--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -301,7 +301,9 @@ def group_all_members_off(self) -> bool:
 
     A member counts as off when its reported HVAC state is ``off`` or, for a
     ``no_off_system_mode`` device (which never reports ``off``), when its
-    current setpoint has dropped to that device's minimum temperature.
+    current setpoint has dropped to that device's minimum temperature. The
+    setpoint is read via :func:`attr_to_celsius` (with ``target_temp_low`` as
+    fallback attribute) so it is compared in Celsius, like ``min_temp``.
     """
     trv_ids = list(self.real_trvs.keys())
     if len(trv_ids) <= 1:
@@ -319,10 +321,13 @@ def group_all_members_off(self) -> bool:
         if member is not None and (member.advanced or {}).get(
             "no_off_system_mode", False
         ):
-            setpoint = convert_to_float(
-                str(state.attributes.get("temperature")),
-                self.device_name,
-                "group_all_members_off()",
+            setpoint_key = (
+                "temperature"
+                if "temperature" in state.attributes
+                else "target_temp_low"
+            )
+            setpoint = attr_to_celsius(
+                self, state, setpoint_key, None, "group_all_members_off()"
             )
             if (
                 setpoint is not None

--- a/tests/unit/test_helpers_group_off.py
+++ b/tests/unit/test_helpers_group_off.py
@@ -8,6 +8,7 @@ its minimum temperature). Single-TRV instances always agree.
 import types
 from unittest.mock import MagicMock
 
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
 
 from custom_components.better_thermostat.utils.helpers import group_all_members_off
@@ -24,12 +25,13 @@ def _state(entity_id, state_str, temperature=19.0):
     return State(entity_id, state_str, attributes={"temperature": temperature})
 
 
-def _fake_self(members, states):
+def _fake_self(members, states, system_unit=UnitOfTemperature.CELSIUS):
     self_ = types.SimpleNamespace()
     self_.device_name = "Test"
     self_.real_trvs = members
     hass = MagicMock()
     hass.states.get.side_effect = states.get
+    hass.config.units.temperature_unit = system_unit
     self_.hass = hass
     return self_
 
@@ -77,6 +79,38 @@ def test_no_off_one_above_min_false():
         "climate.b": _state("climate.b", "heat", temperature=20.0),
     }
     assert group_all_members_off(_fake_self(members, states)) is False
+
+
+def test_no_off_fahrenheit_at_min_true():
+    """no_off members reporting 41 degF (5 degC) at min_temp 5 degC count as off."""
+    members = {"climate.a": _member(no_off=True), "climate.b": _member(no_off=True)}
+    states = {
+        "climate.a": _state("climate.a", "heat", temperature=41.0),
+        "climate.b": _state("climate.b", "heat", temperature=41.0),
+    }
+    self_ = _fake_self(members, states, system_unit=UnitOfTemperature.FAHRENHEIT)
+    assert group_all_members_off(self_) is True
+
+
+def test_no_off_fahrenheit_above_min_false():
+    """A no_off member at 50 degF (10 degC) is above min_temp and blocks group-off."""
+    members = {"climate.a": _member(no_off=True), "climate.b": _member(no_off=True)}
+    states = {
+        "climate.a": _state("climate.a", "heat", temperature=41.0),
+        "climate.b": _state("climate.b", "heat", temperature=50.0),
+    }
+    self_ = _fake_self(members, states, system_unit=UnitOfTemperature.FAHRENHEIT)
+    assert group_all_members_off(self_) is False
+
+
+def test_no_off_target_temp_low_at_min_true():
+    """A member exposing only target_temp_low at min_temp counts as off."""
+    members = {"climate.a": _member(no_off=True), "climate.b": _member(no_off=True)}
+    states = {
+        "climate.a": _state("climate.a", "heat", temperature=5.0),
+        "climate.b": State("climate.b", "heat", attributes={"target_temp_low": 5.0}),
+    }
+    assert group_all_members_off(_fake_self(members, states)) is True
 
 
 def test_unavailable_members_skipped():


### PR DESCRIPTION
## Motivation:

`group_all_members_off()` reads the raw `temperature` attribute of a member's climate state and compares it against `member.min_temp`. Climate entities report attributes in the HA system unit (°F on imperial installs) and expose no per-entity unit attribute, while `min_temp` is normalized to Celsius. On Fahrenheit systems a `no_off_system_mode` valve at its minimum reports e.g. 41 (°F), so `41 <= 5.0` never holds and the member never counts as off — the group-wide OFF adoption in `trigger_trv_change` is permanently blocked. Same bug class as #2029.

Additionally, only the `temperature` attribute was read; devices exposing `target_temp_low` instead (the fallback `trigger_trv_change` itself uses) always yielded `None`.

## Changes:

- Read the setpoint through `attr_to_celsius` with the same `temperature` → `target_temp_low` key selection used in `events/trv.py`, so the comparison happens in Celsius like every other inbound TRV temperature.
- New unit tests: Fahrenheit member at min (counts as off), Fahrenheit member above min (does not), member exposing only `target_temp_low` at min.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2026.6.4 (verified via the full automated test suite / pytest-homeassistant-custom-component, 1582 passed; no physical TRV involved)
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`
