### PR TITLE
fix: address second-pass v2 review findings

### DIFF
--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -562,18 +562,16 @@ def _record_mpc_v2_reid_sample(
     )
 
 
-def _maybe_start_mpc_v2_reid_fit(
-    self, reid_key: str, v2_params: MpcV2Params, controller_key: str | None = None
-) -> None:
+def _maybe_start_mpc_v2_reid_fit(self, reid_key: str, v2_params: MpcV2Params) -> None:
     """Kick off an offline re-identification fit in the executor when due.
 
     At most one attempt per key per ``_MPC_V2_REID_INTERVAL_S``, only once
     the buffer plausibly contains full transients, and never concurrently.
     The fit itself is pure CPU work; an accepted result is adopted through
     the state manager's bumpless path on the completion callback, so the
-    event loop never blocks on the optimisation. ``controller_key`` names
-    the live controller that receives the bumpless transfer; the result
-    itself is stored under ``reid_key``.
+    event loop never blocks on the optimisation. Adoption bumplessly
+    transfers every cached live controller; the result itself is stored
+    under ``reid_key``.
     """
     hass = getattr(self, "hass", None)
     if hass is None:
@@ -627,7 +625,6 @@ def _maybe_start_mpc_v2_reid_fit(
                     rmse_fit_K=outcome.rmse_fit_K or 0.0,
                     n_segments=outcome.n_segments,
                 ),
-                controller_key=controller_key,
             )
             if callable(schedule_save):
                 schedule_save()
@@ -796,7 +793,7 @@ def _compute_mpc_v2_balance(self, entity_id: str):
             trv_temp=trv_state.current_temperature,
             outdoor_temp=outdoor_temp,
         )
-        _maybe_start_mpc_v2_reid_fit(self, reid_key, v2_params, controller_key=mpc_key)
+        _maybe_start_mpc_v2_reid_fit(self, reid_key, v2_params)
 
     if mpc_output is None:
         trv_state.calibration_balance = None

