### PR TITLE
fix: don't hard-require daqp so BT installs on aarch64 (Raspberry Pi)

### DIFF
--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -464,8 +464,8 @@ def _compute_mpc_v2_balance(self, entity_id: str):
         )
     except ImportError as err:
         # Controller construction raises when the daqp wheel is missing.
-        # In a regular HA install the manifest requirement guarantees the
-        # wheel, so this fires only in stripped-down dev environments —
+        # daqp is not a hard manifest requirement (it has no aarch64 wheel for
+        # the HA Python), so a user can select MPC v2 without it installed —
         # warn once per thermostat instead of spamming every cycle.
         if self.device_name not in _MPC_V2_IMPORT_WARNED:
             _MPC_V2_IMPORT_WARNED.add(self.device_name)

--- a/custom_components/better_thermostat/manifest.json
+++ b/custom_components/better_thermostat/manifest.json
@@ -18,7 +18,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/KartoffelToby/better_thermostat/issues",
   "requirements": [
-    "daqp>=0.8.7",
     "numpy>=1.26"
   ],
   "version": "1.9.0-dev"

--- a/custom_components/better_thermostat/utils/calibration/mpc_v2_internals/qp_optimiser.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc_v2_internals/qp_optimiser.py
@@ -31,11 +31,12 @@ from .plant import PlantModelRC2
 def _try_import_daqp() -> tuple[Any | None, str | None]:
     """Return ``(module, None)`` on success or ``(None, error_message)``.
 
-    ``daqp`` is an optional HA runtime requirement (manifest.json) that may be
-    absent in the dev/CI env and ships no type stubs; importing it by name via
-    ``importlib`` keeps the static checkers from resolving (and flagging) it.
-    The wrapping function also avoids ``reportConstantRedefinition`` on the
-    module-level result flags, which are written once at import.
+    ``daqp`` is an optional dependency — it is not a manifest requirement
+    (it has no aarch64 wheel for the HA Python) and may be absent, and it ships
+    no type stubs; importing it by name via ``importlib`` keeps the static
+    checkers from resolving (and flagging) it. The wrapping function also
+    avoids ``reportConstantRedefinition`` on the module-level result flags,
+    which are written once at import.
     """
     try:
         return importlib.import_module("daqp"), None


### PR DESCRIPTION
## Motivation

1.9 added `daqp>=0.8.7` to `manifest.json` `requirements` (the QP solver for the new MPC v2 calibration mode). Home Assistant installs manifest requirements for **every** user at setup — and if an install fails, the **whole integration** fails to set up, not just the feature that needs the package.

**daqp 0.8.7 has no aarch64 (ARM64) wheel for CPython 3.14** (HA's runtime). Verified against PyPI:

- cp314 wheels exist only for **linux x86_64, macOS (x86_64/arm64), Windows**.
- aarch64 wheels exist for cp310–cp313 but **not cp314**; there is no musllinux/cp314 and no armv7 wheel at all.

So on Raspberry Pi and other ARM64 hosts (the most common HA hardware), `pip install daqp` finds no wheel, falls back to a source build the HA container can't perform, and setup of Better Thermostat aborts entirely.

## Changes

- **`manifest.json`:** remove `daqp>=0.8.7` from `requirements`. `numpy>=1.26` stays — it is a hard import and has wheels for every HA platform.
- Update two now-inaccurate code comments that described daqp as a guaranteed manifest requirement.

daqp is only needed for the **opt-in** MPC v2 mode. It is already imported lazily (`DAQP_AVAILABLE` / `require_daqp()`), and the control loop already degrades gracefully when it is absent — `_compute_mpc_v2_balance` catches the `ImportError`, warns once per thermostat, and produces no MPC balance. Users who want MPC v2 install daqp into the HA Python environment themselves (the error message already tells them so).

## Tests

- Integration + MPC v2 suites green (`71 passed`); import smoke of the integration + `qp_optimiser` OK; manifest is valid JSON; ruff clean.
- No test asserts daqp's presence in the manifest.
- daqp remains a **dev** dependency (`[dependency-groups] dev` in `pyproject.toml`), so CI/benchmarks on x86_64 still exercise MPC v2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for users selecting MPC v2 by removing a mandatory dependency requirement that could block installation in some environments.
  * Clarified the app’s handling of the optional optimization package so it can be used when available, without being required upfront.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->