### PR TITLE
fix(cooler): write the payload a range-only cooler accepts

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2822,6 +2822,34 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         )
         self.bt_target_cooltemp = adjusted
 
+    def _enforce_heat_below_cool(self) -> None:
+        """Keep the heating target strictly below the cooling target.
+
+        The counterpart to :meth:`_enforce_cool_above_heat`, for the case where
+        the cooling target is the value that was just set: the heating target
+        yields instead, down to one temperature step below the cooling target
+        and never below the configured minimum.
+        """
+        if (
+            self.hvac_mode != HVACMode.HEAT_COOL
+            or self.bt_target_cooltemp is None
+            or self.bt_target_temp is None
+            or self.bt_target_temp < self.bt_target_cooltemp
+        ):
+            return
+        step = self.bt_target_temp_step or 0.5
+        adjusted = self.bt_target_cooltemp - step
+        if self.bt_min_temp is not None:
+            adjusted = max(adjusted, self.bt_min_temp)
+        _LOGGER.warning(
+            "better_thermostat %s: heating target %.2f adjusted to %.2f to stay below cooling target %.2f",
+            self.device_name,
+            self.bt_target_temp,
+            adjusted,
+            self.bt_target_cooltemp,
+        )
+        self.bt_target_temp = adjusted
+
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         _LOGGER.debug(

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -13,28 +13,12 @@ from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State, callback
 
 from custom_components.better_thermostat.utils.helpers import (
-    attr_to_celsius,
     convert_to_float,
+    get_cooler_setpoint,
     state_temperature_unit,
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _get_cooling_setpoint(self, state: State) -> float | None:
-    """Read the cooler's setpoint from a state and return it in °C.
-
-    A climate entity that supports both a single target and a target range
-    publishes ``temperature`` as None while it runs in range mode, so a
-    present-but-empty attribute must not stop the range key from being read.
-    """
-    for key in ("temperature", "target_temp_high"):
-        if state.attributes.get(key) is None:
-            continue
-        setpoint = attr_to_celsius(self, state, key, None, "trigger_cooler_change()")
-        if setpoint is not None:
-            return setpoint
-    return None
 
 
 def _get_cooler_step(self, state: State) -> float:
@@ -105,8 +89,12 @@ async def trigger_cooler_change(self, event):
         "better_thermostat %s: Cooler %s update received", self.device_name, entity_id
     )
 
-    _old_cooling_setpoint = _get_cooling_setpoint(self, old_state)
-    _new_cooling_setpoint = _get_cooling_setpoint(self, new_state)
+    _old_cooling_setpoint = get_cooler_setpoint(
+        self, old_state, "trigger_cooler_change()"
+    )
+    _new_cooling_setpoint = get_cooler_setpoint(
+        self, new_state, "trigger_cooler_change()"
+    )
     if (
         _new_cooling_setpoint is not None
         and _old_cooling_setpoint is not None

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -9,11 +9,54 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State, callback
 
-from custom_components.better_thermostat.utils.helpers import convert_to_float
+from custom_components.better_thermostat.utils.helpers import (
+    attr_to_celsius,
+    convert_to_float,
+    state_temperature_unit,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _get_cooling_setpoint(self, state: State) -> float | None:
+    """Read the cooler's setpoint from a state and return it in °C.
+
+    A climate entity that supports both a single target and a target range
+    publishes ``temperature`` as None while it runs in range mode, so a
+    present-but-empty attribute must not stop the range key from being read.
+    """
+    for key in ("temperature", "target_temp_high"):
+        if state.attributes.get(key) is None:
+            continue
+        setpoint = attr_to_celsius(self, state, key, None, "trigger_cooler_change()")
+        if setpoint is not None:
+            return setpoint
+    return None
+
+
+def _get_cooler_step(self, state: State) -> float:
+    """Return the cooler's setpoint step as a °C delta."""
+    raw_step = state.attributes.get("target_temp_step")
+    step = (
+        convert_to_float(str(raw_step), self.device_name, "trigger_cooler_change()")
+        if raw_step is not None
+        else None
+    )
+    if (
+        step is not None
+        and state_temperature_unit(
+            state.attributes, self.hass.config.units.temperature_unit
+        )
+        == UnitOfTemperature.FAHRENHEIT
+    ):
+        step = round(step * 5.0 / 9.0, 4)
+    if step is None or step <= 0:
+        fallback = self.bt_target_temp_step
+        step = fallback if isinstance(fallback, (int, float)) and fallback > 0 else 0.5
+    return float(step)
 
 
 @callback
@@ -62,54 +105,57 @@ async def trigger_cooler_change(self, event):
         "better_thermostat %s: Cooler %s update received", self.device_name, entity_id
     )
 
-    def _get_cooling_setpoint(state):
-        """Extract cooling setpoint from state, checking both attribute keys."""
-        for key in ("temperature", "target_temp_high"):
-            if key in state.attributes:
-                return convert_to_float(
-                    str(state.attributes[key]),
-                    self.device_name,
-                    "trigger_cooler_change()",
-                )
-        return None
-
-    _old_cooling_setpoint = _get_cooling_setpoint(old_state)
-    _new_cooling_setpoint = _get_cooling_setpoint(new_state)
+    _old_cooling_setpoint = _get_cooling_setpoint(self, old_state)
+    _new_cooling_setpoint = _get_cooling_setpoint(self, new_state)
     if (
         _new_cooling_setpoint is not None
         and _old_cooling_setpoint is not None
         and self.bt_hvac_mode != HVACMode.OFF
     ):
+        _step = _get_cooler_step(self, new_state)
+        # Adopt only what a user set on the cooler itself. A value within one
+        # step of a setpoint BT wrote is the device reporting our own write
+        # back: rounded to its own grid, or delayed until a poll that carries a
+        # foreign context and therefore passes the context check above. User
+        # input moves the setpoint by at least one step.
+        _bt_known_values = (self.bt_target_cooltemp, self.last_sent_cooler_temp)
+        _is_echo = any(
+            isinstance(value, (int, float))
+            and abs(_new_cooling_setpoint - value) < _step
+            for value in _bt_known_values
+        )
         _LOGGER.debug(
             "better_thermostat %s: trigger_cooler_change / "
-            "_old_cooling_setpoint: %s - _new_cooling_setpoint: %s",
+            "_old_cooling_setpoint: %s - _new_cooling_setpoint: %s - "
+            "bt_target_cooltemp: %s - last_sent: %s - step: %s - echo: %s",
             self.device_name,
             _old_cooling_setpoint,
             _new_cooling_setpoint,
+            self.bt_target_cooltemp,
+            self.last_sent_cooler_temp,
+            _step,
+            _is_echo,
         )
-        if (
-            _new_cooling_setpoint < self.bt_min_temp
-            or self.bt_max_temp < _new_cooling_setpoint
-        ):
-            _LOGGER.warning(
-                "better_thermostat %s: New Cooler %s setpoint outside of range, "
-                "overwriting it",
-                self.device_name,
-                entity_id,
-            )
+        if not _is_echo:
+            if (
+                _new_cooling_setpoint < self.bt_min_temp
+                or self.bt_max_temp < _new_cooling_setpoint
+            ):
+                _LOGGER.warning(
+                    "better_thermostat %s: New Cooler %s setpoint outside of range, "
+                    "overwriting it",
+                    self.device_name,
+                    entity_id,
+                )
 
-            if _new_cooling_setpoint < self.bt_min_temp:
-                _new_cooling_setpoint = self.bt_min_temp
-            else:
-                _new_cooling_setpoint = self.bt_max_temp
+                if _new_cooling_setpoint < self.bt_min_temp:
+                    _new_cooling_setpoint = self.bt_min_temp
+                else:
+                    _new_cooling_setpoint = self.bt_max_temp
 
-        self.bt_target_cooltemp = _new_cooling_setpoint
-        if self.bt_target_temp >= self.bt_target_cooltemp:
-            self.bt_target_temp = max(
-                self.bt_target_cooltemp - max(self.bt_target_temp_step or 0.5, 0.5),
-                self.bt_min_temp,
-            )
-        _main_change = True
+            self.bt_target_cooltemp = _new_cooling_setpoint
+            self._enforce_heat_below_cool()
+            _main_change = True
 
     if _main_change is True:
         self.async_write_ha_state()

--- a/custom_components/better_thermostat/model_fixes/BTH-RM.py
+++ b/custom_components/better_thermostat/model_fixes/BTH-RM.py
@@ -10,7 +10,7 @@ import logging
 
 from custom_components.better_thermostat.utils.helpers import (
     celsius_to_system_temperature,
-    trv_supports_temperature_range,
+    supports_temperature_range,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -85,7 +85,7 @@ async def override_set_temperature(self, entity_id, temperature):
         )
         return True
 
-    _supports_range = trv_supports_temperature_range(state)
+    _supports_range = supports_temperature_range(state)
 
     _LOGGER.debug(
         f"better_thermostat {self.device_name}: TRV {entity_id} device quirk bth-rm "

--- a/custom_components/better_thermostat/model_fixes/BTH-RM230Z.py
+++ b/custom_components/better_thermostat/model_fixes/BTH-RM230Z.py
@@ -10,7 +10,7 @@ import logging
 
 from custom_components.better_thermostat.utils.helpers import (
     celsius_to_system_temperature,
-    trv_supports_temperature_range,
+    supports_temperature_range,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -88,7 +88,7 @@ async def override_set_temperature(self, entity_id, temperature):
         )
         return True
 
-    _supports_range = trv_supports_temperature_range(state)
+    _supports_range = supports_temperature_range(state)
 
     _LOGGER.debug(
         "better_thermostat %s: TRV %s device quirk bth-rm230z "

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -28,6 +28,7 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.helpers import (
+    attr_to_celsius,
     convert_to_float,
     get_cooler_setpoint,
     get_current_set_temperatures,
@@ -285,7 +286,7 @@ async def control_cooler(self):
 
     # A cooler that only advertises the range feature rejects a "temperature"
     # payload with a ServiceValidationError, so it never receives a setpoint.
-    # Devices that advertise neither bit keep the single-setpoint payload.
+    # Devices that advertise neither bit use the single-setpoint payload.
     _write_range = not supports_single_target_temperature(
         cooler_state
     ) and trv_supports_temperature_range(cooler_state)
@@ -295,6 +296,18 @@ async def control_cooler(self):
 
     # Determine desired state based on current conditions
     desired_temp = self.bt_target_cooltemp
+
+    # A range write needs both bounds, and Home Assistant rejects a low bound
+    # above the high one. The heating target is the natural lower bound; it can
+    # only exceed the cooling target while the two are out of sync, so it is
+    # capped at the value being written.
+    _low_to_set = desired_temp
+    if (
+        _write_range
+        and desired_temp is not None
+        and isinstance(self.bt_target_temp, (int, float))
+    ):
+        _low_to_set = min(float(self.bt_target_temp), desired_temp)
 
     if any(
         v is None
@@ -352,6 +365,29 @@ async def control_cooler(self):
     elif current_temp != desired_temp:
         should_send_temp = True
 
+    # A range write carries both bounds, so a lower bound that drifted away
+    # from the heating target needs a send of its own: the cooling target can
+    # stay unchanged for as long as the user only moves the heating side.
+    if _write_range and desired_temp is not None and not should_send_temp:
+        current_low = attr_to_celsius(
+            self, cooler_state, "target_temp_low", None, "control_cooler()"
+        )
+        # The reported bound comes back on convert_to_float's 0.01 grid while
+        # _low_to_set is BT's raw value, so the two are compared with the same
+        # tolerance the TRV write-skip check uses.
+        if current_low is not None and not matches_any_setpoint(
+            current_low, {_low_to_set}
+        ):
+            _LOGGER.debug(
+                "better_thermostat %s: cooler %s lower bound %s differs from %s, "
+                "sending both bounds",
+                self.device_name,
+                self.cooler_entity_id,
+                current_low,
+                _low_to_set,
+            )
+            should_send_temp = True
+
     # Throttle identical resends when the state feedback lags behind.
     if (
         should_send_temp
@@ -378,13 +414,6 @@ async def control_cooler(self):
             desired_temp,
         )
         _temp_to_set = desired_temp
-        # A range write needs both bounds, and Home Assistant rejects a low
-        # bound above the high one. The heating target is the natural lower
-        # bound; it can only exceed the cooling target while the two are out
-        # of sync, so it is capped at the value being written.
-        _low_to_set = desired_temp
-        if _write_range and isinstance(self.bt_target_temp, (int, float)):
-            _low_to_set = min(float(self.bt_target_temp), desired_temp)
         if self.hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             _temp_to_set = round(
                 TemperatureConverter.convert(

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -28,11 +28,13 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.helpers import (
+    SETPOINT_MATCH_TOLERANCE,
     attr_to_celsius,
     convert_to_float,
     get_cooler_setpoint,
     get_current_set_temperatures,
     matches_any_setpoint,
+    state_temperature_unit,
     supports_single_target_temperature,
     supports_temperature_range,
 )
@@ -261,6 +263,33 @@ async def control_queue(self):
             self.ignore_states = False
 
 
+def _device_setpoint_tolerance(self, state) -> float:
+    """Return the tolerance for comparing a commanded setpoint to a reported one.
+
+    A device snaps a written setpoint onto its own step grid, so a snapped
+    value sits at most half a step away from the value that was commanded.
+    SETPOINT_MATCH_TOLERANCE is the floor: it covers the read-back grid for
+    devices that report no usable step.
+    """
+    raw_step = state.attributes.get("target_temp_step")
+    step = (
+        convert_to_float(str(raw_step), self.device_name, "control_cooler()")
+        if raw_step is not None
+        else None
+    )
+    if step is None or step <= 0:
+        return SETPOINT_MATCH_TOLERANCE
+    if (
+        state_temperature_unit(
+            state.attributes, self.hass.config.units.temperature_unit
+        )
+        == UnitOfTemperature.FAHRENHEIT
+    ):
+        step = round(step * 5.0 / 9.0, 4)
+    # Slack against float noise when the difference is exactly half a step.
+    return max(SETPOINT_MATCH_TOLERANCE, step / 2.0 + 1e-6)
+
+
 async def control_cooler(self):
     """Control the cooler entity based on current temperature and cooling setpoint.
 
@@ -350,9 +379,11 @@ async def control_cooler(self):
     # Decide whether a temperature command is needed. When the current
     # temperature is unknown, only send if the desired value changed since the
     # last successful command; otherwise send when it differs from current.
-    # The reported value comes back on convert_to_float's 0.01 grid, and on a
-    # Fahrenheit system through a unit conversion on top, so it is compared
-    # with the same tolerance as the lower bound below.
+    # The reported value comes back on convert_to_float's 0.01 grid, on a
+    # Fahrenheit system through a unit conversion on top, and snapped onto the
+    # device's own step grid, so both bounds are compared with the tolerance
+    # that grid allows.
+    _match_tolerance = _device_setpoint_tolerance(self, cooler_state)
     temp_changed_since_last_send = self.last_sent_cooler_temp != desired_temp
     should_send_temp = False
     if desired_temp is None:
@@ -372,21 +403,22 @@ async def control_cooler(self):
                 self.cooler_entity_id,
                 desired_temp,
             )
-    elif not matches_any_setpoint(current_temp, {desired_temp}):
+    elif not matches_any_setpoint(current_temp, {desired_temp}, _match_tolerance):
         should_send_temp = True
 
     # A range write carries both bounds, so a lower bound that drifted away
     # from the heating target needs a send of its own: the cooling target can
     # stay unchanged for as long as the user only moves the heating side.
+    _low_bound_drifted = False
     if _write_range and desired_temp is not None and not should_send_temp:
         current_low = attr_to_celsius(
             self, cooler_state, "target_temp_low", None, "control_cooler()"
         )
-        # The reported bound comes back on convert_to_float's 0.01 grid while
-        # _low_to_set is BT's raw value, so the two are compared with the same
-        # tolerance the TRV write-skip check uses.
+        # The reported bound comes back on the device's grid while _low_to_set
+        # is BT's raw value, so the two are compared with the same tolerance
+        # the upper bound uses.
         if current_low is not None and not matches_any_setpoint(
-            current_low, {_low_to_set}
+            current_low, {_low_to_set}, _match_tolerance
         ):
             _LOGGER.debug(
                 "better_thermostat %s: cooler %s lower bound %s differs from %s, "
@@ -397,12 +429,17 @@ async def control_cooler(self):
                 _low_to_set,
             )
             should_send_temp = True
+            _low_bound_drifted = True
 
     # Throttle identical resends when the state feedback lags behind.
+    # last_sent_cooler_temp tracks the upper bound alone, so a send armed by
+    # the lower bound carries a payload that was never written before and is
+    # not a resend.
     if (
         should_send_temp
         and min_resend_interval_s > 0
         and not temp_changed_since_last_send
+        and not _low_bound_drifted
     ):
         last_temp_ts = self.last_sent_cooler_temp_ts
         if last_temp_ts is not None and (now_ts - last_temp_ts) < min_resend_interval_s:

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -287,9 +287,16 @@ async def control_cooler(self):
     # A cooler that only advertises the range feature rejects a "temperature"
     # payload with a ServiceValidationError, so it never receives a setpoint.
     # Devices that advertise neither bit use the single-setpoint payload.
-    _write_range = not supports_single_target_temperature(
-        cooler_state
-    ) and supports_temperature_range(cooler_state)
+    # A cooler advertising both publishes the channel it does not drive as
+    # None, so the write follows the channel the reading came from: writing
+    # the other one leaves the two sides permanently out of sync.
+    _write_range = supports_temperature_range(cooler_state) and (
+        not supports_single_target_temperature(cooler_state)
+        or (
+            cooler_state.attributes.get("temperature") is None
+            and cooler_state.attributes.get("target_temp_high") is not None
+        )
+    )
 
     min_resend_interval_s = self.min_cooler_resend_interval_s
     now_ts = monotonic()

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -343,6 +343,9 @@ async def control_cooler(self):
     # Decide whether a temperature command is needed. When the current
     # temperature is unknown, only send if the desired value changed since the
     # last successful command; otherwise send when it differs from current.
+    # The reported value comes back on convert_to_float's 0.01 grid, and on a
+    # Fahrenheit system through a unit conversion on top, so it is compared
+    # with the same tolerance as the lower bound below.
     temp_changed_since_last_send = self.last_sent_cooler_temp != desired_temp
     should_send_temp = False
     if desired_temp is None:
@@ -362,7 +365,7 @@ async def control_cooler(self):
                 self.cooler_entity_id,
                 desired_temp,
             )
-    elif current_temp != desired_temp:
+    elif not matches_any_setpoint(current_temp, {desired_temp}):
         should_send_temp = True
 
     # A range write carries both bounds, so a lower bound that drifted away

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -28,10 +28,12 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.helpers import (
-    attr_to_celsius,
     convert_to_float,
+    get_cooler_setpoint,
     get_current_set_temperatures,
     matches_any_setpoint,
+    supports_single_target_temperature,
+    trv_supports_temperature_range,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -279,9 +281,14 @@ async def control_cooler(self):
     # Resolve the cooler's reported setpoint to Celsius before comparing it
     # against the Celsius desired value; on a Fahrenheit system the raw
     # attribute would never match and defeat the redundant-send dedup.
-    current_temp = attr_to_celsius(
-        self, cooler_state, "temperature", None, "control_cooler()"
-    )
+    current_temp = get_cooler_setpoint(self, cooler_state, "control_cooler()")
+
+    # A cooler that only advertises the range feature rejects a "temperature"
+    # payload with a ServiceValidationError, so it never receives a setpoint.
+    # Devices that advertise neither bit keep the single-setpoint payload.
+    _write_range = not supports_single_target_temperature(
+        cooler_state
+    ) and trv_supports_temperature_range(cooler_state)
 
     min_resend_interval_s = self.min_cooler_resend_interval_s
     now_ts = monotonic()
@@ -371,18 +378,43 @@ async def control_cooler(self):
             desired_temp,
         )
         _temp_to_set = desired_temp
+        # A range write needs both bounds, and Home Assistant rejects a low
+        # bound above the high one. The heating target is the natural lower
+        # bound; it can only exceed the cooling target while the two are out
+        # of sync, so it is capped at the value being written.
+        _low_to_set = desired_temp
+        if _write_range and isinstance(self.bt_target_temp, (int, float)):
+            _low_to_set = min(float(self.bt_target_temp), desired_temp)
         if self.hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
-            _temp_to_set = TemperatureConverter.convert(
-                desired_temp, UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT
+            _temp_to_set = round(
+                TemperatureConverter.convert(
+                    desired_temp,
+                    UnitOfTemperature.CELSIUS,
+                    UnitOfTemperature.FAHRENHEIT,
+                ),
+                1,
             )
-            _temp_to_set = round(_temp_to_set, 1)
+            _low_to_set = round(
+                TemperatureConverter.convert(
+                    _low_to_set, UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT
+                ),
+                1,
+            )
+        if _write_range:
+            _payload = {
+                "entity_id": self.cooler_entity_id,
+                "target_temp_high": _temp_to_set,
+                "target_temp_low": _low_to_set,
+            }
+        else:
+            _payload = {"entity_id": self.cooler_entity_id, "temperature": _temp_to_set}
         # Only prime the send-cache on success. A failed call must not look like
         # a completed send, otherwise the nil-guard would suppress the retry.
         try:
             await self.hass.services.async_call(
                 "climate",
                 "set_temperature",
-                {"entity_id": self.cooler_entity_id, "temperature": _temp_to_set},
+                _payload,
                 blocking=True,
                 context=self.context,
             )

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -34,7 +34,7 @@ from custom_components.better_thermostat.utils.helpers import (
     get_current_set_temperatures,
     matches_any_setpoint,
     supports_single_target_temperature,
-    trv_supports_temperature_range,
+    supports_temperature_range,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -289,7 +289,7 @@ async def control_cooler(self):
     # Devices that advertise neither bit use the single-setpoint payload.
     _write_range = not supports_single_target_temperature(
         cooler_state
-    ) and trv_supports_temperature_range(cooler_state)
+    ) and supports_temperature_range(cooler_state)
 
     min_resend_interval_s = self.min_cooler_resend_interval_s
     now_ts = monotonic()

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -582,6 +582,64 @@ def trv_supports_temperature_range(state: State | None) -> bool:
     return bool(supported_features & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE)
 
 
+def supports_single_target_temperature(state: State | None) -> bool:
+    """Check whether a climate state advertises TARGET_TEMPERATURE.
+
+    The counterpart to :func:`trv_supports_temperature_range`. Home Assistant
+    rejects a ``set_temperature`` call carrying ``temperature`` when the entity
+    does not advertise this feature, so write paths need both bits to pick the
+    payload a device accepts.
+
+    Parameters
+    ----------
+    state : State | None
+            the climate entity state to inspect
+
+    Returns
+    -------
+    bool
+            True if the single-setpoint feature bit is set, False otherwise
+            (including when state is None)
+    """
+    if state is None:
+        return False
+    supported_features = state.attributes.get("supported_features", 0)
+    return bool(supported_features & ClimateEntityFeature.TARGET_TEMPERATURE)
+
+
+def get_cooler_setpoint(self, state: State | None, log_source: str) -> float | None:
+    """Read the cooler's setpoint from a state and return it in °C.
+
+    A climate entity that supports both a single target and a target range
+    publishes ``temperature`` as None while it runs in range mode, so a
+    present-but-empty attribute must not stop the range key from being read.
+
+    Parameters
+    ----------
+    self :
+            the Better Thermostat instance, supplying ``hass`` and ``device_name``
+    state : State | None
+            the cooler entity state to inspect, or None when unavailable
+    log_source : str
+            caller name, forwarded to attr_to_celsius for logging context
+
+    Returns
+    -------
+    float | None
+            the cooling setpoint in Celsius, or None when neither key holds a
+            usable value
+    """
+    if state is None:
+        return None
+    for key in ("temperature", "target_temp_high"):
+        if state.attributes.get(key) is None:
+            continue
+        setpoint = attr_to_celsius(self, state, key, None, log_source)
+        if setpoint is not None:
+            return setpoint
+    return None
+
+
 def attr_to_celsius(
     self,
     state: State | None,

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -557,7 +557,7 @@ def celsius_to_system_temperature(hass: HomeAssistant, temperature: float) -> fl
     return temperature
 
 
-def trv_supports_temperature_range(state: State | None) -> bool:
+def supports_temperature_range(state: State | None) -> bool:
     """Check whether a climate state advertises TARGET_TEMPERATURE_RANGE.
 
     Centralizes the supported_features bitmask check so write paths
@@ -585,7 +585,7 @@ def trv_supports_temperature_range(state: State | None) -> bool:
 def supports_single_target_temperature(state: State | None) -> bool:
     """Check whether a climate state advertises TARGET_TEMPERATURE.
 
-    The counterpart to :func:`trv_supports_temperature_range`. Home Assistant
+    The counterpart to :func:`supports_temperature_range`. Home Assistant
     rejects a ``set_temperature`` call carrying ``temperature`` when the entity
     does not advertise this feature, so write paths need both bits to pick the
     payload a device accepts.
@@ -722,7 +722,7 @@ def get_current_set_temperatures(
     single = attr_to_celsius(self, state, "temperature", None, log_source)
     range_low = (
         attr_to_celsius(self, state, "target_temp_low", None, log_source)
-        if trv_supports_temperature_range(state)
+        if supports_temperature_range(state)
         else None
     )
     return {v for v in (single, range_low) if v is not None}

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -460,22 +460,30 @@ class TestControlCoolerFahrenheit:
         assert "set_temperature" not in service_names
 
 
+_ATTRIBUTE_ABSENT = object()
+
+
 def _make_range_cooler_state(
     state=HVACMode.COOL,
     target_temp_high=None,
     target_temp_low=None,
     supported_features=ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
+    temperature=_ATTRIBUTE_ABSENT,
 ):
-    """Build a cooler State that advertises a target range."""
-    return State(
-        "climate.cooler",
-        str(state),
-        {
-            "target_temp_high": target_temp_high,
-            "target_temp_low": target_temp_low,
-            "supported_features": int(supported_features),
-        },
-    )
+    """Build a cooler State that advertises a target range.
+
+    ``temperature`` defaults to an absent attribute; pass None to model a
+    dual-feature cooler running in range mode and a value to model one
+    driving its single setpoint.
+    """
+    attributes = {
+        "target_temp_high": target_temp_high,
+        "target_temp_low": target_temp_low,
+        "supported_features": int(supported_features),
+    }
+    if temperature is not _ATTRIBUTE_ABSENT:
+        attributes["temperature"] = temperature
+    return State("climate.cooler", str(state), attributes)
 
 
 class TestControlCoolerTargetRange:
@@ -540,11 +548,12 @@ class TestControlCoolerTargetRange:
 
     @pytest.mark.asyncio
     async def test_cooler_supporting_both_features_keeps_single_setpoint(self):
-        """A cooler that also accepts "temperature" gets the single payload."""
+        """A dual-feature cooler driving "temperature" gets the single payload."""
         mock_hass = self._hass()
         mock_hass.states.get.return_value = _make_range_cooler_state(
-            target_temp_high=28.0,
-            target_temp_low=19.0,
+            temperature=28.0,
+            target_temp_high=None,
+            target_temp_low=None,
             supported_features=ClimateEntityFeature.TARGET_TEMPERATURE
             | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
         )
@@ -555,6 +564,36 @@ class TestControlCoolerTargetRange:
 
         payload = self._set_temperature_payload(mock_hass)
         assert payload == {"entity_id": "climate.cooler", "temperature": 24.0}
+
+    @pytest.mark.asyncio
+    async def test_cooler_supporting_both_features_in_range_mode_gets_both_bounds(self):
+        """A dual-feature cooler in range mode is written via both bounds.
+
+        It publishes the channel it does not drive as None, so the setpoint is
+        read from target_temp_high and the write has to follow that channel;
+        writing "temperature" leaves the two sides permanently out of sync.
+        """
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            temperature=None,
+            target_temp_high=28.0,
+            target_temp_low=19.0,
+            supported_features=ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload == {
+            "entity_id": "climate.cooler",
+            "target_temp_high": 24.0,
+            "target_temp_low": 20.0,
+        }
 
     @pytest.mark.asyncio
     async def test_cooler_without_feature_flags_keeps_single_setpoint(self):

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -511,7 +511,7 @@ class TestControlCoolerTargetRange:
 
     @pytest.mark.asyncio
     async def test_cooler_supporting_both_features_keeps_single_setpoint(self):
-        """A cooler that also accepts "temperature" keeps the single payload."""
+        """A cooler that also accepts "temperature" gets the single payload."""
         mock_hass = self._hass()
         mock_hass.states.get.return_value = _make_range_cooler_state(
             target_temp_high=28.0,
@@ -529,7 +529,7 @@ class TestControlCoolerTargetRange:
 
     @pytest.mark.asyncio
     async def test_cooler_without_feature_flags_keeps_single_setpoint(self):
-        """Without advertised features the established payload is used."""
+        """Without advertised features the single-setpoint payload is used."""
         mock_hass = self._hass()
         mock_hass.states.get.return_value = _make_cooler_state(temperature=28.0)
 
@@ -564,6 +564,85 @@ class TestControlCoolerTargetRange:
         mock_hass = self._hass()
         mock_hass.states.get.return_value = _make_range_cooler_state(
             target_temp_high=24.0, target_temp_low=20.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        assert self._set_temperature_payload(mock_hass) is None
+
+    @pytest.mark.asyncio
+    async def test_changed_lower_bound_alone_triggers_a_send(self):
+        """A heating target that moved is written even when cooling is unchanged.
+
+        Both bounds travel in one call, so a lower bound left behind on the
+        device would persist until the cooling target happens to change.
+        """
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=24.0, target_temp_low=19.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=21.0
+        )
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload == {
+            "entity_id": "climate.cooler",
+            "target_temp_high": 24.0,
+            "target_temp_low": 21.0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_matching_bounds_are_not_resent(self):
+        """Both bounds in sync means nothing is written."""
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=24.0, target_temp_low=20.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        assert self._set_temperature_payload(mock_hass) is None
+
+    @pytest.mark.asyncio
+    async def test_lower_bound_within_read_tolerance_is_not_resent(self):
+        """A bound that only differs by the read-back grid is unchanged.
+
+        The device reports on convert_to_float's 0.01 grid while BT holds the
+        raw value, so exact inequality would resend on every cycle.
+        """
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=24.0, target_temp_low=20.005
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        assert self._set_temperature_payload(mock_hass) is None
+
+    @pytest.mark.asyncio
+    async def test_lower_bound_is_ignored_for_single_setpoint_coolers(self):
+        """A single-setpoint cooler has no lower bound to keep in sync."""
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = State(
+            "climate.cooler",
+            str(HVACMode.COOL),
+            {"temperature": 24.0, "target_temp_low": 15.0},
         )
 
         mock_self = _make_mock_self(

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -44,9 +44,12 @@ def _make_mock_self(
     return mock_self
 
 
-def _make_cooler_state(state=HVACMode.COOL, temperature=None):
+def _make_cooler_state(state=HVACMode.COOL, temperature=None, target_temp_step=None):
     """Build a Home Assistant State for the cooler entity in control_cooler tests."""
-    return State("climate.cooler", str(state), {"temperature": temperature})
+    attributes = {"temperature": temperature}
+    if target_temp_step is not None:
+        attributes["target_temp_step"] = target_temp_step
+    return State("climate.cooler", str(state), attributes)
 
 
 class TestControlCooler:
@@ -431,18 +434,19 @@ class TestControlCoolerFahrenheit:
         assert "set_temperature" not in service_names
 
     @pytest.mark.asyncio
-    async def test_reported_temp_within_read_tolerance_is_not_resent(self):
-        """A setpoint that only differs by the read-back grid is unchanged.
+    async def test_reported_temp_within_the_device_step_is_not_resent(self):
+        """A setpoint snapped onto the device's °F step is unchanged.
 
-        The device reports on convert_to_float's 0.01 grid while BT holds the
-        raw value, so exact inequality would resend on every cycle.
+        The device step is a °F interval, so it is worth 0.56 K: 75 °F is
+        23.89 °C, which is the grid position the commanded 24.0 °C snaps to
+        and not a setpoint of its own.
         """
         mock_hass = Mock()
-        mock_hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+        mock_hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
         mock_hass.services = Mock()
         mock_hass.services.async_call = AsyncMock()
         mock_hass.states.get.return_value = _make_cooler_state(
-            state=HVACMode.COOL, temperature=24.005
+            state=HVACMode.COOL, temperature=75, target_temp_step=1
         )
 
         mock_self = _make_mock_self(
@@ -459,6 +463,37 @@ class TestControlCoolerFahrenheit:
         ]
         assert "set_temperature" not in service_names
 
+    @pytest.mark.asyncio
+    async def test_setpoint_change_beyond_the_device_step_is_written(self):
+        """A setpoint the device cannot be holding is written immediately.
+
+        The step tolerance only absorbs the device's own snapping; a genuine
+        change has to reach the cooler on the first cycle.
+        """
+        mock_hass = Mock()
+        mock_hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock()
+        mock_hass.states.get.return_value = _make_cooler_state(
+            state=HVACMode.COOL, temperature=75, target_temp_step=1
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass,
+            bt_hvac_mode=HVACMode.COOL,
+            cur_temp=25.0,
+            bt_target_cooltemp=22.0,
+        )
+
+        await control_cooler(mock_self)
+
+        payload = next(
+            c.args[2]
+            for c in mock_hass.services.async_call.call_args_list
+            if c.args[1] == "set_temperature"
+        )
+        assert payload == {"entity_id": "climate.cooler", "temperature": 71.6}
+
 
 _ATTRIBUTE_ABSENT = object()
 
@@ -469,6 +504,7 @@ def _make_range_cooler_state(
     target_temp_low=None,
     supported_features=ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
     temperature=_ATTRIBUTE_ABSENT,
+    target_temp_step=None,
 ):
     """Build a cooler State that advertises a target range.
 
@@ -483,6 +519,8 @@ def _make_range_cooler_state(
     }
     if temperature is not _ATTRIBUTE_ABSENT:
         attributes["temperature"] = temperature
+    if target_temp_step is not None:
+        attributes["target_temp_step"] = target_temp_step
     return State("climate.cooler", str(state), attributes)
 
 
@@ -687,12 +725,14 @@ class TestControlCoolerTargetRange:
     async def test_lower_bound_within_read_tolerance_is_not_resent(self):
         """A bound that only differs by the read-back grid is unchanged.
 
-        The device reports on convert_to_float's 0.01 grid while BT holds the
-        raw value, so exact inequality would resend on every cycle.
+        The cooler advertises no step, so the comparison falls back to the
+        base tolerance: the device reports on convert_to_float's 0.01 grid
+        while BT holds the raw value, and exact inequality would resend on
+        every cycle.
         """
         mock_hass = self._hass()
         mock_hass.states.get.return_value = _make_range_cooler_state(
-            target_temp_high=24.0, target_temp_low=20.005
+            target_temp_high=24.0, target_temp_low=19.99
         )
 
         mock_self = _make_mock_self(
@@ -702,6 +742,57 @@ class TestControlCoolerTargetRange:
         await control_cooler(mock_self)
 
         assert self._set_temperature_payload(mock_hass) is None
+
+    @pytest.mark.asyncio
+    async def test_lower_bound_within_the_device_step_is_not_resent(self):
+        """A lower bound snapped onto the device's step is unchanged.
+
+        The cooler holds its bounds on a 0.5 K grid, so 20.5 is where the
+        commanded 20.3 lands and rewriting it would change nothing.
+        """
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=24.0, target_temp_low=20.5, target_temp_step=0.5
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.3
+        )
+
+        await control_cooler(mock_self)
+
+        assert self._set_temperature_payload(mock_hass) is None
+
+    @pytest.mark.asyncio
+    async def test_lower_bound_drift_is_not_throttled_as_a_resend(self):
+        """A lower bound left behind is written despite the resend interval.
+
+        last_sent_cooler_temp tracks the upper bound alone, so a payload armed
+        by the lower bound is not an identical resend and the interval must
+        not delay the user's heating-target change.
+        """
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=24.0, target_temp_low=19.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass,
+            bt_target_cooltemp=24.0,
+            bt_target_temp=21.0,
+            last_sent_cooler_temp=24.0,
+            last_sent_cooler_temp_ts=monotonic(),
+            min_cooler_resend_interval_s=300,
+        )
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload == {
+            "entity_id": "climate.cooler",
+            "target_temp_high": 24.0,
+            "target_temp_low": 21.0,
+        }
 
     @pytest.mark.asyncio
     async def test_lower_bound_is_ignored_for_single_setpoint_coolers(self):

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -430,6 +430,35 @@ class TestControlCoolerFahrenheit:
         ]
         assert "set_temperature" not in service_names
 
+    @pytest.mark.asyncio
+    async def test_reported_temp_within_read_tolerance_is_not_resent(self):
+        """A setpoint that only differs by the read-back grid is unchanged.
+
+        The device reports on convert_to_float's 0.01 grid while BT holds the
+        raw value, so exact inequality would resend on every cycle.
+        """
+        mock_hass = Mock()
+        mock_hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock()
+        mock_hass.states.get.return_value = _make_cooler_state(
+            state=HVACMode.COOL, temperature=24.005
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass,
+            bt_hvac_mode=HVACMode.COOL,
+            cur_temp=25.0,
+            bt_target_cooltemp=24.0,
+        )
+
+        await control_cooler(mock_self)
+
+        service_names = [
+            c.args[1] for c in mock_hass.services.async_call.call_args_list
+        ]
+        assert "set_temperature" not in service_names
+
 
 def _make_range_cooler_state(
     state=HVACMode.COOL,

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -3,7 +3,7 @@
 from time import monotonic
 from unittest.mock import AsyncMock, Mock
 
-from homeassistant.components.climate.const import HVACMode
+from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
@@ -429,3 +429,147 @@ class TestControlCoolerFahrenheit:
             c.args[1] for c in mock_hass.services.async_call.call_args_list
         ]
         assert "set_temperature" not in service_names
+
+
+def _make_range_cooler_state(
+    state=HVACMode.COOL,
+    target_temp_high=None,
+    target_temp_low=None,
+    supported_features=ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
+):
+    """Build a cooler State that advertises a target range."""
+    return State(
+        "climate.cooler",
+        str(state),
+        {
+            "target_temp_high": target_temp_high,
+            "target_temp_low": target_temp_low,
+            "supported_features": int(supported_features),
+        },
+    )
+
+
+class TestControlCoolerTargetRange:
+    """Payload selection for coolers that only accept a target range."""
+
+    @staticmethod
+    def _hass(unit=UnitOfTemperature.CELSIUS):
+        mock_hass = Mock()
+        mock_hass.config.units.temperature_unit = unit
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock()
+        return mock_hass
+
+    @staticmethod
+    def _set_temperature_payload(mock_hass):
+        for call in mock_hass.services.async_call.call_args_list:
+            if call.args[1] == "set_temperature":
+                return call.args[2]
+        return None
+
+    @pytest.mark.asyncio
+    async def test_range_only_cooler_receives_both_bounds(self):
+        """A range-only cooler is written via target_temp_high/low.
+
+        Home Assistant rejects a "temperature" payload for such an entity, so
+        it would never receive a setpoint at all.
+        """
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=28.0, target_temp_low=19.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload == {
+            "entity_id": "climate.cooler",
+            "target_temp_high": 24.0,
+            "target_temp_low": 20.0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_low_bound_never_exceeds_the_high_bound(self):
+        """A heating target above the cooling target is capped at it."""
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=28.0, target_temp_low=19.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=26.0
+        )
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload["target_temp_low"] == payload["target_temp_high"] == 24.0
+
+    @pytest.mark.asyncio
+    async def test_cooler_supporting_both_features_keeps_single_setpoint(self):
+        """A cooler that also accepts "temperature" keeps the single payload."""
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=28.0,
+            target_temp_low=19.0,
+            supported_features=ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
+        )
+
+        mock_self = _make_mock_self(mock_hass, bt_target_cooltemp=24.0)
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload == {"entity_id": "climate.cooler", "temperature": 24.0}
+
+    @pytest.mark.asyncio
+    async def test_cooler_without_feature_flags_keeps_single_setpoint(self):
+        """Without advertised features the established payload is used."""
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_cooler_state(temperature=28.0)
+
+        mock_self = _make_mock_self(mock_hass, bt_target_cooltemp=24.0)
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload == {"entity_id": "climate.cooler", "temperature": 24.0}
+
+    @pytest.mark.asyncio
+    async def test_range_payload_is_converted_to_fahrenheit(self):
+        """Both bounds are converted on a °F system."""
+        mock_hass = self._hass(UnitOfTemperature.FAHRENHEIT)
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=82.4, target_temp_low=66.2
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload["target_temp_high"] == 75.2  # 24.0 °C
+        assert payload["target_temp_low"] == 68.0  # 20.0 °C
+
+    @pytest.mark.asyncio
+    async def test_matching_range_setpoint_is_not_resent(self):
+        """The dedup reads the range key, so no redundant write is sent."""
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=24.0, target_temp_low=20.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        assert self._set_temperature_payload(mock_hass) is None

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -1225,3 +1225,76 @@ class TestEnforceCoolAboveHeat:
         mock_bt.bt_target_cooltemp = None
         self._call(mock_bt)
         assert mock_bt.bt_target_cooltemp is None
+
+
+# ===========================================================================
+# 8. TestEnforceHeatBelowCool
+# ===========================================================================
+
+
+class TestEnforceHeatBelowCool:
+    """_enforce_heat_below_cool keeps the heat target strictly below the cool target."""
+
+    def _call(self, bt):
+        return BetterThermostat._enforce_heat_below_cool(bt)
+
+    def test_not_heat_cool_mode_is_noop(self, mock_bt):
+        """Outside HEAT_COOL the heat target is left untouched even if above cool."""
+        mock_bt.hvac_mode = HVACMode.HEAT
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_cooltemp = 20.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 22.0
+
+    def test_heat_below_cool_is_noop(self, mock_bt):
+        """A heat target already below the cool target is unchanged."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 20.0
+        mock_bt.bt_target_cooltemp = 24.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 20.0
+
+    def test_heat_above_cool_is_pushed_down_by_step(self, mock_bt):
+        """A heat target above the cool target drops one step below it."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 24.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 21.5
+
+    def test_heat_equal_cool_is_pushed_down(self, mock_bt):
+        """A heat target equal to the cool target is pushed below it."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 21.5
+
+    def test_step_falls_back_to_half_degree(self, mock_bt):
+        """A missing/zero step falls back to 0.5."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 21.5
+
+    def test_result_is_clamped_to_min_temp(self, mock_bt):
+        """The heat target never drops below the configured minimum."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 6.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_cooltemp = 5.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 5.0
+
+    def test_none_heat_target_is_noop(self, mock_bt):
+        """A None heat target does not raise and stays None."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = None
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp is None

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -1,15 +1,17 @@
 """Tests for events/cooler.py – Cooler event handler.
 
-Covers guard clauses, setpoint adoption, clamping, heat-target sync,
-and control-queue triggering.
+Covers guard clauses, setpoint adoption, echo suppression, unit handling,
+clamping, heat-target sync, and control-queue triggering.
 """
 
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
 import pytest
 
+from custom_components.better_thermostat.climate import BetterThermostat
 from custom_components.better_thermostat.events.cooler import trigger_cooler_change
 
 ENTITY_ID = "climate.test_cooler"
@@ -25,17 +27,21 @@ def mock_bt():
     """Create a mock BetterThermostat instance with sensible defaults."""
     bt = MagicMock()
     bt.hass = MagicMock()
+    bt.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
     bt.device_name = "Test Thermostat"
     bt.bt_hvac_mode = HVACMode.HEAT_COOL
+    bt.hvac_mode = HVACMode.HEAT_COOL
     bt.bt_target_temp = 20.0
     bt.bt_target_cooltemp = 25.0
     bt.bt_target_temp_step = 0.5
     bt.bt_min_temp = 5.0
     bt.bt_max_temp = 30.0
+    bt.last_sent_cooler_temp = None
     bt.startup_running = False
     bt.control_queue_task = AsyncMock()
     bt.context = MagicMock()  # unique context so != event.context
     bt.async_write_ha_state = MagicMock()
+    bt._enforce_heat_below_cool = lambda: BetterThermostat._enforce_heat_below_cool(bt)
     return bt
 
 
@@ -265,6 +271,7 @@ class TestHeatTargetSync:
     async def test_heat_target_pushed_down_when_equal(self, mock_bt):
         """When cooltemp == heat target, heat target is pushed down by step."""
         mock_bt.bt_target_temp = 25.0
+        mock_bt.bt_target_cooltemp = 27.0
         old_state = _make_state(attributes={"temperature": 27.0})
         new_state = _make_state(attributes={"temperature": 25.0})
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
@@ -302,11 +309,10 @@ class TestHeatTargetSync:
 
     @pytest.mark.asyncio
     async def test_heat_target_sync_not_checked_below_min(self, mock_bt):
-        """Heat-target sync should still work correctly after clamping to min.
+        """Heat-target sync keeps the heat target inside the configured range.
 
-        If cooltemp is clamped to min (5.0), and heat target is >= 5.0,
-        heat target should be pushed down to 4.5. But 4.5 < bt_min_temp!
-        The code does NOT clamp the heat target — potential invariant violation.
+        With the cool target clamped to the minimum there is no room for a full
+        step below it, so the heat target stops at bt_min_temp.
         """
         mock_bt.bt_target_temp = 6.0
         mock_bt.bt_min_temp = 5.0
@@ -316,19 +322,14 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
-        # cooltemp clamped to 5.0, heat target >= cooltemp → pushed to 4.5
         assert mock_bt.bt_target_cooltemp == 5.0
-        # BUG: heat target pushed below min_temp without clamping
         assert mock_bt.bt_target_temp >= mock_bt.bt_min_temp
 
     @pytest.mark.asyncio
     async def test_heat_target_sync_with_zero_step(self, mock_bt):
-        """When step is 0, heat-target sync produces cooltemp - 0 = cooltemp.
-
-        This means heat target == cooltemp, which violates the invariant
-        that heat < cool. The >= check would trigger again next time.
-        """
+        """A zero step falls back to 0.5 so heat stays below cool."""
         mock_bt.bt_target_temp = 25.0
+        mock_bt.bt_target_cooltemp = 27.0
         mock_bt.bt_target_temp_step = 0.0
         old_state = _make_state(attributes={"temperature": 27.0})
         new_state = _make_state(attributes={"temperature": 25.0})
@@ -336,8 +337,6 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
-        # With step=0: bt_target_temp = cooltemp - 0 = cooltemp
-        # This should maintain heat < cool invariant
         assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
 
@@ -407,12 +406,11 @@ class TestEdgeCases:
     async def test_main_key_mismatch_old_has_temp_new_has_target_temp_high(
         self, mock_bt
     ):
-        """Key selection uses old_state only to pick the temperature attribute key.
+        """Each state picks its own attribute key.
 
-        If old has 'temperature' but new only has 'target_temp_high', the new
-        setpoint reads from the wrong key. The _main_key is determined from
-        old_state.attributes — if the cooler switches attribute schema between
-        events, new_state is read with the wrong key → None → no adoption.
+        A cooler that switches between single-setpoint and range attributes
+        between two events is read correctly, because the key is resolved per
+        state.
         """
         old_state = _make_state(attributes={"temperature": 25.0})
         # new_state has target_temp_high but NOT temperature
@@ -425,7 +423,166 @@ class TestEdgeCases:
 
         await trigger_cooler_change(mock_bt, event)
 
-        # _main_key is "temperature" (from old_state), but new_state has
-        # no "temperature" → convert_to_float("None") → None → no adoption
-        # The 28.0 setpoint is silently lost
         assert mock_bt.bt_target_cooltemp == 28.0
+
+
+# ---------------------------------------------------------------------------
+# 6. Echo suppression
+# ---------------------------------------------------------------------------
+
+
+class TestEchoSuppression:
+    """Only user input on the cooler is adopted, not BT's own writes."""
+
+    @pytest.mark.asyncio
+    async def test_unchanged_setpoint_is_not_re_adopted(self, mock_bt):
+        """A cooler update without a setpoint change runs no control cycle."""
+        old_state = _make_state(
+            attributes={"temperature": 25.0, "current_temperature": 26.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 25.0, "current_temperature": 26.1}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_echo_of_last_sent_setpoint_is_not_adopted(self, mock_bt):
+        """A write BT sent is not adopted when it returns with a foreign context.
+
+        Cloud and MQTT backed coolers publish the new setpoint from a later poll
+        or broker message whose context is not BT's, so the context check alone
+        does not catch it.
+        """
+        mock_bt.bt_target_cooltemp = 25.0
+        mock_bt.last_sent_cooler_temp = 22.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 22.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_device_rounding_of_own_write_is_not_adopted(self, mock_bt):
+        """A device rounding BT's write to its own grid is not user input."""
+        mock_bt.bt_target_cooltemp = 24.4
+        mock_bt.last_sent_cooler_temp = 24.4
+        old_state = _make_state(
+            attributes={"temperature": 26.0, "target_temp_step": 1.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 24.0, "target_temp_step": 1.0}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 24.4
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_user_change_of_one_full_step_is_adopted(self, mock_bt):
+        """A change of at least one device step is user input."""
+        mock_bt.bt_target_cooltemp = 24.0
+        mock_bt.last_sent_cooler_temp = 24.0
+        old_state = _make_state(
+            attributes={"temperature": 24.0, "target_temp_step": 1.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 25.0, "target_temp_step": 1.0}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        mock_bt.control_queue_task.put.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 7. Unit handling
+# ---------------------------------------------------------------------------
+
+
+class TestCoolerUnitHandling:
+    """Setpoints arrive in the system unit and are stored in °C."""
+
+    @pytest.mark.asyncio
+    async def test_fahrenheit_setpoint_is_converted_to_celsius(self, mock_bt):
+        """On a °F system the reported setpoint is converted, not taken as °C."""
+        mock_bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        mock_bt.bt_target_temp = 18.0
+        old_state = _make_state(attributes={"temperature": 75.0})
+        new_state = _make_state(attributes={"temperature": 68.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 20.0
+        mock_bt.control_queue_task.put.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fahrenheit_step_is_converted_to_a_celsius_delta(self, mock_bt):
+        """The device step is a °F delta on a °F system and must be scaled."""
+        mock_bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        mock_bt.bt_target_cooltemp = 21.11  # 70 °F
+        mock_bt.last_sent_cooler_temp = 21.11
+        old_state = _make_state(
+            attributes={"temperature": 70.0, "target_temp_step": 2.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 71.0, "target_temp_step": 2.0}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        # 1 °F is below the 2 °F device step, so this is a rounding echo.
+        assert mock_bt.bt_target_cooltemp == 21.11
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 8. Range mode
+# ---------------------------------------------------------------------------
+
+
+class TestRangeModeCooler:
+    """Coolers running in range mode publish an empty single setpoint."""
+
+    @pytest.mark.asyncio
+    async def test_empty_temperature_falls_back_to_target_temp_high(self, mock_bt):
+        """A present-but-empty 'temperature' does not hide 'target_temp_high'."""
+        old_state = State(
+            ENTITY_ID,
+            "heat_cool",
+            attributes={
+                "temperature": None,
+                "target_temp_high": 24.0,
+                "target_temp_low": 19.0,
+            },
+        )
+        new_state = State(
+            ENTITY_ID,
+            "heat_cool",
+            attributes={
+                "temperature": None,
+                "target_temp_high": 26.0,
+                "target_temp_low": 19.0,
+            },
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 26.0
+        mock_bt.control_queue_task.put.assert_awaited_once()

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -308,7 +308,7 @@ class TestHeatTargetSync:
         assert mock_bt.bt_target_temp == 20.0  # unchanged
 
     @pytest.mark.asyncio
-    async def test_heat_target_sync_not_checked_below_min(self, mock_bt):
+    async def test_heat_target_sync_respects_min_temp(self, mock_bt):
         """Heat-target sync keeps the heat target inside the configured range.
 
         With the cool target clamped to the minimum there is no room for a full
@@ -403,9 +403,7 @@ class TestEdgeCases:
         mock_bt.control_queue_task.put.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_main_key_mismatch_old_has_temp_new_has_target_temp_high(
-        self, mock_bt
-    ):
+    async def test_setpoint_key_is_resolved_per_state(self, mock_bt):
         """Each state picks its own attribute key.
 
         A cooler that switches between single-setpoint and range attributes
@@ -540,15 +538,16 @@ class TestCoolerUnitHandling:
             attributes={"temperature": 70.0, "target_temp_step": 2.0}
         )
         new_state = _make_state(
-            attributes={"temperature": 71.0, "target_temp_step": 2.0}
+            attributes={"temperature": 73.0, "target_temp_step": 2.0}
         )
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
 
         await trigger_cooler_change(mock_bt, event)
 
-        # 1 °F is below the 2 °F device step, so this is a rounding echo.
-        assert mock_bt.bt_target_cooltemp == 21.11
-        mock_bt.control_queue_task.put.assert_not_awaited()
+        # 3 °F is 1.67 K, above the converted step of 1.11 K and below the
+        # 2.0 the raw attribute would give, so only a converted step adopts it.
+        assert mock_bt.bt_target_cooltemp == 22.78
+        mock_bt.control_queue_task.put.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_helpers_setpoint_range.py
+++ b/tests/unit/test_helpers_setpoint_range.py
@@ -12,7 +12,7 @@ from custom_components.better_thermostat.utils.helpers import (
     get_current_set_temperatures,
     matches_any_setpoint,
     round_by_step,
-    trv_supports_temperature_range,
+    supports_temperature_range,
 )
 
 RANGE_BIT = int(ClimateEntityFeature.TARGET_TEMPERATURE_RANGE)
@@ -26,27 +26,27 @@ def _fake_self():
     return mock_self
 
 
-class TestTrvSupportsTemperatureRange:
+class TestSupportsTemperatureRange:
     """Feature detection reads the supported_features bitmask."""
 
     def test_none_state_returns_false(self):
         """Report no range support when the TRV state is missing."""
-        assert trv_supports_temperature_range(None) is False
+        assert supports_temperature_range(None) is False
 
     def test_missing_attribute_returns_false(self):
         """Report no range support when supported_features is absent."""
         state = State("climate.trv", "heat", {})
-        assert trv_supports_temperature_range(state) is False
+        assert supports_temperature_range(state) is False
 
     def test_bit_not_set_returns_false(self):
         """Report no range support when the range bit is not set."""
         state = State("climate.trv", "heat", {"supported_features": 0})
-        assert trv_supports_temperature_range(state) is False
+        assert supports_temperature_range(state) is False
 
     def test_bit_set_returns_true(self):
         """Report range support when the range bit is set."""
         state = State("climate.trv", "heat", {"supported_features": RANGE_BIT})
-        assert trv_supports_temperature_range(state) is True
+        assert supports_temperature_range(state) is True
 
 
 class TestGetCurrentSetTemperatures:


### PR DESCRIPTION
Stacked on #2145. Review the commits after that one, and merge #2145 first.

## Motivation:

`control_cooler()` always sends `climate.set_temperature` with a `temperature` payload. Home Assistant validates that against the entity's features:

```python
if (
    ATTR_TEMPERATURE in service_call.data
    and not entity.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
):
    raise ServiceValidationError(...)
```

A cooler that only advertises `TARGET_TEMPERATURE_RANGE` therefore rejects every write. BT catches the error, logs "set_temperature for cooler ... failed", and retries on the next cycle, forever. The cooler still gets its `hvac_mode` switched between COOL and OFF, which is what the "AC does not follow the setpoint / keeps toggling" reports describe.

## Changes:

- `control_cooler()` picks the payload from the cooler's advertised features: `target_temp_high` and `target_temp_low` for range-only coolers, `temperature` otherwise. Coolers advertising both features, or none, get the payload they get today.
- The range write needs both bounds (`vol.Inclusive`) and Home Assistant rejects a low bound above the high one, so the heating target is used as the lower bound and capped at the cooling target.
- The send decision also compares the device's reported `target_temp_low` against that lower bound, so a heating target the user moved is written even when the cooling target stayed put. The comparison runs through `matches_any_setpoint()`, because the reported value comes back on a different float grid than the one BT holds.
- Both bounds go through the existing Fahrenheit conversion.
- The reported setpoint is read via the new `get_cooler_setpoint()` helper, so the redundant-send dedup sees a range cooler's `target_temp_high` instead of an empty `temperature` and stops re-sending every cycle.
- `supports_single_target_temperature()` joins `trv_supports_temperature_range()` in `utils/helpers.py`. The setpoint reader moved there from `events/cooler.py` so the read and write paths share one definition.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [ ] There is no related issue ticket

Related to #1461 and #1366, which describe this symptom among other AC topics. No `fixes` keyword: both issues ask for more than this PR delivers.

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

No physical hardware. The behaviour is pinned to Home Assistant's `SET_TEMPERATURE_SCHEMA` and `async_service_temperature_set`, and verified against the test suite on Home Assistant 2026.7.2 / Python 3.14.5: 2160 tests pass. `TestControlCoolerTargetRange` in `tests/unit/controlling/test_control_cooler.py` covers payload selection for range-only, dual-feature and featureless coolers, the low-bound cap, the low-bound change detection with and without read-grid drift, the Fahrenheit conversion of both bounds, and the dedup on the range key.

HA Version: 2026.7.2
Zigbee2MQTT Version: n/a
TRV Hardware: n/a (cooler path)

## New device mappings

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better Thermostat now automatically enforces that heating targets stay strictly below cooling targets during HEAT_COOL operation.
  * Added support for both single-temperature and temperature-range cooling controls, including correct payload selection.
  * Enhanced temperature unit handling (C/F), step sizing, and range low/high bound synchronization.
  * Reduced unnecessary updates by suppressing thermostat-generated “echo” setpoint events.

* **Bug Fixes**
  * Prevented invalid heat/cool setpoint conflicts, including proper clamping and zero/invalid step fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->