### PR TITLE
fix: render per-plant matrices for '--plant all' in benchmark runner

### DIFF
--- a/tests/benchmark/runner.py
+++ b/tests/benchmark/runner.py
@@ -666,6 +666,17 @@ def main(argv: list[str] | None = None) -> int:
             print(f"\n[{label}]")
             print(render_score_matrix(items, profile))
         print(render_plant_sweep(scored_per_plant, profile))
+    elif len(grouped) > 1:
+        # Several plant blocks (e.g. --plant all or multiple --plant names):
+        # render one labelled matrix per plant. Collapsing them into a single
+        # matrix would average scores across unrelated plants into one
+        # meaningless row, hiding which plant a result came from.
+        for label, block in grouped.items():
+            scored = score_results({label: block}, oracle_by_label, profile)
+            print(f"\n[{label}]")
+            print(render_score_matrix(scored, profile))
+            if args.per_scenario:
+                print(render_per_scenario(scored, profile))
     else:
         scored = score_results(grouped, oracle_by_label, profile)
         print("\n[single-TRV]")

--- a/tests/benchmark/tests/test_runner_cli.py
+++ b/tests/benchmark/tests/test_runner_cli.py
@@ -217,6 +217,9 @@ def test_main_plant_all_keyword_runs_full_sweep():
     assert len(plant_labels) >= 2, (
         f"'--plant all' did not expand to a multi-plant sweep: {plant_labels}"
     )
+    # Each plant gets its own labelled matrix; the results must not collapse
+    # into a single merged block that averages across unrelated plants.
+    assert "[single-TRV]" not in out
 
 
 def test_main_rejects_non_positive_step_s():


### PR DESCRIPTION
## Motivation

`tests/benchmark/tests/test_runner_cli.py::test_main_plant_all_keyword_runs_full_sweep` fails on `develop`. It was discovered while triaging the #2070 review findings (unrelated to that PR's changes).

Root cause is in the benchmark runner, not the test: `--plant all` ran all plant profiles but **collapsed them into a single score matrix**, averaging results across unrelated plants into one meaningless aggregate row (`n = number of plants`) and dropping the per-plant `plant=<name>` labels the CLI help promises (`Use 'all' for the full sweep.`).

```
[single-TRV]
  controller          overall      σ  ...    n
 *linear_p              0.753  0.121  ...   13   ← 13 different plants averaged into one row
```

## Changes

- **`runner.main`:** when more than one plant block is selected (`--plant all`, or several `--plant` names), render one labelled score matrix per plant — the same layout `--plant-sweep` uses, but without its realistic-sensor / equal-percentage-actuator overlay and cross-plant summary. A single plant / default still renders one matrix as before, so `--plant realistic` and the default path are unchanged.
- **Test:** the existing regression test now passes; added `assert "[single-TRV]" not in out` to lock that `--plant all` renders per-plant rather than collapsing again.

## Tests

Full benchmark suite green (`348 passed`, previously `347 passed, 1 failed`). This PR touches only `tests/benchmark/` (the pure-simulation benchmark harness) — no production code.
