### PR TITLE
fix: confirm HVAC mode changes against the live TRV state

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -668,8 +668,11 @@ def handle_window_open(self, _remapped_states):
 async def check_system_mode(self, heater_entity_id=None):
     """Wait for TRV to confirm HVAC mode change, timeout after 6 minutes.
 
-    Polls the TRV state every second until hvac_mode matches last_hvac_mode
-    or timeout is reached. Sets system_mode_received flag when complete.
+    Polls the TRV's live entity state every second until it matches
+    last_hvac_mode or timeout is reached. Sets system_mode_received flag
+    when complete. Reading the live state directly avoids depending on the
+    internal hvac_mode cache, which is not refreshed while state events are
+    suppressed (control cycle) or when child lock is configured.
 
     Parameters
     ----------
@@ -685,7 +688,18 @@ async def check_system_mode(self, heater_entity_id=None):
     """
     _timeout = 0
     _real_trv = self.real_trvs[heater_entity_id]
-    while _real_trv.hvac_mode != _real_trv.last_hvac_mode:
+    while True:
+        _trv_state = self.hass.states.get(heater_entity_id)
+        if _trv_state is None or _trv_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            _LOGGER.debug(
+                "better_thermostat %s: %s became unavailable during check_system_mode",
+                self.device_name,
+                heater_entity_id,
+            )
+            break
+        if _trv_state.state == _real_trv.last_hvac_mode:
+            _timeout = 0
+            break
         if _timeout > 360:
             _LOGGER.warning(
                 "better_thermostat %s: TRV %s did not confirm the system mode change "
@@ -693,7 +707,7 @@ async def check_system_mode(self, heater_entity_id=None):
                 self.device_name,
                 heater_entity_id,
                 _real_trv.last_hvac_mode,
-                _real_trv.hvac_mode,
+                _trv_state.state,
             )
             _timeout = 0
             break

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -192,21 +192,39 @@ class TestHandleWindowOpenWithNoOffMode:
 class TestCheckSystemMode:
     """Test check_system_mode function."""
 
-    @pytest.mark.asyncio
-    async def test_mode_matches_immediately(self):
-        """Test when mode matches immediately."""
+    def _mock_self(self, live_state, last_hvac_mode, cached_hvac_mode=None):
+        """Build a mock BetterThermostat with a live TRV state and one Trv."""
+        mock_state = Mock()
+        mock_state.state = live_state
+
+        mock_hass = Mock()
+        mock_hass.states.get.return_value = (
+            mock_state if live_state is not None else None
+        )
+
         mock_self = Mock()
         mock_self.device_name = "test_thermostat"
+        mock_self.hass = mock_hass
         mock_self.real_trvs = {
             "climate.trv1": Trv.from_legacy_dict(
                 "climate.trv1",
                 {
-                    "hvac_mode": HVACMode.HEAT,
-                    "last_hvac_mode": HVACMode.HEAT,
+                    "hvac_mode": cached_hvac_mode,
+                    "last_hvac_mode": last_hvac_mode,
                     "system_mode_received": False,
                 },
             )
         }
+        return mock_self, mock_state
+
+    @pytest.mark.asyncio
+    async def test_mode_matches_immediately(self):
+        """Test when the live state matches immediately."""
+        mock_self, _ = self._mock_self(
+            live_state=HVACMode.HEAT,
+            last_hvac_mode=HVACMode.HEAT,
+            cached_hvac_mode=HVACMode.HEAT,
+        )
 
         result = await check_system_mode(mock_self, "climate.trv1")
 
@@ -214,25 +232,36 @@ class TestCheckSystemMode:
         assert mock_self.real_trvs["climate.trv1"].system_mode_received is True
 
     @pytest.mark.asyncio
-    async def test_mode_matches_after_delay(self):
-        """Test when mode matches after a short delay."""
-        mock_self = Mock()
-        mock_self.device_name = "test_thermostat"
-        mock_self.real_trvs = {
-            "climate.trv1": Trv.from_legacy_dict(
-                "climate.trv1",
-                {
-                    "hvac_mode": HVACMode.OFF,
-                    "last_hvac_mode": HVACMode.HEAT,
-                    "system_mode_received": False,
-                },
-            )
-        }
+    async def test_confirms_via_live_state_with_stale_cache(self):
+        """The live state confirms the write even when the internal cache is stale.
 
-        # Simulate mode change after 0.5 seconds
+        With child lock configured or state events suppressed, the internal
+        hvac_mode cache is never refreshed; confirmation must not depend on it.
+        """
+        mock_self, _ = self._mock_self(
+            live_state=HVACMode.HEAT,
+            last_hvac_mode=HVACMode.HEAT,
+            cached_hvac_mode=HVACMode.OFF,
+        )
+
+        result = await check_system_mode(mock_self, "climate.trv1")
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].system_mode_received is True
+        # The stale cache stays untouched; only the live state was consulted.
+        assert mock_self.real_trvs["climate.trv1"].hvac_mode == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_mode_matches_after_delay(self):
+        """Test when the live state matches after a short delay."""
+        mock_self, mock_state = self._mock_self(
+            live_state=HVACMode.OFF, last_hvac_mode=HVACMode.HEAT
+        )
+
+        # Simulate the device reporting the new mode after a short delay
         async def update_mode():
             await asyncio.sleep(0.1)
