### PR TITLE
fix: stop the startup retry loop when the entity is removed

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1012,6 +1012,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             self._initialize_sensors(sensor_state)
             await check_and_update_degraded_mode(self)
             await self._restore_state(states)
+            # The awaits above yield to the event loop, so the entity may have
+            # been removed in the meantime; bail out before writing to TRVs.
+            if self.is_removed:
+                return
             self._validate_hvac_mode(states)
             await self._initialize_trvs()
             await self._finalize_startup()

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -992,6 +992,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # ``_finalize_startup`` to cover post-startup reconnection blips.
         self._critical_grace_until = dt_util.now() + STARTUP_CRITICAL_GRACE_PERIOD
         while self.startup_running:
+            if self.is_removed:
+                return
             _LOGGER.info(
                 "better_thermostat %s: Starting version %s. Waiting for entity to be ready...",
                 self.device_name,
@@ -1001,6 +1003,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             sensor_state = self.hass.states.get(self.sensor_entity_id)
             if not self._check_entities_ready(sensor_state):
                 await asyncio.sleep(20)
+                if self.is_removed:
+                    return
                 continue
 
             states = self._collect_trv_states()
@@ -3084,6 +3088,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
     async def async_will_remove_from_hass(self):
         """Run when entity will be removed from hass."""
+        # Terminate the startup retry loop so an entity whose dependencies
+        # never became available does not keep polling after unload.
+        self.startup_running = False
         if self._control_task:
             self._control_task.cancel()
             try:

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -4,6 +4,7 @@ Covers: _check_entities_ready, _collect_trv_states, _resolve_temperature_range,
 _initialize_sensors, _restore_state, _validate_hvac_mode.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.climate.const import HVACMode
@@ -102,6 +103,56 @@ def _make_trv_state(entity_id=TRV_ID, state="heat", attrs=None):
 def _make_sensor_state(temp="21.5", state_val=None):
     """Build a sensor State."""
     return State(SENSOR_ID, state_val or temp)
+
+
+# ---------------------------------------------------------------------------
+# 0. startup() retry loop unload behavior
+# ---------------------------------------------------------------------------
+
+
+class TestStartupUnloadBailout:
+    """The startup retry loop exits when the entity is removed."""
+
+    @pytest.mark.asyncio
+    async def test_returns_immediately_when_already_removed(self, bt):
+        """Return before any readiness check when the entity is removed."""
+        bt.is_removed = True
+        bt.startup_running = True
+
+        await asyncio.wait_for(BetterThermostat.startup(bt), timeout=1)
+
+        bt._check_entities_ready.assert_not_called()
+        bt._collect_trv_states.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_when_removed_during_retry_sleep(self, bt):
+        """Exit the retry loop when removal happens while sleeping."""
+        bt.is_removed = False
+        bt.startup_running = True
+        bt._check_entities_ready.return_value = False
+
+        async def fake_sleep(_seconds):
+            bt.is_removed = True
+
+        with patch(
+            "custom_components.better_thermostat.climate.asyncio.sleep",
+            side_effect=fake_sleep,
+        ) as mock_sleep:
+            await asyncio.wait_for(BetterThermostat.startup(bt), timeout=1)
+
+        mock_sleep.assert_awaited_once()
+        bt._collect_trv_states.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_will_remove_from_hass_stops_startup_loop(self, bt):
+        """Unload clears startup_running so the loop condition terminates."""
+        bt._control_task = None
+        bt._window_task = None
+        bt.startup_running = True
+
+        await BetterThermostat.async_will_remove_from_hass(bt)
+
+        assert bt.startup_running is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -144,6 +144,27 @@ class TestStartupUnloadBailout:
         bt._collect_trv_states.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_returns_when_removed_before_trv_initialization(self, bt):
+        """Stop before writing to TRVs when removal happens during restore."""
+        bt.is_removed = False
+        bt.startup_running = True
+        bt._check_entities_ready.return_value = True
+
+        async def fake_restore_state(_states):
+            bt.is_removed = True
+
+        bt._restore_state.side_effect = fake_restore_state
+
+        with patch(
+            "custom_components.better_thermostat.climate.check_and_update_degraded_mode",
+            new=AsyncMock(),
+        ):
+            await asyncio.wait_for(BetterThermostat.startup(bt), timeout=1)
+
+        bt._initialize_trvs.assert_not_called()
+        bt._finalize_startup.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_will_remove_from_hass_stops_startup_loop(self, bt):
         """Unload clears startup_running so the loop condition terminates."""
         bt._control_task = None


### PR DESCRIPTION
## Motivation:

`startup()` runs as an un-cancelled background task, and its retry loop (`while self.startup_running:` with a 20 s sleep) neither checks `self.is_removed` nor is stopped on unload. Unloading a config entry whose TRV or sensor never became available therefore leaks a task that keeps polling and logging "Waiting for entity to be ready..." every 20 s indefinitely and pins the entity object. The other startup wait paths (`await_critical_entities`, `_finalize_startup`) already bail on `is_removed`.

## Changes:

- Bail out of the retry loop at the loop head and right after the 20 s retry sleep when `self.is_removed` is set.
- Bail out after the awaited restore steps, before `_initialize_trvs()` issues writes to TRVs, when removal happened during those awaits.
- Set `self.startup_running = False` at the start of the existing `async_will_remove_from_hass` override so the loop condition itself terminates on unload.
- Four new unit tests: immediate return when already removed, prompt exit when removal happens during the retry sleep (hangs without the fix), no TRV initialization when removal happens during state restore, and `async_will_remove_from_hass` stopping the loop flag.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2026.6.4 (verified via the full automated test suite / pytest-homeassistant-custom-component, 1583 passed; no physical TRV involved)
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py` (this fix is a dedicated `climate.py` change; no device mappings touched)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

A detailed high-level summary could not be generated for this review. Here is an overview derived from the analyzed file changes:

- **custom_components/better_thermostat/climate.py**: ## AI-generated summary of changes
- **tests/unit/test_climate_startup.py**: ## AI-generated summary of changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->