--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -532,7 +532,18 @@ def _record_mpc_v2_reid_sample(
     later fit could choke on. Open-contact samples (window or door) are
     recorded on purpose: they never enter a fit but cut segments at the
     right place.
+
+    Sampling is gated to the OPTIMAL rung of the fail-soft ladder: under
+    SENSOR_FALLBACK ``cur_temp`` freezes at the last valid reading while
+    the valve keeps moving, so a recorded sample would pair a frozen
+    temperature with live valve activity and bias the tau/gain fit (the
+    holdout is drawn from the same buffer and cannot catch this). The
+    resulting recording pause leaves a time gap that the segmenter cuts
+    on (``ReidConfig.max_gap_s``), keeping transients on either side of
+    a degraded episode separate.
     """
+    if self.kernel_state.control_mode.mode != ControlMode.OPTIMAL:
+        return
     try:
         t_room = float(self.cur_temp)
     except TypeError, ValueError:

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -329,8 +329,7 @@ def _arm_degraded_grace(self) -> None:
     self.kernel_state = replace(
         self.kernel_state,
         lifecycle=replace(
-            self.kernel_state.lifecycle,
-            grace_until=self._degraded_grace_until,
+            self.kernel_state.lifecycle, grace_until=self._degraded_grace_until
         ),
     )
 

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -88,7 +88,7 @@ from .core.fsm.mode import (
 )
 from .core.fsm.window import WindowPhase, WindowState
 from .core.recorder import FlightRecorder
-from .device_binding import async_bind_trv_device
+from .device_binding import async_bind_trv_device, async_unbind_trv_device
 from .events.cooler import trigger_cooler_change
 from .events.door import door_queue, trigger_door_change
 from .events.temperature import trigger_temperature_change
@@ -2262,6 +2262,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     "better_thermostat %s: skipping via_device binding for multi-TRV setup",
                     self.device_name,
                 )
+                # A via_device link written while the setup had (or was
+                # treated as having) a single valve would keep the BT device
+                # attached to one arbitrary TRV; clear it.
+                await async_unbind_trv_device(self.hass, self._unique_id)
 
         _LOGGER.debug("better_thermostat %s: sleeping 15s...", self.device_name)
         await asyncio.sleep(15)

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -315,6 +315,26 @@ def _seed_contact_region_at_startup(
     return WindowState(phase=WindowPhase.OPEN if is_open else WindowPhase.CLOSED)
 
 
+def _arm_degraded_grace(self) -> None:
+    """Arm the degraded-mode annunciation grace window once.
+
+    Stores the deadline on the entity and mirrors it into the lifecycle
+    region, so every degraded-mode check that runs while startup is still in
+    progress already sees the grace window. A deadline that is already armed
+    is kept unchanged.
+    """
+    if self._degraded_grace_until is not None:
+        return
+    self._degraded_grace_until = self.clock.now() + STARTUP_DEGRADED_GRACE_PERIOD
+    self.kernel_state = replace(
+        self.kernel_state,
+        lifecycle=replace(
+            self.kernel_state.lifecycle,
+            grace_until=self._degraded_grace_until,
+        ),
+    )
+
+
 class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
     """Representation of a Better Thermostat device."""
 
@@ -1340,6 +1360,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # slow-to-load underlying integration. The window is re-anchored in
         # ``_finalize_startup`` to cover post-startup reconnection blips.
         self._critical_grace_until = self.clock.now() + STARTUP_CRITICAL_GRACE_PERIOD
+        # Arm the degraded-mode grace window before the first degraded check:
+        # the startup loop below and the triggers in _finalize_startup all
+        # call check_and_update_degraded_mode, whose warning suppression
+        # reads the grace deadline from the lifecycle region.
+        _arm_degraded_grace(self)
         while self.startup_running:
             if self.is_removed:
                 return
@@ -2165,6 +2190,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
     async def _finalize_startup(self) -> None:
         """Run post-init tasks: triggers, listeners, periodic jobs."""
+        # The degraded-mode grace window is normally armed at the top of
+        # startup(); arming here as well keeps the deadline in place before
+        # the triggers below run their degraded checks.
+        _arm_degraded_grace(self)
         # Likewise give critical (TRV) entities a short grace before raising
         # ``missing_entity`` repairs; cloud-backed valves (Tado, etc.) can lag
         # behind HA startup and would otherwise produce dismissable noise.
@@ -2203,11 +2232,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         )
         await self._trigger_check_weather(None)
         _LOGGER.debug("better_thermostat %s: startup finishing...", self.device_name)
-        # Arm the degraded-mode grace window together with the transition to
-        # STARTING: the lifecycle region carries the deadline, and the first
-        # control cycle right below already runs a lifecycle tick, which
-        # promotes STARTING to RUNNING as soon as no grace deadline is set.
-        self._degraded_grace_until = self.clock.now() + STARTUP_DEGRADED_GRACE_PERIOD
+        # The transition to STARTING carries the degraded-grace deadline that
+        # was armed when startup began; the first control cycle right below
+        # already runs a lifecycle tick, which promotes STARTING to RUNNING
+        # as soon as no grace deadline is set.
         self.kernel_state = replace(
             self.kernel_state,
             lifecycle=lifecycle_startup_finished(

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1376,9 +1376,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
             # The external room sensor is a required configuration field.
             if self.sensor_entity_id is None:
-                _LOGGER.debug(
-                    "better_thermostat %s: no room temperature sensor configured, "
-                    "aborting startup",
+                _LOGGER.error(
+                    "better_thermostat %s: no room temperature sensor configured "
+                    "(the required 'temperature_sensor' option is missing from "
+                    "the config entry); aborting startup, the entity stays "
+                    "unavailable",
                     self.device_name,
                 )
                 return
@@ -2399,9 +2401,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         # The external room sensor is a required configuration field.
         if self.sensor_entity_id is None:
-            _LOGGER.debug(
-                "better_thermostat %s: no room temperature sensor configured, "
-                "skipping listener registration",
+            _LOGGER.error(
+                "better_thermostat %s: no room temperature sensor configured "
+                "(the required 'temperature_sensor' option is missing from "
+                "the config entry); skipping listener registration",
                 self.device_name,
             )
             return

--- a/custom_components/better_thermostat/core/fsm/control_mode.py
+++ b/custom_components/better_thermostat/core/fsm/control_mode.py
@@ -138,41 +138,63 @@ def step_ladder(
     if target == state.mode:
         return _with_pending(state, down=None, up=None, target=None)
 
-    pending = state.pending_target
-    if _depth(target) > _depth(state.mode):
-        if (
-            state.down_pending_since is not None
-            and pending is not None
-            and _depth(pending) > _depth(state.mode)
-        ):
-            since = state.down_pending_since
-            commit_rung = pending if _depth(pending) < _depth(target) else target
-        else:
-            since = now
-            commit_rung = target
-        if now - since >= params.down_debounce_s:
-            committed = _with_mode(state, commit_rung, now)
-            if commit_rung == target:
-                return committed
-            return _with_pending(committed, down=now, up=None, target=target)
-        return _with_pending(state, down=since, up=None, target=commit_rung)
+    deeper = _depth(target) > _depth(state.mode)
+    threshold_s = params.down_debounce_s if deeper else params.up_stability_s
+    return _advance_window(
+        state, target=target, now=now, threshold_s=threshold_s, deeper=deeper
+    )
 
+
+def _toward(deeper: bool, rung: ControlMode, reference: ControlMode) -> bool:
+    """Return whether ``rung`` lies beyond ``reference`` in window direction."""
+    if deeper:
+        return _depth(rung) > _depth(reference)
+    return _depth(rung) < _depth(reference)
+
+
+def _pend_toward(
+    state: ControlModeState, deeper: bool, since: float, target: ControlMode
+) -> ControlModeState:
+    """Store the window start in the direction's pending field."""
+    if deeper:
+        return _with_pending(state, down=since, up=None, target=target)
+    return _with_pending(state, down=None, up=since, target=target)
+
+
+def _advance_window(
+    state: ControlModeState,
+    *,
+    target: ControlMode,
+    now: float,
+    threshold_s: float,
+    deeper: bool,
+) -> ControlModeState:
+    """Run the direction-bound commit window toward ``target``.
+
+    The window keeps its start time while the pending rung stays on the
+    same side of the current mode, tracks the rung nearest the current
+    one that was continuously supported, and commits to that rung once
+    the window elapses. A commit short of the instantaneous target seeds
+    the follow-up window toward the remaining rung.
+    """
+    since_before = state.down_pending_since if deeper else state.up_pending_since
+    pending = state.pending_target
     if (
-        state.up_pending_since is not None
+        since_before is not None
         and pending is not None
-        and _depth(pending) < _depth(state.mode)
+        and _toward(deeper, pending, state.mode)
     ):
-        since = state.up_pending_since
-        commit_rung = pending if _depth(pending) > _depth(target) else target
+        since = since_before
+        commit_rung = pending if _toward(deeper, target, pending) else target
     else:
         since = now
         commit_rung = target
-    if now - since >= params.up_stability_s:
+    if now - since >= threshold_s:
         committed = _with_mode(state, commit_rung, now)
         if commit_rung == target:
             return committed
-        return _with_pending(committed, down=None, up=now, target=target)
-    return _with_pending(state, down=None, up=since, target=commit_rung)
+        return _pend_toward(committed, deeper, now, target)
+    return _pend_toward(state, deeper, since, commit_rung)
 
 
 def _with_mode(

--- a/custom_components/better_thermostat/core/fsm/control_mode.py
+++ b/custom_components/better_thermostat/core/fsm/control_mode.py
@@ -56,9 +56,11 @@ class ControlModeState:
     down_pending_since: float | None = None
     # Pending upgrade (capability restored, stability window running).
     up_pending_since: float | None = None
-    # Rung the running debounce/stability window is heading toward. A
-    # window only counts for this exact target; when the capability
-    # observation points at a different rung, the window restarts.
+    # Rung the running debounce/stability window commits to on elapse:
+    # the shallowest deeper rung (downgrade) or deepest shallower rung
+    # (upgrade) continuously supported since the window started. The
+    # window restarts when the observation returns to the current rung
+    # or crosses to the other side of it.
     pending_target: ControlMode | None = None
 
     @property
@@ -101,6 +103,14 @@ def _target_rung(room_sensor_ok: bool, trv_temp_ok: bool) -> ControlMode:
     return ControlMode.HOLD
 
 
+_RUNG_ORDER = (ControlMode.OPTIMAL, ControlMode.SENSOR_FALLBACK, ControlMode.HOLD)
+
+
+def _depth(mode: ControlMode) -> int:
+    """Return the degradation depth of a rung (OPTIMAL shallowest)."""
+    return _RUNG_ORDER.index(mode)
+
+
 def step_ladder(
     state: ControlModeState,
     *,
@@ -113,36 +123,56 @@ def step_ladder(
 
     Downgrades commit after ``down_debounce_s`` of sustained loss;
     upgrades commit after ``up_stability_s`` of sustained recovery.
-    The window is bound to its target rung: when the observation starts
-    pointing at a different rung, the window restarts, so the new target
-    must itself persist for the full debounce/stability duration.
+    The window is bound to its direction, not to one exact rung: it
+    keeps running as long as the observation stays on the same side of
+    the current rung (deeper while degrading, shallower while
+    recovering) and commits to the rung nearest the current one that
+    was continuously supported for the full window — the shallowest
+    deeper rung while degrading, the deepest shallower rung while
+    recovering. An observation back at the current rung restarts the
+    bookkeeping from scratch; a rung beyond the committed one must earn
+    its own full window afterwards.
     """
     target = _target_rung(room_sensor_ok, trv_temp_ok)
 
     if target == state.mode:
         return _with_pending(state, down=None, up=None, target=None)
 
-    rung_order = (ControlMode.OPTIMAL, ControlMode.SENSOR_FALLBACK, ControlMode.HOLD)
-    degrading = rung_order.index(target) > rung_order.index(state.mode)
-
-    if degrading:
-        since = (
-            state.down_pending_since
-            if state.down_pending_since is not None and state.pending_target == target
-            else now
-        )
+    pending = state.pending_target
+    if _depth(target) > _depth(state.mode):
+        if (
+            state.down_pending_since is not None
+            and pending is not None
+            and _depth(pending) > _depth(state.mode)
+        ):
+            since = state.down_pending_since
+            commit_rung = pending if _depth(pending) < _depth(target) else target
+        else:
+            since = now
+            commit_rung = target
         if now - since >= params.down_debounce_s:
-            return _with_mode(state, target, now)
-        return _with_pending(state, down=since, up=None, target=target)
+            committed = _with_mode(state, commit_rung, now)
+            if commit_rung == target:
+                return committed
+            return _with_pending(committed, down=now, up=None, target=target)
+        return _with_pending(state, down=since, up=None, target=commit_rung)
 
-    since = (
-        state.up_pending_since
-        if state.up_pending_since is not None and state.pending_target == target
-        else now
-    )
+    if (
+        state.up_pending_since is not None
+        and pending is not None
+        and _depth(pending) < _depth(state.mode)
+    ):
+        since = state.up_pending_since
+        commit_rung = pending if _depth(pending) > _depth(target) else target
+    else:
+        since = now
+        commit_rung = target
     if now - since >= params.up_stability_s:
-        return _with_mode(state, target, now)
-    return _with_pending(state, down=None, up=since, target=target)
+        committed = _with_mode(state, commit_rung, now)
+        if commit_rung == target:
+            return committed
+        return _with_pending(committed, down=None, up=now, target=target)
+    return _with_pending(state, down=None, up=since, target=commit_rung)
 
 
 def _with_mode(

--- a/custom_components/better_thermostat/core/recorder.py
+++ b/custom_components/better_thermostat/core/recorder.py
@@ -110,6 +110,18 @@ def _float_of(value: Json) -> float:
     return number
 
 
+def _float_or_default(value: Json, default: float) -> float:
+    """Read a required float, substituting ``default`` for null.
+
+    The export path writes ``None`` wherever a recorded float was
+    non-finite; a required-float field accepts that null on import so
+    every exported entry stays replayable. Genuinely malformed input
+    (strings, bools) still raises.
+    """
+    number = _float_or_none(value)
+    return default if number is None else number
+
+
 def _int_of(value: Json) -> int:
     if isinstance(value, bool) or not isinstance(value, int):
         raise ValueError(f"expected an integer, got {type(value).__name__}")
@@ -236,9 +248,14 @@ def snapshot_from_dict(data: dict[str, Json]) -> WorldSnapshot:
     now = _datetime_or_none(data["now"])
     if now is None:
         raise ValueError("snapshot export lacks a parseable 'now'")
+    # The required floats accept the exporter's non-finite-to-null
+    # mapping with per-field neutral defaults: a nulled monotonic clock
+    # loads as 0.0 (replay does not depend on clock alignment), a
+    # nulled tolerance as 0.0 (no dead-band), a nulled solar intensity
+    # as 0.0 (no solar contribution).
     return WorldSnapshot(
         now=now,
-        now_monotonic=_float_of(data["now_monotonic"]),
+        now_monotonic=_float_or_default(data["now_monotonic"], 0.0),
         target_temp=_float_or_none(data["target_temp"]),
         target_cooltemp=_float_or_none(data["target_cooltemp"]),
         hvac_mode=parse_hvac_mode(_str_or_none(data["hvac_mode"])),
@@ -248,10 +265,10 @@ def snapshot_from_dict(data: dict[str, Json]) -> WorldSnapshot:
         call_for_heat=_bool_of(data["call_for_heat"]),
         window_open=_bool_or_none(data.get("window_open")),
         preset_mode=_str_or_none(data["preset_mode"]),
-        tolerance=_float_of(data["tolerance"]),
+        tolerance=_float_or_default(data["tolerance"], 0.0),
         outdoor_temp=_float_or_none(data["outdoor_temp"]),
         is_day=_bool_of(data["is_day"]),
-        solar_intensity=_float_of(data["solar_intensity"]),
+        solar_intensity=_float_or_default(data["solar_intensity"], 0.0),
         min_temp=_float_or_none(data["min_temp"]),
         max_temp=_float_or_none(data["max_temp"]),
         trvs=trvs,

--- a/custom_components/better_thermostat/core/safety.py
+++ b/custom_components/better_thermostat/core/safety.py
@@ -49,6 +49,34 @@ def _finite_bound(value: float | None) -> float | None:
     return value if value is not None and math.isfinite(value) else None
 
 
+def _resolve_bounds(
+    reported_lower: float | None,
+    reported_upper: float | None,
+    fallback_lower: float,
+    fallback_upper: float,
+) -> tuple[float, float]:
+    """Combine device-reported and fallback bounds into a valid interval.
+
+    Each missing or non-finite device bound is substituted by its
+    fallback. When the resulting pair is inverted, the resolution
+    depends on where the bounds came from: two device-reported bounds
+    are swapped (a misreporting device inverted an otherwise plausible
+    interval), while a device bound inverted against a fallback bound
+    is distrusted entirely and both ends fall back — otherwise a bogus
+    device floor above the fallback cap would force every intent up to
+    the cap.
+    """
+    lower = _finite_bound(reported_lower)
+    upper = _finite_bound(reported_upper)
+    resolved_lower = lower if lower is not None else fallback_lower
+    resolved_upper = upper if upper is not None else fallback_upper
+    if resolved_lower > resolved_upper:
+        if lower is not None and upper is not None:
+            return resolved_upper, resolved_lower
+        return fallback_lower, fallback_upper
+    return resolved_lower, resolved_upper
+
+
 def _clamp_value(value: float, lower: float | None, upper: float | None) -> float:
     lower = _finite_bound(lower)
     upper = _finite_bound(upper)
@@ -84,13 +112,13 @@ def _clamp_trv(
             # withholds the write instead of inventing one.
             setpoint = None
         else:
-            lower = _finite_bound(reported.min_temp if reported is not None else None)
-            upper = _finite_bound(reported.max_temp if reported is not None else None)
-            setpoint = _clamp_value(
-                setpoint,
-                lower if lower is not None else FALLBACK_MIN_SETPOINT,
-                upper if upper is not None else FALLBACK_MAX_SETPOINT,
+            lower, upper = _resolve_bounds(
+                reported.min_temp if reported is not None else None,
+                reported.max_temp if reported is not None else None,
+                FALLBACK_MIN_SETPOINT,
+                FALLBACK_MAX_SETPOINT,
             )
+            setpoint = _clamp_value(setpoint, lower, upper)
 
     offset = intent.offset
     if offset is not None:
@@ -99,17 +127,13 @@ def _clamp_trv(
             # withholds the write instead of inventing one.
             offset = None
         else:
-            lower = _finite_bound(
-                reported.local_calibration_min if reported is not None else None
+            lower, upper = _resolve_bounds(
+                reported.local_calibration_min if reported is not None else None,
+                reported.local_calibration_max if reported is not None else None,
+                FALLBACK_MIN_OFFSET,
+                FALLBACK_MAX_OFFSET,
             )
-            upper = _finite_bound(
-                reported.local_calibration_max if reported is not None else None
-            )
-            offset = _clamp_value(
-                offset,
-                lower if lower is not None else FALLBACK_MIN_OFFSET,
-                upper if upper is not None else FALLBACK_MAX_OFFSET,
-            )
+            offset = _clamp_value(offset, lower, upper)
 
     valve = intent.valve_percent
     if valve is not None:

--- a/custom_components/better_thermostat/core/safety.py
+++ b/custom_components/better_thermostat/core/safety.py
@@ -4,7 +4,7 @@
 limits on every intent right before it is written to a device — no
 matter what the controller upstream computed:
 
-* non-finite setpoint and offset intents (NaN/inf) are withheld
+* non-finite setpoint, offset, and valve intents (NaN/inf) are withheld
   entirely — the hull expresses "no command" as ``None``,
 * setpoints stay inside the TRV's reported min/max temperature range
   (the min bound doubles as the frost-protection floor); when the TRV
@@ -137,21 +137,29 @@ def _clamp_trv(
 
     valve = intent.valve_percent
     if valve is not None:
-        upper = _finite_bound(
-            reported.valve_max_opening if reported is not None else None
-        )
-        valve = _clamp_value(valve, 0.0, upper if upper is not None else 100.0)
-        if (
-            max_valve_jump is not None
-            and previous is not None
-            and previous.valve_percent is not None
-        ):
-            delta = valve - previous.valve_percent
-            if abs(delta) > max_valve_jump:
-                valve = previous.valve_percent + (
-                    max_valve_jump if delta > 0 else -max_valve_jump
-                )
-                valve = _clamp_value(valve, 0.0, upper if upper is not None else 100.0)
+        if not math.isfinite(valve):
+            # A non-finite valve percentage carries no opening degree at
+            # all; the hull withholds the write instead of coercing it
+            # to a bound and issuing a spurious close command.
+            valve = None
+        else:
+            upper = _finite_bound(
+                reported.valve_max_opening if reported is not None else None
+            )
+            valve = _clamp_value(valve, 0.0, upper if upper is not None else 100.0)
+            if (
+                max_valve_jump is not None
+                and previous is not None
+                and previous.valve_percent is not None
+            ):
+                delta = valve - previous.valve_percent
+                if abs(delta) > max_valve_jump:
+                    valve = previous.valve_percent + (
+                        max_valve_jump if delta > 0 else -max_valve_jump
+                    )
+                    valve = _clamp_value(
+                        valve, 0.0, upper if upper is not None else 100.0
+                    )
 
     if (
         setpoint == intent.setpoint

--- a/custom_components/better_thermostat/device_binding.py
+++ b/custom_components/better_thermostat/device_binding.py
@@ -67,6 +67,31 @@ async def async_bind_trv_device(
     return True
 
 
+async def async_unbind_trv_device(hass: HomeAssistant, bt_unique_id: str) -> bool:
+    """Clear a stale ``via_device`` link on the BT device.
+
+    Multi-TRV setups carry no ``via_device`` link (it is single-valued), but
+    a BT device that was once bound to a single valve keeps that link in the
+    device registry until it is cleared explicitly. Passing ``None`` for
+    ``via_device_id`` removes the link; the registry treats the omitted
+    (UNDEFINED) value as "leave unchanged".
+
+    Returns True when a link was cleared, False otherwise.
+    """
+    dr_reg = dr.async_get(hass)
+    bt_device = dr_reg.async_get_device(identifiers={(DOMAIN, bt_unique_id)})
+    if bt_device is None or bt_device.via_device_id is None:
+        return False
+
+    dr_reg.async_update_device(bt_device.id, via_device_id=None)
+    _LOGGER.debug(
+        "better_thermostat %s: cleared stale via_device link on device %s",
+        bt_unique_id,
+        bt_device.id,
+    )
+    return True
+
+
 @callback
 def async_get_config_entry_bindings(
     hass: HomeAssistant, entry: ConfigEntry

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.climate.const import HVACMode
-from homeassistant.core import State, callback
+from homeassistant.core import State
 
 from custom_components.better_thermostat.utils.helpers import convert_to_float
 from custom_components.better_thermostat.utils.scheduler import request_control_cycle
@@ -17,7 +17,6 @@ from custom_components.better_thermostat.utils.scheduler import request_control_
 _LOGGER = logging.getLogger(__name__)
 
 
-@callback
 async def trigger_cooler_change(self, event):
     """Trigger a change in the cooler state."""
     if self.startup_running:

--- a/custom_components/better_thermostat/events/door.py
+++ b/custom_components/better_thermostat/events/door.py
@@ -119,7 +119,16 @@ async def trigger_door_change(self, event) -> None:
             params=_door_params(self),
         ),
     )
-    await self.door_queue_task.put(was_open)
+    try:
+        self.door_queue_task.put_nowait(was_open)
+    except asyncio.QueueFull:
+        # A settle run is already pending; it re-reads the stepped region.
+        # Only the first-ever item seeds the announced state, and a full
+        # queue implies an earlier item already did or will.
+        _LOGGER.debug(
+            "better_thermostat %s: door settle already pending, coalescing",
+            self.device_name,
+        )
 
 
 def _door_params(self) -> WindowParams:

--- a/custom_components/better_thermostat/events/temperature.py
+++ b/custom_components/better_thermostat/events/temperature.py
@@ -14,7 +14,6 @@ import math
 from time import monotonic
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
-from homeassistant.core import callback
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util import dt as dt_util
@@ -159,7 +158,6 @@ async def _apply_temperature_update(self, new_temp):
     )
 
 
-@callback
 async def trigger_temperature_change(self, event):
     """Handle temperature changes.
 

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -213,6 +213,18 @@ async def trigger_trv_change(self, event):
             )
             _main_change = False
             if trv.calibration == 0:
+                # The awaits above (model detection, quirk loading) can
+                # outlive the entry: the offset read resolves the adapter
+                # through a raw real_trvs index, so skip it once the TRV
+                # is no longer tracked.
+                if entity_id not in self.real_trvs:
+                    _LOGGER.debug(
+                        "better_thermostat %s: TRV %s is no longer tracked, "
+                        "skipping offset read",
+                        self.device_name,
+                        entity_id,
+                    )
+                    return
                 trv.last_calibration = await get_current_offset(self, entity_id)
 
     if self.ignore_states:

--- a/custom_components/better_thermostat/events/window.py
+++ b/custom_components/better_thermostat/events/window.py
@@ -117,7 +117,16 @@ async def trigger_window_change(self, event) -> None:
             params=_window_params(self),
         ),
     )
-    await self.window_queue_task.put(was_open)
+    try:
+        self.window_queue_task.put_nowait(was_open)
+    except asyncio.QueueFull:
+        # A settle run is already pending; it re-reads the stepped region.
+        # Only the first-ever item seeds the announced state, and a full
+        # queue implies an earlier item already did or will.
+        _LOGGER.debug(
+            "better_thermostat %s: window settle already pending, coalescing",
+            self.device_name,
+        )
 
 
 def _window_params(self) -> WindowParams:

--- a/custom_components/better_thermostat/trv.py
+++ b/custom_components/better_thermostat/trv.py
@@ -164,9 +164,13 @@ class Trv:
                 valve_entity or not declared.valve_needs_entity
             )
 
