### PR TITLE
fix: only consider writable domains for the local calibration entity

### DIFF
--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -1016,6 +1016,11 @@ _CALIBRATION_TRANSLATION_KEYS: set[str] = {
     "offset",
 }
 
+# Domains the calibration write path can address (number.set_value or
+# select option handling).  Read-only entities such as the Zigbee2MQTT
+# sensor.*_local_temperature must never be picked as calibration target.
+_CALIBRATION_ENTITY_DOMAINS: set[str] = {"number", "select"}
+
 
 async def find_local_calibration_entity(self, entity_id):
     """Find the local calibration entity for the TRV.
@@ -1023,6 +1028,8 @@ async def find_local_calibration_entity(self, entity_id):
     Uses the entity registry's ``translation_key`` and ``original_name``
     for a stable, language-independent lookup.  Falls back to the legacy
     unique_id / entity_id string matching for older integrations.
+    Only writable candidates (``number`` or ``select`` entities) are
+    considered.
 
     Parameters
     ----------
@@ -1051,6 +1058,8 @@ async def find_local_calibration_entity(self, entity_id):
     for entity in entity_entries:
         if entity.device_id != reg_entity.device_id:
             continue
+        if entity.domain not in _CALIBRATION_ENTITY_DOMAINS:
+            continue
         tk = getattr(entity, "translation_key", None)
         if tk and tk in _CALIBRATION_TRANSLATION_KEYS:
             _LOGGER.debug(
@@ -1063,17 +1072,15 @@ async def find_local_calibration_entity(self, entity_id):
             break
 
     # Second pass: fallback to string matching on unique_id / entity_id / original_name.
-    # Restricted to the "number" domain: only number entities are writable
-    # calibration controls, so a read-only sensor sharing the same substring
-    # (e.g. sensor.*_local_temperature) is never a valid match here. Without
-    # this restriction the winner depended on registry iteration order, which
-    # is not a guaranteed order.
+    # Restricted to writable calibration domains: a read-only sensor sharing
+    # the same substring (e.g. sensor.*_local_temperature) is never a valid
+    # match, and without the restriction the winner depended on registry
+    # iteration order, which is not guaranteed.
     if calibration_entity is None:
         for entity in entity_entries:
             if entity.device_id != reg_entity.device_id:
                 continue
-            domain = (entity.entity_id or "").split(".", 1)[0]
-            if domain != "number":
+            if entity.domain not in _CALIBRATION_ENTITY_DOMAINS:
                 continue
             descriptor = f"{entity.unique_id} {entity.entity_id} {getattr(entity, 'original_name', '') or ''}".lower()
             if (

--- a/tests/test_helpers_valve.py
+++ b/tests/test_helpers_valve.py
@@ -22,6 +22,8 @@ def _make_entity(eid, uid, device_id, translation_key=None, original_name=None):
     e.device_id = device_id
     e.translation_key = translation_key
     e.original_name = original_name
+    # RegistryEntry.domain is derived from the entity_id
+    e.domain = eid.split(".", 1)[0]
     return e
 
 
@@ -493,3 +495,168 @@ async def test_find_local_calibration_translation_key_preferred_over_string():
 
         # translation_key match should be preferred
         assert result == "number.trv_tk_entity"
+
+
+@pytest.mark.anyio
+async def test_find_local_calibration_entity_prefers_number_over_sensor():
+    """Test that the number calibration entity wins over a read-only sensor.
+
+    Zigbee2MQTT exposes both sensor.*_local_temperature and
+    number.*_local_temperature_calibration on the same device; the sensor
+    is registered first here to prove selection is order-independent.
+    """
+
+    bt_instance = _make_bt_instance()
+    device_id = "device_123"
+
+    reg_entity_trv = MagicMock()
+    reg_entity_trv.config_entry_id = "config_123"
+    reg_entity_trv.device_id = device_id
+
+    ent_sensor = _make_entity(
+        eid="sensor.trv_local_temperature",
+        uid="0x1234_local_temperature",
+        device_id=device_id,
+        translation_key=None,
+    )
+    ent_number = _make_entity(
+        eid="number.trv_local_temperature_calibration",
+        uid="0x1234_local_temperature_calibration",
+        device_id=device_id,
+        translation_key=None,
+    )
+
+    with (
+        patch(
+            "custom_components.better_thermostat.utils.helpers.er.async_get"
+        ) as mock_er_get,
+        patch(
+            "custom_components.better_thermostat.utils.helpers.async_entries_for_config_entry"
+        ) as mock_entries,
+    ):
+        mock_registry = MagicMock()
+        mock_er_get.return_value = mock_registry
+        mock_registry.async_get.return_value = reg_entity_trv
+
+        mock_entries.return_value = [ent_sensor, ent_number]
+        result = await find_local_calibration_entity(bt_instance, "climate.my_trv")
+
+        assert result == "number.trv_local_temperature_calibration"
+
+
+@pytest.mark.anyio
+async def test_find_local_calibration_translation_key_ignores_sensor_domain():
+    """Test that the translation_key pass skips non-writable domains.
+
+    A sensor entity carrying a matching translation_key must not be
+    selected; the writable number entity on the same device wins.
+    """
+
+    bt_instance = _make_bt_instance()
+    device_id = "device_123"
+
+    reg_entity_trv = MagicMock()
+    reg_entity_trv.config_entry_id = "config_123"
+    reg_entity_trv.device_id = device_id
+
+    ent_sensor_tk = _make_entity(
+        eid="sensor.trv_offset_readout",
+        uid="opaque_uid_sensor",
+        device_id=device_id,
+        translation_key="local_temperature_calibration",
+    )
+    ent_number_tk = _make_entity(
+        eid="number.trv_calibration",
+        uid="opaque_uid_number",
+        device_id=device_id,
+        translation_key="local_temperature_calibration",
+    )
+
+    with (
+        patch(
+            "custom_components.better_thermostat.utils.helpers.er.async_get"
+        ) as mock_er_get,
+        patch(
+            "custom_components.better_thermostat.utils.helpers.async_entries_for_config_entry"
+        ) as mock_entries,
+    ):
+        mock_registry = MagicMock()
+        mock_er_get.return_value = mock_registry
+        mock_registry.async_get.return_value = reg_entity_trv
+
+        mock_entries.return_value = [ent_sensor_tk, ent_number_tk]
+        result = await find_local_calibration_entity(bt_instance, "climate.my_trv")
+
+        assert result == "number.trv_calibration"
+
+
+@pytest.mark.anyio
+async def test_find_local_calibration_entity_sensor_only_returns_none():
+    """Test that a device exposing only the read-only sensor yields no match."""
+
+    bt_instance = _make_bt_instance()
+    device_id = "device_123"
+
+    reg_entity_trv = MagicMock()
+    reg_entity_trv.config_entry_id = "config_123"
+    reg_entity_trv.device_id = device_id
+
+    ent_sensor = _make_entity(
+        eid="sensor.trv_local_temperature",
+        uid="0x1234_local_temperature",
+        device_id=device_id,
+        translation_key=None,
+    )
+
+    with (
+        patch(
+            "custom_components.better_thermostat.utils.helpers.er.async_get"
+        ) as mock_er_get,
+        patch(
+            "custom_components.better_thermostat.utils.helpers.async_entries_for_config_entry"
+        ) as mock_entries,
+    ):
+        mock_registry = MagicMock()
+        mock_er_get.return_value = mock_registry
+        mock_registry.async_get.return_value = reg_entity_trv
+
+        mock_entries.return_value = [ent_sensor]
+        result = await find_local_calibration_entity(bt_instance, "climate.my_trv")
+
+        assert result is None
+
+
+@pytest.mark.anyio
+async def test_find_local_calibration_entity_accepts_select_domain():
+    """Test that a select calibration entity is accepted as writable target."""
+
+    bt_instance = _make_bt_instance()
+    device_id = "device_123"
+
+    reg_entity_trv = MagicMock()
+    reg_entity_trv.config_entry_id = "config_123"
+    reg_entity_trv.device_id = device_id
+
+    ent_select = _make_entity(
+        eid="select.trv_temperature_offset",
+        uid="0x1234_temperature_offset",
+        device_id=device_id,
+        translation_key=None,
+    )
+
+    with (
+        patch(
+            "custom_components.better_thermostat.utils.helpers.er.async_get"
+        ) as mock_er_get,
+        patch(
+            "custom_components.better_thermostat.utils.helpers.async_entries_for_config_entry"
+        ) as mock_entries,
+    ):
+        mock_registry = MagicMock()
+        mock_er_get.return_value = mock_registry
+        mock_registry.async_get.return_value = reg_entity_trv
+
+        mock_entries.return_value = [ent_select]
+        result = await find_local_calibration_entity(bt_instance, "climate.my_trv")
+
+        assert result == "select.trv_temperature_offset"

--- a/tests/test_helpers_valve.py
+++ b/tests/test_helpers_valve.py
@@ -545,6 +545,52 @@ async def test_find_local_calibration_entity_prefers_number_over_sensor():
 
 
 @pytest.mark.anyio
+async def test_find_local_calibration_entity_first_writable_match_wins():
+    """Test that the fallback pass stops at the first writable match.
+
+    With two number entities whose descriptors both match the fallback
+    substrings, the one earlier in registry order is selected.
+    """
+
+    bt_instance = _make_bt_instance()
+    device_id = "device_123"
+
+    reg_entity_trv = MagicMock()
+    reg_entity_trv.config_entry_id = "config_123"
+    reg_entity_trv.device_id = device_id
+
+    ent_first = _make_entity(
+        eid="number.trv_local_temperature_calibration",
+        uid="0x1234_local_temperature_calibration",
+        device_id=device_id,
+        translation_key=None,
+    )
+    ent_second = _make_entity(
+        eid="number.trv_temperature_offset",
+        uid="0x1234_temperature_offset",
+        device_id=device_id,
+        translation_key=None,
+    )
+
+    with (
+        patch(
+            "custom_components.better_thermostat.utils.helpers.er.async_get"
+        ) as mock_er_get,
+        patch(
+            "custom_components.better_thermostat.utils.helpers.async_entries_for_config_entry"
+        ) as mock_entries,
+    ):
+        mock_registry = MagicMock()
+        mock_er_get.return_value = mock_registry
+        mock_registry.async_get.return_value = reg_entity_trv
+
+        mock_entries.return_value = [ent_first, ent_second]
+        result = await find_local_calibration_entity(bt_instance, "climate.my_trv")
+
+        assert result == "number.trv_local_temperature_calibration"
+
+
+@pytest.mark.anyio
 async def test_find_local_calibration_translation_key_ignores_sensor_domain():
     """Test that the translation_key pass skips non-writable domains.
 


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #2105** — the first commits in the diff belong to that PR; once it merges, this diff shrinks to the last commit.

