### PR TITLE
fix: address remaining review findings from #2070

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1966,12 +1966,21 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.async_write_ha_state()
 
         if isinstance(self.all_trvs, list):
-            for trv_conf in self.all_trvs:
-                trv_id = trv_conf.get("trv")
-                if trv_id:
-                    await async_bind_trv_device(
-                        self.hass, self._unique_id, trv_id, self._config_entry_id
-                    )
+            # via_device is single-valued: binding every TRV rewrites the same
+            # BT device row, leaving it attached only to the last valve. Only
+            # bind when there is exactly one TRV; skip for multi-TRV setups.
+            trv_ids = [
+                trv_conf.get("trv") for trv_conf in self.all_trvs if trv_conf.get("trv")
+            ]
+            if len(trv_ids) == 1:
+                await async_bind_trv_device(
+                    self.hass, self._unique_id, trv_ids[0], self._config_entry_id
+                )
+            elif len(trv_ids) > 1:
+                _LOGGER.debug(
+                    "better_thermostat %s: skipping via_device binding for multi-TRV setup",
+                    self.device_name,
+                )
 
         _LOGGER.debug("better_thermostat %s: sleeping 15s...", self.device_name)
         await asyncio.sleep(15)

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -591,9 +591,8 @@ async def control_trv(self, heater_entity_id=None):
                 await set_valve(self, heater_entity_id, 0)
 
             # Manage TRVs with no HVACMode.OFF
