### PR TITLE
feat: MPC v2 offline batch re-identification of the plant prior

### DIFF
--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import math
-from time import time
 
 from homeassistant.components.climate.const import HVACAction, HVACMode
 
@@ -506,7 +505,7 @@ def _record_mpc_v2_reid_sample(
     runtime = self.state_mgr.get_mpc_v2_reid_runtime(mpc_key)
     runtime.buffer.append(
         ReidSample(
-            t_s=time(),
+            t_s=self.clock.monotonic(),
             T_room_C=t_room,
             u_frac=u_frac,
             T_outdoor_C=outdoor_temp,
@@ -530,7 +529,10 @@ def _maybe_start_mpc_v2_reid_fit(self, mpc_key: str, v2_params: MpcV2Params) -> 
         return
     state_mgr = self.state_mgr
     runtime = state_mgr.get_mpc_v2_reid_runtime(mpc_key)
-    now = time()
+    # Monotonic for the cadence gate and buffer timing (immune to wall-clock
+    # jumps); a separate wall-clock stamp records *when* an accepted fit
+    # happened for the persisted result and diagnostics.
+    now = self.clock.monotonic()
     if runtime.fit_inflight:
         return
     if now - runtime.last_fit_attempt_ts < _MPC_V2_REID_INTERVAL_S:
@@ -539,6 +541,7 @@ def _maybe_start_mpc_v2_reid_fit(self, mpc_key: str, v2_params: MpcV2Params) -> 
         return
     runtime.last_fit_attempt_ts = now
     runtime.fit_inflight = True
+    fitted_wall_ts = self.clock.now().timestamp()
     # Snapshot the buffer so the executor thread never races the event
     # loop's appends; the current prior is the validation baseline.
     samples = list(runtime.buffer.samples)
@@ -568,7 +571,7 @@ def _maybe_start_mpc_v2_reid_fit(self, mpc_key: str, v2_params: MpcV2Params) -> 
                 MpcV2ReidData(
                     tau_room_min=outcome.tau_room_min,
                     gain_heater=outcome.gain_heater,
-                    fitted_ts=now,
+                    fitted_ts=fitted_wall_ts,
                     rmse_prior_K=outcome.rmse_prior_K or 0.0,
                     rmse_fit_K=outcome.rmse_fit_K or 0.0,
                     n_segments=outcome.n_segments,
@@ -599,7 +602,20 @@ def _maybe_start_mpc_v2_reid_fit(self, mpc_key: str, v2_params: MpcV2Params) -> 
                 outcome.n_samples,
             )
 
-    future = hass.async_add_executor_job(run_reid_fit, samples, prior)
+    try:
+        future = hass.async_add_executor_job(run_reid_fit, samples, prior)
+    except Exception as err:
+        # Submitting the job failed before it could run; clear the guard so a
+        # later cycle can retry instead of blocking fits forever.
+        runtime.fit_inflight = False
+        _LOGGER.warning(
+            "better_thermostat %s: could not schedule MPC v2 re-identification "
+            "for %s: %s",
+            device_name,
+            mpc_key,
+            err,
+        )
+        return
     future.add_done_callback(_on_fit_done)
 
 

--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import math
+from time import time
 
 from homeassistant.components.climate.const import HVACAction, HVACMode
 
@@ -24,8 +25,11 @@ from custom_components.better_thermostat.utils.calibration.mpc import (
 from custom_components.better_thermostat.utils.calibration.mpc_v2 import (
     MpcV2Input,
     MpcV2Params,
+    PlantParams,
+    ReidSample,
     compute_mpc_v2,
     make_plant_prior,
+    run_reid_fit,
 )
 from custom_components.better_thermostat.utils.calibration.pid import (
     DEFAULT_PID_AUTO_TUNE,
@@ -68,12 +72,19 @@ from custom_components.better_thermostat.utils.helpers import (
     round_by_step,
     rounding,
 )
+from custom_components.better_thermostat.utils.state_manager import MpcV2ReidData
 
 _LOGGER = logging.getLogger(__name__)
 
 # Thermostats that already logged the MPC-v2-unavailable warning; keeps the
 # per-cycle dispatch from repeating it when the daqp import keeps failing.
 _MPC_V2_IMPORT_WARNED: set[str] = set()
+
+# Offline re-identification cadence: at most one fit attempt per key in this
+# interval, and only once the sample buffer holds enough history to plausibly
+# contain full transients (240 samples ≈ 4-20 h depending on cycle rate).
+_MPC_V2_REID_INTERVAL_S = 6 * 3600.0
+_MPC_V2_REID_MIN_SAMPLES = 240
 
 
 def _compute_zero_open_offset(
@@ -477,6 +488,121 @@ def _compute_mpc_balance(self, entity_id: str):
     return trv_output, supports_valve
 
 
+def _record_mpc_v2_reid_sample(
+    self, mpc_key: str, *, mpc_v2_state, trv_temp, outdoor_temp
+) -> None:
+    """Append one observation to the re-identification buffer for a key.
+
+    The buffer's spacing floor collapses the per-TRV dispatches of a group
+    pass into a single sample, and its finiteness checks reject anything a
+    later fit could choke on. Window-open samples are recorded on purpose:
+    they never enter a fit but cut segments at the right place.
+    """
+    try:
+        t_room = float(self.cur_temp)
+    except TypeError, ValueError:
+        return
+    u_frac = float(mpc_v2_state.last_percent or 0.0) / 100.0
+    runtime = self.state_mgr.get_mpc_v2_reid_runtime(mpc_key)
+    runtime.buffer.append(
+        ReidSample(
+            t_s=time(),
+            T_room_C=t_room,
+            u_frac=u_frac,
+            T_outdoor_C=outdoor_temp,
+            T_trv_C=trv_temp if isinstance(trv_temp, (int, float)) else None,
+            window_open=bool(self.window_open),
+        )
+    )
+
+
+def _maybe_start_mpc_v2_reid_fit(self, mpc_key: str, v2_params: MpcV2Params) -> None:
+    """Kick off an offline re-identification fit in the executor when due.
+
+    At most one attempt per key per ``_MPC_V2_REID_INTERVAL_S``, only once
+    the buffer plausibly contains full transients, and never concurrently.
+    The fit itself is pure CPU work; an accepted result is adopted through
+    the state manager's bumpless path on the completion callback, so the
+    event loop never blocks on the optimisation.
+    """
+    hass = getattr(self, "hass", None)
+    if hass is None:
+        return
+    state_mgr = self.state_mgr
+    runtime = state_mgr.get_mpc_v2_reid_runtime(mpc_key)
+    now = time()
+    if runtime.fit_inflight:
+        return
+    if now - runtime.last_fit_attempt_ts < _MPC_V2_REID_INTERVAL_S:
+        return
+    if len(runtime.buffer.samples) < _MPC_V2_REID_MIN_SAMPLES:
+        return
+    runtime.last_fit_attempt_ts = now
+    runtime.fit_inflight = True
+    # Snapshot the buffer so the executor thread never races the event
+    # loop's appends; the current prior is the validation baseline.
+    samples = list(runtime.buffer.samples)
+    prior = v2_params.plant
+    device_name = self.device_name
+    schedule_save = getattr(self, "schedule_save_state", None)
+
+    def _on_fit_done(future) -> None:
+        runtime.fit_inflight = False
+        try:
+            outcome = future.result()
+        except Exception as err:
+            _LOGGER.warning(
+                "better_thermostat %s: MPC v2 re-identification failed for %s: %s",
+                device_name,
+                mpc_key,
+                err,
+            )
+            return
+        if (
+            outcome.status == "accepted"
+            and outcome.tau_room_min is not None
+            and outcome.gain_heater is not None
+        ):
+            state_mgr.adopt_mpc_v2_reid(
+                mpc_key,
+                MpcV2ReidData(
+                    tau_room_min=outcome.tau_room_min,
+                    gain_heater=outcome.gain_heater,
+                    fitted_ts=now,
+                    rmse_prior_K=outcome.rmse_prior_K or 0.0,
+                    rmse_fit_K=outcome.rmse_fit_K or 0.0,
+                    n_segments=outcome.n_segments,
+                ),
+            )
+            if callable(schedule_save):
+                schedule_save()
+            _LOGGER.info(
+                "better_thermostat %s: adopted re-identified MPC v2 plant prior "
+                "for %s: tau_room=%.0f min gain=%.2f (holdout RMSE %.3f -> %.3f K, "
+                "%d segments)",
+                device_name,
+                mpc_key,
+                outcome.tau_room_min,
+                outcome.gain_heater,
+                outcome.rmse_prior_K or 0.0,
+                outcome.rmse_fit_K or 0.0,
+                outcome.n_segments,
+            )
+        else:
+            _LOGGER.debug(
+                "better_thermostat %s: MPC v2 re-identification for %s: %s "
+                "(segments=%d, samples=%d)",
+                device_name,
+                mpc_key,
+                outcome.status,
+                outcome.n_segments,
+                outcome.n_samples,
+            )
+
+    future = hass.async_add_executor_job(run_reid_fit, samples, prior)
+    future.add_done_callback(_on_fit_done)
+
+
 def _compute_mpc_v2_balance(self, entity_id: str):
     """Run the MPC v2 (QP + Kalman) balance algorithm.
 
@@ -526,13 +652,27 @@ def _compute_mpc_v2_balance(self, entity_id: str):
     except ValueError:
         preset = MpcV2PlantPreset.AUTO
 
-    v2_params = MpcV2Params(
-        plant=make_plant_prior(
+    # Plant-prior resolution: an explicit preset always wins; under AUTO a
+    # validated offline re-identification result beats the heat-loss
+    # heuristic, which remains the fallback until the first accepted fit.
+    reid_result = (
+        self.state_mgr.get_mpc_v2_reid(mpc_key)
+        if preset == MpcV2PlantPreset.AUTO
+        else None
+    )
+    if reid_result is not None:
+        plant_prior = PlantParams(
+            tau_room_min=reid_result.tau_room_min, gain_heater=reid_result.gain_heater
+        )
+    else:
+        plant_prior = make_plant_prior(
             heating_power=getattr(self, "heating_power", None),
             heat_loss_rate=getattr(self, "heat_loss_rate", None),
             preset=None if preset == MpcV2PlantPreset.AUTO else preset.value,
         )
-    )
+    v2_params = MpcV2Params(plant=plant_prior)
+
+    outdoor_temp = _get_current_outdoor_temp(self)
 
     try:
         mpc_v2_state = self.state_mgr.get_mpc_v2_live(mpc_key, v2_params)
@@ -546,7 +686,7 @@ def _compute_mpc_v2_balance(self, entity_id: str):
                 heating_allowed=True,
                 bt_name=self.device_name,
                 entity_id=entity_id,
-                outdoor_temp_C=_get_current_outdoor_temp(self),
+                outdoor_temp_C=outdoor_temp,
                 max_opening_pct=max_opening_pct,
             ),
             v2_params,
@@ -575,6 +715,16 @@ def _compute_mpc_v2_balance(self, entity_id: str):
         return None, False
 
     self.state_mgr.set_mpc_v2_live(mpc_key, mpc_v2_state)
+
+    if preset == MpcV2PlantPreset.AUTO:
+        _record_mpc_v2_reid_sample(
+            self,
+            mpc_key,
+            mpc_v2_state=mpc_v2_state,
+            trv_temp=trv_state.current_temperature,
+            outdoor_temp=outdoor_temp,
+        )
+        _maybe_start_mpc_v2_reid_fit(self, mpc_key, v2_params)
 
     if mpc_output is None:
         trv_state.calibration_balance = None
@@ -609,6 +759,10 @@ def _compute_mpc_v2_balance(self, entity_id: str):
             "group_valve_pct": group_valve_pct,
             "distributed_valve_pct": this_trv_pct,
             "controller_version": "v2",
+            "reid_tau_room": (
+                reid_result.tau_room_min if reid_result is not None else None
+            ),
+            "reid_gain": (reid_result.gain_heater if reid_result is not None else None),
         },
     }
 

--- a/custom_components/better_thermostat/utils/calibration/mpc_v2/__init__.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc_v2/__init__.py
@@ -12,10 +12,12 @@ out of scope.
 
 from __future__ import annotations
 
+from ..mpc_v2_internals.plant import PlantParams
 from .compute import compute_mpc_v2
 from .controller import SNAPSHOT_VERSION, ControllerSnapshot, MpcV2Controller
 from .io import MpcV2Diagnostics, MpcV2Input, MpcV2Output
 from .params import PLANT_PRESETS, MpcV2Params, make_plant_prior
+from .reid import ReidBuffer, ReidConfig, ReidOutcome, ReidSample, run_reid_fit
 from .state import MpcV2State, export_mpc_v2_state, import_mpc_v2_state
 
 __all__ = [
@@ -26,10 +28,16 @@ __all__ = [
     "MpcV2State",
     "MpcV2Controller",
     "ControllerSnapshot",
+    "PlantParams",
+    "ReidBuffer",
+    "ReidConfig",
+    "ReidOutcome",
+    "ReidSample",
     "compute_mpc_v2",
     "export_mpc_v2_state",
     "import_mpc_v2_state",
     "make_plant_prior",
+    "run_reid_fit",
     "PLANT_PRESETS",
     "SNAPSHOT_VERSION",
 ]

--- a/custom_components/better_thermostat/utils/calibration/mpc_v2/reid.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc_v2/reid.py
@@ -1,0 +1,353 @@
+"""Offline batch re-identification of the RC2 plant prior.
+
+The controller's plant prior is static for the lifetime of a room. The
+information needed to correct it lives in the few moments with real
+excitation — the morning heat-up after a night setback and free cool-downs
+with the valve closed; regulation at a constant setpoint carries almost
+none. This module collects one sample per control cycle into a bounded
+in-memory buffer, extracts those transients, fits ``tau_room_min`` and
+``gain_heater`` by minimising the prediction error of a full RC2
+simulation over the training segments, and validates the candidate on a
+held-out segment. Only a fit that predicts the held-out transient
+measurably better than the current prior is offered for adoption;
+everything else leaves the prior untouched.
+
+``tau_rad_min`` and ``coupling_rad_room`` stay at their defaults: with a
+room-temperature output they are weakly identifiable, and across realistic
+building profiles a fixed value is more robust than per-room derivation.
+
+Everything here is pure CPU work with no HA dependencies. The caller runs
+:func:`run_reid_fit` in an executor and applies an accepted result through
+the state manager's bumpless adopt path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field, replace
+import math
+
+from ..mpc_v2_internals.plant import PlantParams
+
+TAU_ROOM_BOUNDS_MIN = (60.0, 2000.0)
+GAIN_HEATER_BOUNDS = (0.5, 5.0)
+
+
+@dataclass
+class ReidSample:
+    """One per-cycle observation of the room/TRV/valve state."""
+
+    t_s: float
+    T_room_C: float
+    u_frac: float
+    T_outdoor_C: float | None = None
+    T_trv_C: float | None = None
+    window_open: bool = False
+
+
+@dataclass
+class ReidBuffer:
+    """Bounded, spacing-deduplicated sample buffer for one MPC key.
+
+    Held in memory only — after a restart the buffer refills within a day,
+    while the *result* of a fit is persisted separately. The spacing floor
+    also collapses the per-TRV dispatches of a multi-TRV group (milliseconds
+    apart) into one sample per control pass.
+    """
+
+    maxlen: int = 2016
+    min_spacing_s: float = 60.0
+    samples: list[ReidSample] = field(default_factory=list)
+
+    def append(self, sample: ReidSample) -> bool:
+        """Add a sample; returns ``False`` when deduped or non-finite."""
+        for value in (sample.t_s, sample.T_room_C, sample.u_frac):
+            if not math.isfinite(value):
+                return False
+        for optional in (sample.T_outdoor_C, sample.T_trv_C):
+            if optional is not None and not math.isfinite(optional):
+                return False
+        if self.samples and sample.t_s - self.samples[-1].t_s < self.min_spacing_s:
+            return False
+        self.samples.append(sample)
+        if len(self.samples) > self.maxlen:
+            del self.samples[: len(self.samples) - self.maxlen]
+        return True
+
+
+@dataclass
+class Segment:
+    """A contiguous, informative transient cut from the sample buffer."""
+
+    kind: str  # "heatup" | "cooldown"
+    samples: list[ReidSample]
+
+    @property
+    def end_t_s(self) -> float:
+        """Timestamp of the segment's last sample."""
+        return self.samples[-1].t_s
+
+
+@dataclass
+class ReidConfig:
+    """Thresholds for segment extraction, fitting, and validation."""
+
+    # Segment extraction. A sample is "heating" above u_heating_frac and
+    # "idle" below u_idle_frac; runs are cut at window-open samples, missing
+    # outdoor readings, class changes, and sampling gaps.
+    u_heating_frac: float = 0.5
+    u_idle_frac: float = 0.05
+    max_gap_s: float = 1800.0
+    min_duration_s: float = 2400.0
+    min_samples: int = 8
+    min_heatup_rise_K: float = 0.8
+    min_cooldown_drop_K: float = 0.3
+
+    # Fit and validation. Acceptance needs both a relative win (so the fit
+    # must clearly beat the prior) and an absolute one (so a near-perfect
+    # prior is not replaced over discretisation noise).
+    min_segments: int = 3
+    min_improvement: float = 0.1
+    min_improvement_K: float = 0.05
+    substep_s: float = 150.0
+    max_iterations: int = 200
+
+
+@dataclass
+class ReidOutcome:
+    """Result of one batch fit attempt."""
+
+    status: str  # "accepted" | "rejected" | "insufficient_data"
+    tau_room_min: float | None = None
+    gain_heater: float | None = None
+    rmse_prior_K: float | None = None
+    rmse_fit_K: float | None = None
+    n_segments: int = 0
+    n_samples: int = 0
+
+
+def _classify(sample: ReidSample, cfg: ReidConfig) -> str:
+    if sample.u_frac >= cfg.u_heating_frac:
+        return "heating"
+    if sample.u_frac <= cfg.u_idle_frac:
+        return "idle"
+    return "other"
+
+
+def extract_segments(samples: list[ReidSample], cfg: ReidConfig) -> list[Segment]:
+    """Cut the buffer into informative heat-up / cool-down transients.
+
+    Runs are contiguous stretches of one activity class with the window
+    closed, an outdoor reading present, and no sampling gap larger than
+    ``max_gap_s``. A run qualifies as a segment when it is long enough and
+    the room temperature actually moved: rose by ``min_heatup_rise_K``
+    during heating, or fell by ``min_cooldown_drop_K`` while idle with the
+    outdoors colder than the room (free cool-down, not solar gain).
+    """
+    segments: list[Segment] = []
+    run: list[ReidSample] = []
+    run_class = ""
+
+    def _flush() -> None:
+        nonlocal run
+        if len(run) >= cfg.min_samples and (
+            run[-1].t_s - run[0].t_s >= cfg.min_duration_s
+        ):
+            delta = run[-1].T_room_C - run[0].T_room_C
+            if run_class == "heating" and delta >= cfg.min_heatup_rise_K:
+                segments.append(Segment(kind="heatup", samples=list(run)))
+            elif run_class == "idle" and -delta >= cfg.min_cooldown_drop_K:
+                outdoor = [s.T_outdoor_C for s in run if s.T_outdoor_C is not None]
+                if outdoor and (sum(outdoor) / len(outdoor)) < run[-1].T_room_C:
+                    segments.append(Segment(kind="cooldown", samples=list(run)))
+        run = []
+
+    for sample in samples:
+        if sample.window_open or sample.T_outdoor_C is None:
+            _flush()
+            run_class = ""
+            continue
+        sample_class = _classify(sample, cfg)
+        gap_broken = bool(run) and sample.t_s - run[-1].t_s > cfg.max_gap_s
+        if sample_class != run_class or gap_broken or sample_class == "other":
+            _flush()
+            run_class = sample_class
+        if sample_class != "other":
+            run.append(sample)
+    _flush()
+    return segments
+
+
+def _simulate_room(
+    params: PlantParams, segment: Segment, substep_s: float
+) -> list[float]:
+    """Simulate T_room over a segment; returns one value per sample.
+
+    Plain-float forward Euler with sub-stepping so the radiator time
+    constant stays resolved even when samples are many minutes apart.
+    Inputs (valve fraction, outdoor) are held zero-order from the left
+    sample of each interval. The initial radiator state is seeded from the
+    TRV reading when available, otherwise from the room temperature.
+    """
+    first = segment.samples[0]
+    T_room = first.T_room_C
+    T_rad = first.T_trv_C if first.T_trv_C is not None else first.T_room_C
+    out: list[float] = [T_room]
+    for prev, cur in zip(segment.samples, segment.samples[1:]):
+        dt_s = cur.t_s - prev.t_s
+        n_sub = max(1, math.ceil(dt_s / substep_s))
+        h_min = (dt_s / n_sub) / 60.0
+        u = max(0.0, min(1.0, prev.u_frac))
+        T_outdoor = prev.T_outdoor_C if prev.T_outdoor_C is not None else T_room
+        for _ in range(n_sub):
+            dT_rad = (
+                params.gain_heater * u * (params.T_water_C - T_rad) - (T_rad - T_room)
+            ) / params.tau_rad_min
+            dT_room = (
+                params.coupling_rad_room * (T_rad - T_room) - (T_room - T_outdoor)
+            ) / params.tau_room_min
+            T_room += dT_room * h_min
+            T_rad += dT_rad * h_min
+        out.append(T_room)
+    return out
+
+
+def _sse(params: PlantParams, segments: list[Segment], cfg: ReidConfig) -> float:
+    total = 0.0
+    for segment in segments:
+        simulated = _simulate_room(params, segment, cfg.substep_s)
+        for sim, sample in zip(simulated[1:], segment.samples[1:]):
+            err = sim - sample.T_room_C
+            total += err * err
+    return total
+
+
+def _rmse(params: PlantParams, segments: list[Segment], cfg: ReidConfig) -> float:
+    n = sum(len(s.samples) - 1 for s in segments)
+    if n <= 0:
+        return math.inf
+    return math.sqrt(_sse(params, segments, cfg) / n)
+
+
+def _nelder_mead(
+    objective: Callable[[list[float]], float],
+    x0: list[float],
+    step: float,
+    max_iterations: int,
+) -> list[float]:
+    """Minimise ``objective`` from ``x0`` with a standard Nelder-Mead simplex.
+
+    Deterministic and dependency-free; adequate for the smooth 2-parameter
+    log-space landscape of the RC2 fit. Stops on iteration budget or when
+    the simplex collapses below a fixed spread.
+    """
+    n = len(x0)
+    simplex = [list(x0)]
+    for i in range(n):
+        vertex = list(x0)
+        vertex[i] += step
+        simplex.append(vertex)
+    values = [objective(v) for v in simplex]
+
+    for _ in range(max_iterations):
+        order = sorted(range(len(simplex)), key=lambda i: values[i])
+        simplex = [simplex[i] for i in order]
+        values = [values[i] for i in order]
+        if abs(values[-1] - values[0]) < 1e-12:
+            break
+        centroid = [sum(vertex[i] for vertex in simplex[:-1]) / n for i in range(n)]
+        worst = simplex[-1]
+        reflected = [c + (c - w) for c, w in zip(centroid, worst)]
+        f_reflected = objective(reflected)
+        if f_reflected < values[0]:
+            expanded = [c + 2.0 * (c - w) for c, w in zip(centroid, worst)]
+            f_expanded = objective(expanded)
+            if f_expanded < f_reflected:
+                simplex[-1], values[-1] = expanded, f_expanded
+            else:
+                simplex[-1], values[-1] = reflected, f_reflected
+        elif f_reflected < values[-2]:
+            simplex[-1], values[-1] = reflected, f_reflected
+        else:
+            contracted = [c + 0.5 * (w - c) for c, w in zip(centroid, worst)]
+            f_contracted = objective(contracted)
+            if f_contracted < values[-1]:
+                simplex[-1], values[-1] = contracted, f_contracted
+            else:
+                best = simplex[0]
+                simplex = [best] + [
+                    [b + 0.5 * (v - b) for b, v in zip(best, vertex)]
+                    for vertex in simplex[1:]
+                ]
+                values = [values[0]] + [objective(v) for v in simplex[1:]]
+    order = sorted(range(len(simplex)), key=lambda i: values[i])
+    return simplex[order[0]]
+
+
+def _clamp(value: float, bounds: tuple[float, float]) -> float:
+    return max(bounds[0], min(bounds[1], value))
+
+
+def _params_from_x(x: list[float], prior: PlantParams) -> PlantParams:
+    """Map log-space optimiser coordinates onto a bounded parameter set."""
+    return replace(
+        prior,
+        tau_room_min=_clamp(math.exp(x[0]), TAU_ROOM_BOUNDS_MIN),
+        gain_heater=_clamp(math.exp(x[1]), GAIN_HEATER_BOUNDS),
+    )
+
+
+def run_reid_fit(
+    samples: list[ReidSample], prior: PlantParams, cfg: ReidConfig | None = None
+) -> ReidOutcome:
+    """Extract segments, fit tau_room/gain, and validate on a holdout.
+
+    The holdout is the most recent segment; training needs at least one
+    heat-up (the only place ``gain_heater`` is identifiable — cool-downs
+    constrain only ``tau_room_min``). The candidate is accepted when its
+    holdout RMSE beats the prior's by at least ``cfg.min_improvement``.
+    """
+    cfg = cfg or ReidConfig()
+    segments = extract_segments(samples, cfg)
+    n_samples = sum(len(s.samples) for s in segments)
+    if len(segments) < cfg.min_segments:
+        return ReidOutcome(
+            status="insufficient_data", n_segments=len(segments), n_samples=n_samples
+        )
+
+    segments = sorted(segments, key=lambda s: s.end_t_s)
+    train, holdout = segments[:-1], [segments[-1]]
+    if not any(s.kind == "heatup" for s in train):
+        return ReidOutcome(
+            status="insufficient_data", n_segments=len(segments), n_samples=n_samples
+        )
+
+    def objective(x: list[float]) -> float:
+        return _sse(_params_from_x(x, prior), train, cfg)
+
+    x0 = [
+        math.log(_clamp(prior.tau_room_min, TAU_ROOM_BOUNDS_MIN)),
+        math.log(_clamp(prior.gain_heater, GAIN_HEATER_BOUNDS)),
+    ]
+    x_best = _nelder_mead(
+        objective, x0, step=math.log(1.3), max_iterations=cfg.max_iterations
+    )
+    fitted = _params_from_x(x_best, prior)
+
+    rmse_prior = _rmse(prior, holdout, cfg)
+    rmse_fit = _rmse(fitted, holdout, cfg)
+    accepted = (
+        math.isfinite(rmse_fit)
+        and math.isfinite(rmse_prior)
+        and rmse_fit <= (1.0 - cfg.min_improvement) * rmse_prior
+        and rmse_prior - rmse_fit >= cfg.min_improvement_K
+    )
+    return ReidOutcome(
+        status="accepted" if accepted else "rejected",
+        tau_room_min=fitted.tau_room_min,
+        gain_heater=fitted.gain_heater,
+        rmse_prior_K=rmse_prior,
+        rmse_fit_K=rmse_fit,
+        n_segments=len(segments),
+        n_samples=n_samples,
+    )

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -599,6 +599,15 @@ class StateManager:
             exported = export_mpc_v2_state(live)
             if exported is not None:
                 self._state.mpc_v2[key] = deserialize_mpc_v2(exported)
+            else:
+                # No exportable observer state to carry over; the rebuild with
+                # the new prior falls back to the last snapshot (or a cold
+                # start). Rare, but log it so a lost transfer is diagnosable.
+                _LOGGER.debug(
+                    "MPC v2 re-identification adopt for %s: live controller had "
+                    "no exportable state; rebuild will not be bumpless",
+                    key,
+                )
         self._state.mpc_v2_reid[key] = data
         self._dirty = True
 

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -47,6 +47,7 @@ from .calibration.mpc_v2 import (
     export_mpc_v2_state,
     import_mpc_v2_state,
 )
+from .calibration.mpc_v2.reid import ReidBuffer
 from .calibration.pid import PIDState
 from .calibration.tpi import TpiState
 from .const import (
@@ -74,6 +75,36 @@ class MpcV2StateData:
     created_ts: float = 0.0
     outdoor_fallback_logged: bool = False
     snapshot: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MpcV2ReidData:
+    """Persisted result of an accepted offline re-identification.
+
+    Carries the fitted plant-prior components plus the validation metrics
+    of the accepting fit; the sample buffer that produced it is in-memory
+    only and never persisted.
+    """
+
+    tau_room_min: float = 0.0
+    gain_heater: float = 0.0
+    fitted_ts: float = 0.0
+    rmse_prior_K: float = 0.0
+    rmse_fit_K: float = 0.0
+    n_segments: int = 0
+
+
+@dataclass
+class MpcV2ReidRuntime:
+    """In-memory collection/scheduling state for one MPC key.
+
+    Lost on restart by design: the buffer refills within a day and the
+    attempt timer simply starts over.
+    """
+
+    buffer: ReidBuffer = field(default_factory=ReidBuffer)
+    last_fit_attempt_ts: float = 0.0
+    fit_inflight: bool = False
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -118,6 +149,7 @@ class RuntimeState:
     version: int = CURRENT_VERSION
     mpc: dict[str, MpcState] = field(default_factory=dict)
     mpc_v2: dict[str, MpcV2StateData] = field(default_factory=dict)
+    mpc_v2_reid: dict[str, MpcV2ReidData] = field(default_factory=dict)
     pid: dict[str, PIDState] = field(default_factory=dict)
     tpi: dict[str, TpiState] = field(default_factory=dict)
     thermal: ThermalStats = field(default_factory=ThermalStats)
@@ -261,6 +293,33 @@ def deserialize_mpc_v2(raw: dict[str, Any]) -> MpcV2StateData:
     return state
 
 
+def deserialize_mpc_v2_reid(raw: dict[str, Any]) -> MpcV2ReidData | None:
+    """Deserialize a persisted re-identification result; None if malformed."""
+    state = MpcV2ReidData()
+    for attr in (
+        "tau_room_min",
+        "gain_heater",
+        "fitted_ts",
+        "rmse_prior_K",
+        "rmse_fit_K",
+    ):
+        value = raw.get(attr)
+        if value is None:
+            continue
+        try:
+            setattr(state, attr, float(value))
+        except TypeError, ValueError, OverflowError:
+            continue
+    try:
+        state.n_segments = int(raw.get("n_segments", 0))
+    except TypeError, ValueError:
+        state.n_segments = 0
+    # A result without both fitted components cannot seed a plant prior.
+    if state.tau_room_min <= 0.0 or state.gain_heater <= 0.0:
+        return None
+    return state
+
+
 def deserialize_pid(raw: dict[str, Any]) -> PIDState:
     """Deserialize a single PID state dict into a PIDState dataclass.
 
@@ -327,6 +386,14 @@ def _deserialize(raw: dict[str, Any]) -> RuntimeState:
         for key, state_dict in mpc_v2_raw.items():
             if isinstance(state_dict, dict):
                 state.mpc_v2[key] = deserialize_mpc_v2(state_dict)
+
+    mpc_v2_reid_raw = raw.get("mpc_v2_reid", {})
+    if isinstance(mpc_v2_reid_raw, Mapping):
+        for key, state_dict in mpc_v2_reid_raw.items():
+            if isinstance(state_dict, dict):
+                reid = deserialize_mpc_v2_reid(state_dict)
+                if reid is not None:
+                    state.mpc_v2_reid[key] = reid
 
     pid_raw = raw.get("pid", {})
     if isinstance(pid_raw, Mapping):
@@ -427,6 +494,8 @@ class StateManager:
         # Live MPC v2 controllers, held in memory across cycles. The persisted
         # ``_state.mpc_v2`` snapshots are folded in only at save time.
         self._mpc_v2_live: dict[str, MpcV2State] = {}
+        # Re-identification sample buffers and scheduling flags, in-memory only.
+        self._mpc_v2_reid_live: dict[str, MpcV2ReidRuntime] = {}
         self._dirty = False
         self._delay_save_pending = False
 
@@ -504,6 +573,34 @@ class StateManager:
             exported = export_mpc_v2_state(live)
             if exported is not None:
                 self._state.mpc_v2[key] = deserialize_mpc_v2(exported)
+
+    def get_mpc_v2_reid(self, key: str) -> MpcV2ReidData | None:
+        """Return the persisted re-identification result for a key, if any."""
+        return self._state.mpc_v2_reid.get(key)
+
+    def get_mpc_v2_reid_runtime(self, key: str) -> MpcV2ReidRuntime:
+        """Return the in-memory re-ID collection state, building it on first use."""
+        runtime = self._mpc_v2_reid_live.get(key)
+        if runtime is None:
+            runtime = MpcV2ReidRuntime()
+            self._mpc_v2_reid_live[key] = runtime
+        return runtime
+
+    def adopt_mpc_v2_reid(self, key: str, data: MpcV2ReidData) -> None:
+        """Adopt a validated re-identification result, bumplessly.
+
+        The live controller is exported into the persisted snapshot and then
+        dropped, so the next :meth:`get_mpc_v2_live` rebuilds it with the new
+        plant prior while restoring the observer state (Kalman, DOB, integral,
+        last command) from that snapshot — no cold start.
+        """
+        live = self._mpc_v2_live.pop(key, None)
+        if live is not None:
+            exported = export_mpc_v2_state(live)
+            if exported is not None:
+                self._state.mpc_v2[key] = deserialize_mpc_v2(exported)
+        self._state.mpc_v2_reid[key] = data
+        self._dirty = True
 
     def get_pid(self, key: str) -> PIDState:
         """Get or create PID state for a key."""

--- a/custom_components/better_thermostat/utils/telemetry.py
+++ b/custom_components/better_thermostat/utils/telemetry.py
@@ -244,6 +244,8 @@ _MPC_V2_FIELDS: tuple[tuple[str, str, int], ...] = (
     ("tau_room_min", "mpc_v2_tau_room_min", 1),
     ("coupling_rad_room", "mpc_v2_coupling_rad_room", 3),
     ("group_valve_pct", "mpc_v2_group_valve_pct", 1),
+    ("reid_tau_room", "mpc_v2_reid_tau_room", 1),
+    ("reid_gain", "mpc_v2_reid_gain", 2),
 )
 
 

--- a/tests/unit/mpc_v2/test_dispatch.py
+++ b/tests/unit/mpc_v2/test_dispatch.py
@@ -17,6 +17,7 @@ pytest.importorskip("daqp")
 from homeassistant.components.climate.const import HVACMode
 
 from custom_components.better_thermostat.calibration import _compute_mpc_v2_balance
+from custom_components.better_thermostat.core.clock import FakeClock
 from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils.calibration.mpc import (
     distribute_valve_percent,
@@ -92,6 +93,7 @@ def _make_bt(*, real_trvs: dict[str, Trv], unique_id: str = "bt_test") -> Any:
         device_id="bt_test_device",
         entry_id="bt_test_entry",
         state_mgr=_FakeStateManager(),
+        clock=FakeClock(monotonic_value=1_000_000.0),
     )
 
 

--- a/tests/unit/mpc_v2/test_dispatch.py
+++ b/tests/unit/mpc_v2/test_dispatch.py
@@ -30,6 +30,7 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
     MpcV2PlantPreset,
 )
+from custom_components.better_thermostat.utils.state_manager import MpcV2ReidRuntime
 
 
 class _FakeStateManager:
@@ -43,6 +44,7 @@ class _FakeStateManager:
     def __init__(self) -> None:
         """Start with an empty per-key live MPC v2 state store."""
         self._mpc_v2_live: dict[str, MpcV2State] = {}
+        self._mpc_v2_reid_live: dict[str, MpcV2ReidRuntime] = {}
 
     def get_mpc_v2_live(self, key: str, params: MpcV2Params) -> MpcV2State:
         """Return the live state for key, creating a fresh one on first use."""
@@ -55,6 +57,18 @@ class _FakeStateManager:
     def set_mpc_v2_live(self, key: str, state: MpcV2State) -> None:
         """Store the live MPC v2 state for key."""
         self._mpc_v2_live[key] = state
+
+    def get_mpc_v2_reid(self, key: str) -> None:
+        """No persisted re-identification result in the fake store."""
+        return None
+
+    def get_mpc_v2_reid_runtime(self, key: str) -> MpcV2ReidRuntime:
+        """Return the in-memory re-ID collection state, building it on first use."""
+        runtime = self._mpc_v2_reid_live.get(key)
+        if runtime is None:
+            runtime = MpcV2ReidRuntime()
+            self._mpc_v2_reid_live[key] = runtime
+        return runtime
 
 
 def _make_bt(*, real_trvs: dict[str, Trv], unique_id: str = "bt_test") -> Any:

--- a/tests/unit/mpc_v2/test_reid.py
+++ b/tests/unit/mpc_v2/test_reid.py
@@ -1,0 +1,241 @@
+"""Unit tests for the offline batch re-identification core (HA/daqp-free)."""
+
+from __future__ import annotations
+
+import math
+
+from custom_components.better_thermostat.utils.calibration.mpc_v2.reid import (
+    ReidBuffer,
+    ReidConfig,
+    ReidSample,
+    Segment,
+    _nelder_mead,
+    _simulate_room,
+    extract_segments,
+    run_reid_fit,
+)
+from custom_components.better_thermostat.utils.calibration.mpc_v2_internals.plant import (
+    PlantParams,
+)
+
+
+def _sample(t_s: float, T_room: float, u: float, **kw: object) -> ReidSample:
+    """Build a ReidSample with sane defaults for outdoor/window."""
+    return ReidSample(
+        t_s=t_s,
+        T_room_C=T_room,
+        u_frac=u,
+        T_outdoor_C=kw.get("outdoor", 5.0),
+        T_trv_C=kw.get("trv"),
+        window_open=bool(kw.get("window", False)),
+    )
+
+
+# -- Buffer -----------------------------------------------------------------
+
+
+def test_buffer_dedupes_samples_closer_than_spacing() -> None:
+    """Two samples milliseconds apart (multi-TRV pass) collapse into one."""
+    buf = ReidBuffer(min_spacing_s=60.0)
+    assert buf.append(_sample(1000.0, 20.0, 0.5)) is True
+    assert buf.append(_sample(1000.005, 20.0, 0.5)) is False
+    assert buf.append(_sample(1061.0, 20.1, 0.5)) is True
+    assert len(buf.samples) == 2
+
+
+def test_buffer_evicts_oldest_beyond_maxlen() -> None:
+    """The buffer stays bounded and keeps the most recent samples."""
+    buf = ReidBuffer(maxlen=5, min_spacing_s=1.0)
+    for i in range(10):
+        buf.append(_sample(float(i * 10), 20.0, 0.0))
+    assert len(buf.samples) == 5
+    assert buf.samples[0].t_s == 50.0
+
+
+def test_buffer_rejects_non_finite_values() -> None:
+    """NaN/Inf in any field must never reach a later fit."""
+    buf = ReidBuffer()
+    assert buf.append(_sample(0.0, float("nan"), 0.5)) is False
+    assert buf.append(_sample(0.0, 20.0, float("inf"))) is False
+    assert buf.append(_sample(0.0, 20.0, 0.5, outdoor=float("nan"))) is False
+    assert buf.samples == []
+
+
+# -- Segment extraction -----------------------------------------------------
+
+
+def _stream(
+    *phases: tuple[float, float, float, int],
+    spacing_s: float = 300.0,
+    window_at: int | None = None,
+) -> list[ReidSample]:
+    """Build a sample stream from (T_start, T_end, u, n) phases."""
+    samples: list[ReidSample] = []
+    t = 0.0
+    idx = 0
+    for T_start, T_end, u, n in phases:
+        for i in range(n):
+            T = T_start + (T_end - T_start) * (i / max(1, n - 1))
+            samples.append(
+                _sample(t, T, u, window=(window_at is not None and idx == window_at))
+            )
+            t += spacing_s
+            idx += 1
+    return samples
+
+
+def test_extracts_heatup_and_cooldown() -> None:
+    """A heating rise and an idle drop become one segment each."""
+    samples = _stream((18.0, 21.0, 1.0, 12), (21.0, 19.5, 0.0, 16))
+    segments = extract_segments(samples, ReidConfig())
+    kinds = [s.kind for s in segments]
+    assert kinds == ["heatup", "cooldown"]
+
+
+def test_window_open_cuts_a_segment() -> None:
+    """A window-open sample in mid-heatup splits the run below min length."""
+    samples = _stream((18.0, 21.0, 1.0, 12), window_at=6)
+    segments = extract_segments(samples, ReidConfig())
+    assert segments == []
+
+
+def test_sampling_gap_cuts_a_segment() -> None:
+    """A gap beyond max_gap_s splits an otherwise valid run."""
+    samples = _stream((18.0, 21.0, 1.0, 12))
+    for s in samples[6:]:
+        s.t_s += 3600.0
+    segments = extract_segments(samples, ReidConfig())
+    assert segments == []
+
+
+def test_missing_outdoor_disqualifies_samples() -> None:
+    """Samples without an outdoor reading cannot be simulated and are cut."""
+    samples = _stream((18.0, 21.0, 1.0, 12))
+    for s in samples:
+        s.T_outdoor_C = None
+    assert extract_segments(samples, ReidConfig()) == []
+
+
+def test_flat_runs_are_not_segments() -> None:
+    """Regulation at constant temperature carries no excitation."""
+    samples = _stream((21.0, 21.1, 1.0, 12), (21.1, 21.0, 0.0, 16))
+    assert extract_segments(samples, ReidConfig()) == []
+
+
+def test_warm_cooldown_requires_colder_outdoors() -> None:
+    """An idle temperature drop with warm outdoors (solar night?) is skipped."""
+    samples = _stream((22.0, 20.0, 0.0, 16))
+    for s in samples:
+        s.T_outdoor_C = 25.0
+    assert extract_segments(samples, ReidConfig()) == []
+
+
+# -- Optimiser --------------------------------------------------------------
+
+
+def test_nelder_mead_minimises_a_quadratic() -> None:
+    """The simplex finds the minimum of a smooth 2-parameter bowl."""
+
+    def bowl(x: list[float]) -> float:
+        return (x[0] - 1.0) ** 2 + (x[1] + 2.0) ** 2
+
+    best = _nelder_mead(bowl, [0.0, 0.0], step=0.5, max_iterations=200)
+    assert abs(best[0] - 1.0) < 1e-3
+    assert abs(best[1] + 2.0) < 1e-3
+
+
+# -- Fit + validation -------------------------------------------------------
+
+_TRUTH = PlantParams(tau_room_min=240.0, gain_heater=3.0)
+
+
+def _generate_day(
+    truth: PlantParams, noise: float = 0.01, spacing_s: float = 300.0
+) -> list[ReidSample]:
+    """Simulate a setback day (cool-down, heat-up, cool-down) from ``truth``.
+
+    Plain Euler at a finer step than the fit's substep so the fit cannot
+    trivially invert its own discretisation. TRV temperature is included so
+    segment simulations seed the radiator state correctly.
+    """
+    T_room, T_rad = 21.0, 21.0
+    T_outdoor = 5.0
+    samples: list[ReidSample] = []
+    t = 0.0
+    phases = [(0.0, 4 * 3600.0), (1.0, 3 * 3600.0), (0.0, 4 * 3600.0)]
+    step_s = 60.0
+    i = 0
+    for u, duration_s in phases:
+        elapsed = 0.0
+        while elapsed < duration_s:
+            if elapsed % spacing_s == 0.0:
+                wobble = noise * math.sin(i * 1.7)
+                samples.append(
+                    _sample(t, T_room + wobble, u, trv=T_rad, outdoor=T_outdoor)
+                )
+                i += 1
+            h_min = step_s / 60.0
+            dT_rad = (
+                truth.gain_heater * u * (truth.T_water_C - T_rad) - (T_rad - T_room)
+            ) / truth.tau_rad_min
+            dT_room = (
+                truth.coupling_rad_room * (T_rad - T_room) - (T_room - T_outdoor)
+            ) / truth.tau_room_min
+            T_room += dT_room * h_min
+            T_rad += dT_rad * h_min
+            t += step_s
+            elapsed += step_s
+    return samples
+
+
+def test_fit_recovers_truth_params_and_is_accepted() -> None:
+    """On data from a plant far off the prior, the fit recovers and wins."""
+    samples = _generate_day(_TRUTH)
+    prior = PlantParams()  # tau 480, gain 2.0 — both well off the truth
+    outcome = run_reid_fit(samples, prior)
+    assert outcome.status == "accepted"
+    assert outcome.tau_room_min is not None and outcome.gain_heater is not None
+    assert abs(outcome.tau_room_min - _TRUTH.tau_room_min) / _TRUTH.tau_room_min < 0.25
+    assert abs(outcome.gain_heater - _TRUTH.gain_heater) / _TRUTH.gain_heater < 0.25
+    assert outcome.rmse_fit_K is not None and outcome.rmse_prior_K is not None
+    assert outcome.rmse_fit_K < outcome.rmse_prior_K
+
+
+def test_fit_rejected_when_prior_already_matches() -> None:
+    """Data generated by the prior itself leaves nothing to improve."""
+    prior = PlantParams()
+    samples = _generate_day(prior)
+    outcome = run_reid_fit(samples, prior)
+    assert outcome.status == "rejected"
+
+
+def test_insufficient_without_a_heatup_in_training() -> None:
+    """Cool-downs alone cannot identify the heater gain."""
+    samples = _generate_day(_TRUTH)
+    idle_only = [s for s in samples if s.u_frac <= 0.05]
+    outcome = run_reid_fit(idle_only, PlantParams())
+    assert outcome.status == "insufficient_data"
+
+
+def test_insufficient_with_too_few_segments() -> None:
+    """Fewer segments than min_segments cannot be split into train/holdout."""
+    samples = _stream((18.0, 21.0, 1.0, 12))
+    outcome = run_reid_fit(samples, PlantParams())
+    assert outcome.status == "insufficient_data"
+
+
+def test_simulate_room_seeds_radiator_from_trv() -> None:
+    """The initial radiator state comes from the TRV reading when present."""
+    seg = Segment(
+        kind="cooldown",
+        samples=[
+            _sample(0.0, 21.0, 0.0, trv=40.0),
+            _sample(300.0, 21.0, 0.0, trv=38.0),
+        ],
+    )
+    with_trv = _simulate_room(PlantParams(), seg, substep_s=150.0)
+    for s in seg.samples:
+        s.T_trv_C = None
+    without_trv = _simulate_room(PlantParams(), seg, substep_s=150.0)
+    # A hot radiator keeps feeding the room; the seeded run must end warmer.
+    assert with_trv[-1] > without_trv[-1]

--- a/tests/unit/mpc_v2/test_reid_integration.py
+++ b/tests/unit/mpc_v2/test_reid_integration.py
@@ -1,0 +1,295 @@
+"""Integration tests for re-identification: adopt path, persistence, dispatch."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("daqp")
+
+from homeassistant.components.climate.const import HVACMode
+
+from custom_components.better_thermostat.calibration import _compute_mpc_v2_balance
+from custom_components.better_thermostat.trv import Trv
+from custom_components.better_thermostat.utils.calibration.mpc_v2 import (
+    MpcV2Input,
+    MpcV2Params,
+    compute_mpc_v2,
+)
+from custom_components.better_thermostat.utils.const import (
+    CalibrationMode,
+    CalibrationType,
+    MpcV2PlantPreset,
+)
+from custom_components.better_thermostat.utils.state_manager import (
+    MpcV2ReidData,
+    StateManager,
+    _deserialize,
+    _serialize,
+    deserialize_mpc_v2_reid,
+)
+
+_REID = MpcV2ReidData(
+    tau_room_min=240.0,
+    gain_heater=3.0,
+    fitted_ts=1000.0,
+    rmse_prior_K=0.4,
+    rmse_fit_K=0.1,
+    n_segments=4,
+)
+
+
+def _make_manager() -> StateManager:
+    """Build a StateManager with a mocked HA Store."""
+    mock_hass = AsyncMock()
+    with patch("custom_components.better_thermostat.utils.state_manager.Store"):
+        return StateManager(mock_hass, "test_entry")
+
+
+def _warm(mgr: StateManager, key: str, params: MpcV2Params) -> None:
+    """Run one compute cycle so the manager holds a live controller."""
+    state = mgr.get_mpc_v2_live(key, params)
+    _out, state = compute_mpc_v2(
+        MpcV2Input(
+            key=key,
+            target_temp_C=22.0,
+            current_temp_C=19.0,
+            outdoor_temp_C=5.0,
+            heating_allowed=True,
+            window_open=False,
+        ),
+        params,
+        state=state,
+        now=0.0,
+    )
+    mgr.set_mpc_v2_live(key, state)
+
+
+# -- StateManager: adopt + persistence ---------------------------------------
+
+
+def test_adopt_is_bumpless() -> None:
+    """Adoption drops the live controller but carries its state across.
+
+    The next live access must rebuild the controller with the new prior
+    while restoring the previous command from the folded snapshot — the
+    definition of a bumpless transfer.
+    """
+    mgr = _make_manager()
+    _warm(mgr, "k", MpcV2Params())
+    old = mgr.get_mpc_v2_live("k", MpcV2Params())
+    assert old.controller is not None
+    last_u_before = old.controller._last_u
+
+    mgr.adopt_mpc_v2_reid("k", _REID)
+
+    new_params = MpcV2Params()
+    new_params.plant.tau_room_min = _REID.tau_room_min
+    new_params.plant.gain_heater = _REID.gain_heater
+    rebuilt = mgr.get_mpc_v2_live("k", new_params)
+    assert rebuilt is not old
+    assert rebuilt.controller is not None
+    assert rebuilt.controller is not old.controller
+    assert rebuilt.controller._last_u == last_u_before
+    assert rebuilt.controller.plant_fine.params.tau_room_min == _REID.tau_room_min
+
+
+def test_adopt_marks_dirty_and_result_readable() -> None:
+    """The adopted result is stored, retrievable, and flagged for saving."""
+    mgr = _make_manager()
+    mgr.adopt_mpc_v2_reid("k", _REID)
+    assert mgr.dirty is True
+    stored = mgr.get_mpc_v2_reid("k")
+    assert stored is not None
+    assert stored.tau_room_min == 240.0
+
+
+def test_reid_result_survives_serialization_round_trip() -> None:
+    """serialize -> deserialize reproduces the persisted re-ID result."""
+    mgr = _make_manager()
+    mgr.adopt_mpc_v2_reid("k", _REID)
+    raw = _serialize(mgr.state)
+    restored = _deserialize(raw)
+    assert restored.mpc_v2_reid["k"].tau_room_min == 240.0
+    assert restored.mpc_v2_reid["k"].gain_heater == 3.0
+    assert restored.mpc_v2_reid["k"].n_segments == 4
+
+
+def test_deserialize_rejects_malformed_reid_payload() -> None:
+    """Zero/garbage fitted components cannot seed a plant prior."""
+    assert deserialize_mpc_v2_reid({"tau_room_min": 0.0, "gain_heater": 2.0}) is None
+    assert deserialize_mpc_v2_reid({"tau_room_min": "junk"}) is None
+    ok = deserialize_mpc_v2_reid({"tau_room_min": 300.0, "gain_heater": 2.5})
+    assert ok is not None and ok.tau_room_min == 300.0
+
+
+# -- Dispatcher wiring --------------------------------------------------------
+
+
+def _trv_info(entity_id: str, preset: MpcV2PlantPreset) -> Trv:
+    """Build a Trv configured for MPC v2 calibration with a given preset."""
+    return Trv(
+        entity_id=entity_id,
+        current_temperature=19.0,
+        valve_max_opening=100.0,
+        advanced={
+            "calibration": CalibrationType.DIRECT_VALVE_BASED,
+            "calibration_mode": CalibrationMode.MPC_V2_CALIBRATION,
+            "mpc_v2_plant_preset": preset,
+        },
+        valve_position_writable=True,
+        valve_position_entity="number.trv_valve",
+        max_temp=30.0,
+        model_quirks=None,
+    )
+
+
+def _make_bt(preset: MpcV2PlantPreset = MpcV2PlantPreset.AUTO) -> Any:
+    """Build a minimal BT-shaped namespace with a real StateManager."""
+    return SimpleNamespace(
+        real_trvs={"climate.x": _trv_info("climate.x", preset)},
+        bt_target_temp=21.0,
+        cur_temp=19.5,
+        tolerance=0.0,
+        window_open=False,
+        device_name="BT_TEST",
+        bt_hvac_mode=HVACMode.HEAT,
+        heating_power=0.04,
+        heat_loss_rate=0.02,
+        outdoor_sensor=None,
+        weather_entity=None,
+        hass=None,
+        state_mgr=_make_manager(),
+    )
+
+
+def test_auto_prior_uses_adopted_reid_result() -> None:
+    """Under AUTO, an adopted re-ID result overrides the heat-loss heuristic."""
+    bt = _make_bt()
+    out, _ = _compute_mpc_v2_balance(bt, "climate.x")
+    assert out is not None
+    key = next(iter(bt.state_mgr._mpc_v2_live))
+    bt.state_mgr.adopt_mpc_v2_reid(key, _REID)
+
+    out, _ = _compute_mpc_v2_balance(bt, "climate.x")
+    assert out is not None
+    live = bt.state_mgr.get_mpc_v2_live(key, MpcV2Params())
+    assert live.controller is not None
+    assert live.controller.plant_fine.params.tau_room_min == _REID.tau_room_min
+    assert live.controller.plant_fine.params.gain_heater == _REID.gain_heater
+    debug = bt.real_trvs["climate.x"].calibration_balance["debug"]
+    assert debug["reid_tau_room"] == _REID.tau_room_min
+
+
+def test_explicit_preset_beats_reid_result() -> None:
+    """A user-chosen preset is an opt-out: the re-ID result is ignored."""
+    bt = _make_bt(preset=MpcV2PlantPreset.SMALL_ROOM)
+    out, _ = _compute_mpc_v2_balance(bt, "climate.x")
+    assert out is not None
+    key = next(iter(bt.state_mgr._mpc_v2_live))
+    bt.state_mgr.adopt_mpc_v2_reid(key, _REID)
+
+    out, _ = _compute_mpc_v2_balance(bt, "climate.x")
+    assert out is not None
+    live = next(iter(bt.state_mgr._mpc_v2_live.values()))
+    assert live.controller is not None
+    assert live.controller.plant_fine.params.tau_room_min == 180.0  # small_room
+
+
+def test_dispatch_records_reid_samples_under_auto() -> None:
+    """Each AUTO-mode compute feeds the re-identification buffer."""
+    bt = _make_bt()
+    out, _ = _compute_mpc_v2_balance(bt, "climate.x")
+    assert out is not None
+    key = next(iter(bt.state_mgr._mpc_v2_reid_live))
+    runtime = bt.state_mgr.get_mpc_v2_reid_runtime(key)
+    assert len(runtime.buffer.samples) == 1
+    sample = runtime.buffer.samples[0]
+    assert sample.T_room_C == 19.5
+    assert sample.window_open is False
+
+
+def test_dispatch_skips_sampling_for_explicit_preset() -> None:
+    """Preset mode is a re-ID opt-out: no samples are collected."""
+    bt = _make_bt(preset=MpcV2PlantPreset.LARGE_ROOM)
+    out, _ = _compute_mpc_v2_balance(bt, "climate.x")
+    assert out is not None
+    assert bt.state_mgr._mpc_v2_reid_live == {}
+
+
+# -- Fit scheduling -----------------------------------------------------------
+
+
+class _FakeFuture:
+    """Future double that resolves synchronously in add_done_callback."""
+
+    def __init__(self, result: object) -> None:
+        self._result = result
+
+    def result(self) -> object:
+        """Return the wrapped result."""
+        return self._result
+
+    def add_done_callback(self, cb) -> None:
+        """Invoke the callback immediately with this future."""
+        cb(self)
+
+
+class _FakeHass:
+    """hass double whose executor runs the job inline."""
+
+    def async_add_executor_job(self, func, *args: object) -> _FakeFuture:
+        """Run ``func`` synchronously and hand back a resolved future."""
+        return _FakeFuture(func(*args))
+
+
+def test_fit_scheduling_adopts_accepted_outcome(monkeypatch) -> None:
+    """A due fit runs via the executor and adopts an accepted result once."""
+    from custom_components.better_thermostat import calibration as cal
+    from custom_components.better_thermostat.utils.calibration.mpc_v2 import (
+        ReidOutcome,
+        ReidSample,
+    )
+
+    bt = _make_bt()
+    bt.hass = _FakeHass()
+    out, _ = _compute_mpc_v2_balance(bt, "climate.x")
+    assert out is not None
+    key = next(iter(bt.state_mgr._mpc_v2_reid_live))
+    runtime = bt.state_mgr.get_mpc_v2_reid_runtime(key)
+    # Replace the dispatch's wall-clock sample with a dense synthetic history;
+    # mixed time bases would trip the buffer's spacing dedupe.
+    runtime.buffer.samples.clear()
+    for i in range(300):
+        runtime.buffer.append(ReidSample(t_s=float(i * 300), T_room_C=20.0, u_frac=0.5))
+    runtime.last_fit_attempt_ts = 0.0
+
+    calls: list[int] = []
+
+    def _fake_fit(samples, prior):
+        calls.append(len(samples))
+        return ReidOutcome(
+            status="accepted",
+            tau_room_min=_REID.tau_room_min,
+            gain_heater=_REID.gain_heater,
+            rmse_prior_K=0.4,
+            rmse_fit_K=0.1,
+            n_segments=4,
+            n_samples=300,
+        )
+
+    monkeypatch.setattr(cal, "run_reid_fit", _fake_fit)
+
+    cal._maybe_start_mpc_v2_reid_fit(bt, key, MpcV2Params())
+    assert calls == [len(runtime.buffer.samples)]
+    adopted = bt.state_mgr.get_mpc_v2_reid(key)
+    assert adopted is not None
+    assert adopted.tau_room_min == _REID.tau_room_min
+    assert runtime.fit_inflight is False
+
+    # A second immediate call is throttled by the attempt interval.
+    cal._maybe_start_mpc_v2_reid_fit(bt, key, MpcV2Params())
+    assert len(calls) == 1

--- a/tests/unit/mpc_v2/test_reid_integration.py
+++ b/tests/unit/mpc_v2/test_reid_integration.py
@@ -13,6 +13,7 @@ pytest.importorskip("daqp")
 from homeassistant.components.climate.const import HVACMode
 
 from custom_components.better_thermostat.calibration import _compute_mpc_v2_balance
+from custom_components.better_thermostat.core.clock import FakeClock
 from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils.calibration.mpc_v2 import (
     MpcV2Input,
@@ -163,6 +164,7 @@ def _make_bt(preset: MpcV2PlantPreset = MpcV2PlantPreset.AUTO) -> Any:
         weather_entity=None,
         hass=None,
         state_mgr=_make_manager(),
+        clock=FakeClock(monotonic_value=1_000_000.0),
     )
 
 


### PR DESCRIPTION
## What

The follow-up promised when the RLS online identifier was removed from #2094: periodic **offline/batch grey-box identification on logged transients**, validated before a bumpless apply.

> [!NOTE]
> **Stacked on #2094**: the base is `feature/mpc-v2-integration`, so this PR's diff is only the re-identification change set — `a612e89a` (core) and `ffc8f429` (wiring). Will be retargeted onto `develop` once #2094 merges.

- **Collect**: one sample per control cycle (room temp, TRV temp, applied valve fraction, outdoor temp, window flag) into a bounded in-memory buffer per MPC key. The buffer is never persisted; only accepted results are.
- **Extract**: informative transients only — heat-ups (valve open, temperature rising) and free cool-downs (valve closed, outdoors colder than the room). Window-open samples, missing outdoor readings, and sampling gaps cut segments.
- **Fit**: prediction-error minimisation of the RC2 simulation over the training segments, Nelder-Mead in log-space over `tau_room_min` + `gain_heater`. `tau_rad`/`coupling` stay at their robust defaults (weakly identifiable from a room-temperature output). Runs in the executor, never on the event loop.
- **Validate**: holdout = most recent segment; acceptance requires a ≥10 % relative *and* ≥0.05 K absolute holdout-RMSE win over the current prior. Training without a heat-up is rejected (gain is only identifiable there).
- **Apply**: bumpless — the live controller is folded into its persisted snapshot and dropped; the next cycle rebuilds it with the new prior while restoring Kalman/DOB/integral state and the last command.

Prior resolution under AUTO: explicit preset > adopted re-ID result > heat-loss heuristic. A preset is a full opt-out (no sampling, no fits).

## Why offline instead of RLS

Closed-loop regulation at a constant setpoint has no persistent excitation; online RLS drifted on noise (closed-loop bias, errors-in-variables, covariance windup) and was benchmark-neutral. Batch fitting can *select* the segments that carry information and validate before touching the controller — per Ljung / Åström & Wittenmark / Bacher & Madsen.

## Notes

- New attributes: `mpc_v2_reid_tau_room`, `mpc_v2_reid_gain`.
- 24 new tests (core fit recovery on synthetic plants, validation gates, bumpless adopt, dispatch wiring); full suite 2091 passed.
- Benchmark adapter intentionally untouched — multi-episode adaptation scenarios are the separate Adaptation-Suite work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new advanced calibration mode for more adaptive thermostat control.
  * Added a plant preset selector with room-size options and automatic defaults.
  * Exposed new diagnostic details in the thermostat’s state for better troubleshooting.
  * Added support for saving and restoring smarter controller state across restarts.

* **Bug Fixes**
  * Improved handling when sensor data is missing or invalid.
  * Made controller behavior more stable during rapid updates and edge cases.
  * Added safer fallback behavior when optional control capabilities are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---
**Update 2026-07-03:** rebased onto the refreshed #2094 (which now sits on the reviewed benchmark stack and `develop`@74185870); commit hashes above updated accordingly. Full suite on this tip: 2091 passed; benchmark suite 348 passed; ruff clean.