## Motivation:

`find_local_calibration_entity()` filters candidates only by `device_id`, never by domain. The substring fallback matches `"local_temperature"`, which also matches the read-only `sensor.*_local_temperature` that Zigbee2MQTT creates on virtually every TRV — alongside the intended `number.*_local_temperature_calibration`. Registry iteration order is arbitrary, so which one wins is a coin flip per install. When the sensor wins, the corruption is silent: `number.set_value` on a `sensor.` entity is a no-op in HA (only a generic "referenced entities missing" warning), BT records the offset as applied and re-issues the ghost write every cycle, and `get_current_offset` returns the room temperature as the current calibration offset.

## Changes:

- Both lookup passes (translation_key and substring fallback) now skip entities outside `{number, select}` — exactly the domains the `set_offset` write paths can address (generic: select + number; mqtt: number).
- New tests: sensor-registered-first still yields the number entity (order independence); translation-key pass ignores non-writable domains; sensor-only device returns None; select-domain calibration entities still match.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2026.6.4 (full automated test suite, 1591 passed; ruff and pyrefly clean; no physical TRV involved)
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calibration entity selection so only writable controls are chosen.
  * Prevented read-only entities from being picked when a writable calibration option is available.
  * Ensured matching stops as soon as the best calibration entity is found.
  * Expanded coverage for thermostat calibration lookups, including support for writable select-based controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->