### PR TITLE
fix: dispatch window events even when the sensor is unavailable

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1133,12 +1133,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if (event.data.get("new_state")) is None:
             return
 
-        # Only process window changes if window sensor is available
-        if is_entity_available(self.hass, self.window_id):
-            self.hass.async_create_background_task(
-                trigger_window_change(self, event),
-                name=f"bt_trigger_window_change_{self.device_name}",
-            )
+        # The window handler interprets unknown/unavailable readings itself
+        # (a lost sensor counts as closed so heating resumes), so events are
+        # dispatched regardless of sensor availability.
+        self.hass.async_create_background_task(
+            trigger_window_change(self, event),
+            name=f"bt_trigger_window_change_{self.device_name}",
+        )
 
     async def _trigger_cooler_change(self, event):
         _check = await check_critical_entities(self)

--- a/tests/unit/test_climate_window_dispatch.py
+++ b/tests/unit/test_climate_window_dispatch.py
@@ -1,0 +1,73 @@
+"""Tests for the window state-change dispatcher in climate.py.
+
+``_trigger_window_change`` forwards window sensor events to the window
+event handler. The handler in events/window.py owns the state
+interpretation, including unknown/unavailable readings (a lost sensor
+counts as closed so heating resumes) and garbage readings (repair
+issue). The dispatcher therefore must not filter events by sensor
+availability — otherwise that handling is unreachable and a sensor that
+dies while the window is open strands the thermostat with heating off.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+
+CLIMATE_MOD = "custom_components.better_thermostat.climate"
+
+
+def _make_self():
+    """Build a BetterThermostat stand-in for the window dispatcher."""
+    return SimpleNamespace(
+        device_name="Test BT",
+        window_id="binary_sensor.window",
+        hass=MagicMock(),
+        async_set_context=MagicMock(),
+    )
+
+
+def _event(state_value):
+    new_state = MagicMock()
+    new_state.state = state_value
+    event = MagicMock()
+    event.data = {"new_state": new_state}
+    return event
+
+
+def _patch_checks():
+    """Patch the watcher helpers and the window handler coroutine."""
+    return patch.multiple(
+        CLIMATE_MOD,
+        check_critical_entities=AsyncMock(return_value=True),
+        check_and_update_degraded_mode=AsyncMock(),
+        trigger_window_change=MagicMock(return_value=MagicMock()),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reading", ["on", "off", "unknown", "unavailable"])
+async def test_window_event_is_dispatched_regardless_of_availability(reading):
+    """Every sensor reading reaches the handler, including a lost sensor."""
+    bt = _make_self()
+    bt.hass.states.get.return_value = MagicMock(state=reading)
+
+    with _patch_checks():
+        await BetterThermostat._trigger_window_change(bt, _event(reading))
+
+    bt.hass.async_create_background_task.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_event_without_new_state_is_dropped():
+    """An event carrying no new state dispatches nothing."""
+    bt = _make_self()
+    event = MagicMock()
+    event.data = {"new_state": None}
+
+    with _patch_checks():
+        await BetterThermostat._trigger_window_change(bt, event)
+
+    bt.hass.async_create_background_task.assert_not_called()


### PR DESCRIPTION
## Problem

`_trigger_window_change` in `climate.py` gated event dispatch on `is_entity_available()`, which returns `False` for `unknown`/`unavailable` states. Window sensor events carrying those states were silently dropped, so the dedicated handling in `events/window.py` — treat a lost sensor as *closed* so heating resumes, with a logged warning — was unreachable dead code on the live event path.

Concrete failure: a window sensor whose battery dies while the window state is *open* leaves the thermostat stuck with heating off until the sensor recovers.

## Fix

Remove the availability gate; the dispatcher now forwards every event, matching `_trigger_cooler_change`. The window event handler already owns the interpretation of all readings (open/closed synonyms, unknown/unavailable, unrecognized values with a repair issue) and guards against a missing sensor state itself.

## Tests

New `tests/unit/test_climate_window_dispatch.py` pins the dispatcher contract: every sensor reading (including `unknown`/`unavailable`) reaches the handler, while events without a new state are still dropped. The `unknown`/`unavailable` cases failed before the fix. Full suite: 2459 passed.