### PR TITLE
feat: Z-Wave JS adapter + Eurotronic Spirit/Aeotec ZWA021 valve control

### DIFF
--- a/custom_components/better_thermostat/adapters/zwave_js.py
+++ b/custom_components/better_thermostat/adapters/zwave_js.py
@@ -15,7 +15,11 @@ import logging
 from homeassistant.components.number.const import SERVICE_SET_VALUE
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
-from ..utils.helpers import find_local_calibration_entity, find_valve_entity
+from ..utils.helpers import (
+    find_local_calibration_entity,
+    find_valve_entity,
+    get_device_model,
+)
 from .base import wait_for_calibration_entity_or_timeout
 from .generic import (
     set_hvac_mode as generic_set_hvac_mode,
@@ -24,13 +28,20 @@ from .generic import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Models whose valve is driven through a model quirk (Multilevel Switch command
+# class while in manufacturer-specific mode) rather than a writable number
+# helper. For these, valve support is reported even though no valve number
+# entity is exposed, so the config flow offers direct valve control.
+_QUIRK_VALVE_MODELS = {"ZWA021"}
+
 
 async def get_info(self, entity_id):
     """Report offset and valve capabilities of the TRV.
 
     Capabilities are derived from the entities the device actually exposes, so
     a Z-Wave JS TRV without a writable valve helper falls back to the same
-    (offset-only or plain) behaviour as the generic adapter.
+    (offset-only or plain) behaviour as the generic adapter. Devices whose valve
+    is controlled through a model quirk are reported as valve-capable regardless.
     """
     support_offset = False
     support_valve = False
@@ -40,6 +51,13 @@ async def get_info(self, entity_id):
     valve = await find_valve_entity(self, entity_id)
     if valve is not None and valve.get("entity_id"):
         support_valve = bool(valve.get("writable", False))
+    if not support_valve:
+        try:
+            model = await get_device_model(self, entity_id)
+        except Exception:
+            model = ""
+        if model in _QUIRK_VALVE_MODELS:
+            support_valve = True
     return {"support_offset": support_offset, "support_valve": support_valve}
 
 

--- a/custom_components/better_thermostat/adapters/zwave_js.py
+++ b/custom_components/better_thermostat/adapters/zwave_js.py
@@ -1,0 +1,234 @@
+"""Z-Wave JS adapter for TRV devices.
+
+Implements Z-Wave JS specific behaviour for TRV devices used by Better
+Thermostat. The adapter is a strict superset of the generic adapter: when a
+device exposes neither a writable valve helper nor a local calibration entity
+it behaves exactly like ``generic``. Direct valve control is only offered when
+the device actually exposes a writable valve ``number`` entity (e.g. the
+Eurotronic Spirit Z / Aeotec ZWA021 family under its manufacturer-specific
+mode).
+"""
+
+import asyncio
+import logging
+
+from homeassistant.components.number.const import SERVICE_SET_VALUE
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+
+from ..utils.helpers import find_local_calibration_entity, find_valve_entity
+from .base import wait_for_calibration_entity_or_timeout
+from .generic import (
+    set_hvac_mode as generic_set_hvac_mode,
+    set_temperature as generic_set_temperature,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def get_info(self, entity_id):
+    """Report offset and valve capabilities of the TRV.
+
+    Capabilities are derived from the entities the device actually exposes, so
+    a Z-Wave JS TRV without a writable valve helper falls back to the same
+    (offset-only or plain) behaviour as the generic adapter.
+    """
+    support_offset = False
+    support_valve = False
+    offset = await find_local_calibration_entity(self, entity_id)
+    if offset is not None:
+        support_offset = True
+    valve = await find_valve_entity(self, entity_id)
+    if valve is not None and valve.get("entity_id"):
+        support_valve = bool(valve.get("writable", False))
+    return {"support_offset": support_offset, "support_valve": support_valve}
+
+
+async def init(self, entity_id):
+    """Initialize the Z-Wave JS adapter for a TRV entity.
+
+    Discovers the valve position entity (when writable) and the local
+    calibration entity early, mirroring the generic initialization for the
+    calibration path.
+    """
+    # Discover a writable valve helper early so the reconciler can use it.
+    try:
+        valve = await find_valve_entity(self, entity_id)
+        if valve is not None:
+            self.real_trvs[entity_id]["valve_position_entity"] = valve.get("entity_id")
+            self.real_trvs[entity_id]["valve_position_writable"] = bool(
+                valve.get("writable", False)
+            )
+    except Exception:
+        _LOGGER.debug(
+            "better_thermostat %s: valve discovery failed for %s",
+            self.device_name,
+            entity_id,
+        )
+
+    if (
+        self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None
+        and self.real_trvs[entity_id]["calibration"] != 1
+    ):
+        self.real_trvs[entity_id][
+            "local_temperature_calibration_entity"
+        ] = await find_local_calibration_entity(self, entity_id)
+        _LOGGER.debug(
+            "better_thermostat %s: uses local calibration entity %s",
+            self.device_name,
+            self.real_trvs[entity_id]["local_temperature_calibration_entity"],
+        )
+        if (
+            self.real_trvs[entity_id]["local_temperature_calibration_entity"]
+            is not None
+        ):
+            await wait_for_calibration_entity_or_timeout(
+                self,
+                entity_id,
+                self.real_trvs[entity_id]["local_temperature_calibration_entity"],
+            )
+        else:
+            _LOGGER.warning(
+                "better_thermostat %s: no local calibration entity found for '%s', skipping calibration init",
+                self.device_name,
+                entity_id,
+            )
+
+
+async def get_current_offset(self, entity_id):
+    """Get current offset."""
+    if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None:
+        return 0.0
+    state = self.hass.states.get(
+        self.real_trvs[entity_id]["local_temperature_calibration_entity"]
+    )
+    if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+        return 0.0
+    try:
+        return float(str(state.state))
+    except ValueError, TypeError:
+        _LOGGER.warning(
+            "better_thermostat %s: Could not convert calibration offset '%s' to float, using 0",
+            self.device_name,
+            state.state,
+        )
+        return 0.0
+
+
+async def get_offset_step(self, entity_id):
+    """Get offset step."""
+    if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None:
+        return None
+    state = self.hass.states.get(
+        self.real_trvs[entity_id]["local_temperature_calibration_entity"]
+    )
+    if state is None:
+        return None
+    return float(str(state.attributes.get("step", 1)))
+
+
+async def get_min_offset(self, entity_id):
+    """Get min offset."""
+    if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None:
+        return -6.0
+    state = self.hass.states.get(
+        self.real_trvs[entity_id]["local_temperature_calibration_entity"]
+    )
+    if state is None:
+        return -6.0
+    return float(str(state.attributes.get("min", -10)))
+
+
+async def get_max_offset(self, entity_id):
+    """Get max offset."""
+    if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None:
+        return 6.0
+    state = self.hass.states.get(
+        self.real_trvs[entity_id]["local_temperature_calibration_entity"]
+    )
+    if state is None:
+        return 6.0
+    return float(str(state.attributes.get("max", 10)))
+
+
+async def set_temperature(self, entity_id, temperature):
+    """Set new target temperature."""
+    return await generic_set_temperature(self, entity_id, temperature)
+
+
+async def set_hvac_mode(self, entity_id, hvac_mode):
+    """Set new target hvac mode."""
+    return await generic_set_hvac_mode(self, entity_id, hvac_mode)
+
+
+async def set_offset(self, entity_id, offset):
+    """Set new target offset."""
+    if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None:
+        return  # Not supported
+
+    max_calibration = await get_max_offset(self, entity_id)
+    min_calibration = await get_min_offset(self, entity_id)
+
+    offset = min(max_calibration, offset)
+    offset = max(min_calibration, offset)
+
+    await self.hass.services.async_call(
+        "number",
+        SERVICE_SET_VALUE,
+        {
+            "entity_id": self.real_trvs[entity_id][
+                "local_temperature_calibration_entity"
+            ],
+            "value": offset,
+        },
+        blocking=True,
+        context=self.context,
+    )
+    self.real_trvs[entity_id]["last_calibration"] = offset
+    if (
+        self.real_trvs[entity_id]["last_hvac_mode"] is not None
+        and self.real_trvs[entity_id]["last_hvac_mode"] != "off"
+    ):
+        await asyncio.sleep(3)
+        return await generic_set_hvac_mode(
+            self, entity_id, self.real_trvs[entity_id]["last_hvac_mode"]
+        )
+    return offset
+
+
+async def set_valve(self, entity_id, valve):
+    """Write a valve position (0-100 %) to the device's valve number entity."""
+    _LOGGER.debug(
+        "better_thermostat %s: TO TRV %s set_valve: %s",
+        self.device_name,
+        entity_id,
+        valve,
+    )
+    if self.real_trvs.get(entity_id, {}).get("valve_position_writable") is False:
+        _LOGGER.debug(
+            "better_thermostat %s: valve entity for %s is read-only, skip adapter write",
+            self.device_name,
+            entity_id,
+        )
+        return
+
+    valve_entity_id = self.real_trvs[entity_id]["valve_position_entity"]
+    if valve_entity_id is None:
+        return
+
+    # Scale the 0-100 % request onto the number entity's own min/max/step.
+    valve_entity = self.hass.states.get(valve_entity_id)
+    if valve_entity is not None:
+        min_valve = float(str(valve_entity.attributes.get("min", 0)))
+        max_valve = float(str(valve_entity.attributes.get("max", 100)))
+        valve = min_valve + (valve / 100.0) * (max_valve - min_valve)
+        step = float(str(valve_entity.attributes.get("step", 1)))
+        if step > 0:
+            valve = round(valve / step) * step
+
+    await self.hass.services.async_call(
+        "number",
+        SERVICE_SET_VALUE,
+        {"entity_id": valve_entity_id, "value": valve},
+        blocking=True,
+        context=self.context,
+    )

--- a/custom_components/better_thermostat/adapters/zwave_js.py
+++ b/custom_components/better_thermostat/adapters/zwave_js.py
@@ -3,10 +3,11 @@
 Implements Z-Wave JS specific behaviour for TRV devices used by Better
 Thermostat. The adapter is a strict superset of the generic adapter: when a
 device exposes neither a writable valve helper nor a local calibration entity
-it behaves exactly like ``generic``. Direct valve control is only offered when
-the device actually exposes a writable valve ``number`` entity (e.g. the
-Eurotronic Spirit Z / Aeotec ZWA021 family under its manufacturer-specific
-mode).
+it behaves exactly like ``generic``. Valve control is offered for devices that
+expose a writable valve ``number`` entity, and additionally for models whose
+valve is driven through a model quirk (the Eurotronic Spirit Z / Aeotec ZWA021
+family, which control the valve via the Multilevel Switch command class while
+in their manufacturer-specific mode).
 """
 
 import asyncio
@@ -72,8 +73,8 @@ async def init(self, entity_id):
     try:
         valve = await find_valve_entity(self, entity_id)
         if valve is not None:
-            self.real_trvs[entity_id]["valve_position_entity"] = valve.get("entity_id")
-            self.real_trvs[entity_id]["valve_position_writable"] = bool(
+            self.real_trvs[entity_id].valve_position_entity = valve.get("entity_id")
+            self.real_trvs[entity_id].valve_position_writable = bool(
                 valve.get("writable", False)
             )
     except Exception:
@@ -84,25 +85,24 @@ async def init(self, entity_id):
         )
 
     if (
-        self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None
-        and self.real_trvs[entity_id]["calibration"] != 1
+        self.real_trvs[entity_id].local_temperature_calibration_entity is None
+        and self.real_trvs[entity_id].calibration != 1
     ):
-        self.real_trvs[entity_id][
-            "local_temperature_calibration_entity"
-        ] = await find_local_calibration_entity(self, entity_id)
+        self.real_trvs[
+            entity_id
+        ].local_temperature_calibration_entity = await find_local_calibration_entity(
+            self, entity_id
+        )
         _LOGGER.debug(
             "better_thermostat %s: uses local calibration entity %s",
             self.device_name,
-            self.real_trvs[entity_id]["local_temperature_calibration_entity"],
+            self.real_trvs[entity_id].local_temperature_calibration_entity,
         )
-        if (
-            self.real_trvs[entity_id]["local_temperature_calibration_entity"]
-            is not None
-        ):
+        if self.real_trvs[entity_id].local_temperature_calibration_entity is not None:
             await wait_for_calibration_entity_or_timeout(
                 self,
                 entity_id,
-                self.real_trvs[entity_id]["local_temperature_calibration_entity"],
+                self.real_trvs[entity_id].local_temperature_calibration_entity,
             )
         else:
             _LOGGER.warning(
@@ -114,10 +114,10 @@ async def init(self, entity_id):
 
 async def get_current_offset(self, entity_id):
     """Get current offset."""
-    if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None:
+    if self.real_trvs[entity_id].local_temperature_calibration_entity is None:
         return 0.0
     state = self.hass.states.get(
-        self.real_trvs[entity_id]["local_temperature_calibration_entity"]
+        self.real_trvs[entity_id].local_temperature_calibration_entity
     )
     if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
         return 0.0
@@ -134,10 +134,10 @@ async def get_current_offset(self, entity_id):
 
 async def get_offset_step(self, entity_id):
     """Get offset step."""
-    if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None:
+    if self.real_trvs[entity_id].local_temperature_calibration_entity is None:
         return None
     state = self.hass.states.get(
-        self.real_trvs[entity_id]["local_temperature_calibration_entity"]
+        self.real_trvs[entity_id].local_temperature_calibration_entity
     )
     if state is None:
         return None
@@ -146,10 +146,10 @@ async def get_offset_step(self, entity_id):
 
 async def get_min_offset(self, entity_id):
     """Get min offset."""
-    if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None:
+    if self.real_trvs[entity_id].local_temperature_calibration_entity is None:
         return -6.0
     state = self.hass.states.get(
-        self.real_trvs[entity_id]["local_temperature_calibration_entity"]
+        self.real_trvs[entity_id].local_temperature_calibration_entity
     )
     if state is None:
         return -6.0
@@ -158,10 +158,10 @@ async def get_min_offset(self, entity_id):
 
 async def get_max_offset(self, entity_id):
     """Get max offset."""
-    if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None:
+    if self.real_trvs[entity_id].local_temperature_calibration_entity is None:
         return 6.0
     state = self.hass.states.get(
-        self.real_trvs[entity_id]["local_temperature_calibration_entity"]
+        self.real_trvs[entity_id].local_temperature_calibration_entity
     )
     if state is None:
         return 6.0
@@ -180,7 +180,7 @@ async def set_hvac_mode(self, entity_id, hvac_mode):
 
 async def set_offset(self, entity_id, offset):
     """Set new target offset."""
-    if self.real_trvs[entity_id]["local_temperature_calibration_entity"] is None:
+    if self.real_trvs[entity_id].local_temperature_calibration_entity is None:
         return  # Not supported
 
     max_calibration = await get_max_offset(self, entity_id)
@@ -193,22 +193,20 @@ async def set_offset(self, entity_id, offset):
         "number",
         SERVICE_SET_VALUE,
         {
-            "entity_id": self.real_trvs[entity_id][
-                "local_temperature_calibration_entity"
-            ],
+            "entity_id": self.real_trvs[entity_id].local_temperature_calibration_entity,
             "value": offset,
         },
         blocking=True,
         context=self.context,
     )
-    self.real_trvs[entity_id]["last_calibration"] = offset
+    self.real_trvs[entity_id].last_calibration = offset
     if (
-        self.real_trvs[entity_id]["last_hvac_mode"] is not None
-        and self.real_trvs[entity_id]["last_hvac_mode"] != "off"
+        self.real_trvs[entity_id].last_hvac_mode is not None
+        and self.real_trvs[entity_id].last_hvac_mode != "off"
     ):
         await asyncio.sleep(3)
         return await generic_set_hvac_mode(
-            self, entity_id, self.real_trvs[entity_id]["last_hvac_mode"]
+            self, entity_id, self.real_trvs[entity_id].last_hvac_mode
         )
     return offset
 
@@ -221,7 +219,8 @@ async def set_valve(self, entity_id, valve):
         entity_id,
         valve,
     )
-    if self.real_trvs.get(entity_id, {}).get("valve_position_writable") is False:
+    trv = self.real_trvs.get(entity_id)
+    if trv is not None and trv.valve_position_writable is False:
         _LOGGER.debug(
             "better_thermostat %s: valve entity for %s is read-only, skip adapter write",
             self.device_name,
@@ -229,7 +228,7 @@ async def set_valve(self, entity_id, valve):
         )
         return
 
-    valve_entity_id = self.real_trvs[entity_id]["valve_position_entity"]
+    valve_entity_id = self.real_trvs[entity_id].valve_position_entity
     if valve_entity_id is None:
         return
 

--- a/custom_components/better_thermostat/adapters/zwave_js.py
+++ b/custom_components/better_thermostat/adapters/zwave_js.py
@@ -233,15 +233,19 @@ async def set_valve(self, entity_id, valve):
     if valve_entity_id is None:
         return
 
-    # Scale the 0-100 % request onto the number entity's own min/max/step.
+    # Scale the 0-100 % request onto the number entity's own min/max/step,
+    # clamping both the incoming percentage and the quantized result so a
+    # rounding step or an out-of-range input never leaves the entity's bounds.
     valve_entity = self.hass.states.get(valve_entity_id)
     if valve_entity is not None:
         min_valve = float(str(valve_entity.attributes.get("min", 0)))
         max_valve = float(str(valve_entity.attributes.get("max", 100)))
-        valve = min_valve + (valve / 100.0) * (max_valve - min_valve)
+        pct = max(0.0, min(100.0, valve))
+        valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
         step = float(str(valve_entity.attributes.get("step", 1)))
         if step > 0:
             valve = round(valve / step) * step
+        valve = max(min_valve, min(max_valve, valve))
 
     await self.hass.services.async_call(
         "number",

--- a/custom_components/better_thermostat/model_fixes/ZWA021.py
+++ b/custom_components/better_thermostat/model_fixes/ZWA021.py
@@ -40,7 +40,7 @@ _VALVE_MAX = 99
 
 def _is_direct_valve(self, entity_id):
     """Return True when this TRV is configured for direct valve control."""
-    adv = self.real_trvs[entity_id].get("advanced", {}) or {}
+    adv = self.real_trvs[entity_id].advanced or {}
     return adv.get("calibration") == CalibrationType.DIRECT_VALVE_BASED
 
 

--- a/custom_components/better_thermostat/model_fixes/ZWA021.py
+++ b/custom_components/better_thermostat/model_fixes/ZWA021.py
@@ -23,9 +23,19 @@ _ZWAVE_JS_DOMAIN = "zwave_js"
 _ZWAVE_JS_SET_VALUE = "set_value"
 
 # Thermostat Mode command class (0x40) with the manufacturer-specific mode
-# value that lets the device accept external valve positions.
+# value that lets the device accept external valve positions. The mode is not
+# advertised during the device interview (firmware omission), so it has to be
+# written directly.
 _THERMOSTAT_MODE_COMMAND_CLASS = "64"
 _MANUFACTURER_SPECIFIC_MODE = "31"
+
+# While in manufacturer-specific mode the valve is driven through the
+# Multilevel Switch command class (0x26); its ``targetValue`` takes the valve
+# opening on a 0-99 scale (0 = closed, 99 = fully open). This is the same
+# mechanism the zwave-js "Multilevel Switch" control and OpenZWave use — the
+# device exposes no writable valve *number* helper.
+_MULTILEVEL_SWITCH_COMMAND_CLASS = 38
+_VALVE_MAX = 99
 
 
 def _is_direct_valve(self, entity_id):
@@ -89,5 +99,38 @@ async def override_set_temperature(self, entity_id, temperature):
 
 
 async def override_set_valve(self, entity_id, percent):
-    """Do not override valve writes; the adapter handles the valve number entity."""
-    return False
+    """Drive the valve directly via the Multilevel Switch command class.
+
+    Active only in direct valve control; otherwise returns ``False`` so the
+    generic valve handling applies. The device is expected to already be in
+    manufacturer-specific mode (see :func:`override_set_hvac_mode`). The
+    requested 0-100 % opening is mapped onto the device's 0-99 range.
+    """
+    if not _is_direct_valve(self, entity_id):
+        return False
+    try:
+        value = int(round(min(max(float(percent), 0.0), 100.0) / 100.0 * _VALVE_MAX))
+    except TypeError, ValueError:
+        return False
+
+    _LOGGER.debug(
+        "better_thermostat %s: TRV %s ZWA021 set valve %s%% -> %s/%s",
+        self.device_name,
+        entity_id,
+        percent,
+        value,
+        _VALVE_MAX,
+    )
+    await self.hass.services.async_call(
+        _ZWAVE_JS_DOMAIN,
+        _ZWAVE_JS_SET_VALUE,
+        {
+            "entity_id": entity_id,
+            "command_class": _MULTILEVEL_SWITCH_COMMAND_CLASS,
+            "property": "targetValue",
+            "value": value,
+        },
+        blocking=True,
+        context=self.context,
+    )
+    return True

--- a/custom_components/better_thermostat/model_fixes/ZWA021.py
+++ b/custom_components/better_thermostat/model_fixes/ZWA021.py
@@ -1,0 +1,93 @@
+"""Model quirks for the Eurotronic Spirit Z / Aeotec ZWA021 family.
+
+These Z-Wave TRVs can be driven by externally supplied valve positions, but
+only after being switched into a hidden "Manufacturer Specific" thermostat
+mode. The quirk below engages that mode when — and only when — Better
+Thermostat is configured for direct valve control. In every other calibration
+mode the module is inert and the device is driven through the standard
+``climate`` services, exactly like an unquirked TRV.
+"""
+
+import logging
+
+from homeassistant.components.climate.const import HVACMode
+
+from ..utils.const import CalibrationType
+
+_LOGGER = logging.getLogger(__name__)
+
+# Z-Wave JS service identifiers. Kept as literals to avoid importing the
+# zwave_js integration package (which pulls in the zwave_js_server dependency)
+# at module load time; the values are stable public service names.
+_ZWAVE_JS_DOMAIN = "zwave_js"
+_ZWAVE_JS_SET_VALUE = "set_value"
+
+# Thermostat Mode command class (0x40) with the manufacturer-specific mode
+# value that lets the device accept external valve positions.
+_THERMOSTAT_MODE_COMMAND_CLASS = "64"
+_MANUFACTURER_SPECIFIC_MODE = "31"
+
+
+def _is_direct_valve(self, entity_id):
+    """Return True when this TRV is configured for direct valve control."""
+    adv = self.real_trvs[entity_id].get("advanced", {}) or {}
+    return adv.get("calibration") == CalibrationType.DIRECT_VALVE_BASED
+
+
+def fix_local_calibration(self, entity_id, offset):
+    """Return the given local calibration offset unchanged."""
+    return offset
+
+
+def fix_valve_calibration(self, entity_id, valve):
+    """Return the given valve calibration unchanged."""
+    return valve
+
+
+def fix_target_temperature_calibration(self, entity_id, temperature):
+    """Return the given target temperature unchanged."""
+    return temperature
+
+
+async def override_set_hvac_mode(self, entity_id, hvac_mode):
+    """Engage the manufacturer-specific mode for direct valve control.
+
+    Only active when the TRV is configured for direct valve control and the
+    requested mode is not OFF. In all other cases this returns ``False`` so the
+    caller falls back to the standard ``climate.set_hvac_mode`` service, leaving
+    behaviour identical to a device without this quirk.
+    """
+    if not _is_direct_valve(self, entity_id):
+        return False
+    if hvac_mode == HVACMode.OFF:
+        # Let the standard off path close the device / drive the valve to 0.
+        return False
+
+    _LOGGER.debug(
+        "better_thermostat %s: TRV %s ZWA021 manufacturer-specific valve mode",
+        self.device_name,
+        entity_id,
+    )
+    await self.hass.services.async_call(
+        _ZWAVE_JS_DOMAIN,
+        _ZWAVE_JS_SET_VALUE,
+        {
+            "entity_id": entity_id,
+            "command_class": _THERMOSTAT_MODE_COMMAND_CLASS,
+            "property": "mode",
+            "value": _MANUFACTURER_SPECIFIC_MODE,
+        },
+        blocking=True,
+        context=self.context,
+    )
+    return True
+
+
+async def override_set_temperature(self, entity_id, temperature):
+    """Do not override set temperature."""
+    return False
+
+
+async def override_set_valve(self, entity_id, percent):
+    """Do not override valve writes; the adapter handles the valve number entity."""
+    return False

--- a/tests/unit/test_zwave_js_adapter.py
+++ b/tests/unit/test_zwave_js_adapter.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant.core import State
 import pytest
 
+from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils.const import CalibrationType
 
 quirk = importlib.import_module(
@@ -33,15 +34,9 @@ def _make_self(calibration=None):
     mock_self.context = MagicMock()
     mock_self.hass.services.async_call = AsyncMock()
     mock_self.real_trvs = {
-        "climate.trv1": {
-            "advanced": {"calibration": calibration},
-            "local_temperature_calibration_entity": None,
-            "valve_position_entity": None,
-            "valve_position_writable": None,
-            "calibration": 0,
-            "last_hvac_mode": None,
-            "last_calibration": None,
-        }
+        "climate.trv1": Trv(
+            entity_id="climate.trv1", advanced={"calibration": calibration}
+        )
     }
     return mock_self
 
@@ -244,7 +239,7 @@ class TestAdapterSetValve:
     async def test_skips_readonly_helper(self):
         """A read-only valve helper is skipped without any service call."""
         mock_self = _make_self()
-        mock_self.real_trvs["climate.trv1"]["valve_position_writable"] = False
+        mock_self.real_trvs["climate.trv1"].valve_position_writable = False
         await adapter.set_valve(mock_self, "climate.trv1", 50)
         mock_self.hass.services.async_call.assert_not_awaited()
 
@@ -252,10 +247,8 @@ class TestAdapterSetValve:
     async def test_scales_percentage_onto_entity_range(self):
         """50 % maps onto the midpoint of a 0..99 valve, snapped to step."""
         mock_self = _make_self()
-        mock_self.real_trvs["climate.trv1"]["valve_position_writable"] = True
-        mock_self.real_trvs["climate.trv1"]["valve_position_entity"] = (
-            "number.trv1_valve"
-        )
+        mock_self.real_trvs["climate.trv1"].valve_position_writable = True
+        mock_self.real_trvs["climate.trv1"].valve_position_entity = "number.trv1_valve"
         state = State("number.trv1_valve", "50", {"min": 0, "max": 99, "step": 1})
         mock_self.hass.states.get = MagicMock(return_value=state)
 
@@ -272,10 +265,8 @@ class TestAdapterSetValve:
     async def test_out_of_range_input_is_clamped(self):
         """An over-100 % request never exceeds the entity's max value."""
         mock_self = _make_self()
-        mock_self.real_trvs["climate.trv1"]["valve_position_writable"] = True
-        mock_self.real_trvs["climate.trv1"]["valve_position_entity"] = (
-            "number.trv1_valve"
-        )
+        mock_self.real_trvs["climate.trv1"].valve_position_writable = True
+        mock_self.real_trvs["climate.trv1"].valve_position_entity = "number.trv1_valve"
         state = State("number.trv1_valve", "50", {"min": 0, "max": 99, "step": 1})
         mock_self.hass.states.get = MagicMock(return_value=state)
 

--- a/tests/unit/test_zwave_js_adapter.py
+++ b/tests/unit/test_zwave_js_adapter.py
@@ -1,0 +1,196 @@
+"""Tests for the Z-Wave JS adapter and the ZWA021 model quirks.
+
+These tests assert two safety properties that hold without access to real
+hardware:
+
+1. The ZWA021 quirk only engages its manufacturer-specific valve mode when the
+   TRV is configured for direct valve control; in every other case it declines
+   and the standard climate path is used.
+2. The adapter reports valve support only for a writable valve helper and
+   degrades to generic offset/plain behaviour otherwise.
+"""
+
+import importlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.utils.const import CalibrationType
+
+quirk = importlib.import_module(
+    "custom_components.better_thermostat.model_fixes.ZWA021"
+)
+adapter = importlib.import_module(
+    "custom_components.better_thermostat.adapters.zwave_js"
+)
+
+
+def _make_self(calibration=None):
+    """Create a mock BetterThermostat with a spied service-call layer."""
+    mock_self = MagicMock()
+    mock_self.device_name = "test_thermostat"
+    mock_self.context = MagicMock()
+    mock_self.hass.services.async_call = AsyncMock()
+    mock_self.real_trvs = {
+        "climate.trv1": {
+            "advanced": {"calibration": calibration},
+            "local_temperature_calibration_entity": None,
+            "valve_position_entity": None,
+            "valve_position_writable": None,
+            "calibration": 0,
+            "last_hvac_mode": None,
+            "last_calibration": None,
+        }
+    }
+    return mock_self
+
+
+class TestZWA021HvacOverride:
+    """The manufacturer-specific mode is engaged only for direct valve control."""
+
+    @pytest.mark.asyncio
+    async def test_declines_when_not_direct_valve(self):
+        """Non valve-based calibration falls through to the standard path."""
+        mock_self = _make_self(calibration=CalibrationType.TARGET_TEMP_BASED)
+
+        handled = await quirk.override_set_hvac_mode(mock_self, "climate.trv1", "heat")
+
+        assert handled is False
+        mock_self.hass.services.async_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_declines_for_off_even_in_valve_mode(self):
+        """OFF uses the standard path so the device closes normally."""
+        mock_self = _make_self(calibration=CalibrationType.DIRECT_VALVE_BASED)
+
+        handled = await quirk.override_set_hvac_mode(mock_self, "climate.trv1", "off")
+
+        assert handled is False
+        mock_self.hass.services.async_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_engages_manufacturer_mode_for_valve_heat(self):
+        """Valve mode + a heating request switches the device into mode 31."""
+        mock_self = _make_self(calibration=CalibrationType.DIRECT_VALVE_BASED)
+
+        handled = await quirk.override_set_hvac_mode(mock_self, "climate.trv1", "heat")
+
+        assert handled is True
+        mock_self.hass.services.async_call.assert_awaited_once()
+        args, _ = mock_self.hass.services.async_call.call_args
+        assert args[0] == "zwave_js"
+        assert args[2]["entity_id"] == "climate.trv1"
+        assert args[2]["property"] == "mode"
+        assert args[2]["value"] == "31"
+        assert args[2]["command_class"] == "64"
+
+
+class TestZWA021Passthroughs:
+    """The remaining quirks are safe no-ops."""
+
+    def test_fix_calibrations_are_identity(self):
+        mock_self = _make_self()
+        assert quirk.fix_local_calibration(mock_self, "climate.trv1", 1.5) == 1.5
+        assert quirk.fix_valve_calibration(mock_self, "climate.trv1", 42) == 42
+        assert (
+            quirk.fix_target_temperature_calibration(mock_self, "climate.trv1", 21.0)
+            == 21.0
+        )
+
+    @pytest.mark.asyncio
+    async def test_overrides_decline(self):
+        mock_self = _make_self(calibration=CalibrationType.DIRECT_VALVE_BASED)
+        assert (
+            await quirk.override_set_temperature(mock_self, "climate.trv1", 21.0)
+            is False
+        )
+        assert await quirk.override_set_valve(mock_self, "climate.trv1", 50) is False
+
+
+class TestAdapterGetInfo:
+    """get_info reports capabilities strictly from the discovered entities."""
+
+    @pytest.mark.asyncio
+    async def test_no_entities_degrades_to_plain(self):
+        """Without offset or valve entities the adapter looks like generic."""
+        mock_self = _make_self()
+        with (
+            patch.object(
+                adapter, "find_local_calibration_entity", AsyncMock(return_value=None)
+            ),
+            patch.object(adapter, "find_valve_entity", AsyncMock(return_value=None)),
+        ):
+            info = await adapter.get_info(mock_self, "climate.trv1")
+        assert info == {"support_offset": False, "support_valve": False}
+
+    @pytest.mark.asyncio
+    async def test_readonly_valve_is_not_supported(self):
+        """A read-only valve helper does not enable valve support."""
+        mock_self = _make_self()
+        with (
+            patch.object(
+                adapter, "find_local_calibration_entity", AsyncMock(return_value=None)
+            ),
+            patch.object(
+                adapter,
+                "find_valve_entity",
+                AsyncMock(
+                    return_value={"entity_id": "number.trv1_valve", "writable": False}
+                ),
+            ),
+        ):
+            info = await adapter.get_info(mock_self, "climate.trv1")
+        assert info["support_valve"] is False
+
+    @pytest.mark.asyncio
+    async def test_writable_valve_and_offset_supported(self):
+        """A writable valve helper plus a calibration entity enables both."""
+        mock_self = _make_self()
+        with (
+            patch.object(
+                adapter,
+                "find_local_calibration_entity",
+                AsyncMock(return_value="number.trv1_calibration"),
+            ),
+            patch.object(
+                adapter,
+                "find_valve_entity",
+                AsyncMock(
+                    return_value={"entity_id": "number.trv1_valve", "writable": True}
+                ),
+            ),
+        ):
+            info = await adapter.get_info(mock_self, "climate.trv1")
+        assert info == {"support_offset": True, "support_valve": True}
+
+
+class TestAdapterSetValve:
+    """set_valve scales onto the number entity and honours read-only helpers."""
+
+    @pytest.mark.asyncio
+    async def test_skips_readonly_helper(self):
+        mock_self = _make_self()
+        mock_self.real_trvs["climate.trv1"]["valve_position_writable"] = False
+        await adapter.set_valve(mock_self, "climate.trv1", 50)
+        mock_self.hass.services.async_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_scales_percentage_onto_entity_range(self):
+        """50 % maps onto the midpoint of a 0..99 valve, snapped to step."""
+        mock_self = _make_self()
+        mock_self.real_trvs["climate.trv1"]["valve_position_writable"] = True
+        mock_self.real_trvs["climate.trv1"]["valve_position_entity"] = (
+            "number.trv1_valve"
+        )
+        state = MagicMock()
+        state.attributes = {"min": 0, "max": 99, "step": 1}
+        mock_self.hass.states.get = MagicMock(return_value=state)
+
+        await adapter.set_valve(mock_self, "climate.trv1", 50)
+
+        mock_self.hass.services.async_call.assert_awaited_once()
+        args, _ = mock_self.hass.services.async_call.call_args
+        assert args[0] == "number"
+        assert args[2]["entity_id"] == "number.trv1_valve"
+        # 0 + 0.5 * 99 = 49.5 -> snapped to step 1 -> 50 (round-half-to-even)
+        assert args[2]["value"] == pytest.approx(50)

--- a/tests/unit/test_zwave_js_adapter.py
+++ b/tests/unit/test_zwave_js_adapter.py
@@ -13,6 +13,7 @@ hardware:
 import importlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.core import State
 import pytest
 
 from custom_components.better_thermostat.utils.const import CalibrationType
@@ -89,6 +90,7 @@ class TestZWA021Passthroughs:
     """The remaining quirks are safe no-ops."""
 
     def test_fix_calibrations_are_identity(self):
+        """The calibration fix helpers return their inputs unchanged."""
         mock_self = _make_self()
         assert quirk.fix_local_calibration(mock_self, "climate.trv1", 1.5) == 1.5
         assert quirk.fix_valve_calibration(mock_self, "climate.trv1", 42) == 42
@@ -99,6 +101,7 @@ class TestZWA021Passthroughs:
 
     @pytest.mark.asyncio
     async def test_set_temperature_declines(self):
+        """The temperature override always declines so the adapter writes it."""
         mock_self = _make_self(calibration=CalibrationType.DIRECT_VALVE_BASED)
         assert (
             await quirk.override_set_temperature(mock_self, "climate.trv1", 21.0)
@@ -239,6 +242,7 @@ class TestAdapterSetValve:
 
     @pytest.mark.asyncio
     async def test_skips_readonly_helper(self):
+        """A read-only valve helper is skipped without any service call."""
         mock_self = _make_self()
         mock_self.real_trvs["climate.trv1"]["valve_position_writable"] = False
         await adapter.set_valve(mock_self, "climate.trv1", 50)
@@ -252,8 +256,7 @@ class TestAdapterSetValve:
         mock_self.real_trvs["climate.trv1"]["valve_position_entity"] = (
             "number.trv1_valve"
         )
-        state = MagicMock()
-        state.attributes = {"min": 0, "max": 99, "step": 1}
+        state = State("number.trv1_valve", "50", {"min": 0, "max": 99, "step": 1})
         mock_self.hass.states.get = MagicMock(return_value=state)
 
         await adapter.set_valve(mock_self, "climate.trv1", 50)
@@ -264,3 +267,19 @@ class TestAdapterSetValve:
         assert args[2]["entity_id"] == "number.trv1_valve"
         # 0 + 0.5 * 99 = 49.5 -> snapped to step 1 -> 50 (round-half-to-even)
         assert args[2]["value"] == pytest.approx(50)
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_input_is_clamped(self):
+        """An over-100 % request never exceeds the entity's max value."""
+        mock_self = _make_self()
+        mock_self.real_trvs["climate.trv1"]["valve_position_writable"] = True
+        mock_self.real_trvs["climate.trv1"]["valve_position_entity"] = (
+            "number.trv1_valve"
+        )
+        state = State("number.trv1_valve", "50", {"min": 0, "max": 99, "step": 1})
+        mock_self.hass.states.get = MagicMock(return_value=state)
+
+        await adapter.set_valve(mock_self, "climate.trv1", 150)
+
+        args, _ = mock_self.hass.services.async_call.call_args
+        assert args[2]["value"] == pytest.approx(99)

--- a/tests/unit/test_zwave_js_adapter.py
+++ b/tests/unit/test_zwave_js_adapter.py
@@ -98,13 +98,53 @@ class TestZWA021Passthroughs:
         )
 
     @pytest.mark.asyncio
-    async def test_overrides_decline(self):
+    async def test_set_temperature_declines(self):
         mock_self = _make_self(calibration=CalibrationType.DIRECT_VALVE_BASED)
         assert (
             await quirk.override_set_temperature(mock_self, "climate.trv1", 21.0)
             is False
         )
-        assert await quirk.override_set_valve(mock_self, "climate.trv1", 50) is False
+
+
+class TestZWA021SetValve:
+    """The valve is driven via the Multilevel Switch command class (0x26)."""
+
+    @pytest.mark.asyncio
+    async def test_declines_when_not_direct_valve(self):
+        """Outside direct valve control the quirk does not touch the valve."""
+        mock_self = _make_self(calibration=CalibrationType.TARGET_TEMP_BASED)
+
+        handled = await quirk.override_set_valve(mock_self, "climate.trv1", 50)
+
+        assert handled is False
+        mock_self.hass.services.async_call.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_writes_multilevel_switch_scaled_to_99(self):
+        """100 % maps onto the device's fully-open value of 99."""
+        mock_self = _make_self(calibration=CalibrationType.DIRECT_VALVE_BASED)
+
+        handled = await quirk.override_set_valve(mock_self, "climate.trv1", 100)
+
+        assert handled is True
+        mock_self.hass.services.async_call.assert_awaited_once()
+        args, _ = mock_self.hass.services.async_call.call_args
+        assert args[0] == "zwave_js"
+        assert args[1] == "set_value"
+        assert args[2]["entity_id"] == "climate.trv1"
+        assert args[2]["command_class"] == 38
+        assert args[2]["property"] == "targetValue"
+        assert args[2]["value"] == 99
+
+    @pytest.mark.asyncio
+    async def test_closed_valve_writes_zero(self):
+        """0 % maps onto a fully closed valve."""
+        mock_self = _make_self(calibration=CalibrationType.DIRECT_VALVE_BASED)
+
+        await quirk.override_set_valve(mock_self, "climate.trv1", 0)
+
+        args, _ = mock_self.hass.services.async_call.call_args
+        assert args[2]["value"] == 0
 
 
 class TestAdapterGetInfo:
@@ -137,6 +177,36 @@ class TestAdapterGetInfo:
                 AsyncMock(
                     return_value={"entity_id": "number.trv1_valve", "writable": False}
                 ),
+            ),
+        ):
+            info = await adapter.get_info(mock_self, "climate.trv1")
+        assert info["support_valve"] is False
+
+    @pytest.mark.asyncio
+    async def test_quirk_model_reports_valve_without_number_entity(self):
+        """A ZWA021 reports valve support although it exposes no number helper."""
+        mock_self = _make_self()
+        with (
+            patch.object(
+                adapter, "find_local_calibration_entity", AsyncMock(return_value=None)
+            ),
+            patch.object(adapter, "find_valve_entity", AsyncMock(return_value=None)),
+            patch.object(adapter, "get_device_model", AsyncMock(return_value="ZWA021")),
+        ):
+            info = await adapter.get_info(mock_self, "climate.trv1")
+        assert info["support_valve"] is True
+
+    @pytest.mark.asyncio
+    async def test_other_model_without_valve_stays_unsupported(self):
+        """An unknown model without a writable helper reports no valve support."""
+        mock_self = _make_self()
+        with (
+            patch.object(
+                adapter, "find_local_calibration_entity", AsyncMock(return_value=None)
+            ),
+            patch.object(adapter, "find_valve_entity", AsyncMock(return_value=None)),
+            patch.object(
+                adapter, "get_device_model", AsyncMock(return_value="MT02650")
             ),
         ):
             info = await adapter.get_info(mock_self, "climate.trv1")


### PR DESCRIPTION
## Motivation

Adds native Z-Wave JS support for the Eurotronic Spirit Z / Aeotec ZWA021 TRV
family, which can be driven by externally supplied valve positions once switched
into a hidden "Manufacturer Specific" thermostat mode. Revives the intent of the
long-stale WIP #1048 (author disengaged, branch conflicting) against the current
`develop`, where the supporting plumbing (`find_valve_entity`, the `set_valve`
delegate path, dynamic adapter loading by integration name) already exists.

Refs #1048, fixes #579.

## Design — safe by construction

The goal was a change that ideally solves the problem for Spirit/Aeotec owners
but, in the worst case, changes nothing for anyone else. Isolation is structural:

- **Non-`zwave_js` users** never load the adapter — `delegate.load_adapter` keys
  on the integration name. Zero impact.
- **No forced dependency** — `zwave_js` is already `after_dependencies` (soft),
  not a hard dependency. The quirk uses the stable service-name literals instead
  of importing the `zwave_js` integration package (which pulls in
  `zwave_js_server`), so installs without Z-Wave JS are unaffected.
- **`zwave_js` users without a valve** — the adapter is a strict superset of
  `generic`: offset support is detected exactly like generic (no calibration
  regression for offset-only models like the MT02650), and a plain device keeps
  today's behaviour.
- **The ZWA021 quirk** only acts when the TRV is configured for **direct valve
  control**; in every other calibration mode it declines and the standard
  `climate` path runs — identical to an unquirked device.

## Verified against real implementations

The hardware-specific values were cross-checked against authoritative sources
rather than assumed:

- **Manufacturer-specific mode = value `31` (0x1F) over Thermostat Mode command
  class `64` (0x40)** — confirmed by the Eurotronic Spirit manual (ch. 6.8),
  zwave-js#3301 and HA core#45703. The mode is not advertised during the device
  interview (firmware omission), which is why it must be written directly.
- **The valve is driven through the Multilevel Switch command class `38`
  (0x26), `targetValue` on a 0-99 scale** — confirmed by HA core#45703 ("control
  the valve position via a separate dimmer entity"), the zwave-js device DB
  (`0x0371/zwa021.json`) and the HA community "set the valve directly" thread.
  The device exposes **no writable valve *number* helper**, so this corrects the
  original PR's number-entity assumption, which would not have actuated the
  device. `get_info` therefore reports valve support for this model directly so
  the config flow offers direct valve control.
- **zigbee2mqtt cross-check (SPZB0001)** — the same device family uses the same
  two-step logic (`trv_mode = 1` to switch to manual, then write `valve_position`),
  differing only in transport (Zigbee attribute vs. Z-Wave command class) and
  scale (0-255 vs. 0-99).

## Changes

- `adapters/zwave_js.py` — new adapter (superset of `generic`; valve support
  reported for quirk-driven models)
- `model_fixes/ZWA021.py` — Spirit/ZWA021 quirks: mode-31 switch + Multilevel
  Switch valve write, both gated on `DIRECT_VALVE_BASED`
- `tests/unit/test_zwave_js_adapter.py` — 15 unit tests

## Status / testing

- Unit-tested (15) and green; the adapter degrades cleanly and is provably inert
  for all other configurations.
- **Command-class values are now sourced, but not yet exercised on hardware.**
  Open points a tester should confirm on a real ZWA021:
  1. `zwave_js.set_value` on CC 38 `targetValue` (0-99) moves the valve while in
     mode 31, and the 0-99 (vs 0-100) fully-open point is correct.
  2. `get_device_model()` returns `"ZWA021"` for the Aeotec (device-registry
     `model` / `model_id`); Eurotronic-branded Spirits may report a different
     model string and would need adding to the known-model set / their own quirk.
- @QuenotteKst offered to test (20 Spirit/Aeotec clones) — feedback on the two
  points above would be very welcome before this leaves draft.

## Checklist

- [x] The code change is tested (unit tests); hardware validation pending
- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Z-Wave JS TRV support with automatic discovery for local temperature offset calibration and direct valve position control.
  * Added device-specific support for Eurotronic Spirit Z / Aeotec ZWA021 to enable direct valve mode, including manufacturer-specific mode and valve updates.
* **Bug Fixes**
  * Improved safety when calibration/valve entities are missing or unavailable, including sensible defaults, clamping to supported ranges, and skipping writes to read-only valves.
* **Tests**
  * Added unit tests covering Z-Wave JS adapter behavior and ZWA021 direct-valve/override handling, including value scaling and mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->