-            _no_off_system_mode = (
-                HVACMode.OFF not in self.real_trvs[heater_entity_id].hvac_modes
-            ) or (
+            _hvac_modes = self.real_trvs[heater_entity_id].hvac_modes or []
+            _no_off_system_mode = (HVACMode.OFF not in _hvac_modes) or (
                 self.real_trvs[heater_entity_id].advanced.get(
                     "no_off_system_mode", False
                 )

--- a/custom_components/better_thermostat/utils/watcher.py
+++ b/custom_components/better_thermostat/utils/watcher.py
@@ -245,16 +245,27 @@ async def check_critical_entities(self) -> bool:
                     )
             all_available = False
         else:
+            recovered = entity in self.devices_errors
             # Clear error if entity is now available (covers recovery after an
             # outage and stale issues from a previous run).
-            if entity in self.devices_errors:
+            if recovered:
                 self.devices_errors.remove(entity)
                 self.async_write_ha_state()
             ir.async_delete_issue(self.hass, DOMAIN, f"missing_entity_{entity}")
-            # Update battery status for available entities
-            self.hass.async_create_background_task(
-                get_battery_status(self, entity), name=f"bt_battery_status_{entity}"
+            # Refresh battery status only when it is still unpopulated (first
+            # pass after startup) or when the entity just recovered. This
+            # avoids spawning a redundant background task on every periodic
+            # check, since check_critical_entities runs on nearly every event.
+            info = self.devices_states.get(entity)
+            needs_initial = (
+                info is not None
+                and info.get("battery_id") is not None
+                and info.get("battery") is None
             )
+            if recovered or needs_initial:
+                self.hass.async_create_background_task(
+                    get_battery_status(self, entity), name=f"bt_battery_status_{entity}"
+                )
     return all_available
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "better-thermostat"
-version = "1.8.0-dev"  # keep in sync with manifest.json
+version = "1.9.0-dev"  # keep in sync with manifest.json
 description = "Better Thermostat — Home Assistant custom integration for smart TRV control"
 requires-python = ">=3.14.2"  # floor inherited from Home Assistant 2026.6.x
 dependencies = ["homeassistant>=2026.6.2"]

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -499,6 +499,48 @@ class TestControlTrvUnavailablePath:
             assert args[2] == 5.0  # min_temp
 
     @pytest.mark.asyncio
+    async def test_none_hvac_modes_does_not_crash(self):
+        """A TRV reporting no hvac_modes (None) must not crash control_trv.
+
+        ``Trv.hvac_modes`` defaults to None and stays None when a TRV exposes
+        no ``hvac_modes`` attribute. The membership check for HVACMode.OFF must
+        tolerate that instead of raising TypeError; a None list is treated as
+        "no OFF mode available", so an OFF request falls back to min_temp.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=False,  # No heat needed -> OFF
+            real_trvs={"climate.trv1": _default_trv_config(hvac_modes=None)},
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["handle_contact_open"]) as mock_window,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_temp.return_value = None
+            mock_window.return_value = HVACMode.HEAT
+
+            await control_trv(mock_self, "climate.trv1")
+
+            # None hvac_modes -> treated as no OFF mode -> min_temp (5.0) sent.
+            mock_set_temp.assert_called_once()
+            assert mock_set_temp.call_args[0][2] == 5.0
+
+    @pytest.mark.asyncio
     async def test_ignore_trv_states_flag_set_and_reset(self):
         """Test that ignore_trv_states flag is set during processing and reset after."""
         mock_self = _make_mock_self(trv_state=STATE_UNAVAILABLE)

--- a/tests/unit/test_climate_tick_registration.py
+++ b/tests/unit/test_climate_tick_registration.py
@@ -110,3 +110,36 @@ async def test_maintenance_tick_skipped_when_no_trv_enables_it():
     track_interval = await _run_finalize_startup(bt)
     callbacks = _registered_callbacks(track_interval, bt)
     assert bt._maintenance_tick not in callbacks
+
+
+def _make_bt_for_binding(trv_confs):
+    """Build a _finalize_startup mock with a configured all_trvs list."""
+    bt = _make_bt({"calibration_mode": CalibrationMode.NO_CALIBRATION.value})
+    bt.all_trvs = trv_confs
+    bt._unique_id = "bt_uid"
+    bt._config_entry_id = "entry_1"
+    return bt
+
+
+@pytest.mark.asyncio
+async def test_via_device_binding_runs_for_single_trv():
+    """A single-TRV setup binds the BT device via that one valve."""
+    bt = _make_bt_for_binding([{"trv": TRV_ID}])
+    with patch(f"{_CLIMATE}.async_bind_trv_device", AsyncMock()) as bind:
+        await _run_finalize_startup(bt)
+
+    bind.assert_awaited_once_with(bt.hass, "bt_uid", TRV_ID, "entry_1")
+
+
+@pytest.mark.asyncio
+async def test_via_device_binding_skipped_for_multi_trv():
+    """A multi-TRV setup skips via_device binding.
+
+    via_device is single-valued, so binding each TRV would just rewrite the
+    same BT device row and leave it attached to the last valve only.
+    """
+    bt = _make_bt_for_binding([{"trv": TRV_ID}, {"trv": "climate.second_trv"}])
+    with patch(f"{_CLIMATE}.async_bind_trv_device", AsyncMock()) as bind:
+        await _run_finalize_startup(bt)
+
+    bind.assert_not_awaited()

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -362,6 +362,92 @@ class TestCheckCriticalEntities:
         assert mock_ir.async_delete_issue.called
 
 
+class TestCheckCriticalEntitiesBattery:
+    """Battery-refresh de-duplication in check_critical_entities.
+
+    check_critical_entities runs on nearly every event, so it must not queue a
+    get_battery_status background task on every call. A refresh is spawned only
+    on the first pass (battery still unpopulated) or when a TRV recovers.
+    """
+
+    @staticmethod
+    def _make_available(mock_bt_instance):
+        state = MagicMock()
+        state.state = "heat"
+        mock_bt_instance.hass.states.get.return_value = state
+        mock_bt_instance.devices_errors = []
+        return mock_bt_instance
+
+    @pytest.mark.anyio
+    async def test_no_task_when_battery_already_populated(self, mock_bt_instance):
+        """Steady state: populated battery values spawn no background task."""
+        from custom_components.better_thermostat.utils.watcher import (
+            check_critical_entities,
+        )
+
+        bt = self._make_available(mock_bt_instance)
+        bt.devices_states = {
+            "climate.trv_1": {"battery_id": "sensor.b1", "battery": "80"},
+            "climate.trv_2": {"battery_id": "sensor.b2", "battery": "90"},
+        }
+        with patch("custom_components.better_thermostat.utils.watcher.ir"):
+            await check_critical_entities(bt)
+
+        assert bt.hass.async_create_background_task.call_count == 0
+
+    @pytest.mark.anyio
+    async def test_task_on_initial_unpopulated_battery(self, mock_bt_instance):
+        """First pass: an unpopulated battery spawns one task per TRV."""
+        from custom_components.better_thermostat.utils.watcher import (
+            check_critical_entities,
+        )
+
+        bt = self._make_available(mock_bt_instance)
+        bt.devices_states = {
+            "climate.trv_1": {"battery_id": "sensor.b1", "battery": None},
+            "climate.trv_2": {"battery_id": "sensor.b2", "battery": None},
+        }
+        with patch("custom_components.better_thermostat.utils.watcher.ir"):
+            await check_critical_entities(bt)
+
+        assert bt.hass.async_create_background_task.call_count == 2
+
+    @pytest.mark.anyio
+    async def test_task_on_recovery_even_if_populated(self, mock_bt_instance):
+        """A recovering TRV refreshes battery even if a value already exists."""
+        from custom_components.better_thermostat.utils.watcher import (
+            check_critical_entities,
+        )
+
+        bt = self._make_available(mock_bt_instance)
+        bt.devices_errors = ["climate.trv_1", "climate.trv_2"]
+        bt.devices_states = {
+            "climate.trv_1": {"battery_id": "sensor.b1", "battery": "80"},
+            "climate.trv_2": {"battery_id": "sensor.b2", "battery": "90"},
+        }
+        with patch("custom_components.better_thermostat.utils.watcher.ir"):
+            await check_critical_entities(bt)
+
+        assert bt.hass.async_create_background_task.call_count == 2
+
+    @pytest.mark.anyio
+    async def test_no_task_when_entity_has_no_battery(self, mock_bt_instance):
+        """Entities without a battery id never spawn a refresh in steady state."""
+        from custom_components.better_thermostat.utils.watcher import (
+            check_critical_entities,
+        )
+
+        bt = self._make_available(mock_bt_instance)
+        bt.devices_states = {
+            "climate.trv_1": {"battery_id": None, "battery": None},
+            "climate.trv_2": {},
+        }
+        with patch("custom_components.better_thermostat.utils.watcher.ir"):
+            await check_critical_entities(bt)
+
+        assert bt.hass.async_create_background_task.call_count == 0
+
+
 class TestCheckAndUpdateDegradedMode:
     """Tests for check_and_update_degraded_mode function."""
 
@@ -1149,7 +1235,7 @@ class TestBatteryStatusCalls:
 
     @pytest.mark.anyio
     async def test_check_critical_entities_calls_battery_status(self, mock_bt_instance):
-        """Test that check_critical_entities calls get_battery_status for available TRVs."""
+        """check_critical_entities fetches battery for available TRVs on first pass."""
         from custom_components.better_thermostat.utils.watcher import (
             check_critical_entities,
         )
@@ -1157,6 +1243,11 @@ class TestBatteryStatusCalls:
         mock_state = MagicMock()
         mock_state.state = "heat"
         mock_bt_instance.hass.states.get.return_value = mock_state
+        # Battery still unpopulated -> the initial refresh must fire.
+        mock_bt_instance.devices_states = {
+            "climate.trv_1": {"battery_id": "sensor.b1", "battery": None},
+            "climate.trv_2": {"battery_id": "sensor.b2", "battery": None},
+        }
 
         with patch("custom_components.better_thermostat.utils.watcher.ir"):
             with patch(

--- a/uv.lock
+++ b/uv.lock
@@ -423,7 +423,7 @@ wheels = [
 
 [[package]]
 name = "better-thermostat"
-version = "1.8.0.dev0"
+version = "1.9.0.dev0"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
## Motivation

Follow-up to the review findings on #2070 (the 1.9.0 release PR, `develop → master`). Most CodeRabbit findings there were already addressed on `develop`; this PR fixes the ones that were still valid, isolated so they can land on `develop` independently of the release.

## Changes

- **`control_trv`: tolerate a TRV with no `hvac_modes`.** `Trv.hvac_modes` defaults to `None` and stays `None` when a TRV exposes no `hvac_modes` attribute. The `HVACMode.OFF not in ...` membership check dereferenced it directly and raised `TypeError`, aborting the control cycle. A missing list is now treated as "no OFF mode available".
- **`check_critical_entities`: stop the battery-task storm.** The helper runs on nearly every event and previously queued a `get_battery_status` background task for every available TRV on every call. Battery is now refreshed only on the first pass (value still unpopulated) or when a TRV recovers.
- **Multi-TRV `via_device` binding.** `via_device` is single-valued, so binding every TRV in `_finalize_startup` rewrote the same BT device-registry row and left the BT device attached to the last valve only. Binding now runs only for single-TRV setups; multi-TRV setups are skipped (with a debug log).
- **Version sync.** `pyproject.toml` was still `1.8.0-dev` while `manifest.json` is `1.9.0-dev`.

## Tests

- New regression tests for each fix (`hvac_modes=None`, battery de-duplication incl. initial/recovery/no-battery cases, single-vs-multi-TRV binding).
- Full suite green except one **pre-existing, unrelated** failure on `develop` (`tests/benchmark/tests/test_runner_cli.py::test_main_plant_all_keyword_runs_full_sweep` — the `--plant all` sweep prints no `plant=` labels; not touched here).

## Not included (findings judged out of scope)
- `state_mgr` None-guards in `calibration.py` — unreachable given setup ordering (`state_mgr` is attached in `async_added_to_hass` before any control cycle); defensive noise only.
- Docstring/comment/dedup nitpicks and benchmark test tightenings.