-        no_off = (self.hvac_modes is not None and "off" not in self.hvac_modes) or (
-            self.advanced or {}
-        ).get("no_off_system_mode", False) is True
+        # An unreported mode list counts as no-off: BT then sends min temp
+        # instead of an OFF the device may not support.
+        no_off = (
+            self.hvac_modes is None
+            or "off" not in self.hvac_modes
+            or (self.advanced or {}).get("no_off_system_mode", False) is True
+        )
         return TrvCapabilities(
             supports_offset_write=offset,
             supports_valve_write=valve or quirk_valve,

--- a/custom_components/better_thermostat/utils/calibration/mpc.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc.py
@@ -315,7 +315,11 @@ def _seed_state_from_siblings(
     ``loss_est``, ``ka_est``) are not touched.
 
     Existing values in *state* are never overwritten — seeding only
-    fills in defaults.
+    fills in defaults. Candidate values are copied only when finite:
+    a sibling holding NaN/inf for a field (e.g. a poisoned state parked
+    under an inactive bucket, which the active-key sanitizer never
+    heals) is skipped for that field and the next-nearest sibling is
+    tried, so seeding cannot re-poison a freshly sanitized state.
     """
     uid, entity, bucket = _split_mpc_key(key)
     if not uid or not entity:
@@ -345,14 +349,16 @@ def _seed_state_from_siblings(
         getattr(params, "enable_min_effective_percent", True)
     ):
         for _, sib in siblings:
-            if sib.min_effective_percent is not None:
+            if sib.min_effective_percent is not None and _all_finite(
+                sib.min_effective_percent
+            ):
                 state.min_effective_percent = sib.min_effective_percent
                 break
 
     # --- Target-independent learned characteristics ---
     if not state.perf_curve:
         for _, sib in siblings:
-            if sib.perf_curve:
+            if sib.perf_curve and _all_finite(sib.perf_curve):
                 state.perf_curve = {
                     label: dict(stats) for label, stats in sib.perf_curve.items()
                 }
@@ -360,7 +366,12 @@ def _seed_state_from_siblings(
 
     if state.trv_profile == "unknown" and state.profile_samples == 0:
         for _, sib in siblings:
-            if sib.trv_profile != "unknown" and sib.profile_samples > 0:
+            if (
+                sib.trv_profile != "unknown"
+                and sib.profile_samples > 0
+                and _all_finite(sib.profile_confidence)
+                and _all_finite(sib.profile_samples)
+            ):
                 state.trv_profile = sib.trv_profile
                 state.profile_confidence = sib.profile_confidence
                 state.profile_samples = sib.profile_samples
@@ -368,7 +379,7 @@ def _seed_state_from_siblings(
 
     if state.solar_gain_est is None:
         for _, sib in siblings:
-            if sib.solar_gain_est is not None:
+            if sib.solar_gain_est is not None and _all_finite(sib.solar_gain_est):
                 state.solar_gain_est = sib.solar_gain_est
                 break
 

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -8,7 +8,6 @@ import logging
 
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfTemperature
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from custom_components.better_thermostat.adapters.delegate import (
@@ -780,7 +779,10 @@ async def control_cooler(self, snapshot=None):
             _temp_to_set = round(_temp_to_set, 1)
         # Only prime the send-cache on success. A failed call must not look
         # like a completed send, otherwise the throttle would suppress the
-        # retry.
+        # retry. Any exception from this one service call is isolated
+        # (cloud integrations propagate raw errors such as ConnectionError)
+        # so the hvac_mode command below still runs; CancelledError derives
+        # from BaseException and propagates.
         try:
             await self.hass.services.async_call(
                 "climate",
@@ -789,7 +791,7 @@ async def control_cooler(self, snapshot=None):
                 blocking=True,
                 context=self.context,
             )
-        except HomeAssistantError as err:
+        except Exception as err:
             _LOGGER.warning(
                 "better_thermostat %s: set_temperature for cooler %s failed (%s); "
                 "will retry on the next cycle",
@@ -832,6 +834,8 @@ async def control_cooler(self, snapshot=None):
             current_hvac_mode,
             desired_mode,
         )
+        # Isolated like the temperature call above: one failing channel must
+        # not abort the cooler cycle.
         try:
             await self.hass.services.async_call(
                 "climate",
@@ -840,7 +844,7 @@ async def control_cooler(self, snapshot=None):
                 blocking=True,
                 context=self.context,
             )
-        except HomeAssistantError as err:
+        except Exception as err:
             _LOGGER.warning(
                 "better_thermostat %s: set_hvac_mode for cooler %s failed (%s); "
                 "will retry on the next cycle",

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -59,6 +59,10 @@ RECONCILE_TOLERANCE_K = 0.05
 # suppressed while the device's state feedback lags. A changed desired
 # value always sends immediately.
 COOLER_RESEND_INTERVAL_S = 30.0
+# A cooler may snap a received setpoint onto its own step grid (e.g. 0.5 °C,
+# or a whole-°F grid). A post-send reading within this distance of the sent
+# value counts as that device-side quantization, not as an unapplied command.
+COOLER_QUANTIZATION_TOLERANCE_K = 0.5
 # Valve deviations below this are the device's own business.
 RECONCILE_VALVE_TOLERANCE_PCT = 5.0
 
@@ -688,6 +692,20 @@ async def control_cooler(self, snapshot=None):
     # reported value beyond the device tolerance.
     last_temp, last_temp_ts = last_sent.get("temperature", (None, None))
     temp_changed_since_last_send = last_temp != desired_temp
+    # A quantizing device settles near the sent value on its own grid. The
+    # first post-send reading close to the sent value is remembered as the
+    # device's answer; while it holds and the desired value is unchanged,
+    # the command counts as converged.
+    settled_temp = last_sent.get("temperature_settled")
+    if (
+        not temp_changed_since_last_send
+        and last_temp is not None
+        and current_temp is not None
+        and settled_temp is None
+        and abs(current_temp - last_temp) <= COOLER_QUANTIZATION_TOLERANCE_K
+    ):
+        settled_temp = current_temp
+        last_sent["temperature_settled"] = settled_temp
     temp_to_send: float | None = None
     if desired_temp is None:
         _LOGGER.debug(
@@ -709,6 +727,26 @@ async def control_cooler(self, snapshot=None):
             )
     elif abs(current_temp - desired_temp) > RECONCILE_TOLERANCE_K:
         temp_to_send = desired_temp
+
+    # Device quantization accepted: the reported value still sits on the
+    # settled post-send reading, so the residual difference is the device's
+    # own grid, not an unapplied command.
+    if (
+        temp_to_send is not None
+        and not temp_changed_since_last_send
+        and settled_temp is not None
+        and current_temp is not None
+        and abs(current_temp - settled_temp) <= RECONCILE_TOLERANCE_K
+    ):
+        _LOGGER.debug(
+            "better_thermostat %s: cooler %s settled at %s for desired %s "
+            "(device quantization), skipping set_temperature",
+            self.device_name,
+            self.cooler_entity_id,
+            settled_temp,
+            desired_temp,
+        )
+        temp_to_send = None
 
     # Throttle identical resends when the device's state feedback lags.
     if (
@@ -761,6 +799,9 @@ async def control_cooler(self, snapshot=None):
             )
         else:
             last_sent["temperature"] = (temp_to_send, now_monotonic)
+            # A fresh send invalidates the previously settled reading; the
+            # device answers anew.
+            last_sent.pop("temperature_settled", None)
 
     # Decide whether an hvac_mode command is needed, throttling identical
     # resends the same way as temperature commands.

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -841,9 +841,14 @@ async def control_trv(self, heater_entity_id=None, cycle=None):
     if not hasattr(self, "task_manager"):
         self.task_manager = TaskManager(hass=self.hass)
 
+    # The suppression flag is owned by the invocation that set it under the
+    # lock; a caller cancelled while still waiting for the lock never set it
+    # and must not clear it for a concurrent holder mid-write.
+    _suppression_owned = False
     try:
         async with self._temp_lock:
             self.real_trvs[heater_entity_id].ignore_trv_states = True
+            _suppression_owned = True
             try:
                 # Preserve old action for change detection if attributes exist
                 if hasattr(self, "attr_hvac_action"):
@@ -1268,7 +1273,8 @@ async def control_trv(self, heater_entity_id=None, cycle=None):
         await asyncio.sleep(3)
         return True
     finally:
-        self.real_trvs[heater_entity_id].ignore_trv_states = False
+        if _suppression_owned:
+            self.real_trvs[heater_entity_id].ignore_trv_states = False
 
 
 async def check_system_mode(self, heater_entity_id=None):

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -586,23 +586,25 @@ class StateManager:
             self._mpc_v2_reid_live[key] = runtime
         return runtime
 
-    def adopt_mpc_v2_reid(
-        self, key: str, data: MpcV2ReidData, *, controller_key: str | None = None
-    ) -> None:
+    def adopt_mpc_v2_reid(self, key: str, data: MpcV2ReidData) -> None:
         """Adopt a validated re-identification result, bumplessly.
 
-        The live controller is exported into the persisted snapshot and then
-        dropped, so the next :meth:`get_mpc_v2_live` rebuilds it with the new
-        plant prior while restoring the observer state (Kalman, DOB, integral,
-        last command) from that snapshot — no cold start. The result is
-        stored under ``key``; ``controller_key`` names the live controller
-        that receives the bumpless transfer when the two are keyed
-        differently (the result key is target-independent, the controller
-        key is per target bucket).
+        The plant prior describes the room, so every cached live controller
+        of this instance is stale after adoption — regardless of which
+        target bucket it is keyed under. Each one is exported into the
+        persisted snapshot and then dropped, so the next
+        :meth:`get_mpc_v2_live` for that key rebuilds the controller with
+        the new plant prior while restoring the observer state (Kalman,
+        DOB, integral, last command) from the snapshot — no cold start.
+        The result is stored under ``key``.
+
+        When ``key`` is the shared, target-independent ``{uid}:reid`` key,
+        this instance's obsolete per-bucket result entries are removed:
+        the shared key wins every read, so they are dead weight that could
+        only resurrect stale data through the legacy fallback lookup.
         """
-        live_key = controller_key or key
-        live = self._mpc_v2_live.pop(live_key, None)
-        if live is not None:
+        for live_key in list(self._mpc_v2_live):
+            live = self._mpc_v2_live.pop(live_key)
             exported = export_mpc_v2_state(live)
             if exported is not None:
                 self._state.mpc_v2[live_key] = deserialize_mpc_v2(exported)
@@ -616,6 +618,14 @@ class StateManager:
                     live_key,
                 )
         self._state.mpc_v2_reid[key] = data
+        if key.endswith(":reid"):
+            uid_prefix = key[: -len("reid")]
+            for legacy_key in [
+                k
+                for k in self._state.mpc_v2_reid
+                if k != key and k.startswith(uid_prefix)
+            ]:
+                del self._state.mpc_v2_reid[legacy_key]
         self._dirty = True
 
     def get_pid(self, key: str) -> PIDState:

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -1,5 +1,6 @@
 """Tests for control_cooler function in utils/controlling.py."""
 
+import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
 from homeassistant.components.climate.const import HVACMode
@@ -508,3 +509,55 @@ class TestControlCoolerSendCache:
         await control_cooler(mock_self)
 
         assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+    @pytest.mark.asyncio
+    async def test_connection_error_on_set_temperature_still_attempts_hvac_mode(self):
+        """A raw ConnectionError from set_temperature does not skip set_hvac_mode.
+
+        Cloud integrations can propagate non-HomeAssistantError exceptions
+        through the service call; one failing channel must not abort the other.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=20.0
+        )
+
+        async def _fail_set_temperature(domain, service, *args, **kwargs):
+            if service == "set_temperature":
+                raise ConnectionError("cloud endpoint unreachable")
+
+        mock_hass.services.async_call = AsyncMock(side_effect=_fail_set_temperature)
+
+        await control_cooler(mock_self)
+
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 1
+        assert mode_calls[0].args[2]["hvac_mode"] == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_on_hvac_mode_call_does_not_propagate(self):
+        """A raw TimeoutError from set_hvac_mode is logged, not raised."""
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=20.0
+        )
+
+        async def _fail_set_hvac_mode(domain, service, *args, **kwargs):
+            if service == "set_hvac_mode":
+                raise TimeoutError("cloud call timed out")
+
+        mock_hass.services.async_call = AsyncMock(side_effect=_fail_set_hvac_mode)
+
+        await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+    @pytest.mark.asyncio
+    async def test_cancellation_during_service_call_propagates(self):
+        """CancelledError is not swallowed by the per-call error isolation."""
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=20.0
+        )
+
+        mock_hass.services.async_call = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with pytest.raises(asyncio.CancelledError):
+            await control_cooler(mock_self)

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -412,6 +412,70 @@ class TestControlCoolerSendCache:
         assert temp_calls[1].args[2]["temperature"] == 23.0
 
     @pytest.mark.asyncio
