### PR TITLE
fix(cooler): adopt only user setpoints from the cooler entity

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2822,6 +2822,34 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         )
         self.bt_target_cooltemp = adjusted
 
+    def _enforce_heat_below_cool(self) -> None:
+        """Keep the heating target strictly below the cooling target.
+
+        The counterpart to :meth:`_enforce_cool_above_heat`, for the case where
+        the cooling target is the value that was just set: the heating target
+        yields instead, down to one temperature step below the cooling target
+        and never below the configured minimum.
+        """
+        if (
+            self.hvac_mode != HVACMode.HEAT_COOL
+            or self.bt_target_cooltemp is None
+            or self.bt_target_temp is None
+            or self.bt_target_temp < self.bt_target_cooltemp
+        ):
+            return
+        step = self.bt_target_temp_step or 0.5
+        adjusted = self.bt_target_cooltemp - step
+        if self.bt_min_temp is not None:
+            adjusted = max(adjusted, self.bt_min_temp)
+        _LOGGER.warning(
+            "better_thermostat %s: heating target %.2f adjusted to %.2f to stay below cooling target %.2f",
+            self.device_name,
+            self.bt_target_temp,
+            adjusted,
+            self.bt_target_cooltemp,
+        )
+        self.bt_target_temp = adjusted
+
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         _LOGGER.debug(

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -9,11 +9,54 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State, callback
 
-from custom_components.better_thermostat.utils.helpers import convert_to_float
+from custom_components.better_thermostat.utils.helpers import (
+    attr_to_celsius,
+    convert_to_float,
+    state_temperature_unit,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _get_cooling_setpoint(self, state: State) -> float | None:
+    """Read the cooler's setpoint from a state and return it in °C.
+
+    A climate entity that supports both a single target and a target range
+    publishes ``temperature`` as None while it runs in range mode, so a
+    present-but-empty attribute must not stop the range key from being read.
+    """
+    for key in ("temperature", "target_temp_high"):
+        if state.attributes.get(key) is None:
+            continue
+        setpoint = attr_to_celsius(self, state, key, None, "trigger_cooler_change()")
+        if setpoint is not None:
+            return setpoint
+    return None
+
+
+def _get_cooler_step(self, state: State) -> float:
+    """Return the cooler's setpoint step as a °C delta."""
+    raw_step = state.attributes.get("target_temp_step")
+    step = (
+        convert_to_float(str(raw_step), self.device_name, "trigger_cooler_change()")
+        if raw_step is not None
+        else None
+    )
+    if (
+        step is not None
+        and state_temperature_unit(
+            state.attributes, self.hass.config.units.temperature_unit
+        )
+        == UnitOfTemperature.FAHRENHEIT
+    ):
+        step = round(step * 5.0 / 9.0, 4)
+    if step is None or step <= 0:
+        fallback = self.bt_target_temp_step
+        step = fallback if isinstance(fallback, (int, float)) and fallback > 0 else 0.5
+    return float(step)
 
 
 @callback
@@ -62,54 +105,57 @@ async def trigger_cooler_change(self, event):
         "better_thermostat %s: Cooler %s update received", self.device_name, entity_id
     )
 
-    def _get_cooling_setpoint(state):
-        """Extract cooling setpoint from state, checking both attribute keys."""
-        for key in ("temperature", "target_temp_high"):
-            if key in state.attributes:
-                return convert_to_float(
-                    str(state.attributes[key]),
-                    self.device_name,
-                    "trigger_cooler_change()",
-                )
-        return None
-
-    _old_cooling_setpoint = _get_cooling_setpoint(old_state)
-    _new_cooling_setpoint = _get_cooling_setpoint(new_state)
+    _old_cooling_setpoint = _get_cooling_setpoint(self, old_state)
+    _new_cooling_setpoint = _get_cooling_setpoint(self, new_state)
     if (
         _new_cooling_setpoint is not None
         and _old_cooling_setpoint is not None
         and self.bt_hvac_mode != HVACMode.OFF
     ):
+        _step = _get_cooler_step(self, new_state)
+        # Adopt only what a user set on the cooler itself. A value within one
+        # step of a setpoint BT wrote is the device reporting our own write
+        # back: rounded to its own grid, or delayed until a poll that carries a
+        # foreign context and therefore passes the context check above. User
+        # input moves the setpoint by at least one step.
+        _bt_known_values = (self.bt_target_cooltemp, self.last_sent_cooler_temp)
+        _is_echo = any(
+            isinstance(value, (int, float))
+            and abs(_new_cooling_setpoint - value) < _step
+            for value in _bt_known_values
+        )
         _LOGGER.debug(
             "better_thermostat %s: trigger_cooler_change / "
-            "_old_cooling_setpoint: %s - _new_cooling_setpoint: %s",
+            "_old_cooling_setpoint: %s - _new_cooling_setpoint: %s - "
+            "bt_target_cooltemp: %s - last_sent: %s - step: %s - echo: %s",
             self.device_name,
             _old_cooling_setpoint,
             _new_cooling_setpoint,
+            self.bt_target_cooltemp,
+            self.last_sent_cooler_temp,
+            _step,
+            _is_echo,
         )
-        if (
-            _new_cooling_setpoint < self.bt_min_temp
-            or self.bt_max_temp < _new_cooling_setpoint
-        ):
-            _LOGGER.warning(
-                "better_thermostat %s: New Cooler %s setpoint outside of range, "
-                "overwriting it",
-                self.device_name,
-                entity_id,
-            )
+        if not _is_echo:
+            if (
+                _new_cooling_setpoint < self.bt_min_temp
+                or self.bt_max_temp < _new_cooling_setpoint
+            ):
+                _LOGGER.warning(
+                    "better_thermostat %s: New Cooler %s setpoint outside of range, "
+                    "overwriting it",
+                    self.device_name,
+                    entity_id,
+                )
 
-            if _new_cooling_setpoint < self.bt_min_temp:
-                _new_cooling_setpoint = self.bt_min_temp
-            else:
-                _new_cooling_setpoint = self.bt_max_temp
+                if _new_cooling_setpoint < self.bt_min_temp:
+                    _new_cooling_setpoint = self.bt_min_temp
+                else:
+                    _new_cooling_setpoint = self.bt_max_temp
 
-        self.bt_target_cooltemp = _new_cooling_setpoint
-        if self.bt_target_temp >= self.bt_target_cooltemp:
-            self.bt_target_temp = max(
-                self.bt_target_cooltemp - max(self.bt_target_temp_step or 0.5, 0.5),
-                self.bt_min_temp,
-            )
-        _main_change = True
+            self.bt_target_cooltemp = _new_cooling_setpoint
+            self._enforce_heat_below_cool()
+            _main_change = True
 
     if _main_change is True:
         self.async_write_ha_state()

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -1225,3 +1225,76 @@ class TestEnforceCoolAboveHeat:
         mock_bt.bt_target_cooltemp = None
         self._call(mock_bt)
         assert mock_bt.bt_target_cooltemp is None
+
+
+# ===========================================================================
+# 8. TestEnforceHeatBelowCool
+# ===========================================================================
+
+
+class TestEnforceHeatBelowCool:
+    """_enforce_heat_below_cool keeps the heat target strictly below the cool target."""
+
+    def _call(self, bt):
+        return BetterThermostat._enforce_heat_below_cool(bt)
+
+    def test_not_heat_cool_mode_is_noop(self, mock_bt):
+        """Outside HEAT_COOL the heat target is left untouched even if above cool."""
+        mock_bt.hvac_mode = HVACMode.HEAT
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_cooltemp = 20.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 22.0
+
+    def test_heat_below_cool_is_noop(self, mock_bt):
+        """A heat target already below the cool target is unchanged."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 20.0
+        mock_bt.bt_target_cooltemp = 24.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 20.0
+
+    def test_heat_above_cool_is_pushed_down_by_step(self, mock_bt):
+        """A heat target above the cool target drops one step below it."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 24.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 21.5
+
+    def test_heat_equal_cool_is_pushed_down(self, mock_bt):
+        """A heat target equal to the cool target is pushed below it."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 21.5
+
+    def test_step_falls_back_to_half_degree(self, mock_bt):
+        """A missing/zero step falls back to 0.5."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 21.5
+
+    def test_result_is_clamped_to_min_temp(self, mock_bt):
+        """The heat target never drops below the configured minimum."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 6.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_cooltemp = 5.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 5.0
+
+    def test_none_heat_target_is_noop(self, mock_bt):
+        """A None heat target does not raise and stays None."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = None
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp is None

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -1,15 +1,17 @@
 """Tests for events/cooler.py – Cooler event handler.
 
-Covers guard clauses, setpoint adoption, clamping, heat-target sync,
-and control-queue triggering.
+Covers guard clauses, setpoint adoption, echo suppression, unit handling,
+clamping, heat-target sync, and control-queue triggering.
 """
 
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
 import pytest
 
+from custom_components.better_thermostat.climate import BetterThermostat
 from custom_components.better_thermostat.events.cooler import trigger_cooler_change
 
 ENTITY_ID = "climate.test_cooler"
@@ -25,17 +27,21 @@ def mock_bt():
     """Create a mock BetterThermostat instance with sensible defaults."""
     bt = MagicMock()
     bt.hass = MagicMock()
+    bt.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
     bt.device_name = "Test Thermostat"
     bt.bt_hvac_mode = HVACMode.HEAT_COOL
+    bt.hvac_mode = HVACMode.HEAT_COOL
     bt.bt_target_temp = 20.0
     bt.bt_target_cooltemp = 25.0
     bt.bt_target_temp_step = 0.5
     bt.bt_min_temp = 5.0
     bt.bt_max_temp = 30.0
+    bt.last_sent_cooler_temp = None
     bt.startup_running = False
     bt.control_queue_task = AsyncMock()
     bt.context = MagicMock()  # unique context so != event.context
     bt.async_write_ha_state = MagicMock()
+    bt._enforce_heat_below_cool = lambda: BetterThermostat._enforce_heat_below_cool(bt)
     return bt
 
 
@@ -265,6 +271,7 @@ class TestHeatTargetSync:
     async def test_heat_target_pushed_down_when_equal(self, mock_bt):
         """When cooltemp == heat target, heat target is pushed down by step."""
         mock_bt.bt_target_temp = 25.0
+        mock_bt.bt_target_cooltemp = 27.0
         old_state = _make_state(attributes={"temperature": 27.0})
         new_state = _make_state(attributes={"temperature": 25.0})
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
@@ -302,11 +309,10 @@ class TestHeatTargetSync:
 
     @pytest.mark.asyncio
     async def test_heat_target_sync_not_checked_below_min(self, mock_bt):
-        """Heat-target sync should still work correctly after clamping to min.
+        """Heat-target sync keeps the heat target inside the configured range.
 
-        If cooltemp is clamped to min (5.0), and heat target is >= 5.0,
-        heat target should be pushed down to 4.5. But 4.5 < bt_min_temp!
-        The code does NOT clamp the heat target — potential invariant violation.
+        With the cool target clamped to the minimum there is no room for a full
+        step below it, so the heat target stops at bt_min_temp.
         """
         mock_bt.bt_target_temp = 6.0
         mock_bt.bt_min_temp = 5.0
@@ -316,19 +322,14 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
-        # cooltemp clamped to 5.0, heat target >= cooltemp → pushed to 4.5
         assert mock_bt.bt_target_cooltemp == 5.0
-        # BUG: heat target pushed below min_temp without clamping
         assert mock_bt.bt_target_temp >= mock_bt.bt_min_temp
 
     @pytest.mark.asyncio
     async def test_heat_target_sync_with_zero_step(self, mock_bt):
-        """When step is 0, heat-target sync produces cooltemp - 0 = cooltemp.
-
-        This means heat target == cooltemp, which violates the invariant
-        that heat < cool. The >= check would trigger again next time.
-        """
+        """A zero step falls back to 0.5 so heat stays below cool."""
         mock_bt.bt_target_temp = 25.0
+        mock_bt.bt_target_cooltemp = 27.0
         mock_bt.bt_target_temp_step = 0.0
         old_state = _make_state(attributes={"temperature": 27.0})
         new_state = _make_state(attributes={"temperature": 25.0})
@@ -336,8 +337,6 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
-        # With step=0: bt_target_temp = cooltemp - 0 = cooltemp
-        # This should maintain heat < cool invariant
         assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
 
@@ -407,12 +406,11 @@ class TestEdgeCases:
     async def test_main_key_mismatch_old_has_temp_new_has_target_temp_high(
         self, mock_bt
     ):
-        """Key selection uses old_state only to pick the temperature attribute key.
+        """Each state picks its own attribute key.
 
-        If old has 'temperature' but new only has 'target_temp_high', the new
-        setpoint reads from the wrong key. The _main_key is determined from
-        old_state.attributes — if the cooler switches attribute schema between
-        events, new_state is read with the wrong key → None → no adoption.
+        A cooler that switches between single-setpoint and range attributes
+        between two events is read correctly, because the key is resolved per
+        state.
         """
         old_state = _make_state(attributes={"temperature": 25.0})
         # new_state has target_temp_high but NOT temperature
@@ -425,7 +423,166 @@ class TestEdgeCases:
 
         await trigger_cooler_change(mock_bt, event)
 
-        # _main_key is "temperature" (from old_state), but new_state has
-        # no "temperature" → convert_to_float("None") → None → no adoption
-        # The 28.0 setpoint is silently lost
         assert mock_bt.bt_target_cooltemp == 28.0
+
+
+# ---------------------------------------------------------------------------
+# 6. Echo suppression
+# ---------------------------------------------------------------------------
+
+
+class TestEchoSuppression:
+    """Only user input on the cooler is adopted, not BT's own writes."""
+
+    @pytest.mark.asyncio
+    async def test_unchanged_setpoint_is_not_re_adopted(self, mock_bt):
+        """A cooler update without a setpoint change runs no control cycle."""
+        old_state = _make_state(
+            attributes={"temperature": 25.0, "current_temperature": 26.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 25.0, "current_temperature": 26.1}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_echo_of_last_sent_setpoint_is_not_adopted(self, mock_bt):
+        """A write BT sent is not adopted when it returns with a foreign context.
+
+        Cloud and MQTT backed coolers publish the new setpoint from a later poll
+        or broker message whose context is not BT's, so the context check alone
+        does not catch it.
+        """
+        mock_bt.bt_target_cooltemp = 25.0
+        mock_bt.last_sent_cooler_temp = 22.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 22.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_device_rounding_of_own_write_is_not_adopted(self, mock_bt):
+        """A device rounding BT's write to its own grid is not user input."""
+        mock_bt.bt_target_cooltemp = 24.4
+        mock_bt.last_sent_cooler_temp = 24.4
+        old_state = _make_state(
+            attributes={"temperature": 26.0, "target_temp_step": 1.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 24.0, "target_temp_step": 1.0}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 24.4
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_user_change_of_one_full_step_is_adopted(self, mock_bt):
+        """A change of at least one device step is user input."""
+        mock_bt.bt_target_cooltemp = 24.0
+        mock_bt.last_sent_cooler_temp = 24.0
+        old_state = _make_state(
+            attributes={"temperature": 24.0, "target_temp_step": 1.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 25.0, "target_temp_step": 1.0}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        mock_bt.control_queue_task.put.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 7. Unit handling
+# ---------------------------------------------------------------------------
+
+
+class TestCoolerUnitHandling:
+    """Setpoints arrive in the system unit and are stored in °C."""
+
+    @pytest.mark.asyncio
+    async def test_fahrenheit_setpoint_is_converted_to_celsius(self, mock_bt):
+        """On a °F system the reported setpoint is converted, not taken as °C."""
+        mock_bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        mock_bt.bt_target_temp = 18.0
+        old_state = _make_state(attributes={"temperature": 75.0})
+        new_state = _make_state(attributes={"temperature": 68.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 20.0
+        mock_bt.control_queue_task.put.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fahrenheit_step_is_converted_to_a_celsius_delta(self, mock_bt):
+        """The device step is a °F delta on a °F system and must be scaled."""
+        mock_bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        mock_bt.bt_target_cooltemp = 21.11  # 70 °F
+        mock_bt.last_sent_cooler_temp = 21.11
+        old_state = _make_state(
+            attributes={"temperature": 70.0, "target_temp_step": 2.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 71.0, "target_temp_step": 2.0}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        # 1 °F is below the 2 °F device step, so this is a rounding echo.
+        assert mock_bt.bt_target_cooltemp == 21.11
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 8. Range mode
+# ---------------------------------------------------------------------------
+
+
+class TestRangeModeCooler:
+    """Coolers running in range mode publish an empty single setpoint."""
+
+    @pytest.mark.asyncio
+    async def test_empty_temperature_falls_back_to_target_temp_high(self, mock_bt):
+        """A present-but-empty 'temperature' does not hide 'target_temp_high'."""
+        old_state = State(
+            ENTITY_ID,
+            "heat_cool",
+            attributes={
+                "temperature": None,
+                "target_temp_high": 24.0,
+                "target_temp_low": 19.0,
+            },
+        )
+        new_state = State(
+            ENTITY_ID,
+            "heat_cool",
+            attributes={
+                "temperature": None,
+                "target_temp_high": 26.0,
+                "target_temp_low": 19.0,
+            },
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 26.0
+        mock_bt.control_queue_task.put.assert_awaited_once()

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -308,7 +308,7 @@ class TestHeatTargetSync:
         assert mock_bt.bt_target_temp == 20.0  # unchanged
 
     @pytest.mark.asyncio
-    async def test_heat_target_sync_not_checked_below_min(self, mock_bt):
+    async def test_heat_target_sync_respects_min_temp(self, mock_bt):
         """Heat-target sync keeps the heat target inside the configured range.
 
         With the cool target clamped to the minimum there is no room for a full
@@ -403,9 +403,7 @@ class TestEdgeCases:
         mock_bt.control_queue_task.put.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_main_key_mismatch_old_has_temp_new_has_target_temp_high(
-        self, mock_bt
-    ):
+    async def test_setpoint_key_is_resolved_per_state(self, mock_bt):
         """Each state picks its own attribute key.
 
         A cooler that switches between single-setpoint and range attributes
@@ -540,15 +538,16 @@ class TestCoolerUnitHandling:
             attributes={"temperature": 70.0, "target_temp_step": 2.0}
         )
         new_state = _make_state(
-            attributes={"temperature": 71.0, "target_temp_step": 2.0}
+            attributes={"temperature": 73.0, "target_temp_step": 2.0}
         )
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
 
         await trigger_cooler_change(mock_bt, event)
 
-        # 1 °F is below the 2 °F device step, so this is a rounding echo.
-        assert mock_bt.bt_target_cooltemp == 21.11
-        mock_bt.control_queue_task.put.assert_not_awaited()
+        # 3 °F is 1.67 K, above the converted step of 1.11 K and below the
+        # 2.0 the raw attribute would give, so only a converted step adopts it.
+        assert mock_bt.bt_target_cooltemp == 22.78
+        mock_bt.control_queue_task.put.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation:

`trigger_cooler_change()` adopts any setpoint the cooler entity reports as the user's cooling target. The only protection against adopting BT's own writes is a context comparison, and the value is read without unit conversion. The TRV path has grown four guards over time; the cooler path has one. Four defects follow from that.

On a °F system the setpoint is stored as if it were °C. `_get_cooling_setpoint()` used `convert_to_float()` on the raw attribute, but climate entities publish temperatures in the system unit, so 72 °F became 72 °C and was then clamped to `bt_max_temp`, dragging the heating target down with it. `control_cooler()` and the startup path already convert through `attr_to_celsius()`.

BT also adopts its own writes. `self.context` catches the immediate echo, but cloud and MQTT backed coolers publish the new setpoint from a later poll or broker message that carries its own context. BT then takes its own value, rounded to the device grid, as user intent, and `bt_target_temp` follows it down. That is the mechanism behind the report in #2144; the driver setpoint described there does not exist in this code base.

Every cooler update runs a control cycle. The adoption block ran whenever both states carried a setpoint, so each `current_temperature` report from the AC re-assigned the cooling target and enqueued a full cycle including all TRV writes.

A cooler in range mode is never adopted at all. Such a device publishes `temperature: None` while it drives the range, and the key loop returned on the first present key, so the `target_temp_high` fallback was never reached.

## Changes:

- setpoints are read through `attr_to_celsius()`
- adoption is skipped when the reported value is within one device step of `bt_target_cooltemp` or `last_sent_cooler_temp`, mirroring the step-aware echo detection in `events/trv.py`; the step is read from the cooler and scaled when the system runs in °F
- an empty `temperature` attribute no longer hides `target_temp_high`
- the heat/cool ordering rule moved from open code into `_enforce_heat_below_cool()` in `climate.py`, the counterpart to the existing `_enforce_cool_above_heat()`: same HEAT_COOL gating, same step fallback, and the heating target is clamped to `bt_min_temp` instead of being pushed below it
- the debug line carries the values the decision was made on

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [ ] There is no related issue ticket

Addresses the symptom reported in #2144. Deliberately no `fixes` keyword: that issue stays open until the reporter confirms which integration provides their cooler entity.

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

No physical hardware. Verified against the test suite on Home Assistant 2026.7.2 / Python 3.14.5: 2150 tests pass, including new cases for echo suppression, °F handling and range-mode coolers in `tests/unit/test_cooler_events.py` and `TestEnforceHeatBelowCool` in `tests/unit/test_climate_baseline.py`.

HA Version: 2026.7.2
Zigbee2MQTT Version: n/a
TRV Hardware: n/a (cooler path)

## New device mappings

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

No device mapping is added. `climate.py` is touched for one reason: `_enforce_heat_below_cool()` is the counterpart to `_enforce_cool_above_heat()` and belongs next to it. Splitting it into its own PR would leave the cooler handler calling a method that does not exist yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heat/cool target coordination to always maintain a valid gap in HEAT_COOL mode.
  * Cooling setpoints now parse correctly across standard and range-based inputs and respect missing temperature attributes.
  * Added echo suppression to avoid re-adopting near-identical cooler updates.
  * Clamp out-of-range cooling targets with warnings, and sync heat targets to minimum limits.
  * Improved Fahrenheit handling and step fallback behavior.
* **Tests**
  * Expanded unit coverage for heat/cool ordering, unit conversion, echo suppression, range mode adoption, and clamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->