### PR TITLE
fix: register valve maintenance tick independently of calibration mode

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1901,31 +1901,32 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 self.device_name,
             )
 
-            # Valve maintenance: only enable a separate tick when at least one TRV has it turned on
-            try:
-                maint_trvs = collect_maintenance_trvs(self.real_trvs)
-            except Exception:
-                maint_trvs = []
+        # Valve maintenance is independent of the balance/calibration tick:
+        # enable a separate tick when at least one TRV has it turned on
+        try:
+            maint_trvs = collect_maintenance_trvs(self.real_trvs)
+        except Exception:
+            maint_trvs = []
 
-            if maint_trvs:
-                self.next_valve_maintenance = compute_initial_maintenance(
-                    self.real_trvs, maint_trvs
+        if maint_trvs:
+            self.next_valve_maintenance = compute_initial_maintenance(
+                self.real_trvs, maint_trvs
+            )
+            self.async_on_remove(
+                async_track_time_interval(
+                    self.hass, self._maintenance_tick, timedelta(minutes=5)
                 )
-                self.async_on_remove(
-                    async_track_time_interval(
-                        self.hass, self._maintenance_tick, timedelta(minutes=5)
-                    )
-                )
-                _LOGGER.debug(
-                    "better_thermostat %s: valve maintenance tick enabled (5min), first run at %s",
-                    self.device_name,
-                    self.next_valve_maintenance,
-                )
-            else:
-                _LOGGER.debug(
-                    "better_thermostat %s: valve maintenance tick skipped (no TRV enabled)",
-                    self.device_name,
-                )
+            )
+            _LOGGER.debug(
+                "better_thermostat %s: valve maintenance tick enabled (5min), first run at %s",
+                self.device_name,
+                self.next_valve_maintenance,
+            )
+        else:
+            _LOGGER.debug(
+                "better_thermostat %s: valve maintenance tick skipped (no TRV enabled)",
+                self.device_name,
+            )
 
         self.async_on_remove(
             async_track_state_change_event(

--- a/tests/unit/test_climate_tick_registration.py
+++ b/tests/unit/test_climate_tick_registration.py
@@ -1,0 +1,111 @@
+"""Periodic tick registration in BetterThermostat._finalize_startup.
+
+_finalize_startup registers two independent 5-minute intervals: the control
+tick (_trigger_time, gated on an active balance/calibration mode) and the
+valve maintenance tick (_maintenance_tick, gated only on a TRV having valve
+maintenance enabled). These tests pin down that the maintenance tick is
+registered whenever a TRV enables it, regardless of the calibration mode.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+from custom_components.better_thermostat.trv import Trv
+from custom_components.better_thermostat.utils.const import (
+    CONF_VALVE_MAINTENANCE,
+    CalibrationMode,
+)
+
+_CLIMATE = "custom_components.better_thermostat.climate"
+SENSOR_ID = "sensor.room_temp"
+TRV_ID = "climate.test_trv"
+
+
+def _make_bt(advanced):
+    """Build a minimal BetterThermostat mock for _finalize_startup."""
+    mock = MagicMock(spec=BetterThermostat)
+    mock.hass = MagicMock()
+    mock.device_name = "Test BT"
+    mock.is_removed = False
+    mock.real_trvs = {TRV_ID: Trv(entity_id=TRV_ID, advanced=advanced)}
+    mock.all_trvs = None
+    mock.all_entities = []
+    mock.entity_ids = [TRV_ID]
+    mock.sensor_entity_id = SENSOR_ID
+    mock.humidity_sensor_entity_id = None
+    mock.window_id = None
+    mock.cooler_entity_id = None
+    mock.outdoor_sensor = None
+    mock._async_unsub_state_changed = None
+    # Plain MagicMocks so the un-awaited coroutines handed to the background
+    # task mock do not raise "coroutine was never awaited" warnings.
+    mock._post_grace_recheck = MagicMock()
+    mock._external_temperature_keepalive = MagicMock()
+    return mock
+
+
+async def _run_finalize_startup(bt):
+    """Run _finalize_startup and return the async_track_time_interval mock."""
+    with (
+        patch(f"{_CLIMATE}.await_critical_entities", AsyncMock()),
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
+        patch(f"{_CLIMATE}.await_optional_sensors", AsyncMock()),
+        patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
+        patch(f"{_CLIMATE}.asyncio.sleep", AsyncMock()),
+        patch(f"{_CLIMATE}.async_track_time_interval") as track_interval,
+        patch(f"{_CLIMATE}.async_track_state_change_event"),
+        patch(f"{_CLIMATE}.async_track_time_change"),
+    ):
+        await BetterThermostat._finalize_startup(bt)
+    return track_interval
+
+
+def _registered_callbacks(track_interval, bt):
+    """Extract the callbacks registered via async_track_time_interval."""
+    return [call.args[1] for call in track_interval.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_maintenance_tick_registered_with_calibration_mode():
+    """A calibrating instance with valve maintenance enabled gets the tick."""
+    bt = _make_bt(
+        {
+            "calibration_mode": CalibrationMode.PID_CALIBRATION.value,
+            CONF_VALVE_MAINTENANCE: True,
+        }
+    )
+    track_interval = await _run_finalize_startup(bt)
+    callbacks = _registered_callbacks(track_interval, bt)
+    assert bt._trigger_time in callbacks
+    assert bt._maintenance_tick in callbacks
+
+
+@pytest.mark.asyncio
+async def test_maintenance_tick_registered_without_calibration_mode():
+    """Without balance/calibration, valve maintenance is still registered."""
+    bt = _make_bt(
+        {
+            "calibration_mode": CalibrationMode.NO_CALIBRATION.value,
+            CONF_VALVE_MAINTENANCE: True,
+        }
+    )
+    track_interval = await _run_finalize_startup(bt)
+    callbacks = _registered_callbacks(track_interval, bt)
+    assert bt._trigger_time not in callbacks
+    assert bt._maintenance_tick in callbacks
+
+
+@pytest.mark.asyncio
+async def test_maintenance_tick_skipped_when_no_trv_enables_it():
+    """Without any TRV enabling valve maintenance, no tick is registered."""
+    bt = _make_bt(
+        {
+            "calibration_mode": CalibrationMode.NO_CALIBRATION.value,
+            CONF_VALVE_MAINTENANCE: False,
+        }
+    )
+    track_interval = await _run_finalize_startup(bt)
+    callbacks = _registered_callbacks(track_interval, bt)
+    assert bt._maintenance_tick not in callbacks


### PR DESCRIPTION
## Problem

In `_finalize_startup` (climate.py), the valve maintenance tick registration was nested inside the `else:` branch of the `if active_balance_modes or active_calibration_modes:` check. Any instance with an active balance mode (`heuristic`/`pid`) or a supported calibration mode (`default`/`mpc`/`tpi`/`pid`) therefore never registered `_maintenance_tick` — periodic valve maintenance silently never ran for those instances, even with `valve_maintenance` enabled on a TRV. `_trigger_time` does not run maintenance either, so there was no fallback path.

Since `default` calibration counts as an active calibration mode, this affected virtually every configuration.

## Fix

Valve maintenance is orthogonal to the balance/calibration tick. The registration block is dedented out of the `else:` branch so it always runs, gated only on `collect_maintenance_trvs()` finding at least one TRV with valve maintenance enabled.

## Tests

New `tests/unit/test_climate_tick_registration.py`:
- a calibrating instance with valve maintenance enabled gets `_maintenance_tick` registered (regression, failed before the fix)
- an instance without balance/calibration still gets it registered
- without any TRV enabling valve maintenance, no maintenance tick is registered

Full suite: 1656 passed. ruff and pyrefly clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup handling for valve-maintenance scheduling so it reliably runs when enabled and is skipped cleanly when not needed.
  * Ensured periodic maintenance timing is registered consistently, including cases where calibration-related behavior is not active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->