+    async def test_quantized_device_reading_is_accepted_without_resend(self):
+        """A device that snaps the setpoint onto its own grid gets one send.
+
+        The device answers a desired 22.22 with a reported 22.0. That settled
+        reading counts as convergence, so the identical command is not re-sent
+        even after the resend interval expires.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_temp_attr=22.0, target_cooltemp=22.22
+        )
+
+        await control_cooler(mock_self)
+        # Post-send cycle observes the device's quantized reading.
+        mock_self.clock.monotonic_value += 1.0
+        await control_cooler(mock_self)
+        # Nothing changed after the resend interval: still converged.
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+    @pytest.mark.asyncio
+    async def test_reported_drift_after_settling_triggers_resend(self):
+        """A reported value that moves off its settled reading is corrected."""
+        mock_self, mock_hass, mock_cooler_state = _make_cooler_setup(
+            cooler_temp_attr=22.0, target_cooltemp=22.22
+        )
+
+        await control_cooler(mock_self)
+        mock_self.clock.monotonic_value += 1.0
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+        # The device leaves its settled reading (external change).
+        mock_cooler_state.attributes = {"temperature": 24.0}
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        temp_calls = _service_calls(mock_hass, "set_temperature")
+        assert len(temp_calls) == 2
+        assert temp_calls[1].args[2]["temperature"] == 22.22
+
+    @pytest.mark.asyncio
+    async def test_changed_target_overrides_quantization_acceptance(self):
+        """A new desired value sends immediately despite a settled reading."""
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_temp_attr=22.0, target_cooltemp=22.22
+        )
+
+        await control_cooler(mock_self)
+        mock_self.clock.monotonic_value += 1.0
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+        mock_self.bt_target_cooltemp = 23.0
+        await control_cooler(mock_self)
+
+        temp_calls = _service_calls(mock_hass, "set_temperature")
+        assert len(temp_calls) == 2
+        assert temp_calls[1].args[2]["temperature"] == 23.0
+
+    @pytest.mark.asyncio
     async def test_failed_set_temperature_still_attempts_hvac_mode(self):
         """A failing set_temperature does not suppress set_hvac_mode."""
         mock_self, mock_hass, _ = _make_cooler_setup(

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -1065,6 +1065,62 @@ class TestControlTrvIgnoreFlagReset:
 
         assert mock_self.real_trvs["climate.trv1"].ignore_trv_states is False
 
+    @pytest.mark.asyncio
+    async def test_cancel_while_waiting_for_lock_keeps_holder_flag(self):
+        """Cancelling a caller queued on the lock leaves the holder's flag alone.
+
+        Only the invocation that set ignore_trv_states may clear it. A second
+        invocation cancelled while still waiting for _temp_lock never set the
+        flag, so its cleanup must not clear it for the concurrent holder that
+        is mid-write.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT, trv_attrs={"temperature": 20.0}
+        )
+        entered_write = asyncio.Event()
+        release_write = asyncio.Event()
+
+        async def _blocking_set_temperature(*args, **kwargs):
+            entered_write.set()
+            await release_write.wait()
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+            patch(_PATCHES["set_temperature"], new=_blocking_set_temperature),
+        ):
+            mock_convert.return_value = {
+                "temperature": 21.0,
+                "system_mode": HVACMode.HEAT,
+            }
+
+            holder = asyncio.create_task(control_trv(mock_self, "climate.trv1"))
+            await asyncio.wait_for(entered_write.wait(), timeout=5)
+            assert mock_self.real_trvs["climate.trv1"].ignore_trv_states is True
+
+            waiter = asyncio.create_task(control_trv(mock_self, "climate.trv1"))
+            # Let the waiter run until it suspends on the held lock.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+
+            # The holder is still mid-write; its suppression flag must survive.
+            assert mock_self.real_trvs["climate.trv1"].ignore_trv_states is True
+
+            holder.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await holder
+
+        assert mock_self.real_trvs["climate.trv1"].ignore_trv_states is False
+
 
 # ---------------------------------------------------------------------------
 # Boost mode with safety override (from test_boost_mode.py)

--- a/tests/unit/mpc_v2/test_reid_integration.py
+++ b/tests/unit/mpc_v2/test_reid_integration.py
@@ -268,10 +268,7 @@ def test_fallback_episode_gap_splits_reid_segments() -> None:
     for i in range(10):
         samples.append(
             ReidSample(
-                t_s=i * spacing,
-                T_room_C=19.0 + 0.2 * i,
-                u_frac=0.8,
-                T_outdoor_C=5.0,
+                t_s=i * spacing, T_room_C=19.0 + 0.2 * i, u_frac=0.8, T_outdoor_C=5.0
             )
         )
     # Degraded episode: no samples for longer than the gap threshold.

--- a/tests/unit/mpc_v2/test_reid_integration.py
+++ b/tests/unit/mpc_v2/test_reid_integration.py
@@ -404,26 +404,73 @@ def test_reid_buffer_is_shared_across_target_buckets() -> None:
     assert len(runtime.buffer.samples) == 2
 
 
-def test_adopt_with_controller_key_splits_result_and_transfer() -> None:
-    """The result lands under the shared key; the bumpless transfer hits the controller key."""
-    mgr = _make_manager()
-    _warm(mgr, "k", MpcV2Params())
-    old = mgr.get_mpc_v2_live("k", MpcV2Params())
-    assert old.controller is not None
-    last_u_before = old.controller._last_u
+def test_adopt_transfers_all_live_controllers_bumplessly() -> None:
+    """Adoption folds and drops every cached live controller, not just one.
 
-    mgr.adopt_mpc_v2_reid("uid:reid", _REID, controller_key="k")
+    The plant prior describes the room, so a controller cached under any
+    target bucket is stale after adoption. Each one must take the
+    bumpless rebuild path on its next activation: observer state carried
+    over from the folded snapshot and the new prior's signature stamped,
+    so ``compute_mpc_v2`` does not force a cold rebuild on the first
+    cycle back in that bucket.
+    """
+    from custom_components.better_thermostat.utils.calibration.mpc_v2.state import (
+        _plant_signature_of,
+    )
+
+    mgr = _make_manager()
+    key_a = "uid:climate.x:t21.0"
+    key_b = "uid:climate.x:t22.5"
+    _warm(mgr, key_a, MpcV2Params())
+    _warm(mgr, key_b, MpcV2Params())
+    old_a = mgr.get_mpc_v2_live(key_a, MpcV2Params())
+    old_b = mgr.get_mpc_v2_live(key_b, MpcV2Params())
+    assert old_a.controller is not None and old_b.controller is not None
+    last_u_a = old_a.controller._last_u
+    last_u_b = old_b.controller._last_u
+
+    mgr.adopt_mpc_v2_reid("uid:reid", _REID)
 
     assert mgr.get_mpc_v2_reid("uid:reid") is _REID
-    assert mgr.get_mpc_v2_reid("k") is None
-    # The controller-keyed live state was folded and dropped for the rebuild.
+    assert mgr.get_mpc_v2_reid(key_a) is None
+
     new_params = MpcV2Params()
     new_params.plant.tau_room_min = _REID.tau_room_min
     new_params.plant.gain_heater = _REID.gain_heater
-    rebuilt = mgr.get_mpc_v2_live("k", new_params)
-    assert rebuilt is not old
-    assert rebuilt.controller is not None
-    assert rebuilt.controller._last_u == last_u_before
+    for key, old, last_u in ((key_a, old_a, last_u_a), (key_b, old_b, last_u_b)):
+        rebuilt = mgr.get_mpc_v2_live(key, new_params)
+        assert rebuilt is not old
+        assert rebuilt.controller is not None
+        assert rebuilt.controller is not old.controller
+        assert rebuilt.controller._last_u == last_u
+        # The new prior's signature is stamped on the rebuilt state, so the
+        # signature guard in compute_mpc_v2 keeps this controller (bumpless)
+        # instead of discarding it for a cold rebuild.
+        assert rebuilt.plant_signature == _plant_signature_of(new_params)
+
+
+def test_adopt_under_shared_key_removes_legacy_bucket_entries() -> None:
+    """Writing the shared key clears this uid's per-bucket result entries.
+
+    The shared key wins every read, so bucket entries are dead weight;
+    left in place they could only resurrect stale data through the
+    legacy fallback if the shared entry ever disappeared. Entries of
+    other uids are untouched.
+    """
+    mgr = _make_manager()
+    legacy = MpcV2ReidData(
+        tau_room_min=600.0, gain_heater=1.0, fitted_ts=100.0, n_segments=3
+    )
+    mgr.adopt_mpc_v2_reid("uid:climate.x:t21.0", legacy)
+    mgr.adopt_mpc_v2_reid("uid:group:t19.0", legacy)
+    mgr.adopt_mpc_v2_reid("other:climate.y:t20.0", legacy)
+
+    mgr.adopt_mpc_v2_reid("uid:reid", _REID)
+
+    assert mgr.get_mpc_v2_reid("uid:reid") is _REID
+    assert mgr.get_mpc_v2_reid("uid:climate.x:t21.0") is None
+    assert mgr.get_mpc_v2_reid("uid:group:t19.0") is None
+    assert mgr.get_mpc_v2_reid("other:climate.y:t20.0") is legacy
 
 
 def test_shared_reid_key_survives_serialization_round_trip() -> None:

