### PR TITLE
fix: recheck critical entities once the startup grace window elapses

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC
 import asyncio
 from collections import deque
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
 from functools import cached_property
 import json
@@ -1698,6 +1699,37 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     exc,
                 )
 
+    async def _post_grace_recheck(
+        self,
+        grace_until: datetime | None,
+        recheck: Callable[[BetterThermostat], Awaitable[bool]],
+    ) -> None:
+        """Re-run an availability check once a startup grace window elapses.
+
+        During a startup grace window, availability checks defer their
+        Home Assistant repair issue. This helper sleeps for the remaining
+        grace time (if any) and runs the check again, so an entity that is
+        still unavailable after the window surfaces a repair issue without
+        waiting for the next unrelated trigger.
+
+        Parameters
+        ----------
+        grace_until : datetime | None
+            End of the grace window; ``None`` or a past instant runs the
+            recheck immediately.
+        recheck : Callable[[BetterThermostat], Awaitable[bool]]
+            Availability check coroutine function, invoked with this
+            thermostat instance.
+        """
+        remaining = (
+            (grace_until - dt_util.now()).total_seconds() if grace_until else 0.0
+        )
+        if remaining > 0:
+            await asyncio.sleep(remaining)
+        if self.is_removed:
+            return
+        await recheck(self)
+
     async def _finalize_startup(self) -> None:
         """Run post-init tasks: triggers, listeners, periodic jobs."""
         # Likewise give critical (TRV) entities a short grace before raising
@@ -1719,6 +1751,17 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             "better_thermostat %s: checking critical entities...", self.device_name
         )
         await check_critical_entities(self)
+
+        # The retry schedule above finishes before the critical grace window
+        # ends, so a TRV that is still missing defers its repair issue. Re-run
+        # the check once the grace window has elapsed; otherwise the issue
+        # only appears when some later event happens to trigger a check.
+        self.hass.async_create_background_task(
+            self._post_grace_recheck(
+                self._critical_grace_until, check_critical_entities
+            ),
+            name=f"bt_post_grace_critical_{self.device_name}",
+        )
 
         _LOGGER.debug("better_thermostat %s: triggering time...", self.device_name)
         await self._trigger_time(None)
@@ -1774,20 +1817,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         await await_optional_sensors(self)
         await check_and_update_degraded_mode(self)
 
-        async def _post_grace_degraded_recheck() -> None:
-            remaining = (
-                (self._degraded_grace_until - dt_util.now()).total_seconds()
-                if self._degraded_grace_until
-                else 0.0
-            )
-            if remaining > 0:
-                await asyncio.sleep(remaining)
-            if self.is_removed:
-                return
-            await check_and_update_degraded_mode(self)
-
         self.hass.async_create_background_task(
-            _post_grace_degraded_recheck(),
+            self._post_grace_recheck(
+                self._degraded_grace_until, check_and_update_degraded_mode
+            ),
             name=f"bt_post_grace_degraded_{self.device_name}",
         )
 

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1728,7 +1728,14 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             await asyncio.sleep(remaining)
         if self.is_removed:
             return
-        await recheck(self)
+        try:
+            await recheck(self)
+        except Exception:
+            _LOGGER.warning(
+                "better_thermostat %s: post-grace availability recheck failed",
+                self.device_name,
+                exc_info=True,
+            )
 
     async def _finalize_startup(self) -> None:
         """Run post-init tasks: triggers, listeners, periodic jobs."""

