### PR TITLE
fix: backport PID integration-step bound and cooler Fahrenheit dedup from v2

### DIFF
--- a/custom_components/better_thermostat/utils/calibration/pid.py
+++ b/custom_components/better_thermostat/utils/calibration/pid.py
@@ -24,6 +24,13 @@ from .types import CalibrationHost
 
 _LOGGER = logging.getLogger(__name__)
 
+# Upper bound for one integration step. Control cycles nominally run every
+# few minutes; 600 s covers two 5-minute cycles, so a single missed cycle
+# still integrates fully while a stale ``pid_last_time`` (calibrator
+# switched away and back hours later) cannot wind the integrator up in one
+# giant step.
+MAX_DT_S = 600.0
+
 
 class PIDDebugInfo(TypedDict, total=False):
     """Debug information from PID controller."""
@@ -227,11 +234,13 @@ def compute_pid(
     st.previous_abs_error = st.last_abs_error
     st.last_abs_error = abs(delta_T)
 
-    # Zeitdifferenz
+    # Time difference, bounded to [1.0, MAX_DT_S] seconds. A stale
+    # pid_last_time (calibrator switched away and back hours later) would
+    # otherwise produce a huge dt and wind the integrator up in one step.
     dt = now - st.pid_last_time if st.pid_last_time > 0 else 0.0
-    # Fix dt handling: if dt <= 0 or dt < 1.0, treat as 1.0
     if dt <= 0 or dt < 1.0:
         dt = 1.0
+    dt = min(dt, MAX_DT_S)
 
     # Initialize the learned gains once from the passed-in params
     if st.pid_kp is None:

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -28,6 +28,7 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.helpers import (
+    attr_to_celsius,
     convert_to_float,
     get_current_set_temperatures,
     matches_any_setpoint,
@@ -275,7 +276,12 @@ async def control_cooler(self):
         return
 
     current_hvac_mode = cooler_state.state
-    current_temp = cooler_state.attributes.get("temperature")
+    # Resolve the cooler's reported setpoint to Celsius before comparing it
+    # against the Celsius desired value; on a Fahrenheit system the raw
+    # attribute would never match and defeat the redundant-send dedup.
+    current_temp = attr_to_celsius(
+        self, cooler_state, "temperature", None, "control_cooler()"
+    )
 
     min_resend_interval_s = self.min_cooler_resend_interval_s
     now_ts = monotonic()

--- a/tests/test_pid.py
+++ b/tests/test_pid.py
@@ -1,6 +1,11 @@
 """Tests for the PID controller."""
 
+from unittest.mock import patch
+
+import pytest
+
 from custom_components.better_thermostat.utils.calibration.pid import (
+    MAX_DT_S,
     PIDDebugInfo,
     PIDParams,
     PIDState,
@@ -669,3 +674,28 @@ class TestPIDController:
         bt.bt_target_temp = None
         key = build_pid_key(bt, "climate.test")
         assert key == "test_bt:climate.test:tunknown"
+
+
+class TestPidIntegrationStepBound:
+    """The integration step is bounded so a stale timestamp cannot wind up."""
+
+    def test_stale_last_time_bounds_the_integral_step(self):
+        """An hours-old ``pid_last_time`` integrates at most MAX_DT_S seconds."""
+        params = PIDParams(
+            auto_tune=False, kp=0.0, ki=0.001, kd=0.0, min_hold_time_s=0.0
+        )
+        state = PIDState()
+        state.pid_last_time = 100.0
+        stale_now = 100.0 + 6 * 3600.0
+
+        with patch(
+            "custom_components.better_thermostat.utils.calibration.pid.monotonic",
+            return_value=stale_now,
+        ):
+            _, debug, state = compute_pid(
+                params, 22.0, 21.0, 21.0, 0.0, "k", state=state
+            )
+
+        assert debug["dt_s"] == MAX_DT_S
+        # error = 1 K -> integral step = ki * e * MAX_DT_S, not ki * e * 6 h.
+        assert state.pid_integral == pytest.approx(0.001 * 1.0 * MAX_DT_S)

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -4,6 +4,7 @@ from time import monotonic
 from unittest.mock import AsyncMock, Mock
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
 import pytest
@@ -393,3 +394,38 @@ class TestControlCoolerSendCache:
         assert mock_self.last_sent_cooler_hvac_mode is None
         assert mock_self.last_sent_cooler_temp_ts is None
         assert mock_self.last_sent_cooler_hvac_mode_ts is None
+
+
+class TestControlCoolerFahrenheit:
+    """Unit handling in the redundant-send dedup on Fahrenheit systems."""
+
+    @pytest.mark.asyncio
+    async def test_reported_temp_matching_target_in_fahrenheit_is_not_resent(self):
+        """A cooler reporting the target in °F triggers no set_temperature.
+
+        The reported setpoint is resolved to Celsius before the dedup
+        comparison; without that, the raw °F value never equals the Celsius
+        desired setpoint and a redundant set_temperature fires every cycle.
+        """
+        mock_hass = Mock()
+        mock_hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock()
+        # 75.2 °F == 24.0 °C, the desired cooling setpoint.
+        mock_hass.states.get.return_value = _make_cooler_state(
+            state=HVACMode.COOL, temperature=75.2
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass,
+            bt_hvac_mode=HVACMode.COOL,
+            cur_temp=25.0,
+            bt_target_cooltemp=24.0,
+        )
+
+        await control_cooler(mock_self)
+
+        service_names = [
+            c.args[1] for c in mock_hass.services.async_call.call_args_list
+        ]
+        assert "set_temperature" not in service_names


### PR DESCRIPTION
Two logic bugfixes that exist in both the v2 branch and the v1 line (develop) are backported here. Both were reviewed as genuinely present in develop (not v2-arch-specific and not already fixed on develop).

## 1. PID integration step is unbounded against a stale timestamp

`compute_pid` derives `dt = now - pid_last_time` and clamps only the lower bound (`< 1.0 → 1.0`). When the PID calibrator is not invoked for a long stretch (window open, HVAC off, calibration mode switched away) and then resumes, `pid_last_time` is hours stale → `dt` becomes thousands of seconds → the integral accumulates `ki · error · dt` in one giant step → integrator windup → the valve slams open / overshoots.

**Fix:** clamp `dt` to `MAX_DT_S = 600 s` (covers two nominal 5-minute cycles). Only the numeric clamp is ported; the v2 clock-injection plumbing is v2-specific and left out.

## 2. Cooler redundant-send dedup ignores the temperature unit

`control_cooler` read the cooler's reported setpoint raw (system unit) and compared it against `bt_target_cooltemp` (Celsius). On a Fahrenheit system the cooler reports e.g. `75.2` (°F = 24 °C) while the desired value is `24` (°C), so `75.2 != 24` is always true → a redundant `set_temperature` service call fires **every control cycle**. This is exactly the cloud-AC rate-limit exposure the resend throttle (#2133) was built to contain. The value actually sent was always converted correctly, so this is service-call spam, not a wrong setpoint.

**Fix:** resolve the reported setpoint to Celsius via `attr_to_celsius` before the dedup comparison. Throttle and per-call error isolation are already present on develop (#2133); only the unit slice is ported.

## Tests
- `tests/test_pid.py::TestPidIntegrationStepBound` — a 6-hour-stale `pid_last_time` integrates at most `MAX_DT_S`, not 6 h.
- `tests/unit/controlling/test_control_cooler.py::TestControlCoolerFahrenheit` — a cooler reporting the target in °F triggers no `set_temperature`.

Both tests were verified to fail on the pre-fix code and pass on the fix. Full sweep across pid/cooler/control/calibration: 405 passed; ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bounded the PID controller’s effective integration step to prevent overly large integral updates after long gaps between control cycles.
  * Correctly converts cooler reported temperature to Celsius before comparisons and deduplication, fixing unit mismatch behavior on Fahrenheit systems.

* **Tests**
  * Added coverage to verify PID integration step clamping when the last cycle time is stale.
  * Added a Fahrenheit-specific test to ensure cooler setpoint deduplication avoids unnecessary repeated commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->