### PR TITLE
ci: restrict types workflow token to read-only contents

### DIFF
--- a/.github/workflows/types.yaml
+++ b/.github/workflows/types.yaml
@@ -5,6 +5,9 @@ on:
     branches: [develop, master]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
The `Types` workflow declared no `permissions:` block, so its `GITHUB_TOKEN` received the repository default permissions. The job only checks out the repo and runs `pyrefly check`; it needs nothing beyond read access.

This adds a workflow-level least-privilege block, matching the style used in `pages.yml`:

```yaml
permissions:
  contents: read
```

No behavior change to the check itself.