--- a/tests/unit/mpc_v2/test_reid_integration.py
+++ b/tests/unit/mpc_v2/test_reid_integration.py
@@ -19,6 +19,8 @@ from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils.calibration.mpc_v2 import (
     MpcV2Input,
     MpcV2Params,
+    ReidConfig,
+    ReidSample,
     compute_mpc_v2,
 )
 from custom_components.better_thermostat.utils.const import (
@@ -217,6 +219,86 @@ def test_dispatch_records_reid_samples_under_auto() -> None:
     sample = runtime.buffer.samples[0]
     assert sample.T_room_C == 19.5
     assert sample.window_open is False
+
+
+def test_dispatch_skips_sampling_when_control_mode_degraded() -> None:
+    """Samples are recorded only on the OPTIMAL rung of the fail-soft ladder.
+
+    Under SENSOR_FALLBACK ``cur_temp`` freezes at the last valid reading
+    while the valve keeps moving; recording such samples would fit the
+    plant against a frozen temperature tail. HOLD has no usable reading
+    at all. Both rungs must leave the buffer untouched.
+    """
+    bt = _make_bt()
+    out, _ = _compute_mpc_v2_balance(bt, "climate.x")
+    assert out is not None
+    key = next(iter(bt.state_mgr._mpc_v2_reid_live))
+    runtime = bt.state_mgr.get_mpc_v2_reid_runtime(key)
+    assert len(runtime.buffer.samples) == 1
+
+    for degraded_mode in (ControlMode.SENSOR_FALLBACK, ControlMode.HOLD):
+        bt.kernel_state.control_mode = SimpleNamespace(mode=degraded_mode)
+        bt.clock.advance(120.0)
+        out, _ = _compute_mpc_v2_balance(bt, "climate.x")
+        assert out is not None
+        assert len(runtime.buffer.samples) == 1
+
+    bt.kernel_state.control_mode = SimpleNamespace(mode=ControlMode.OPTIMAL)
+    bt.clock.advance(120.0)
+    out, _ = _compute_mpc_v2_balance(bt, "climate.x")
+    assert out is not None
+    assert len(runtime.buffer.samples) == 2
+
+
+def test_fallback_episode_gap_splits_reid_segments() -> None:
+    """A sampling pause longer than ``max_gap_s`` cuts the segment there.
+
+    Skipping samples during a degraded episode leaves a time gap in the
+    buffer; the segmenter breaks runs on gaps above ``ReidConfig.max_gap_s``,
+    so the frozen episode can never bridge two transients into one.
+    """
+    from custom_components.better_thermostat.utils.calibration.mpc_v2.reid import (
+        extract_segments,
+    )
+
+    cfg = ReidConfig()
+    spacing = 300.0
+    samples: list[ReidSample] = []
+    # First heat-up run: 10 samples over 2700 s, rising 1.8 K.
+    for i in range(10):
+        samples.append(
+            ReidSample(
+                t_s=i * spacing,
+                T_room_C=19.0 + 0.2 * i,
+                u_frac=0.8,
+                T_outdoor_C=5.0,
+            )
+        )
+    # Degraded episode: no samples for longer than the gap threshold.
+    gap_start = samples[-1].t_s
+    resume = gap_start + cfg.max_gap_s + spacing
+    # Second heat-up run after recovery.
+    for i in range(10):
+        samples.append(
+            ReidSample(
+                t_s=resume + i * spacing,
+                T_room_C=20.0 + 0.2 * i,
+                u_frac=0.8,
+                T_outdoor_C=5.0,
+            )
+        )
+
+    segments = extract_segments(samples, cfg)
+    assert len(segments) == 2
+    assert all(s.kind == "heatup" for s in segments)
+    # Without the gap the same samples form one contiguous run.
+    contiguous = [
+        ReidSample(
+            t_s=i * spacing, T_room_C=19.0 + 0.1 * i, u_frac=0.8, T_outdoor_C=5.0
+        )
+        for i in range(20)
+    ]
+    assert len(extract_segments(contiguous, cfg)) == 1
 
 
 def test_dispatch_skips_sampling_for_explicit_preset() -> None:

--- a/tests/unit/test_calibration_sensor_fallback.py
+++ b/tests/unit/test_calibration_sensor_fallback.py
@@ -259,6 +259,8 @@ def test_reid_sample_records_open_door_as_open_contact() -> None:
     """
     state_mgr = _StateStub()
     bt = _make_bt(state_mgr, trv_temp=21.0)
+    # Sampling is gated to the OPTIMAL rung; the door flag is orthogonal.
+    bt.kernel_state.control_mode.mode = ControlMode.OPTIMAL
     bt.cur_temp = 20.5
     bt.window_open = False
     bt.door_open = True

--- a/tests/unit/test_climate_maintenance.py
+++ b/tests/unit/test_climate_maintenance.py
@@ -292,21 +292,30 @@ def _binding_bt(trv_confs):
 async def test_via_device_binding_runs_for_single_trv():
     """A single-TRV setup binds the BT device via that one valve."""
     bt = _binding_bt([{"trv": "climate.trv"}])
-    with patch(f"{_CLIMATE}.async_bind_trv_device", AsyncMock()) as bind:
+    with (
+        patch(f"{_CLIMATE}.async_bind_trv_device", AsyncMock()) as bind,
+        patch(f"{_CLIMATE}.async_unbind_trv_device", AsyncMock()) as unbind,
+    ):
         await _run_finalize_startup(bt)
 
     bind.assert_awaited_once_with(bt.hass, "bt_uid", "climate.trv", "entry_1")
+    unbind.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_via_device_binding_skipped_for_multi_trv():
-    """A multi-TRV setup skips via_device binding.
+async def test_via_device_binding_skipped_and_cleared_for_multi_trv():
+    """A multi-TRV setup skips via_device binding and clears a stale link.
 
     via_device is single-valued, so binding each TRV would just rewrite the
-    same BT device row and leave it attached to the last valve only.
+    same BT device row and leave it attached to the last valve only. A link
+    that an earlier single-valve binding pass left behind is removed.
     """
     bt = _binding_bt([{"trv": "climate.trv"}, {"trv": "climate.second_trv"}])
-    with patch(f"{_CLIMATE}.async_bind_trv_device", AsyncMock()) as bind:
+    with (
+        patch(f"{_CLIMATE}.async_bind_trv_device", AsyncMock()) as bind,
+        patch(f"{_CLIMATE}.async_unbind_trv_device", AsyncMock()) as unbind,
+    ):
         await _run_finalize_startup(bt)
 
     bind.assert_not_awaited()
+    unbind.assert_awaited_once_with(bt.hass, "bt_uid")

--- a/tests/unit/test_climate_missing_sensor_guard.py
+++ b/tests/unit/test_climate_missing_sensor_guard.py
@@ -1,0 +1,101 @@
+"""Guards for a missing room temperature sensor configuration.
+
+The external room sensor is a required configuration field. When it is
+absent, startup() and _finalize_startup() abort gracefully instead of
+crashing, and both log at ERROR so the misconfiguration is visible: the
+entity stays unavailable and no listeners are registered, which would
+otherwise look like a silent hang.
+"""
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+from custom_components.better_thermostat.core.clock import FakeClock
+from custom_components.better_thermostat.core.decide import KernelState
+from custom_components.better_thermostat.trv import Trv
+
+_CLIMATE = "custom_components.better_thermostat.climate"
+TRV_ID = "climate.test_trv"
+
+
+def _bt_without_sensor():
+    """Build a minimal BetterThermostat mock with no room sensor configured."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.is_removed = False
+    mock.version = "1.0.0"
+    mock.kernel_state = KernelState()
+    mock.clock = FakeClock()
+    mock.real_trvs = {TRV_ID: Trv(entity_id=TRV_ID, advanced={})}
+    mock.entity_ids = [TRV_ID]
+    mock.all_trvs = None
+    mock.all_entities = []
+    mock.sensor_entity_id = None
+    mock.humidity_sensor_entity_id = None
+    mock.window_id = None
+    mock.door_id = None
+    mock.cooler_entity_id = None
+    mock.outdoor_sensor = None
+    mock.weather_entity = None
+    mock.unavailable_sensors = []
+    mock._degraded_warning_emitted = False
+    mock._degraded_grace_until = None
+    mock._async_unsub_state_changed = None
+    mock._trigger_time = AsyncMock()
+    mock._trigger_check_weather = AsyncMock()
+    mock._startup_control_trvs = AsyncMock()
+    mock.hass = MagicMock()
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_startup_logs_error_and_aborts_without_room_sensor(caplog):
+    """startup() names the missing required sensor at ERROR and returns."""
+    bt = _bt_without_sensor()
+
+    with caplog.at_level(logging.ERROR):
+        await asyncio.wait_for(BetterThermostat.startup(bt), timeout=1)
+
+    errors = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.ERROR
+        and "no room temperature sensor configured" in r.message
+    ]
+    assert errors, "missing-sensor abort must be logged at ERROR"
+    bt._check_entities_ready.assert_not_called()
+    bt._collect_trv_states.assert_not_called()
+    bt._finalize_startup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_finalize_startup_logs_error_and_skips_listeners(caplog):
+    """_finalize_startup names the missing required sensor at ERROR."""
+    bt = _bt_without_sensor()
+    track_state = MagicMock()
+
+    with (
+        caplog.at_level(logging.ERROR),
+        patch(f"{_CLIMATE}.await_critical_entities", AsyncMock()),
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
+        patch(f"{_CLIMATE}.await_optional_sensors", AsyncMock()),
+        patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
+        patch(f"{_CLIMATE}.async_track_time_interval", MagicMock()),
+        patch(f"{_CLIMATE}.async_track_state_change_event", track_state),
+        patch(f"{_CLIMATE}.async_track_time_change", MagicMock()),
+        patch(f"{_CLIMATE}.asyncio.sleep", AsyncMock()),
+    ):
+        await BetterThermostat._finalize_startup(bt)
+
+    errors = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.ERROR
+        and "no room temperature sensor configured" in r.message
+    ]
+    assert errors, "missing-sensor listener skip must be logged at ERROR"
+    track_state.assert_not_called()

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -48,6 +48,7 @@ def bt():
     mock = MagicMock(spec=BetterThermostat)
     mock.clock = MagicMock()
     mock.kernel_state = KernelState()
+    mock._degraded_grace_until = None
     mock.state_mgr = None
     mock.hass = MagicMock()
     mock.device_name = "Test BT"

--- a/tests/unit/test_climate_startup_grace.py
+++ b/tests/unit/test_climate_startup_grace.py
@@ -1,16 +1,21 @@
 """Startup grace window for degraded-mode annunciation.
 
-_finalize_startup arms the degraded-mode grace deadline on the lifecycle
-region together with the INITIALISING -> STARTING transition, so the very
+startup() arms the degraded-mode grace deadline on the lifecycle region
+before any degraded-mode check can run, so an optional sensor that is still
+unavailable while startup is in progress stays quiet. The INITIALISING ->
+STARTING transition in _finalize_startup carries that same deadline, and the
 first control cycle (which runs a lifecycle tick) does not promote the
 region straight to RUNNING. While the grace window is active,
 check_and_update_degraded_mode defers the degraded-mode warning and the
 Home Assistant repair issue; both fire once the window has elapsed.
 """
 
+import asyncio
 from contextlib import ExitStack
+from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.core import State
 import pytest
 
 from custom_components.better_thermostat.climate import BetterThermostat
@@ -27,8 +32,10 @@ from custom_components.better_thermostat.utils.watcher import (
 )
 
 _CLIMATE = "custom_components.better_thermostat.climate"
+_WATCHER = "custom_components.better_thermostat.utils.watcher"
 SENSOR_ID = "sensor.room_temp"
 TRV_ID = "climate.test_trv"
+WEATHER_ID = "weather.home"
 
 
 def _startup_bt():
@@ -78,6 +85,106 @@ async def _run_finalize_startup(bt, *, patch_degraded_check=True):
         for p in patches:
             stack.enter_context(p)
         await BetterThermostat._finalize_startup(bt)
+
+
+def _startup_loop_bt():
+    """Build a mock for startup() with an unavailable optional weather entity."""
+    bt = _startup_bt()
+    bt.weather_entity = WEATHER_ID
+    bt.version = "1.0.0"
+    bt._check_entities_ready = MagicMock(return_value=True)
+    bt._collect_trv_states = MagicMock(return_value=[])
+    bt._resolve_temperature_range = MagicMock()
+    bt._initialize_sensors = MagicMock()
+    bt._restore_state = AsyncMock()
+    bt._validate_hvac_mode = MagicMock()
+    bt._initialize_trvs = AsyncMock()
+    bt._finalize_startup = AsyncMock()
+
+    def states_get(entity_id):
+        if entity_id == SENSOR_ID:
+            return State(SENSOR_ID, "21.0")
+        return None
+
+    bt.hass.states.get.side_effect = states_get
+    return bt
+
+
+@pytest.mark.asyncio
+async def test_startup_arms_grace_before_the_first_degraded_check(caplog):
+    """A dead optional sensor stays quiet during startup and warns post-grace.
+
+    startup() runs a degraded-mode check before _finalize_startup arms the
+    STARTING transition; the grace deadline must already be on the lifecycle
+    region at that point, or the warning and the repair issue fire while
+    startup is still in progress.
+    """
+    bt = _startup_loop_bt()
+    start = bt.clock.now()
+
+    with (
+        patch(f"{_WATCHER}.ir.async_create_issue") as create_issue,
+        patch(f"{_WATCHER}.get_battery_status", MagicMock()),
+    ):
+        await asyncio.wait_for(BetterThermostat.startup(bt), timeout=1)
+
+        # The grace deadline is armed on the (still INITIALISING) lifecycle
+        # region, so the in-startup degraded check saw an active window.
+        assert bt._degraded_grace_until == start + STARTUP_DEGRADED_GRACE_PERIOD
+        assert bt.kernel_state.lifecycle.phase == LifecyclePhase.INITIALISING
+        assert bt.kernel_state.lifecycle.grace_until == bt._degraded_grace_until
+        assert bt.kernel_state.control_mode.degraded is True
+        assert not any("Entering degraded mode" in r.message for r in caplog.records)
+        create_issue.assert_not_called()
+        assert bt._degraded_warning_emitted is False
+
+        # The window still expires: with the sensor dead past the deadline,
+        # the warning and the repair issue fire.
+        bt.clock.advance(STARTUP_DEGRADED_GRACE_PERIOD.total_seconds() + 1)
+        with patch(
+            "custom_components.better_thermostat.utils.helpers.async_fire_logbook_entry",
+            AsyncMock(),
+        ):
+            await check_and_update_degraded_mode(bt)
+
+        assert any("Entering degraded mode" in r.message for r in caplog.records)
+        create_issue.assert_called_once()
+        assert bt._degraded_warning_emitted is True
+
+
+@pytest.mark.asyncio
+async def test_startup_finished_carries_the_deadline_armed_at_startup_begin():
+    """_finalize_startup does not restart an already armed grace window."""
+    bt = _startup_bt()
+    armed = bt.clock.now() + STARTUP_DEGRADED_GRACE_PERIOD
+    bt._degraded_grace_until = armed
+    bt.kernel_state = replace(
+        bt.kernel_state,
+        lifecycle=replace(bt.kernel_state.lifecycle, grace_until=armed),
+    )
+    bt.clock.advance(60)
+
+    await _run_finalize_startup(bt)
+
+    assert bt._degraded_grace_until == armed
+    assert bt.kernel_state.lifecycle.phase == LifecyclePhase.STARTING
+    assert bt.kernel_state.lifecycle.grace_until == armed
+
+
+@pytest.mark.asyncio
+async def test_finalize_startup_arms_grace_before_the_startup_triggers():
+    """The startup triggers already see an active grace window."""
+    bt = _startup_bt()
+    seen = {}
+
+    async def capture(_event):
+        seen["in_grace"] = bt.kernel_state.lifecycle.in_grace(bt.clock.now())
+
+    bt._trigger_time = AsyncMock(side_effect=capture)
+
+    await _run_finalize_startup(bt)
+
+    assert seen["in_grace"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_climate_startup_grace.py
+++ b/tests/unit/test_climate_startup_grace.py
@@ -159,8 +159,7 @@ async def test_startup_finished_carries_the_deadline_armed_at_startup_begin():
     armed = bt.clock.now() + STARTUP_DEGRADED_GRACE_PERIOD
     bt._degraded_grace_until = armed
     bt.kernel_state = replace(
-        bt.kernel_state,
-        lifecycle=replace(bt.kernel_state.lifecycle, grace_until=armed),
+        bt.kernel_state, lifecycle=replace(bt.kernel_state.lifecycle, grace_until=armed)
     )
     bt.clock.advance(60)
 

--- a/tests/unit/test_core_safety.py
+++ b/tests/unit/test_core_safety.py
@@ -108,10 +108,26 @@ def test_non_finite_offset_is_withheld():
         assert out.trvs["climate.trv"].offset is None
 
 
-def test_non_finite_valve_is_pinned_to_a_bound():
-    """NaN/inf valve percentages are clamped instead of leaking through."""
-    out = clamp(_desired(valve=float("inf")), _snapshot())
-    assert out.trvs["climate.trv"].valve_percent == 0.0
+def test_non_finite_valve_is_withheld():
+    """NaN/inf valve percentages are withheld, not coerced to a bound.
+
+    A non-finite value carries no opening degree at all; coercing it to
+    the lower bound would issue a spurious close command.
+    """
+    for value in (float("nan"), float("inf"), float("-inf")):
+        out = clamp(_desired(valve=value), _snapshot())
+        assert out.trvs["climate.trv"].valve_percent is None
+
+
+def test_non_finite_valve_is_withheld_under_the_jump_limiter():
+    """The jump limiter passes a withheld valve intent through as None."""
+    out = clamp(
+        _desired(valve=float("nan")),
+        _snapshot(),
+        previous=_desired(valve=50.0),
+        max_valve_jump=20.0,
+    )
+    assert out.trvs["climate.trv"].valve_percent is None
 
 
 def test_unknown_trv_falls_back_to_conservative_bounds():

--- a/tests/unit/test_core_safety.py
+++ b/tests/unit/test_core_safety.py
@@ -158,6 +158,50 @@ def test_inverted_reported_bounds_are_normalized():
     assert out.trvs["climate.trv"].setpoint == 21.0
 
 
+def test_device_bound_inverted_against_fallback_uses_pure_fallback_bounds():
+    """A device bound that inverts against a fallback bound is distrusted.
+
+    With min_temp=50 and no usable max_temp, pairing the device floor
+    with the fallback cap yields an inverted interval; swapping it would
+    clamp every intent up to at least 35. The hull instead falls back to
+    the pure fallback bounds on both ends.
+    """
+    snapshot = _snapshot(min_temp=50.0, max_temp=float("nan"))
+    out = clamp(_desired(setpoint=21.0), snapshot)
+    assert out.trvs["climate.trv"].setpoint == 21.0
+    out = clamp(_desired(setpoint=42.0), snapshot)
+    assert out.trvs["climate.trv"].setpoint == 35.0
+    out = clamp(_desired(setpoint=2.0), snapshot)
+    assert out.trvs["climate.trv"].setpoint == 4.5
+
+    # Mirror case: a device cap below the fallback floor.
+    snapshot = _snapshot(min_temp=None, max_temp=2.0)
+    out = clamp(_desired(setpoint=21.0), snapshot)
+    assert out.trvs["climate.trv"].setpoint == 21.0
+
+
+def test_offset_device_bound_inverted_against_fallback_uses_pure_fallback():
+    """The offset channel applies the same distrust rule to mixed pairs."""
+    snapshot = _snapshot(local_calibration_min=15.0, local_calibration_max=None)
+    out = clamp(_desired(offset=1.5), snapshot)
+    assert out.trvs["climate.trv"].offset == 1.5
+    out = clamp(_desired(offset=25.0), snapshot)
+    assert out.trvs["climate.trv"].offset == 12.0
+
+    snapshot = _snapshot(local_calibration_min=None, local_calibration_max=-14.0)
+    out = clamp(_desired(offset=-1.5), snapshot)
+    assert out.trvs["climate.trv"].offset == -1.5
+
+
+def test_inverted_device_calibration_range_is_normalized():
+    """A genuinely inverted device calibration range is swapped, not dropped."""
+    snapshot = _snapshot(local_calibration_min=7.0, local_calibration_max=-7.0)
+    out = clamp(_desired(offset=-9.5), snapshot)
+    assert out.trvs["climate.trv"].offset == -7.0
+    out = clamp(_desired(offset=9.5), snapshot)
+    assert out.trvs["climate.trv"].offset == 7.0
+
+
 def test_jump_limit_is_opt_in():
     """Without max_valve_jump, big changes pass; with it, they are limited."""
     previous = _desired(valve=10.0)

--- a/tests/unit/test_device_binding.py
+++ b/tests/unit/test_device_binding.py
@@ -10,9 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from custom_components.better_thermostat.device_binding import (
-    async_unbind_trv_device,
-)
+from custom_components.better_thermostat.device_binding import async_unbind_trv_device
 from custom_components.better_thermostat.utils.const import DOMAIN
 
 _BINDING = "custom_components.better_thermostat.device_binding"
@@ -38,9 +36,7 @@ async def test_unbind_clears_a_stale_via_device_link():
         result = await async_unbind_trv_device(MagicMock(), BT_UID)
 
     assert result is True
-    registry.async_get_device.assert_called_once_with(
-        identifiers={(DOMAIN, BT_UID)}
-    )
+    registry.async_get_device.assert_called_once_with(identifiers={(DOMAIN, BT_UID)})
     registry.async_update_device.assert_called_once_with(
         "bt_device_id", via_device_id=None
     )

--- a/tests/unit/test_device_binding.py
+++ b/tests/unit/test_device_binding.py
@@ -1,0 +1,72 @@
+"""Device-registry binding helpers.
+
+async_bind_trv_device attaches the BT device to its single TRV via
+``via_device``; async_unbind_trv_device clears a stale ``via_device_id``
+left behind on the BT device by an earlier single-valve binding pass, which
+matters for multi-TRV setups where no binding is written anymore.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.device_binding import (
+    async_unbind_trv_device,
+)
+from custom_components.better_thermostat.utils.const import DOMAIN
+
+_BINDING = "custom_components.better_thermostat.device_binding"
+BT_UID = "bt_uid"
+
+
+def _registry_with(bt_device):
+    """Build a device-registry mock returning the given BT device entry."""
+    registry = MagicMock()
+    registry.async_get_device.return_value = bt_device
+    return registry
+
+
+@pytest.mark.asyncio
+async def test_unbind_clears_a_stale_via_device_link():
+    """A set via_device_id is cleared with an explicit None update."""
+    bt_device = MagicMock()
+    bt_device.id = "bt_device_id"
+    bt_device.via_device_id = "stale_trv_device_id"
+    registry = _registry_with(bt_device)
+
+    with patch(f"{_BINDING}.dr.async_get", return_value=registry):
+        result = await async_unbind_trv_device(MagicMock(), BT_UID)
+
+    assert result is True
+    registry.async_get_device.assert_called_once_with(
+        identifiers={(DOMAIN, BT_UID)}
+    )
+    registry.async_update_device.assert_called_once_with(
+        "bt_device_id", via_device_id=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_unbind_is_a_noop_without_a_via_device_link():
+    """A BT device without via_device_id is left untouched."""
+    bt_device = MagicMock()
+    bt_device.via_device_id = None
+    registry = _registry_with(bt_device)
+
+    with patch(f"{_BINDING}.dr.async_get", return_value=registry):
+        result = await async_unbind_trv_device(MagicMock(), BT_UID)
+
+    assert result is False
+    registry.async_update_device.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unbind_is_a_noop_without_a_registry_entry():
+    """A missing BT device registry entry is tolerated."""
+    registry = _registry_with(None)
+
+    with patch(f"{_BINDING}.dr.async_get", return_value=registry):
+        result = await async_unbind_trv_device(MagicMock(), BT_UID)
+
+    assert result is False
+    registry.async_update_device.assert_not_called()

--- a/tests/unit/test_door_events.py
+++ b/tests/unit/test_door_events.py
@@ -150,6 +150,38 @@ class TestTriggerDoorChange:
         assert bt.kernel_state.door.pending_since == bt.clock.monotonic()
 
     @pytest.mark.asyncio
+    async def test_rapid_flips_on_bounded_queue_do_not_block(self):
+        """Mid-debounce flips on the production maxsize-1 queue coalesce.
+
+        Extra flips drop their queue item instead of blocking a putter;
+        the settle worker still commits the region and announces once.
+        """
+        bt = _make_bt(sensor_state="on", open_delay=5)
+        bt.door_queue_task = asyncio.Queue(maxsize=1)
+        tasks_before = asyncio.all_tasks()
+        for reading in ("on", "off", "on", "off", "on"):
+            bt.hass.states.get.return_value.state = reading
+            await asyncio.wait_for(trigger_door_change(bt, _event(reading)), timeout=1)
+        assert bt.door_queue_task.qsize() == 1
+        assert asyncio.all_tasks() == tasks_before
+        assert bt.kernel_state.door.phase == WindowPhase.OPENING
+
+        async def fake_sleep(seconds):
+            bt.clock.advance(seconds)
+
+        with (
+            patch(f"{_DOOR}.asyncio.sleep", side_effect=fake_sleep),
+            patch(_LOGBOOK, new_callable=AsyncMock) as logbook,
+            patch(f"{_DOOR}.request_control_cycle") as kick,
+        ):
+            await _run_queue_once(bt)
+
+        assert bt.kernel_state.door.phase == WindowPhase.OPEN
+        assert logbook.call_count == 1
+        assert logbook.call_args.args[1] == "door_open"
+        assert kick.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_unrecognized_state_raises_an_issue(self):
         """Garbage sensor values raise a repair issue and queue nothing."""
         bt = _make_bt(sensor_state="banana")

--- a/tests/unit/test_flight_recorder.py
+++ b/tests/unit/test_flight_recorder.py
@@ -188,11 +188,6 @@ class TestReplayValidation:
             replay(entry)
 
         entry = self._entry()
-        entry["snapshot"]["tolerance"] = None
-        with pytest.raises(ValueError, match="number"):
-            replay(entry)
-
-        entry = self._entry()
         entry["state"]["window"]["phase"] = 7
         with pytest.raises(ValueError, match="string"):
             replay(entry)
@@ -217,6 +212,36 @@ class TestReplayValidation:
         entry["state"]["control_mode"]["unavailable_sensors"] = "sensor.x"
         with pytest.raises(ValueError, match="list"):
             replay(entry)
+
+
+def test_non_finite_required_floats_roundtrip_to_neutral_defaults():
+    """An export nulled by the JSON path re-imports with neutral defaults.
+
+    The exporter writes None wherever a recorded float was non-finite;
+    the import path accepts those nulls on the required-float fields
+    and substitutes the documented neutral defaults (now_monotonic 0.0,
+    tolerance 0.0, solar_intensity 0.0) instead of rejecting the entry.
+    """
+    recorder = FlightRecorder()
+    state = replace(
+        running_kernel_state(), window=WindowState(phase=WindowPhase.CLOSED)
+    )
+    desired, _ = decide(_snapshot(), state)
+    snapshot = replace(
+        _snapshot(),
+        now_monotonic=float("inf"),
+        tolerance=float("nan"),
+        solar_intensity=float("nan"),
+    )
+    recorder.record(snapshot, state, desired)
+    entry = json.loads(json.dumps(recorder.export(), allow_nan=False))[0]
+    assert entry["snapshot"]["now_monotonic"] is None
+    assert entry["snapshot"]["tolerance"] is None
+    assert entry["snapshot"]["solar_intensity"] is None
+    rebuilt = snapshot_from_dict(entry["snapshot"])
+    assert rebuilt.now_monotonic == 0.0
+    assert rebuilt.tolerance == 0.0
+    assert rebuilt.solar_intensity == 0.0
 
 
 def test_replay_roundtrips_reachability_and_null_window_state():

--- a/tests/unit/test_fsm_ladder.py
+++ b/tests/unit/test_fsm_ladder.py
@@ -81,46 +81,53 @@ def test_flap_during_recovery_restarts_the_window():
     assert state.mode == ControlMode.OPTIMAL
 
 
-def test_escalation_mid_debounce_restarts_the_debounce():
-    """A deeper target during the debounce does not inherit its credit.
+def test_escalation_mid_debounce_commits_the_shallowest_observed_rung():
+    """A deeper target mid-debounce does not drag the commit deeper.
 
     Room sensor lost at t=0 (pending toward SENSOR_FALLBACK), TRV
-    temperatures lost at t=119 (pending toward HOLD): HOLD must persist
-    for its own full debounce before it commits.
+    temperatures lost at t=119: the window keeps running under the
+    sustained deeper pressure, but commits only the shallowest rung
+    observed throughout — HOLD must then earn its own full debounce.
     """
     state = _down(ControlModeState(), now=0.0)
     assert state.pending_target == ControlMode.SENSOR_FALLBACK
     state = _down(state, now=119.0, trv_ok=False)
     assert state.mode == ControlMode.OPTIMAL
-    assert state.pending_target == ControlMode.HOLD
-    # One second after the escalation the HOLD condition is 1 s old.
+    assert state.pending_target == ControlMode.SENSOR_FALLBACK
+    # The window elapses with only SENSOR_FALLBACK continuously
+    # supported; the deeper HOLD pressure starts its own window.
     state = _down(state, now=120.0, trv_ok=False)
-    assert state.mode == ControlMode.OPTIMAL
-    state = _down(state, now=238.0, trv_ok=False)
-    assert state.mode == ControlMode.OPTIMAL
+    assert state.mode == ControlMode.SENSOR_FALLBACK
+    assert state.pending_target == ControlMode.HOLD
     state = _down(state, now=239.0, trv_ok=False)
+    assert state.mode == ControlMode.SENSOR_FALLBACK
+    state = _down(state, now=240.0, trv_ok=False)
     assert state.mode == ControlMode.HOLD
 
 
-def test_second_recovery_restarts_the_stability_window():
-    """A later, deeper recovery target restarts the stability window.
+def test_second_recovery_commits_the_deepest_observed_rung_first():
+    """A later, shallower recovery target does not fast-track OPTIMAL.
 
     TRV temperature back at t=1000 (pending toward SENSOR_FALLBACK),
-    room sensor back at t=1250 (pending toward OPTIMAL): OPTIMAL only
-    commits after the room sensor was stable for the full window.
+    room sensor back at t=1250: the window keeps running under the
+    sustained shallower pressure, but commits only the deepest rung
+    observed throughout — OPTIMAL must then earn its own full window
+    of room-sensor stability.
     """
     state = ControlModeState(mode=ControlMode.HOLD, degraded_since=0.0)
     state = _down(state, now=1000.0, trv_ok=True)
     assert state.pending_target == ControlMode.SENSOR_FALLBACK
     state = _up(state, now=1250.0)
     assert state.mode == ControlMode.HOLD
-    assert state.pending_target == ControlMode.OPTIMAL
-    # 300 s after the first recovery, but only 50 s of room stability.
+    assert state.pending_target == ControlMode.SENSOR_FALLBACK
+    # The window elapses with only SENSOR_FALLBACK continuously
+    # supported; the shallower OPTIMAL pressure starts its own window.
     state = _up(state, now=1300.0)
-    assert state.mode == ControlMode.HOLD
-    state = _up(state, now=1549.0)
-    assert state.mode == ControlMode.HOLD
-    state = _up(state, now=1550.0)
+    assert state.mode == ControlMode.SENSOR_FALLBACK
+    assert state.pending_target == ControlMode.OPTIMAL
+    state = _up(state, now=1599.0)
+    assert state.mode == ControlMode.SENSOR_FALLBACK
+    state = _up(state, now=1600.0)
     assert state.mode == ControlMode.OPTIMAL
 
 
@@ -129,6 +136,44 @@ def test_hold_recovers_stepwise_to_fallback():
     state = ControlModeState(mode=ControlMode.HOLD, degraded_since=0.0)
     state = _down(state, now=1000.0, trv_ok=True)  # room still dead, TRV back
     state = _down(state, now=1300.0, trv_ok=True)
+    assert state.mode == ControlMode.SENSOR_FALLBACK
+
+
+def test_flapping_deeper_targets_do_not_starve_the_downgrade():
+    """A target oscillating between deeper rungs still commits a downgrade.
+
+    Room sensor dead, TRV availability flapping with a 60 s period: the
+    instantaneous target alternates SENSOR_FALLBACK/HOLD, both deeper
+    than OPTIMAL. The window keeps running under sustained deeper
+    pressure and commits the shallowest continuously supported rung.
+    """
+    state = ControlModeState()
+    trv_ok = True
+    for tick in range(11):
+        state = _down(state, now=tick * 60.0, trv_ok=trv_ok)
+        trv_ok = not trv_ok
+    assert state.mode == ControlMode.SENSOR_FALLBACK
+
+
+def test_flapping_shallower_targets_do_not_starve_the_upgrade():
+    """A target oscillating between shallower rungs still leaves HOLD.
+
+    TRV temperature solidly back, room sensor flapping with a 60 s
+    period: the instantaneous target alternates OPTIMAL/SENSOR_FALLBACK,
+    both shallower than HOLD. The stability window keeps running and
+    commits the deepest continuously supported rung.
+    """
+    state = ControlModeState(mode=ControlMode.HOLD, degraded_since=0.0)
+    room_ok = False
+    for tick in range(11):
+        state = step_ladder(
+            state,
+            room_sensor_ok=room_ok,
+            trv_temp_ok=True,
+            now=tick * 60.0,
+            params=P,
+        )
+        room_ok = not room_ok
     assert state.mode == ControlMode.SENSOR_FALLBACK
 
 

--- a/tests/unit/test_fsm_ladder.py
+++ b/tests/unit/test_fsm_ladder.py
@@ -167,11 +167,7 @@ def test_flapping_shallower_targets_do_not_starve_the_upgrade():
     room_ok = False
     for tick in range(11):
         state = step_ladder(
-            state,
-            room_sensor_ok=room_ok,
-            trv_temp_ok=True,
-            now=tick * 60.0,
-            params=P,
+            state, room_sensor_ok=room_ok, trv_temp_ok=True, now=tick * 60.0, params=P
         )
         room_ok = not room_ok
     assert state.mode == ControlMode.SENSOR_FALLBACK

--- a/tests/unit/test_fsm_sweeps.py
+++ b/tests/unit/test_fsm_sweeps.py
@@ -115,24 +115,47 @@ class TestLadderSweep:
             params=self.PARAMS,
         )
 
-        # The rung only ever moves to the capability target.
-        assert result.mode in (mode, target)
-
         order = (
             cm.ControlMode.OPTIMAL,
             cm.ControlMode.SENSOR_FALLBACK,
             cm.ControlMode.HOLD,
         )
+        depth = order.index
+        # The rung only ever moves toward the capability target, never
+        # past it and never against the pressure direction.
+        assert min(depth(mode), depth(target)) <= depth(result.mode) <= max(
+            depth(mode), depth(target)
+        )
+
+        degrading = depth(target) > depth(mode)
+        # A running window continues only while the prior pending rung
+        # sits on the same side of the current rung as the observation.
+        window_continued = (
+            pending_target is not None
+            and (
+                (degrading and down_since is not None and depth(pending_target) > depth(mode))
+                or (
+                    not degrading
+                    and target != mode
+                    and up_since is not None
+                    and depth(pending_target) < depth(mode)
+                )
+            )
+        )
         if result.mode != mode:
-            degrading = order.index(target) > order.index(mode)
             threshold = (
                 self.PARAMS.down_debounce_s if degrading else self.PARAMS.up_stability_s
             )
             since = down_since if degrading else up_since
-            # A commit requires the full debounce/stability window,
-            # accrued toward this exact target rung.
+            # A commit requires the full debounce/stability window of
+            # continuous same-direction pressure.
+            assert window_continued
             assert since is not None and NOW - since >= threshold
-            assert pending_target == target
+            # The commit lands on the rung nearest the old one that was
+            # continuously supported: the prior pending rung capped by
+            # the instantaneous target.
+            nearest = min if degrading else max
+            assert result.mode == nearest(pending_target, target, key=depth)
 
         # Matching capability clears all pending timers.
         if target == mode:
@@ -140,18 +163,31 @@ class TestLadderSweep:
             assert result.up_pending_since is None
             assert result.pending_target is None
 
-        # A still-pending transition records the rung it heads toward.
+        # A still-pending transition records the rung it would commit.
         if result.mode == mode and target != mode:
-            assert result.pending_target == target
+            nearest = min if degrading else max
+            expected_pending = (
+                nearest(pending_target, target, key=depth)
+                if window_continued
+                else target
+            )
+            assert result.pending_target == expected_pending
             since = (
-                result.down_pending_since
-                if order.index(target) > order.index(mode)
-                else result.up_pending_since
+                result.down_pending_since if degrading else result.up_pending_since
             )
             assert since is not None
-            # A window inherited from a different target restarts now.
-            if pending_target != target:
+            # A freshly started window begins now.
+            if not window_continued:
                 assert since == NOW
+
+        # A commit short of the instantaneous target immediately opens
+        # the follow-up window toward that target.
+        if result.mode != mode and result.mode != target:
+            assert result.pending_target == target
+            since = (
+                result.down_pending_since if degrading else result.up_pending_since
+            )
+            assert since == NOW
 
         # After a commit, degraded_since exactly mirrors the new rung.
         if result.mode != mode:

--- a/tests/unit/test_fsm_sweeps.py
+++ b/tests/unit/test_fsm_sweeps.py
@@ -123,23 +123,26 @@ class TestLadderSweep:
         depth = order.index
         # The rung only ever moves toward the capability target, never
         # past it and never against the pressure direction.
-        assert min(depth(mode), depth(target)) <= depth(result.mode) <= max(
-            depth(mode), depth(target)
+        assert (
+            min(depth(mode), depth(target))
+            <= depth(result.mode)
+            <= max(depth(mode), depth(target))
         )
 
         degrading = depth(target) > depth(mode)
         # A running window continues only while the prior pending rung
         # sits on the same side of the current rung as the observation.
-        window_continued = (
-            pending_target is not None
-            and (
-                (degrading and down_since is not None and depth(pending_target) > depth(mode))
-                or (
-                    not degrading
-                    and target != mode
-                    and up_since is not None
-                    and depth(pending_target) < depth(mode)
-                )
+        window_continued = pending_target is not None and (
+            (
+                degrading
+                and down_since is not None
+                and depth(pending_target) > depth(mode)
+            )
+            or (
+                not degrading
+                and target != mode
+                and up_since is not None
+                and depth(pending_target) < depth(mode)
             )
         )
         if result.mode != mode:
@@ -172,9 +175,7 @@ class TestLadderSweep:
                 else target
             )
             assert result.pending_target == expected_pending
-            since = (
-                result.down_pending_since if degrading else result.up_pending_since
-            )
+            since = result.down_pending_since if degrading else result.up_pending_since
             assert since is not None
             # A freshly started window begins now.
             if not window_continued:
@@ -182,11 +183,9 @@ class TestLadderSweep:
 
         # A commit short of the instantaneous target immediately opens
         # the follow-up window toward that target.
-        if result.mode != mode and result.mode != target:
+        if result.mode not in (mode, target):
             assert result.pending_target == target
-            since = (
-                result.down_pending_since if degrading else result.up_pending_since
-            )
+            since = result.down_pending_since if degrading else result.up_pending_since
             assert since == NOW
 
         # After a commit, degraded_since exactly mirrors the new rung.

--- a/tests/unit/test_mpc_comprehensive.py
+++ b/tests/unit/test_mpc_comprehensive.py
@@ -10,6 +10,7 @@ from time import time
 
 import pytest
 
+from custom_components.better_thermostat.core.calibrator import CalibratorHealth
 from custom_components.better_thermostat.utils.calibration.mpc import (
     DISTRIBUTE_COMPENSATION_PCT_PER_K,
     MpcInput,
@@ -21,6 +22,7 @@ from custom_components.better_thermostat.utils.calibration.mpc import (
     _MpcState,
     _round_for_debug,
     _seed_state_from_siblings,
+    sanitize_mpc_state,
     _split_mpc_key,
     _update_perf_curve,
     build_mpc_group_key,
@@ -1400,6 +1402,89 @@ class TestSeedFromSiblings:
         # uid matches but the entity slot differs ("group" vs "climate.trv"),
         # so seeding must not happen.
         assert fresh.solar_gain_est is None
+
+    def test_seeding_skips_nonfinite_sibling_values(self):
+        """A sibling holding non-finite values is skipped per field.
+
+        The nearest sibling is poisoned in every seedable field; the
+        next-nearest sibling is clean. Seeding must fall through to the
+        clean sibling instead of copying NaN/inf into the fresh state.
+        """
+        params = _default_params(enable_min_effective_percent=True)
+        poisoned = _MpcState()
+        poisoned.min_effective_percent = float("inf")
+        poisoned.perf_curve = {
+            "p20_22": {"count": 3, "avg_room_rate": float("inf"), "avg_percent": 21.0}
+        }
+        poisoned.trv_profile = "threshold"
+        poisoned.profile_confidence = float("nan")
+        poisoned.profile_samples = 9
+        poisoned.solar_gain_est = float("nan")
+        clean = _MpcState()
+        clean.min_effective_percent = 12.0
+        clean.perf_curve = {
+            "p20_22": {"count": 6, "avg_room_rate": 0.03, "avg_percent": 21.0}
+        }
+        clean.trv_profile = "linear"
+        clean.profile_confidence = 0.8
+        clean.profile_samples = 12
+        clean.solar_gain_est = 0.02
+        # 21.5 is nearer to 22.0 than 19.0: the poisoned sibling is tried first.
+        _STATES["uidN:climate.trv:t21.5"] = poisoned
+        _STATES["uidN:climate.trv:t19.0"] = clean
+
+        fresh = _MpcState()
+        _seed_state_from_siblings(
+            "uidN:climate.trv:t22.0", fresh, params, all_states=_STATES
+        )
+
+        assert fresh.min_effective_percent == pytest.approx(12.0)
+        assert fresh.perf_curve == clean.perf_curve
+        assert fresh.trv_profile == "linear"
+        assert fresh.profile_confidence == pytest.approx(0.8)
+        assert fresh.profile_samples == 12
+        assert fresh.solar_gain_est == pytest.approx(0.02)
+
+    def test_seeding_with_only_poisoned_sibling_leaves_defaults(self):
+        """When every sibling candidate is non-finite, nothing is copied."""
+        params = _default_params(enable_min_effective_percent=True)
+        poisoned = _MpcState()
+        poisoned.min_effective_percent = float("nan")
+        poisoned.perf_curve = {"p20_22": {"count": 3, "avg_room_rate": float("nan")}}
+        poisoned.solar_gain_est = float("inf")
+        _STATES["uidO:climate.trv:t21.0"] = poisoned
+
+        fresh = _MpcState()
+        _seed_state_from_siblings(
+            "uidO:climate.trv:t22.0", fresh, params, all_states=_STATES
+        )
+
+        assert fresh.min_effective_percent is None
+        assert fresh.perf_curve == {}
+        assert fresh.solar_gain_est is None
+
+    def test_poisoned_zombie_sibling_does_not_repoison_active_state(self):
+        """sanitize -> compute cycles keep the active state finite.
+
+        A poisoned state persisted under an inactive target bucket is never
+        the active key, so it is never healed. Seeding runs on every
+        compute; copying its non-finite values would re-poison the freshly
+        sanitized active state each cycle, wiping the learned state forever.
+        """
+        params = _default_params()
+        zombie = _MpcState()
+        zombie.solar_gain_est = float("nan")
+        zombie.perf_curve = {"p40_42": {"count": 2, "avg_room_rate": float("inf")}}
+        _STATES["uidZ:climate.trv:t20.0"] = zombie
+
+        key = "uidZ:climate.trv:t22.0"
+        for _ in range(3):
+            state = _STATES.setdefault(key, _MpcState())
+            healed, _health = sanitize_mpc_state(state)
+            _STATES[key] = healed
+            _compute(_inp(key=key, current_temp_C=20.0), params)
+            _resanitized, health_after = sanitize_mpc_state(_STATES[key])
+            assert health_after == CalibratorHealth.HEALTHY
 
     def test_seeding_runs_through_compute_mpc_on_first_call(self):
         """Integration: first compute_mpc call on a new bucket triggers seeding."""

--- a/tests/unit/test_mpc_comprehensive.py
+++ b/tests/unit/test_mpc_comprehensive.py
@@ -22,13 +22,13 @@ from custom_components.better_thermostat.utils.calibration.mpc import (
     _MpcState,
     _round_for_debug,
     _seed_state_from_siblings,
-    sanitize_mpc_state,
     _split_mpc_key,
     _update_perf_curve,
     build_mpc_group_key,
     build_mpc_key,
     compute_mpc as _compute_mpc_raw,
     distribute_valve_percent,
+    sanitize_mpc_state,
 )
 from custom_components.better_thermostat.utils.state_manager import deserialize_mpc
 

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -94,6 +94,9 @@ class TestReconcileTick:
         bt.kernel_state = replace(
             bt.kernel_state, mode=ModeState(hvac_mode=CoreHvacMode.OFF)
         )
+        # An OFF-capable device: an unreported mode list would count as
+        # no-off and legitimately keep heating under an OFF intent.
+        bt.real_trvs["climate.trv"].hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
         await reconcile_tick(bt)
         bt.control_queue_task.put_nowait.assert_called_once()
 

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -471,7 +471,6 @@ class TestInternalTemperatureChange:
 
         async def pop_entry(bt, entity_id):
             bt.real_trvs.pop(entity_id)
-            return None
 
         with (
             patch(

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -448,6 +448,49 @@ class TestInternalTemperatureChange:
         assert trv.last_calibration == 2.5
         assert trv.current_temperature == 20.0
 
+    @pytest.mark.asyncio
+    async def test_entry_removed_before_offset_read_skips_it(self, mock_bt):
+        """A removal before the offset read skips it instead of raising.
+
+        The handler awaits model detection before the calibration branch;
+        the entry can vanish there. The unpatched offset read resolves the
+        adapter through a raw ``real_trvs[entity_id]`` index, so reaching
+        it after the removal would raise KeyError.
+        """
+        trv = mock_bt.real_trvs[ENTITY_ID]
+        trv.calibration_received = False
+        trv.calibration = 0
+        trv.model = None
+        trv_state = _make_state(
+            attributes={"current_temperature": 20.0, "model_id": "TRV-X"}
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        trv.current_temperature = 18.0
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        async def pop_entry(bt, entity_id):
+            bt.real_trvs.pop(entity_id)
+            return None
+
+        with (
+            patch(
+                "custom_components.better_thermostat.events.trv.get_device_model",
+                side_effect=pop_entry,
+            ),
+            patch(
+                "custom_components.better_thermostat.events.trv.convert_inbound_states",
+                return_value=HVACMode.HEAT,
+            ),
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs == {}
+        # The offset read was skipped; the flag still flipped on the
+        # detached Trv object.
+        assert trv.calibration_received is True
+        assert trv.last_calibration == 0.0
+
 
 # ---------------------------------------------------------------------------
 # 3. HVAC action and valve position

--- a/tests/unit/test_trv_object.py
+++ b/tests/unit/test_trv_object.py
@@ -122,6 +122,35 @@ class TestTrvCapabilities:
         trv.valve_position_writable = False
         assert trv.capabilities().supports_valve_write is False
 
+    def test_unknown_hvac_modes_disable_off(self):
+        """A TRV that never reported its modes is conservatively no-off.
+
+        BT then sends min temp instead of an OFF the device may not
+        support.
+        """
+        trv = _make()
+        assert trv.hvac_modes is None
+        assert trv.capabilities().supports_off_mode is False
+
+    def test_off_in_hvac_modes_enables_off(self):
+        """A reported mode list containing off keeps the OFF capability."""
+        trv = _make()
+        trv.hvac_modes = ["heat", "off"]
+        assert trv.capabilities().supports_off_mode is True
+
+    def test_hvac_modes_without_off_disable_off(self):
+        """A reported mode list without off yields no OFF capability."""
+        trv = _make()
+        trv.hvac_modes = ["heat", "auto"]
+        assert trv.capabilities().supports_off_mode is False
+
+    def test_no_off_system_mode_config_disables_off(self):
+        """The explicit no_off_system_mode config wins over the mode list."""
+        trv = _make()
+        trv.hvac_modes = ["heat", "off"]
+        trv.advanced = {"no_off_system_mode": True}
+        assert trv.capabilities().supports_off_mode is False
+
     def test_valve_capability_from_quirk_override(self):
         """A quirk-provided override_set_valve enables valve writes."""
 

--- a/tests/unit/test_window_events.py
+++ b/tests/unit/test_window_events.py
@@ -151,6 +151,40 @@ class TestTriggerWindowChange:
         assert bt.kernel_state.window.pending_since == bt.clock.monotonic()
 
     @pytest.mark.asyncio
+    async def test_rapid_flips_on_bounded_queue_do_not_block(self):
+        """Mid-debounce flips on the production maxsize-1 queue coalesce.
+
+        Extra flips drop their queue item instead of blocking a putter;
+        the settle worker still commits the region and announces once.
+        """
+        bt = _make_bt(sensor_state="on", open_delay=5)
+        bt.window_queue_task = asyncio.Queue(maxsize=1)
+        tasks_before = asyncio.all_tasks()
+        for reading in ("on", "off", "on", "off", "on"):
+            bt.hass.states.get.return_value.state = reading
+            await asyncio.wait_for(
+                trigger_window_change(bt, _event(reading)), timeout=1
+            )
+        assert bt.window_queue_task.qsize() == 1
+        assert asyncio.all_tasks() == tasks_before
+        assert bt.kernel_state.window.phase == WindowPhase.OPENING
+
+        async def fake_sleep(seconds):
+            bt.clock.advance(seconds)
+
+        with (
+            patch(f"{_WINDOW}.asyncio.sleep", side_effect=fake_sleep),
+            patch(_LOGBOOK, new_callable=AsyncMock) as logbook,
+            patch(f"{_WINDOW}.request_control_cycle") as kick,
+        ):
+            await _run_queue_once(bt)
+
+        assert bt.kernel_state.window.phase == WindowPhase.OPEN
+        assert logbook.call_count == 1
+        assert logbook.call_args.args[1] == "window_open"
+        assert kick.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_unrecognized_state_raises_an_issue(self):
         """Garbage sensor values raise a repair issue and queue nothing."""
         bt = _make_bt(sensor_state="banana")


### PR DESCRIPTION
## What this is

Follow-up review pass over `v2` at ee7d93dd (the state after #2138). Five parallel review agents re-examined the #2138 fix delta, plus a survival audit of all ~75 develop fixes against the wholesale-merge convention. Full test suite was green before and after (3955 → 3990 tests). This PR fixes everything the pass surfaced: 2 majors, 12 minors.

## Majors

- **Degraded-mode grace was armed too late in `startup()`** — `_trigger_time(None)` / `_trigger_check_weather(None)` run before `lifecycle_startup_finished(grace_until=…)`, and both begin with `check_and_update_degraded_mode`. With the lifecycle still INITIALISING (`grace_until=None`), an optional sensor that is slow to come up (e.g. a cloud weather entity after an HA restart) fired the degraded WARNING + repair issue seconds before the grace window existed. The grace deadline is now armed at the top of `startup()` on the INITIALISING lifecycle state and carried unchanged into `startup_finished`.
- **MPC v1 sibling seeding could re-poison a freshly sanitized state every cycle** — `_seed_state_from_siblings` copied values with only `is not None` / truthiness guards, so NaN/inf from a stale target-bucket entry (never active, hence never healed) passed. Sequence per cycle: sanitize discards the poisoned state → seeding re-copies the NaN → health `NON_FINITE` forever, learned state wiped each cycle. Every seeded value now passes `_all_finite`; poisoned siblings are skipped in favor of the next-nearest clean one.

## Minors

**Core (strictly typed, pyrefly clean)**
- Degradation-ladder pending windows reset whenever the instantaneous target changed, so a target oscillating between two degraded rungs faster than the debounce pinned the mode at OPTIMAL indefinitely (mirror case: frozen in HOLD during recovery flapping). Windows are now direction-bound: a downgrade window keeps running while any deeper rung is targeted and commits to the shallowest rung observed; upgrades mirror that. Export format unchanged.
- The safety-hull inverted-bounds swap could pair a finite device bound with a fallback bound (`min=50 °C`, `max=NaN` → range [35, 50]) and clamp a 21 °C intent up to 35 °C. A mixed device/fallback pair that inverts now distrusts the device bound and uses pure fallback bounds; a genuinely inverted device pair still swaps.
- A non-finite valve intent was coerced to a 0 % close command by the clamp; it is now withheld as `None` like the other channels.
- The flight recorder exported non-finite floats as `null` that its own `snapshot_from_dict` refused to read back; the import path now accepts exactly those nulls with neutral defaults.

**Controlling**
- `control_trv`'s new `finally` cleared `ignore_trv_states` even when the invocation was cancelled while still waiting for the lock — wiping the flag of a concurrent holder mid-write, so BT's own setpoint echo could be processed as an external change. The reset is now ownership-guarded.
- Cooler dedup vs. device setpoint quantization: a device snapping 22.22 °C to 22.0 never converged below the 0.05 K tolerance and got an identical resend every 30 s forever. The send cache now remembers the settled post-send reading (within 0.5 K of the sent value) and stops resending until the desired or reported value moves.
- Per-call error isolation in `control_cooler` only caught `HomeAssistantError`; raw `ConnectionError`/`TimeoutError` from cloud integrations aborted the whole call and skipped the second command. Each call now isolates any `Exception` (CancelledError still propagates).

**Events / TRV**
- Leftover `@callback` on the async `trigger_temperature_change` / `trigger_cooler_change` handlers removed.
- `trigger_trv_change` could still KeyError in `get_current_offset` when the TRV entry was removed while the handler was suspended in earlier awaits; the calibration branch now re-checks entry presence.
- Mid-debounce contact flips did a blocking `await put()` on the maxsize-1 window/door queues; a bouncy sensor piled up blocked putter tasks that outlive a cancelled worker. Puts now coalesce via `put_nowait` (the region is stepped before the put, so dropping a queued wake-up is safe).
- `Trv` treated an unreported `hvac_modes` list as OFF-capable and could send `HVACMode.OFF` to a device that never advertised it; restored the conservative polarity (unknown modes → no-off, min-temp fallback).

**Climate**
- Installs that ran the old multi-TRV code keep a stale `via_device` link to the last TRV in the device registry; startup now clears it once for multi-TRV setups.
- The `sensor_entity_id is None` guards logged at DEBUG and left the entity silently unavailable; raised to ERROR naming the missing config option.
- MPC v2 re-ID sampling recorded the raw (possibly frozen) `cur_temp` regardless of control mode, biasing the tau/gain fit with fallback-episode tails; sampling is now gated on the OPTIMAL rung, and the resulting gap splits the segment.
- Re-ID adoption transferred only the controller of the bucket that scheduled the fit; other cached live controllers kept the old prior and later hit a cold rebuild via the plant-signature guard. Adoption now folds all cached controllers bumplessly and removes the obsolete legacy per-bucket entries after the shared key is written.

## Survival audit (develop fixes vs. wholesale merges)

All ~75 fix commits reachable from `origin/develop` were checked for semantic survival at v2 HEAD. **No further silent reverts** beyond the four already re-fixed in #2138. Two items of note:
- The runtime `unavailable → closed` contact policy is an intentional, documented divergence (already in the #2128 PR body), not a merge casualty.
- Config entries created on develop may still carry the removed `CONF_MIN_COOLER_RESEND_INTERVAL` option; it is silently ignored on v2 (superseded by the built-in send cache). Worth a line in the release notes.

## Verification

- Full suite: **3990 passed** on the merged branch (was 3955 before; +35 regression tests, each written red-first).
- ruff check/format clean; pyrefly strict clean on `core/`.
- Merge structure: five per-area branches with disjoint file ownership, merged with `--no-ff`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved thermostat recovery and degraded-mode handling with more consistent startup grace periods.
  * Added safer support for devices with unknown or limited HVAC modes.
  * Improved control for devices that round or quantize temperature setpoints.

* **Bug Fixes**
  * Prevented invalid valve commands and corrupted learned values from affecting control.
  * Improved snapshot import compatibility when optional numeric values are unavailable.
  * Prevented stale device associations from persisting in multi-TRV setups.
  * Reduced blocking during rapid door and window sensor changes.
  * Improved calibration and re-identification reliability during degraded operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->