### PR TITLE
fix: reject non-finite values at the input boundary

### DIFF
--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -464,15 +464,13 @@ def convert_to_float(
     Returns
     -------
     float | None
-            the converted value, or None if conversion failed
+            the converted value, or None if the value cannot be parsed
+            or is not finite (NaN/inf)
     """
     if value is None or value == "None":
         return None
     try:
-        # Use 0.01 step (2 decimal places) to preserve sensor precision.
-        # Rounding to 0.1 can turn 19.97 into 20.0, leading to incorrect
-        # HVAC action decisions.
-        return round_by_step(float(value), 0.01)
+        numeric = float(value)
     except ValueError, TypeError, AttributeError, KeyError:
         _LOGGER.debug(
             "better thermostat %s: Could not convert '%s' to float in %s",
@@ -481,6 +479,18 @@ def convert_to_float(
             context,
         )
         return None
+    if not math.isfinite(numeric):
+        _LOGGER.debug(
+            "better thermostat %s: Rejected non-finite value '%s' in %s",
+            instance_name,
+            value,
+            context,
+        )
+        return None
+    # Use 0.01 step (2 decimal places) to preserve sensor precision.
+    # Rounding to 0.1 can turn 19.97 into 20.0, leading to incorrect
+    # HVAC action decisions.
+    return round_by_step(numeric, 0.01)
 
 
 def convert_to_float_celsius(

--- a/tests/unit/test_helpers_normalize.py
+++ b/tests/unit/test_helpers_normalize.py
@@ -5,6 +5,7 @@ which are critical for handling user input and TRV state conversions.
 """
 
 from homeassistant.components.climate.const import HVACMode
+import pytest
 
 from custom_components.better_thermostat.utils.const import CalibrationMode
 from custom_components.better_thermostat.utils.helpers import (
@@ -234,6 +235,15 @@ class TestConvertToFloat:
         result = convert_to_float("1.5e-3", "test", "temperature")
         # Expected behavior: 0.0015 rounded to 0.0 due to 0.01 step
         assert result == 0.0
+
+    @pytest.mark.parametrize(
+        "value",
+        [float("nan"), float("inf"), float("-inf"), "nan", "inf", "-inf", "Infinity"],
+    )
+    def test_returns_none_for_non_finite(self, value):
+        """Test that NaN/inf values (numeric or string) return None."""
+        result = convert_to_float(value, "test", "temperature")
+        assert result is None
 
 
 class TestIsReasonableTemperature:

--- a/tests/unit/test_world_snapshot.py
+++ b/tests/unit/test_world_snapshot.py
@@ -119,6 +119,14 @@ class TestSnapshotCompleteness:
         snapshot = build_snapshot(bt)
         assert snapshot.room_temp == 19.97
 
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_observations_become_none(self, bad):
+        """NaN/inf readings are rejected at the snapshot boundary."""
+        bt = _make_bt()
+        bt.cur_temp = bad
+        snapshot = build_snapshot(bt)
+        assert snapshot.room_temp is None
+
     def test_time_comes_from_the_injected_clock(self):
         """The snapshot carries both clock axes at build time."""
         bt = _make_bt()
@@ -171,6 +179,16 @@ class TestTrvReportedBuilding:
         trv = snapshot.trvs["climate.trv"]
         assert trv.current_temp is None
         assert trv.hvac_mode is None
+
+    def test_non_finite_reported_values_become_none(self):
+        """NaN/inf in the real_trvs entry degrades to None, not a crash."""
+        bt = _make_bt()
+        bt.real_trvs["climate.trv"].current_temperature = float("nan")
+        bt.real_trvs["climate.trv"].last_temperature = float("inf")
+        snapshot = build_snapshot(bt)
+        trv = snapshot.trvs["climate.trv"]
+        assert trv.current_temp is None
+        assert trv.setpoint is None
 
 
 class TestWorldSnapshotType:


### PR DESCRIPTION
## Problem

`convert_to_float()` in `utils/helpers.py` — the shared input-boundary converter used by `build_snapshot()`'s `_as_float` and by the event/control paths — did not reject non-finite numbers:

- **Infinity** (`inf`, `-inf`, from a numeric attribute or a string state like `"Infinity"`) raised an uncaught `OverflowError` inside `round_by_step` (`round(inf)` cannot convert to integer). The exception is not in the function's `except` tuple, so it propagated into `build_snapshot()` and every other caller instead of degrading to `None`.
- **NaN** only returned `None` by accident of `round()` raising `ValueError`; nothing pinned that behavior.

This contradicts the input-boundary policy applied elsewhere (e.g. the state-manager deserializers reject NaN/inf with explicit `math.isfinite` guards).

## Fix

`convert_to_float()` now parses the value first and returns `None` for any non-finite result (both numeric and parsed-string inputs), with a debug log. Finite values are rounded on the 0.01 grid exactly as before. `_as_float` in `utils/snapshot.py` therefore yields `None` for NaN/inf readings instead of crashing the snapshot build.

Note: the persistence side (`utils/state_manager.py`) already guards the MPC/PID/TPI, thermal, and filter deserialization paths with `math.isfinite`; no change was needed there.

## Testing

- New unit tests: `TestConvertToFloat::test_returns_none_for_non_finite` (parametrized over NaN/inf/-inf as float and string) in `tests/unit/test_helpers_normalize.py`; `test_non_finite_observations_become_none` and `test_non_finite_reported_values_become_none` in `tests/unit/test_world_snapshot.py`. The infinity cases fail (uncaught `OverflowError`) without the fix.
- Full suite: `uv run pytest tests/ -q` — 2465 passed.
- `ruff check`, `ruff format`, `pyrefly check` clean.