### PR TITLE
fix: honor explicit entity_id and merge extra key in Trv.from_legacy_dict

### DIFF
--- a/custom_components/better_thermostat/trv.py
+++ b/custom_components/better_thermostat/trv.py
@@ -178,11 +178,18 @@ class Trv:
         """Build a Trv from a plain per-entity dict.
 
         Known keys become typed fields; unknown keys land in ``extra``.
+        The explicit ``entity_id`` argument wins over an ``entity_id``
+        key in the dict, and an ``extra`` key is merged into the extra
+        mapping instead of being nested under it.
         """
         fields_in = {}
         extra: dict[str, Any] = {}
         for key, value in data.items():
-            if key != "extra" and key in cls.__dataclass_fields__:
+            if key == "entity_id":
+                continue
+            if key == "extra":
+                extra.update(value)
+            elif key in cls.__dataclass_fields__:
                 fields_in[key] = value
             else:
                 extra[key] = value

--- a/tests/unit/test_trv_object.py
+++ b/tests/unit/test_trv_object.py
@@ -60,6 +60,22 @@ class TestExtraScratchpad:
         assert trv.advanced == {"child_lock": True}
         assert trv.extra == {"_quirk_scratch": 3}
 
+    def test_from_legacy_dict_explicit_entity_id_wins(self):
+        """An ``entity_id`` key in the dict yields to the explicit argument."""
+        trv = Trv.from_legacy_dict(
+            "climate.trv", {"entity_id": "climate.stale", "current_temperature": 21.0}
+        )
+        assert trv.entity_id == "climate.trv"
+        assert trv.current_temperature == 21.0
+        assert trv.extra == {}
+
+    def test_from_legacy_dict_merges_extra_key(self):
+        """An ``extra`` key is merged into the scratchpad, not nested under it."""
+        trv = Trv.from_legacy_dict(
+            "climate.trv", {"extra": {"_quirk_scratch": 3}, "_other_scratch": 7}
+        )
+        assert trv.extra == {"_quirk_scratch": 3, "_other_scratch": 7}
+
     def test_no_dict_protocol(self):
         """Trv does not speak the dict protocol: attribute access only."""
         trv = _make()


### PR DESCRIPTION
## Problem

`Trv.from_legacy_dict` mishandles two keys in the input dict:

- **`entity_id`**: the key is recognized as a dataclass field and forwarded via `**fields_in`, colliding with the explicit `entity_id` argument and raising `TypeError: got multiple values for argument 'entity_id'`.
- **`extra`**: the key falls into the catch-all branch, so its value ends up nested as `extra["extra"]` instead of being merged into the extra mapping.

Only tests construct `Trv` objects through this path today, but the contract should be correct.

## Fix

- The explicit `entity_id` argument wins; an `entity_id` key in the dict is ignored.
- An `extra` key is merged into the extra mapping instead of being nested under it.

## Tests

- `test_from_legacy_dict_explicit_entity_id_wins`
- `test_from_legacy_dict_merges_extra_key`

Full suite: 2456 passed. ruff check/format and pyrefly clean.