--- a/tests/unit/test_climate_post_grace_recheck.py
+++ b/tests/unit/test_climate_post_grace_recheck.py
@@ -1,0 +1,111 @@
+"""Tests for BetterThermostat._post_grace_recheck.
+
+The helper backs the post-grace background tasks scheduled in
+_finalize_startup: it sleeps until the startup grace window has elapsed and
+then re-runs an availability check (check_critical_entities for TRVs,
+check_and_update_degraded_mode for optional sensors) unless the entity has
+been removed in the meantime.
+"""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.util import dt as dt_util
+import pytest
+
+import custom_components.better_thermostat.climate as climate_module
+from custom_components.better_thermostat.climate import BetterThermostat
+
+GRACE_SECONDS = 90
+
+
+@pytest.fixture
+def bt():
+    """Create a mock BetterThermostat with the attributes the helper reads."""
+    mock = MagicMock(spec=BetterThermostat)
+    mock.device_name = "Test BT"
+    mock.is_removed = False
+    return mock
+
+
+class TestPostGraceRecheck:
+    """Tests for the sleep-then-recheck behavior of _post_grace_recheck."""
+
+    @pytest.mark.asyncio
+    async def test_sleeps_remaining_grace_then_rechecks(self, bt):
+        """With grace time remaining, sleep the remainder and run the check."""
+        grace_until = dt_util.now() + timedelta(seconds=GRACE_SECONDS)
+        with (
+            patch.object(
+                climate_module, "check_critical_entities", new_callable=AsyncMock
+            ) as check,
+            patch.object(
+                climate_module.asyncio, "sleep", new_callable=AsyncMock
+            ) as sleep,
+        ):
+            await BetterThermostat._post_grace_recheck(
+                bt, grace_until, climate_module.check_critical_entities
+            )
+        sleep.assert_awaited_once()
+        assert 0 < sleep.await_args.args[0] <= GRACE_SECONDS
+        check.assert_awaited_once_with(bt)
+
+    @pytest.mark.asyncio
+    async def test_removed_during_sleep_skips_recheck(self, bt):
+        """When the entity is removed while sleeping, skip the recheck."""
+        grace_until = dt_util.now() + timedelta(seconds=GRACE_SECONDS)
+
+        async def _remove_during_sleep(_delay):
+            bt.is_removed = True
+
+        with (
+            patch.object(
+                climate_module, "check_critical_entities", new_callable=AsyncMock
+            ) as check,
+            patch.object(
+                climate_module.asyncio,
+                "sleep",
+                new_callable=AsyncMock,
+                side_effect=_remove_during_sleep,
+            ) as sleep,
+        ):
+            await BetterThermostat._post_grace_recheck(
+                bt, grace_until, climate_module.check_critical_entities
+            )
+        sleep.assert_awaited_once()
+        check.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_expired_grace_rechecks_without_sleep(self, bt):
+        """With the grace window already over, recheck immediately."""
+        grace_until = dt_util.now() - timedelta(seconds=1)
+        with (
+            patch.object(
+                climate_module, "check_critical_entities", new_callable=AsyncMock
+            ) as check,
+            patch.object(
+                climate_module.asyncio, "sleep", new_callable=AsyncMock
+            ) as sleep,
+        ):
+            await BetterThermostat._post_grace_recheck(
+                bt, grace_until, climate_module.check_critical_entities
+            )
+        sleep.assert_not_awaited()
+        check.assert_awaited_once_with(bt)
+
+    @pytest.mark.asyncio
+    async def test_no_grace_window_rechecks_without_sleep(self, bt):
+        """With no grace window set, recheck immediately."""
+        with (
+            patch.object(
+                climate_module, "check_critical_entities", new_callable=AsyncMock
+            ) as check,
+            patch.object(
+                climate_module.asyncio, "sleep", new_callable=AsyncMock
+            ) as sleep,
+        ):
+            await BetterThermostat._post_grace_recheck(
+                bt, None, climate_module.check_critical_entities
+            )
+        sleep.assert_not_awaited()
+        check.assert_awaited_once_with(bt)


### PR DESCRIPTION
## Motivation:

`_finalize_startup` anchors a 2-minute critical grace window, then `await_critical_entities` exhausts its retry schedule after ~88 s, so the subsequent `check_critical_entities` call still lands inside the grace window. For a permanently missing TRV the `missing_entity` repair issue is deferred — and nothing re-arms a check when the grace window expires. The issue only surfaces when some unrelated event happens to trigger a check, worst case the hourly weather timer. The degraded-mode path in the same function already schedules exactly this post-grace recheck.

## Changes:

- Factored the "sleep the remaining grace time, then recheck unless removed" shape into a private `_post_grace_recheck(grace_until, recheck)` method and scheduled it for the critical path right after the initial check.
- The existing degraded-mode closure is replaced by the same helper (task names and behavior unchanged).
- `check_critical_entities` itself is untouched — the change is purely additive scheduling.
- Four new unit tests: recheck after sleeping the remaining grace, no recheck when the entity was removed during the sleep, immediate recheck when the window already expired, immediate recheck when no window is set.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2026.6.4 (verified via the full automated test suite / pytest-homeassistant-custom-component, 1583 passed; no physical TRV involved)
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py` (this fix is a dedicated `climate.py` change; no device mappings touched)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup behavior so the thermostat rechecks critical entities and degraded mode after their grace periods elapse.
  * Avoids running follow-up rechecks when the entity has already been removed.
  * Ensures the appropriate recheck happens immediately if the grace window has already expired.
* **Tests**
  * Added unit coverage for the async grace-window wait-and-recheck behavior, including removal and expired/disabled grace scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->