### PR TITLE
fix: publish and apply hvac_mode-only payloads in async_set_temperature

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2983,6 +2983,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             and _new_setpointlow is None
             and _new_setpointhigh is None
         ):
+            if _new_hvac_mode is not None:
+                # A mode-only payload still needs to be published and
+                # applied, exactly like async_set_hvac_mode.
+                self.async_write_ha_state()
+                if getattr(self, "in_maintenance", False):
+                    self._control_needed_after_maintenance = True
+                    return
+                request_control_cycle(self)
+                return
             _LOGGER.debug(
                 "better_thermostat %s: received a new setpoint from HA, but temperature attribute was not set, ignoring",
                 self.device_name,

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -985,6 +985,38 @@ class TestAsyncSetTemperature:
         assert mock_bt.bt_hvac_mode == HVACMode.OFF
 
     @pytest.mark.asyncio
+    async def test_mode_only_payload_writes_state_and_requests_control(self, mock_bt):
+        """A payload with only an hvac_mode publishes the state and queues a cycle."""
+        mock_bt.preset_mgr.mode = PRESET_NONE
+        mock_bt.bt_hvac_mode = HVACMode.HEAT
+        await self._call(mock_bt, **{ATTR_HVAC_MODE: HVACMode.OFF})
+        assert mock_bt.bt_hvac_mode == HVACMode.OFF
+        mock_bt.async_write_ha_state.assert_called_once()
+        mock_bt.control_queue_task.put_nowait.assert_called_once_with(mock_bt)
+
+    @pytest.mark.asyncio
+    async def test_mode_only_payload_during_maintenance_defers_control(self, mock_bt):
+        """A mode-only payload during maintenance defers the cycle, no queue.put."""
+        mock_bt.preset_mgr.mode = PRESET_NONE
+        mock_bt.bt_hvac_mode = HVACMode.HEAT
+        mock_bt.in_maintenance = True
+        await self._call(mock_bt, **{ATTR_HVAC_MODE: HVACMode.OFF})
+        assert mock_bt.bt_hvac_mode == HVACMode.OFF
+        mock_bt.async_write_ha_state.assert_called_once()
+        assert mock_bt._control_needed_after_maintenance is True
+        mock_bt.control_queue_task.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_payload_is_ignored(self, mock_bt):
+        """A payload without temperature and without hvac_mode changes nothing."""
+        mock_bt.preset_mgr.mode = PRESET_NONE
+        mock_bt.bt_hvac_mode = HVACMode.HEAT
+        await self._call(mock_bt)
+        assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+        mock_bt.async_write_ha_state.assert_not_called()
+        mock_bt.control_queue_task.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_garbage_temperature_rejected(self, mock_bt):
         """A present but non-numeric temperature raises.
 


### PR DESCRIPTION
## Problem

When a `climate.set_temperature` service call carries only an `hvac_mode` and no temperature attribute, `async_set_temperature` sets `self.bt_hvac_mode` and then returns early. Unlike the normal path at the end of the method (and unlike `async_set_hvac_mode`), it neither calls `async_write_ha_state()` nor requests a control cycle. The mode change is therefore not shown in HA and not applied to the TRVs until some unrelated event happens to trigger a cycle.

## Fix

The hvac_mode-only path now takes the same publish/apply steps as `async_set_hvac_mode`: write the HA state, defer during valve maintenance via `_control_needed_after_maintenance`, otherwise request a control cycle.

## Tests

New unit tests in `tests/unit/test_climate_baseline.py` (`TestAsyncSetTemperature`):
- `test_mode_only_payload_writes_state_and_requests_control`
- `test_mode_only_payload_during_maintenance_defers_control`
- `test_empty_payload_is_ignored` (guards the no-op path)

Full suite: 2457 passed. ruff and pyrefly clean.