### PR TITLE
fix: match setpoints with a tolerance across rounding grids

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -28,6 +28,7 @@ from custom_components.better_thermostat.utils.const import (
 from custom_components.better_thermostat.utils.helpers import (
     convert_to_float,
     get_current_set_temperatures,
+    matches_any_setpoint,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -617,7 +618,10 @@ async def control_trv(self, heater_entity_id=None):
         if _temperature is not None and (
             _new_hvac_mode != HVACMode.OFF or _no_off_system_mode
         ):
-            if _temperature not in _current_set_temperatures:
+            # Tolerance-based comparison: the outbound value lies on the
+            # device step grid, the read-back values on the 0.01 grid, so
+            # exact set membership would re-send identical setpoints.
+            if not matches_any_setpoint(_temperature, _current_set_temperatures):
                 old = self.real_trvs[heater_entity_id].last_temperature
                 _LOGGER.debug(
                     "better_thermostat %s: TO TRV set_temperature: %s from: %s to: %s",
@@ -723,7 +727,8 @@ async def check_target_temperature(self, heater_entity_id=None):
 
     Polls the TRV's temperature (and target_temp_low, when range mode is
     supported) attribute every second until either matches last_temperature
-    or timeout is reached. Sets target_temp_received flag when complete.
+    within SETPOINT_MATCH_TOLERANCE or timeout is reached. Sets
+    target_temp_received flag when complete.
 
     Parameters
     ----------
@@ -761,9 +766,11 @@ async def check_target_temperature(self, heater_entity_id=None):
                 _real_trv.last_temperature,
                 _current_set_temperatures,
             )
-        if (
-            not _current_set_temperatures
-            or _real_trv.last_temperature in _current_set_temperatures
+        # An empty set (no readable setpoint) is treated as confirmed; a
+        # non-empty set is matched with a tolerance because written and
+        # read-back setpoints lie on different float rounding grids.
+        if not _current_set_temperatures or matches_any_setpoint(
+            _real_trv.last_temperature, _current_set_temperatures
         ):
             _timeout = 0
             break

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -670,6 +670,51 @@ def get_current_set_temperatures(
     return {v for v in (single, range_low) if v is not None}
 
 
+# Written setpoints are rounded on the device step grid (round_by_step with
+# e.g. 0.1, or a Fahrenheit step converted to Celsius), while read-back values
+# pass through convert_to_float's 0.01 grid. The two grids are not
+# binary-float compatible, so exact equality between a written and a read-back
+# setpoint is unreliable. 0.01 covers both the float-grid noise (~1e-14) and
+# the worst legitimate write-vs-readback divergence (half the 0.01 read grid,
+# 0.005), while staying far below the smallest distinguishable setpoint step
+# (0.1) — it can never conflate two distinct setpoints.
+SETPOINT_MATCH_TOLERANCE = 0.01
+
+
+def matches_any_setpoint(
+    value: float | None,
+    setpoints: set[float],
+    tolerance: float = SETPOINT_MATCH_TOLERANCE,
+) -> bool:
+    """Check whether a setpoint matches any element of a set within a tolerance.
+
+    Written setpoints (rounded on the device step grid) and read-back
+    setpoints (rounded on convert_to_float's 0.01 grid) land on different
+    binary-float grids, so callers compare them with this tolerance-based
+    check instead of exact set membership.
+
+    Parameters
+    ----------
+    value : float | None
+            the setpoint to look for, or None when no value is available
+    setpoints : set[float]
+            the setpoints to compare against
+    tolerance : float
+            maximum absolute difference still considered a match
+            (default: SETPOINT_MATCH_TOLERANCE)
+
+    Returns
+    -------
+    bool
+            True if value is not None and lies within tolerance of any
+            element of setpoints, False otherwise (including for an
+            empty set)
+    """
+    if value is None:
+        return False
+    return any(abs(value - setpoint) <= tolerance for setpoint in setpoints)
+
+
 class rounding:
     """Rounding helpers for stable step-based rounding.
 

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -599,6 +599,48 @@ class TestControlTrvAvailablePath:
             mock_set_temp.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_skip_guard_matches_across_float_rounding_grids(self):
+        """An already-applied setpoint is not re-sent despite grid mismatch.
+
+        The outbound value comes from the device step grid
+        (round_by_step(20.7, 0.1) == 20.700000000000003), while the TRV
+        state reads back 20.7 through the 0.01 grid. The tolerance-based
+        skip guard must recognize the match and suppress the write.
+        """
+        from custom_components.better_thermostat.utils.helpers import round_by_step
+
+        outbound = round_by_step(20.7, 0.1)
+        assert outbound != 20.7  # the grids genuinely diverge
+
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT, trv_attrs={"temperature": 20.7}
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["handle_window_open"]) as mock_window,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ) as mock_override,
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": outbound,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_window.return_value = HVACMode.HEAT
+
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_override.assert_not_called()
+            mock_set_temp.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_set_temperature_falls_back_to_generic_adapter(self):
         """Without a model quirk, the generic adapter performs the write."""
         mock_self = _make_mock_self(

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -376,6 +376,44 @@ class TestCheckTargetTemperature:
         assert mock_self.real_trvs["climate.trv1"].target_temp_received is True
 
     @pytest.mark.asyncio
+    async def test_step_grid_written_value_confirms_against_read_grid(self):
+        """A step-grid written setpoint confirms against the 0.01 read grid.
+
+        The write side stores last_temperature rounded on the device step
+        grid (round_by_step(20.7, 0.1) == 20.700000000000003), while the
+        read-back passes through convert_to_float's 0.01 grid (20.7). The
+        tolerance-based comparison must confirm immediately instead of
+        polling until the 360s timeout.
+        """
+        from custom_components.better_thermostat.utils.helpers import round_by_step
+
+        written = round_by_step(20.7, 0.1)
+        assert written != 20.7  # the grids genuinely diverge
+
+        mock_state = Mock()
+        mock_state.attributes = {"temperature": 20.7}
+
+        mock_hass = Mock()
+        mock_hass.states.get.return_value = mock_state
+
+        mock_self = Mock()
+        mock_self.device_name = "test_thermostat"
+        mock_self.hass = mock_hass
+        mock_self.real_trvs = {
+            "climate.trv1": Trv.from_legacy_dict(
+                "climate.trv1",
+                {"last_temperature": written, "target_temp_received": False},
+            )
+        }
+
+        result = await asyncio.wait_for(
+            check_target_temperature(mock_self, "climate.trv1"), timeout=10
+        )
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].target_temp_received is True
+
+    @pytest.mark.asyncio
     async def test_range_mode_confirms_via_target_temp_low(self):
         """A range-capable TRV confirms the write through target_temp_low."""
         mock_state = Mock()

--- a/tests/unit/test_helpers_setpoint_range.py
+++ b/tests/unit/test_helpers_setpoint_range.py
@@ -117,31 +117,39 @@ class TestMatchesAnySetpoint:
     """Tolerance-based setpoint matching across float rounding grids."""
 
     def test_exact_match(self):
+        """Match a value that equals a setpoint exactly."""
         assert matches_any_setpoint(20.7, {20.7}) is True
 
     def test_match_within_tolerance(self):
+        """Match a value that deviates by less than the default tolerance."""
         # 0.005 is the worst legitimate write-vs-readback divergence
         # (half the 0.01 read grid).
         assert matches_any_setpoint(20.705, {20.7}) is True
 
     def test_no_match_outside_tolerance(self):
+        """Reject a value that deviates by more than the default tolerance."""
         assert matches_any_setpoint(20.72, {20.7}) is False
 
     def test_no_match_on_adjacent_step(self):
+        """Reject the adjacent setpoint one 0.1 step away."""
         # 0.1 is the smallest distinguishable setpoint step; the tolerance
         # must never conflate two distinct setpoints.
         assert matches_any_setpoint(20.8, {20.7}) is False
 
     def test_none_value_returns_false(self):
+        """Reject a missing value."""
         assert matches_any_setpoint(None, {20.7}) is False
 
     def test_empty_set_returns_false(self):
+        """Reject any value against an empty setpoint set."""
         assert matches_any_setpoint(20.7, set()) is False
 
     def test_matches_any_element_of_set(self):
+        """Match when any element of the setpoint set is within tolerance."""
         assert matches_any_setpoint(21.0, {17.0, 21.0}) is True
 
     def test_step_grid_value_matches_read_grid_value(self):
+        """Match a step-grid write against its read-back-grid counterpart."""
         # round_by_step(20.7, 0.1) yields 20.700000000000003, which is not
         # set-equal to the 20.7 produced by the 0.01 read-back grid.
         written = round_by_step(20.7, 0.1)
@@ -149,7 +157,9 @@ class TestMatchesAnySetpoint:
         assert matches_any_setpoint(written, {20.7}) is True
 
     def test_custom_tolerance_is_honored(self):
+        """Honor a caller-supplied tolerance wider than the default."""
         assert matches_any_setpoint(20.9, {20.7}, tolerance=0.25) is True
 
     def test_default_tolerance_constant(self):
+        """Pin the default tolerance constant at 0.01."""
         assert SETPOINT_MATCH_TOLERANCE == 0.01

--- a/tests/unit/test_helpers_setpoint_range.py
+++ b/tests/unit/test_helpers_setpoint_range.py
@@ -7,8 +7,11 @@ from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
 
 from custom_components.better_thermostat.utils.helpers import (
+    SETPOINT_MATCH_TOLERANCE,
     celsius_to_system_temperature,
     get_current_set_temperatures,
+    matches_any_setpoint,
+    round_by_step,
     trv_supports_temperature_range,
 )
 
@@ -108,3 +111,45 @@ class TestCelsiusToSystemTemperature:
         hass = self._hass(UnitOfTemperature.FAHRENHEIT)
         # 21.11 C is 69.998 F; the result is rounded to one decimal.
         assert celsius_to_system_temperature(hass, 21.11) == 70.0
+
+
+class TestMatchesAnySetpoint:
+    """Tolerance-based setpoint matching across float rounding grids."""
+
+    def test_exact_match(self):
+        assert matches_any_setpoint(20.7, {20.7}) is True
+
+    def test_match_within_tolerance(self):
+        # 0.005 is the worst legitimate write-vs-readback divergence
+        # (half the 0.01 read grid).
+        assert matches_any_setpoint(20.705, {20.7}) is True
+
+    def test_no_match_outside_tolerance(self):
+        assert matches_any_setpoint(20.72, {20.7}) is False
+
+    def test_no_match_on_adjacent_step(self):
+        # 0.1 is the smallest distinguishable setpoint step; the tolerance
+        # must never conflate two distinct setpoints.
+        assert matches_any_setpoint(20.8, {20.7}) is False
+
+    def test_none_value_returns_false(self):
+        assert matches_any_setpoint(None, {20.7}) is False
+
+    def test_empty_set_returns_false(self):
+        assert matches_any_setpoint(20.7, set()) is False
+
+    def test_matches_any_element_of_set(self):
+        assert matches_any_setpoint(21.0, {17.0, 21.0}) is True
+
+    def test_step_grid_value_matches_read_grid_value(self):
+        # round_by_step(20.7, 0.1) yields 20.700000000000003, which is not
+        # set-equal to the 20.7 produced by the 0.01 read-back grid.
+        written = round_by_step(20.7, 0.1)
+        assert written not in {20.7}
+        assert matches_any_setpoint(written, {20.7}) is True
+
+    def test_custom_tolerance_is_honored(self):
+        assert matches_any_setpoint(20.9, {20.7}, tolerance=0.25) is True
+
+    def test_default_tolerance_constant(self):
+        assert SETPOINT_MATCH_TOLERANCE == 0.01


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #2105** — the first commits in the diff belong to that PR; once it merges, this diff shrinks to the last commit.

## Motivation:

Setpoint comparisons in `controlling.py` use exact float equality across incompatible rounding grids. Written setpoints land on the device step grid (`round_by_step`), read-backs on `convert_to_float`'s 0.01 grid — and those are not binary-float compatible: `round_by_step(20.7, 0.1)` yields `20.700000000000003`, the read-back `20.7`. 96 values between 5.0 and 59.9 mismatch for step 0.1 alone; on Fahrenheit installs a converted step (e.g. 0.2778 °C) never lies on the 0.01 grid at all. Consequences: `check_target_temperature` times out with a false "did not confirm the target temperature after 360s" warning on every affected write, and `control_trv`'s write-skip guard never suppresses, re-sending the identical setpoint every control cycle (Zigbee write churn).

## Changes:

- New helper `matches_any_setpoint(value, setpoints, tolerance)` with `SETPOINT_MATCH_TOLERANCE = 0.01` in `utils/helpers.py`. Rationale: float-grid noise is ~1e-14 and the worst legitimate write-vs-readback divergence is half the 0.01 read grid (0.005), while the smallest distinguishable setpoint step is 0.1 — so 0.01 can never conflate two distinct setpoints.
- Used at both comparison sites (`control_trv` skip guard, `check_target_temperature` confirmation); the "no readable setpoint → treat as confirmed" semantics is preserved. `round_by_step` itself is untouched.
- Tests: 10 direct cases for the helper (incl. the real grid-mismatch value and adjacent-step non-conflation), a `check_target_temperature` regression test using the real `round_by_step` value, and a `control_trv` skip-guard test asserting no write is issued across the grids.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2026.6.4 (full automated test suite, 1599 passed; ruff and pyrefly clean; no physical TRV involved)
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Better Thermostat now detects thermostats that support temperature ranges and handles both single setpoints and range setpoints more reliably.

* **Bug Fixes**
  * Improved temperature update behavior so writes are skipped when the target is already effectively set, even across small rounding differences.
  * Fixed temperature setting for range-capable thermostats by confirming updates using the read-back low/high values when available.
  * Improved fallback behavior when a device’s live state isn’t available, ensuring temperature changes still go through.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->