### PR TITLE
fix: offer device automations for the Better Thermostat climate entity

### DIFF
--- a/custom_components/better_thermostat/device_action.py
+++ b/custom_components/better_thermostat/device_action.py
@@ -46,7 +46,11 @@ async def async_get_actions(
 
     # Get all the integrations entities for this device
     for entry in entity_registry.async_entries_for_device(registry, device_id):
-        if entry.domain != DOMAIN:
+        # Both action types call climate services on the Better Thermostat
+        # climate entity (the action schema restricts the entity to the
+        # climate domain), so only that entity qualifies: it must belong to
+        # this integration (platform) and be a climate entity (domain).
+        if entry.platform != DOMAIN or entry.domain != CLIMATE_DOMAIN:
             continue
 
         base_action = {

--- a/custom_components/better_thermostat/device_condition.py
+++ b/custom_components/better_thermostat/device_condition.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from homeassistant.components.climate.const import (
     ATTR_HVAC_ACTION,
     ATTR_HVAC_MODE,
+    DOMAIN as CLIMATE_DOMAIN,
     HVACAction,
     HVACMode,
 )
@@ -58,7 +59,10 @@ async def async_get_conditions(
 
     # Get all the integrations entities for this device
     for entry in entity_registry.async_entries_for_device(registry, device_id):
-        if entry.domain != DOMAIN:
+        # Both condition types read attributes of the Better Thermostat
+        # climate entity, so only that entity qualifies: it must belong to
+        # this integration (platform) and be a climate entity (domain).
+        if entry.platform != DOMAIN or entry.domain != CLIMATE_DOMAIN:
             continue
 
         base_condition = {

--- a/custom_components/better_thermostat/device_trigger.py
+++ b/custom_components/better_thermostat/device_trigger.py
@@ -22,7 +22,7 @@ Classic triggers (kept for backwards compatibility):
 
 from __future__ import annotations
 
-from homeassistant.components.climate.const import HVAC_MODES
+from homeassistant.components.climate.const import DOMAIN as CLIMATE_DOMAIN, HVAC_MODES
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.homeassistant.triggers import (
     numeric_state as numeric_state_trigger,
@@ -102,7 +102,10 @@ async def async_get_triggers(
     triggers: list[dict[str, str | dict[str, bool]]] = []
 
     for entry in entity_registry.async_entries_for_device(registry, device_id):
-        if entry.domain != DOMAIN:
+        # All trigger templates read attributes of the Better Thermostat
+        # climate entity, so only that entity qualifies: it must belong to
+        # this integration (platform) and be a climate entity (domain).
+        if entry.platform != DOMAIN or entry.domain != CLIMATE_DOMAIN:
             continue
 
         if not hass.states.get(entry.entity_id):

--- a/tests/unit/test_device_automations.py
+++ b/tests/unit/test_device_automations.py
@@ -1,0 +1,180 @@
+"""Tests for the device automation modules (trigger, condition, action).
+
+Each ``async_get_*`` function enumerates the entities of a device and must
+pick up exactly the Better Thermostat climate entity: an entity created by
+this integration (``entry.platform``) in the climate domain
+(``entry.domain``). Entities from other integrations on the same device and
+non-climate entities from this integration must be skipped.
+
+The tests use the real ``hass`` fixture with the real device and entity
+registries so the functions under test run against genuine
+``RegistryEntry`` objects.
+"""
+
+from __future__ import annotations
+
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_ENTITY_ID, CONF_TYPE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.better_thermostat import DOMAIN
+from custom_components.better_thermostat.device_action import (
+    ACTION_TYPES,
+    async_get_actions,
+)
+from custom_components.better_thermostat.device_condition import (
+    CONDITION_TYPES,
+    async_get_conditions,
+)
+from custom_components.better_thermostat.device_trigger import (
+    TRIGGER_TYPES,
+    async_get_triggers,
+)
+
+
+def _create_device(hass: HomeAssistant) -> dr.DeviceEntry:
+    """Register a device attached to a mock config entry.
+
+    Parameters
+    ----------
+    hass : HomeAssistant
+        The Home Assistant test instance.
+
+    Returns
+    -------
+    dr.DeviceEntry
+        The registered device entry.
+    """
+    config_entry = MockConfigEntry(domain=DOMAIN)
+    config_entry.add_to_hass(hass)
+    device_registry = dr.async_get(hass)
+    return device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id, identifiers={(DOMAIN, "test_device")}
+    )
+
+
+def _register_entity(
+    hass: HomeAssistant,
+    device: dr.DeviceEntry,
+    *,
+    domain: str = "climate",
+    platform: str = DOMAIN,
+    unique_id: str = "bt_unique",
+) -> er.RegistryEntry:
+    """Register an entity on a device in the real entity registry.
+
+    Parameters
+    ----------
+    hass : HomeAssistant
+        The Home Assistant test instance.
+    device : dr.DeviceEntry
+        The device the entity belongs to.
+    domain : str
+        Entity-id domain of the entity (e.g. ``climate``, ``sensor``).
+    platform : str
+        Integration domain that created the entity.
+    unique_id : str
+        Unique id of the entity within its platform.
+
+    Returns
+    -------
+    er.RegistryEntry
+        The registered entity entry.
+    """
+    entity_registry = er.async_get(hass)
+    return entity_registry.async_get_or_create(
+        domain, platform, unique_id, device_id=device.id
+    )
+
+
+async def test_get_triggers_lists_all_types_for_bt_climate_entity(
+    hass: HomeAssistant,
+) -> None:
+    """A BT climate entity on the device yields the full trigger list."""
+    device = _create_device(hass)
+    entity = _register_entity(hass, device)
+    hass.states.async_set(entity.entity_id, "heat")
+
+    triggers = await async_get_triggers(hass, device.id)
+
+    assert {trigger[CONF_TYPE] for trigger in triggers} == TRIGGER_TYPES
+    for trigger in triggers:
+        assert trigger[CONF_DOMAIN] == DOMAIN
+        assert trigger[CONF_DEVICE_ID] == device.id
+        assert trigger[CONF_ENTITY_ID] == entity.entity_id
+
+
+async def test_get_triggers_skips_entity_without_state(hass: HomeAssistant) -> None:
+    """A registered BT climate entity without a state yields no triggers."""
+    device = _create_device(hass)
+    _register_entity(hass, device)
+
+    assert await async_get_triggers(hass, device.id) == []
+
+
+async def test_get_triggers_skips_foreign_and_non_climate_entities(
+    hass: HomeAssistant,
+) -> None:
+    """Foreign-platform and non-climate entities yield no triggers."""
+    device = _create_device(hass)
+    foreign = _register_entity(hass, device, platform="demo", unique_id="foreign")
+    sensor = _register_entity(hass, device, domain="sensor", unique_id="bt_sensor")
+    hass.states.async_set(foreign.entity_id, "heat")
+    hass.states.async_set(sensor.entity_id, "21.0")
+
+    assert await async_get_triggers(hass, device.id) == []
+
+
+async def test_get_conditions_lists_all_types_for_bt_climate_entity(
+    hass: HomeAssistant,
+) -> None:
+    """A BT climate entity on the device yields the full condition list."""
+    device = _create_device(hass)
+    entity = _register_entity(hass, device)
+
+    conditions = await async_get_conditions(hass, device.id)
+
+    assert {condition[CONF_TYPE] for condition in conditions} == CONDITION_TYPES
+    for condition in conditions:
+        assert condition[CONF_DOMAIN] == DOMAIN
+        assert condition[CONF_DEVICE_ID] == device.id
+        assert condition[CONF_ENTITY_ID] == entity.entity_id
+
+
+async def test_get_conditions_skips_foreign_and_non_climate_entities(
+    hass: HomeAssistant,
+) -> None:
+    """Foreign-platform and non-climate entities yield no conditions."""
+    device = _create_device(hass)
+    _register_entity(hass, device, platform="demo", unique_id="foreign")
+    _register_entity(hass, device, domain="switch", unique_id="bt_switch")
+
+    assert await async_get_conditions(hass, device.id) == []
+
+
+async def test_get_actions_lists_all_types_for_bt_climate_entity(
+    hass: HomeAssistant,
+) -> None:
+    """A BT climate entity on the device yields the full action list."""
+    device = _create_device(hass)
+    entity = _register_entity(hass, device)
+
+    actions = await async_get_actions(hass, device.id)
+
+    assert {action[CONF_TYPE] for action in actions} == ACTION_TYPES
+    for action in actions:
+        assert action[CONF_DOMAIN] == DOMAIN
+        assert action[CONF_DEVICE_ID] == device.id
+        assert action[CONF_ENTITY_ID] == entity.entity_id
+
+
+async def test_get_actions_skips_foreign_and_non_climate_entities(
+    hass: HomeAssistant,
+) -> None:
+    """Foreign-platform and non-climate entities yield no actions."""
+    device = _create_device(hass)
+    _register_entity(hass, device, platform="demo", unique_id="foreign")
+    _register_entity(hass, device, domain="number", unique_id="bt_number")
+
+    assert await async_get_actions(hass, device.id) == []


### PR DESCRIPTION
## Motivation:

`async_get_triggers`, `async_get_conditions`, and `async_get_actions` filter the device's registry entries with `entry.domain != DOMAIN`. `RegistryEntry.domain` is the entity-id domain (`climate`, `sensor`, `switch`, `number`) and never the integration domain `"better_thermostat"`, so the filter rejects every entity and all three functions always return empty lists. The documented device automations (battery_low, humidity_high, window/hvac triggers, conditions, actions) have therefore never been offered in the HA UI — a silent no-op with no logging. These modules had no test coverage.

## Changes:

- The filter now checks `entry.platform != DOMAIN` (integration ownership) plus `entry.domain != CLIMATE_DOMAIN`, since every trigger/condition/action in these modules operates on the Better Thermostat climate entity (BT also registers sensor/number/switch entities that must stay excluded; the action schema already restricts entities to the climate domain).
- New tests (tests/unit/test_device_automations.py, 7 tests) run the real functions against genuine device/entity registries: positive tests assert the full trigger/condition/action type sets are returned for the BT climate entity; negative tests assert foreign-platform and non-climate entities are not picked up. Verified the positive tests fail without the fix.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2026.6.4 (full automated test suite, 1589 passed; ruff and pyrefly clean; no physical TRV involved)
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device automation matching so only the correct thermostat climate entities appear for triggers, conditions, and actions.
  * Reduced incorrect matches from unrelated platforms, non-climate entities, and entities without a valid state.

* **Tests**
  * Added coverage for device automation helpers to verify the correct entities are included and invalid ones are filtered out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->