-            mock_self.real_trvs["climate.trv1"].hvac_mode = HVACMode.HEAT
+            mock_state.state = HVACMode.HEAT
 
         update_task = asyncio.create_task(update_mode())
 
@@ -248,18 +277,9 @@ class TestCheckSystemMode:
 
         Note: We use a shorter timeout for testing by mocking sleep.
         """
-        mock_self = Mock()
-        mock_self.device_name = "test_thermostat"
-        mock_self.real_trvs = {
-            "climate.trv1": Trv.from_legacy_dict(
-                "climate.trv1",
-                {
-                    "hvac_mode": HVACMode.OFF,
-                    "last_hvac_mode": HVACMode.HEAT,
-                    "system_mode_received": False,
-                },
-            )
-        }
+        mock_self, _ = self._mock_self(
+            live_state=HVACMode.OFF, last_hvac_mode=HVACMode.HEAT
+        )
 
         # Track sleep calls
         sleep_count = 0
@@ -286,26 +306,37 @@ class TestCheckSystemMode:
             assert result is True
             # Flag should still be set to True after timeout
             assert mock_self.real_trvs["climate.trv1"].system_mode_received is True
-            # Mode should not have changed
-            assert mock_self.real_trvs["climate.trv1"].hvac_mode == HVACMode.OFF
         finally:
             controlling_module.asyncio.sleep = original_sleep_func
 
     @pytest.mark.asyncio
+    async def test_unavailable_state_treated_as_done(self):
+        """An unavailable TRV ends the wait and still sets the flag."""
+        mock_self, _ = self._mock_self(
+            live_state="unavailable", last_hvac_mode=HVACMode.HEAT
+        )
+
+        result = await check_system_mode(mock_self, "climate.trv1")
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].system_mode_received is True
+
+    @pytest.mark.asyncio
+    async def test_missing_state_treated_as_done(self):
+        """A missing TRV state ends the wait and still sets the flag."""
+        mock_self, _ = self._mock_self(live_state=None, last_hvac_mode=HVACMode.HEAT)
+
+        result = await check_system_mode(mock_self, "climate.trv1")
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].system_mode_received is True
+
+    @pytest.mark.asyncio
     async def test_system_mode_received_flag_set(self):
         """Test that system_mode_received flag is always set to True."""
-        mock_self = Mock()
-        mock_self.device_name = "test_thermostat"
-        mock_self.real_trvs = {
-            "climate.trv1": Trv.from_legacy_dict(
-                "climate.trv1",
-                {
-                    "hvac_mode": HVACMode.HEAT,
-                    "last_hvac_mode": HVACMode.HEAT,
-                    "system_mode_received": False,
-                },
-            )
-        }
+        mock_self, _ = self._mock_self(
+            live_state=HVACMode.HEAT, last_hvac_mode=HVACMode.HEAT
+        )
 
         await check_system_mode(mock_self, "climate.trv1")
 


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #2105** — the first commits in the diff belong to that PR; once it merges, this diff shrinks to the last commit.

## Motivation:

`check_system_mode` waits for a TRV to confirm an HVAC-mode write by polling the internal `hvac_mode` cache — unlike `check_target_temperature`, which polls the live state. The cache is only refreshed by the TRV event handler, and that refresh is suppressed in exactly the situations where confirmation matters: (a) while state events are ignored during the control cycle, which drops the device's write echo (sparse reporters like battery TRVs then intermittently hit the 360 s timeout and log a false warning); (b) with child lock configured, the cache is never updated at all, so every mode change deterministically spins the full 360 s and keeps `system_mode_received` False for 6 minutes.

## Changes:

- `check_system_mode` now polls `hass.states.get()` each iteration, mirroring `check_target_temperature`'s structure (unavailable/unknown → treated as done). The compared value pair is unchanged: the cache was always a delayed copy of the raw live state, so the comparison against `last_hvac_mode` is identical minus the stale-cache indirection. Timeout structure and flag semantics untouched; `events/trv.py` untouched.
- Tests rewritten to drive the live state: stale-cache confirmation (the child-lock regression case), timeout, unavailable/missing state, immediate and delayed match, flag-always-set.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2026.6.4 (full automated test suite, 1590 passed; ruff and pyrefly clean; no physical TRV involved)
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat mode confirmation by checking the live device state, reducing false mismatches from stale cached values.
  * Better handles devices that become unavailable or unknown during mode changes.
  * Temperature updates now confirm correctly for thermostats that support range-based settings, including low/high setpoints.
  * Timeout messages are more informative, showing the requested value and the live value observed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->