### PR TITLE
fix: retry the boost safety valve reset when the write fails

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -956,7 +956,23 @@ async def control_trv(self, heater_entity_id=None, cycle=None):
             )
             if not _valve_at_target(self, heater_entity_id, _reset_pct):
                 _consume_budget(self, heater_entity_id, "valve", bypass=True)
-                await set_valve(self, heater_entity_id, _reset_pct)
+                ok = await set_valve(self, heater_entity_id, _reset_pct)
+                if not ok:
+                    _LOGGER.debug(
+                        "better_thermostat %s: delegate.set_valve returned False for "
+                        "safety reset (target=%s%%, entity=%s)",
+                        self.device_name,
+                        _reset_pct,
+                        heater_entity_id,
+                    )
+                    # The budget slot is stamped but the valve never moved;
+                    # re-derive on the catch-up cycle so the reset is not
+                    # dropped permanently.
+                    _schedule_budget_retry(
+                        self,
+                        heater_entity_id,
+                        _budget_remaining(self, heater_entity_id, "valve"),
+                    )
 
         # Manage TRVs with no HVACMode.OFF
         _trv_has_no_off = _no_off_system_mode(self.real_trvs[heater_entity_id])

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -1204,6 +1204,79 @@ class TestBoostModeSafetyOverride:
         assert mock_self.real_trvs["climate.trv1"].last_valve_write_monotonic == 10.0
 
     @pytest.mark.asyncio
+    async def test_failed_safety_reset_schedules_a_retry_cycle(self):
+        """A failed 0% safety reset is re-requested like any other write.
+
+        The budget slot is already stamped when the delegate reports
+        failure, so without a follow-up cycle the valve stays at 100%
+        with HVAC OFF until some unrelated event triggers control.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            preset_mode=PRESET_BOOST,
+            cur_temp=18.0,
+            bt_target_temp=22.0,
+            window_open=True,
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    advanced={
+                        "calibration_mode": CalibrationMode.MPC_CALIBRATION,
+                        "calibration": CalibrationType.DIRECT_VALVE_BASED,
+                        "no_off_system_mode": False,
+                    }
+                )
+            },
+        )
+
+        captured = []
+        mock_self.task_manager.create_task = Mock(
+            side_effect=lambda coro, name=None: captured.append((coro, name)) or Mock()
+        )
+
+        set_valve_calls = []
+
+        async def failing_set_valve(*args, **kwargs):
+            set_valve_calls.append(args)
+            # The boost 100% write succeeds; the 0% safety reset fails.
+            return args[2] != 0
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_valve"], side_effect=failing_set_valve),
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            result = await control_trv(mock_self, "climate.trv1")
+
+        assert result is True
+        assert [call[2] for call in set_valve_calls] == [100, 0]
+
+        retries = [
+            (coro, name) for coro, name in captured if "budget_retry" in (name or "")
+        ]
+        assert len(retries) == 1
+        assert mock_self.real_trvs["climate.trv1"].budget_retry_pending is True
+
+        coro, _name = retries[0]
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await coro
+        mock_self.control_queue_task.put_nowait.assert_called_once()
+        assert mock_self.real_trvs["climate.trv1"].budget_retry_pending is False
+
+        # Close any other captured coroutines to avoid RuntimeWarning.
+        for coro, name in captured:
+            if "budget_retry" not in (name or ""):
+                coro.close()
+
+    @pytest.mark.asyncio
     async def test_no_heat_call_resets_valve_during_boost(self):
         """Test that call_for_heat=False resets valve to 0% when boost mode was active.
 


### PR DESCRIPTION
## Problem

The boost safety override in `control_trv` resets the valve to 0% when boost mode is overridden by HVAC OFF (open window, no heat demand). Unlike the normal valve-write path, it ignored the `set_valve` result:

- On a failed write the valve stayed at 100% with HVAC OFF — the exact overheating conflict the override exists to prevent.
- The write budget slot was already stamped, so the reconciler saw no divergence and no follow-up cycle was triggered; the reset was dropped permanently until some unrelated event ran control again.

## Fix

Honor the `set_valve` result on the reset path the same way the normal valve-write path does: log the failure and schedule a budget retry (`_schedule_budget_retry`) so the reset converges on the catch-up cycle.

## Testing

- New unit test `test_failed_safety_reset_schedules_a_retry_cycle` in `tests/unit/controlling/test_control_trv.py` (fails without the fix).
- Full suite: 2455 passed.
- `ruff check`, `ruff format`, `pyrefly check` clean.