### PR TITLE
Add extensible selector and entity localization with Russian coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,9 @@ async def set_temperature(self, entity_id, temperature):
 
 ## Translations
 
-[INLANG Editor](https://inlang.com/editor/github.com/KartoffelToby/better_thermostat)
+See the [translation contributor guide](custom_components/better_thermostat/translations/README.md) for the catalog format, placeholder rules, and validation command.
+
+Translations can also be edited with the [INLANG Editor](https://inlang.com/editor/github.com/KartoffelToby/better_thermostat).
 
 ### Reporting Bugs
 

--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -599,8 +599,11 @@ def _normalize_user_submission(
             CONF_TARGET_TEMP_STEP, _USER_FIELD_DEFAULTS[CONF_TARGET_TEMP_STEP]
         ),
     )
-    target_step = _TARGET_TEMP_STEP_SELECTOR_TO_VALUE.get(str(target_step), target_step)
-    if target_step in (None, ""):
+    target_step_key = str(target_step)
+    target_step_from_selector = target_step_key in _TARGET_TEMP_STEP_SELECTOR_TO_VALUE
+    if target_step_from_selector:
+        target_step = _TARGET_TEMP_STEP_SELECTOR_TO_VALUE[target_step_key]
+    if target_step is None or (target_step == "" and not target_step_from_selector):
         target_step = _USER_FIELD_DEFAULTS[CONF_TARGET_TEMP_STEP]
     normalized[CONF_TARGET_TEMP_STEP] = str(target_step)
 

--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -60,20 +60,25 @@ CONFIG_WALKTHROUGH_URL = (
 )
 
 
+_TARGET_TEMP_STEP_SELECTOR_TO_VALUE = {
+    "auto_legacy": "0.0",
+    "auto": "",
+    "step_0_1": "0.1",
+    "step_0_2": "0.2",
+    "step_0_25": "0.25",
+    "step_0_5": "0.5",
+    "step_1_0": "1.0",
+}
+_TARGET_TEMP_STEP_VALUE_TO_SELECTOR = {
+    value: key for key, value in _TARGET_TEMP_STEP_SELECTOR_TO_VALUE.items()
+}
+
 TEMP_STEP_SELECTOR = selector.SelectSelector(
     selector.SelectSelectorConfig(
-        options=[
-            selector.SelectOptionDict(
-                value="0.0", label="Auto"
-            ),  # Keep for backwards compatibility
-            selector.SelectOptionDict(value="", label="Auto (New)"),
-            selector.SelectOptionDict(value="0.1", label="0.1 °C"),
-            selector.SelectOptionDict(value="0.2", label="0.2 °C"),
-            selector.SelectOptionDict(value="0.25", label="0.25 °C"),
-            selector.SelectOptionDict(value="0.5", label="0.5 °C"),
-            selector.SelectOptionDict(value="1.0", label="1 °C"),
-        ],
+        # Stable selector tokens keep labels translatable without changing stored values.
+        options=list(_TARGET_TEMP_STEP_SELECTOR_TO_VALUE),
         mode=selector.SelectSelectorMode.DROPDOWN,
+        translation_key="target_temp_step",
     )
 )
 
@@ -81,30 +86,16 @@ TEMP_STEP_SELECTOR = selector.SelectSelector(
 CALIBRATION_MODE_SELECTOR = selector.SelectSelector(
     selector.SelectSelectorConfig(
         options=[
-            selector.SelectOptionDict(
-                value=CalibrationMode.HEATING_POWER_CALIBRATION, label="(AI) Time Based"
-            ),
-            selector.SelectOptionDict(
-                value=CalibrationMode.DEFAULT,
-                label="External Sensor Offset Only (Default)",
-            ),
-            selector.SelectOptionDict(
-                value=CalibrationMode.MPC_CALIBRATION, label="MPC Predictive (Beta)"
-            ),
-            selector.SelectOptionDict(
-                value=CalibrationMode.AGGRESIVE_CALIBRATION, label="Agressive"
-            ),
-            selector.SelectOptionDict(
-                value=CalibrationMode.TPI_CALIBRATION, label="TPI Controller"
-            ),
-            selector.SelectOptionDict(
-                value=CalibrationMode.PID_CALIBRATION, label="PID Controller"
-            ),
-            selector.SelectOptionDict(
-                value=CalibrationMode.NO_CALIBRATION, label="No Calibration"
-            ),
+            CalibrationMode.HEATING_POWER_CALIBRATION,
+            CalibrationMode.DEFAULT,
+            CalibrationMode.MPC_CALIBRATION,
+            CalibrationMode.AGGRESIVE_CALIBRATION,
+            CalibrationMode.TPI_CALIBRATION,
+            CalibrationMode.PID_CALIBRATION,
+            CalibrationMode.NO_CALIBRATION,
         ],
         mode=selector.SelectSelectorMode.DROPDOWN,
+        translation_key="calibration_mode",
     )
 )
 
@@ -112,13 +103,13 @@ CALIBRATION_MODE_SELECTOR = selector.SelectSelector(
 PRESET_SELECTOR = selector.SelectSelector(
     selector.SelectSelectorConfig(
         options=[
-            selector.SelectOptionDict(value=PRESET_ECO, label="Eco"),
-            selector.SelectOptionDict(value=PRESET_AWAY, label="Away"),
-            selector.SelectOptionDict(value=PRESET_BOOST, label="Boost"),
-            selector.SelectOptionDict(value=PRESET_COMFORT, label="Comfort"),
-            selector.SelectOptionDict(value=PRESET_HOME, label="Home"),
-            selector.SelectOptionDict(value=PRESET_SLEEP, label="Sleep"),
-            selector.SelectOptionDict(value=PRESET_ACTIVITY, label="Activity"),
+            PRESET_ECO,
+            PRESET_AWAY,
+            PRESET_BOOST,
+            PRESET_COMFORT,
+            PRESET_HOME,
+            PRESET_SLEEP,
+            PRESET_ACTIVITY,
         ],
         mode=selector.SelectSelectorMode.DROPDOWN,
         multiple=True,
@@ -244,28 +235,18 @@ def _build_advanced_fields(
 
     options = []
     if support_valve:
-        options.append(
-            selector.SelectOptionDict(
-                value=CalibrationType.DIRECT_VALVE_BASED, label="Direct Valve Based"
-            )
-        )
+        options.append(CalibrationType.DIRECT_VALVE_BASED)
 
-    options.append(
-        selector.SelectOptionDict(
-            value=CalibrationType.TARGET_TEMP_BASED, label="Target Temperature Based"
-        )
-    )
+    options.append(CalibrationType.TARGET_TEMP_BASED)
 
     if support_offset:
-        options.append(
-            selector.SelectOptionDict(
-                value=CalibrationType.LOCAL_BASED, label="Offset Based"
-            )
-        )
+        options.append(CalibrationType.LOCAL_BASED)
 
     calib_selector = selector.SelectSelector(
         selector.SelectSelectorConfig(
-            options=options, mode=selector.SelectSelectorMode.DROPDOWN
+            options=options,
+            mode=selector.SelectSelectorMode.DROPDOWN,
+            translation_key="calibration_type",
         )
     )
     ordered: OrderedDict = OrderedDict()
@@ -517,7 +498,9 @@ def _build_user_fields(
         CONF_TARGET_TEMP_STEP, _USER_FIELD_DEFAULTS[CONF_TARGET_TEMP_STEP]
     )
     if target_step_default is not None:
-        target_step_default = str(target_step_default)
+        target_step_default = _TARGET_TEMP_STEP_VALUE_TO_SELECTOR.get(
+            str(target_step_default), "auto_legacy"
+        )
     add_field(CONF_TARGET_TEMP_STEP, TEMP_STEP_SELECTOR, default=target_step_default)
 
     return fields
@@ -616,6 +599,7 @@ def _normalize_user_submission(
             CONF_TARGET_TEMP_STEP, _USER_FIELD_DEFAULTS[CONF_TARGET_TEMP_STEP]
         ),
     )
+    target_step = _TARGET_TEMP_STEP_SELECTOR_TO_VALUE.get(str(target_step), target_step)
     if target_step in (None, ""):
         target_step = _USER_FIELD_DEFAULTS[CONF_TARGET_TEMP_STEP]
     normalized[CONF_TARGET_TEMP_STEP] = str(target_step)

--- a/custom_components/better_thermostat/number.py
+++ b/custom_components/better_thermostat/number.py
@@ -2,7 +2,16 @@
 
 import logging
 
-from homeassistant.components.climate.const import PRESET_NONE
+from homeassistant.components.climate.const import (
+    PRESET_ACTIVITY,
+    PRESET_AWAY,
+    PRESET_BOOST,
+    PRESET_COMFORT,
+    PRESET_ECO,
+    PRESET_HOME,
+    PRESET_NONE,
+    PRESET_SLEEP,
+)
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, UnitOfTemperature
@@ -29,6 +38,16 @@ from .utils.helpers import convert_to_float_celsius
 
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = "better_thermostat"
+
+_PRESET_TRANSLATION_KEYS = {
+    PRESET_ECO: "preset_eco",
+    PRESET_AWAY: "preset_away",
+    PRESET_BOOST: "preset_boost",
+    PRESET_COMFORT: "preset_comfort",
+    PRESET_HOME: "preset_home",
+    PRESET_SLEEP: "preset_sleep",
+    PRESET_ACTIVITY: "preset_activity",
+}
 
 
 async def async_setup_entry(
@@ -144,7 +163,7 @@ class BetterThermostatPresetNumber(NumberEntity, RestoreEntity):
         self._bt_climate = bt_climate
         self._preset_mode = preset_mode
         self._attr_unique_id = f"{bt_climate.unique_id}_preset_{preset_mode}"
-        self._attr_name = f"Preset {preset_mode.capitalize()}"
+        self._attr_translation_key = _PRESET_TRANSLATION_KEYS[preset_mode]
 
         # Set min/max/step based on climate entity configuration
         self._attr_native_min_value = bt_climate.min_temp
@@ -303,9 +322,10 @@ class BetterThermostatValveMaxOpeningNumber(NumberEntity, RestoreEntity):
         if show_trv_name:
             trv_state = bt_climate.hass.states.get(trv_entity_id)
             trv_name = trv_state.name if trv_state and trv_state.name else trv_entity_id
-            self._attr_name = f"{trv_name} Valve Max Opening"
+            self._attr_translation_key = "valve_max_opening"
+            self._attr_translation_placeholders = {"trv_name": trv_name}
         else:
-            self._attr_name = "Valve Max Opening"
+            self._attr_translation_key = "valve_max_opening_no_trv"
 
         self._attr_native_min_value = 0.0
         self._attr_native_max_value = 100.0

--- a/custom_components/better_thermostat/sensor.py
+++ b/custom_components/better_thermostat/sensor.py
@@ -676,7 +676,7 @@ class _BtSimpleAttributeSensor(_BtSensorBase):
 class BetterThermostatExternalTempSensor(_BtSensorBase):
     """Representation of a Better Thermostat External Temperature Sensor (EMA)."""
 
-    _attr_name = "Temperature EMA"
+    _attr_translation_key = "external_temp_ema"
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _unique_id_suffix = "external_temp_ema"
@@ -696,7 +696,7 @@ class BetterThermostatExternalTempSensor(_BtSensorBase):
 class BetterThermostatExternalTemp1hEMASensor(_BtSensorBase):
     """Representation of a Better Thermostat External Temperature 1h EMA Sensor."""
 
-    _attr_name = "Temperature EMA 1h"
+    _attr_translation_key = "external_temp_ema_1h"
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_suggested_display_precision = 2
@@ -745,7 +745,7 @@ class BetterThermostatExternalTemp1hEMASensor(_BtSensorBase):
 class BetterThermostatTempSlopeSensor(_BtSimpleAttributeSensor):
     """Representation of a Better Thermostat Temperature Slope Sensor."""
 
-    _attr_name = "Temperature Slope"
+    _attr_translation_key = "temp_slope"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "K/min"
     _attr_icon = "mdi:chart-line"
@@ -757,7 +757,7 @@ class BetterThermostatTempSlopeSensor(_BtSimpleAttributeSensor):
 class BetterThermostatHeatingPowerSensor(_BtSimpleAttributeSensor):
     """Representation of a Better Thermostat Heating Power Sensor."""
 
-    _attr_name = "Heating Power"
+    _attr_translation_key = "heating_power"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "K/min"
     _attr_icon = "mdi:thermometer-plus"
@@ -769,7 +769,7 @@ class BetterThermostatHeatingPowerSensor(_BtSimpleAttributeSensor):
 class BetterThermostatHeatLossSensor(_BtSimpleAttributeSensor):
     """Representation of a Better Thermostat Heat Loss Sensor."""
 
-    _attr_name = "Heat Loss"
+    _attr_translation_key = "heat_loss"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "K/min"
     _attr_icon = "mdi:thermometer-minus"
@@ -781,7 +781,7 @@ class BetterThermostatHeatLossSensor(_BtSimpleAttributeSensor):
 class BetterThermostatVirtualTempSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat Virtual Temperature Sensor (MPC)."""
 
-    _attr_name = "Virtual Temperature"
+    _attr_translation_key = "virtual_temp"
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_icon = "mdi:thermometer-auto"
@@ -792,7 +792,7 @@ class BetterThermostatVirtualTempSensor(_BtMpcSensorBase):
 class BetterThermostatMpcGainSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat MPC Gain Sensor."""
 
-    _attr_name = "MPC Gain"
+    _attr_translation_key = "mpc_gain"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "K/min"
     _attr_icon = "mdi:thermometer-plus"
@@ -804,7 +804,7 @@ class BetterThermostatMpcGainSensor(_BtMpcSensorBase):
 class BetterThermostatMpcLossSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat MPC Loss Sensor."""
 
-    _attr_name = "MPC Loss"
+    _attr_translation_key = "mpc_loss"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "K/min"
     _attr_icon = "mdi:thermometer-minus"
@@ -816,7 +816,7 @@ class BetterThermostatMpcLossSensor(_BtMpcSensorBase):
 class BetterThermostatMpcKaSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat MPC Ka (Insulation) Sensor."""
 
-    _attr_name = "MPC Insulation (Ka)"
+    _attr_translation_key = "mpc_ka"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "1/min"
     _attr_icon = "mdi:home-thermometer-outline"
@@ -828,7 +828,7 @@ class BetterThermostatMpcKaSensor(_BtMpcSensorBase):
 class BetterThermostatSolarIntensitySensor(_BtSensorBase):
     """Representation of a Better Thermostat Solar Intensity Sensor."""
 
-    _attr_name = "Sun Intensity Heatup"
+    _attr_translation_key = "solar_intensity"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "%"
     _attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/custom_components/better_thermostat/strings.json
+++ b/custom_components/better_thermostat/strings.json
@@ -174,6 +174,35 @@
         "sleep": "Sleep",
         "activity": "Activity"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Auto (legacy)",
+        "auto": "Auto",
+        "step_0_1": "0.1 °C",
+        "step_0_2": "0.2 °C",
+        "step_0_25": "0.25 °C",
+        "step_0_5": "0.5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "(AI) Time based",
+        "default": "External sensor offset only (default)",
+        "mpc_calibration": "MPC predictive (beta)",
+        "fix_calibration": "Aggressive",
+        "tpi_calibration": "TPI controller",
+        "pid_calibration": "PID controller",
+        "no_calibration": "No calibration"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Direct valve control",
+        "target_temp_based": "Target temperature based",
+        "local_calibration_based": "Offset based"
+      }
     }
   },
   "entity": {
@@ -195,6 +224,33 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (Derivative)"
+      },
+      "preset_eco": {
+        "name": "Eco preset temperature"
+      },
+      "preset_away": {
+        "name": "Away preset temperature"
+      },
+      "preset_boost": {
+        "name": "Boost preset temperature"
+      },
+      "preset_comfort": {
+        "name": "Comfort preset temperature"
+      },
+      "preset_home": {
+        "name": "Home preset temperature"
+      },
+      "preset_sleep": {
+        "name": "Sleep preset temperature"
+      },
+      "preset_activity": {
+        "name": "Activity preset temperature"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name} maximum valve opening"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Maximum valve opening"
       }
     },
     "switch": {
@@ -209,6 +265,38 @@
       },
       "child_lock_no_trv": {
         "name": "Child Lock"
+      }
+    },
+    "sensor": {
+      "external_temp_ema": {
+        "name": "Temperature EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Temperature EMA (1 hour)"
+      },
+      "temp_slope": {
+        "name": "Temperature slope"
+      },
+      "heating_power": {
+        "name": "Heating power"
+      },
+      "heat_loss": {
+        "name": "Heat loss"
+      },
+      "virtual_temp": {
+        "name": "Virtual temperature"
+      },
+      "mpc_gain": {
+        "name": "MPC heating gain"
+      },
+      "mpc_loss": {
+        "name": "MPC heat loss"
+      },
+      "mpc_ka": {
+        "name": "MPC insulation (Ka)"
+      },
+      "solar_intensity": {
+        "name": "Solar heat gain"
       }
     }
   },

--- a/custom_components/better_thermostat/switch.py
+++ b/custom_components/better_thermostat/switch.py
@@ -150,7 +150,6 @@ class BetterThermostatChildLockSwitch(SwitchEntity, RestoreEntity):
         self._bt_climate = bt_climate
         self._trv_entity_id = trv_entity_id
         self._attr_unique_id = f"{bt_climate.unique_id}_{trv_entity_id}_child_lock"
-        self._attr_name = "Child Lock"
         if show_trv_name:
             trv_state = bt_climate.hass.states.get(trv_entity_id)
             trv_name = trv_state.name if trv_state and trv_state.name else trv_entity_id

--- a/custom_components/better_thermostat/translations/README.md
+++ b/custom_components/better_thermostat/translations/README.md
@@ -1,0 +1,48 @@
+# Better Thermostat translations
+
+Better Thermostat uses Home Assistant's native custom-integration localization.
+Home Assistant selects the catalog from the user's frontend language; no locale
+switch or Python registration table is needed.
+
+## Catalog layout
+
+- `en.json` is the canonical runtime catalog and English fallback.
+- `<language-tag>.json` contains one complete translation. File names use BCP 47
+  language tags, for example `ru.json`, `de.json`, or `pt-BR.json`.
+- `../strings.json` mirrors `en.json` for repository tooling and must remain
+  byte-for-byte equivalent after JSON parsing.
+- `../../../project.inlang.json` lists every catalog for the Inlang editor.
+
+The catalogs cover config and options flows, repairs, services, selectors,
+device automations, and entity names. Python entities reference these strings by
+stable `translation_key`; do not add user-facing `_attr_name` strings to entity
+classes.
+
+## Add a language
+
+1. Copy `en.json` to `<language-tag>.json`.
+2. Translate values only. Preserve object keys, Markdown, line breaks, and every
+   placeholder such as `{name}`, `{trv_name}`, or `{docs_url}` exactly.
+3. Add the language tag to `project.inlang.json` so it appears in the Inlang
+   editor.
+4. Run:
+
+   ```bash
+   pytest tests/test_translations.py
+   ```
+
+The validation checks JSON structure, complete key coverage, unknown keys,
+placeholder parity, non-empty values, entity translation coverage, and the
+Inlang catalog list. A developer can therefore add another language without
+changing the integration's Python logic.
+
+## Add or change a source string
+
+1. Edit the English value in `en.json` and mirror the same structure in
+   `../strings.json`.
+2. Update every language catalog. Until a translator supplies localized copy,
+   use the English value rather than omitting the key, so Home Assistant never
+   exposes a raw translation key.
+3. When adding an entity name, add its key below `entity.<platform>` and set the
+   entity's `_attr_translation_key` to that stable key.
+4. Run the translation tests before opening a pull request.

--- a/custom_components/better_thermostat/translations/da.json
+++ b/custom_components/better_thermostat/translations/da.json
@@ -174,6 +174,35 @@
         "sleep": "Søvn",
         "activity": "Aktivitet"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Automatisk (gammel)",
+        "auto": "Automatisk",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "AI tidsbaseret",
+        "default": "Kun ekstern sensorforskydning (standard)",
+        "mpc_calibration": "MPC forudsigende (beta)",
+        "fix_calibration": "Aggressiv",
+        "tpi_calibration": "TPI-regulator",
+        "pid_calibration": "PID-regulator",
+        "no_calibration": "Ingen kalibrering"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Direkte ventilstyring",
+        "target_temp_based": "Baseret på måltemperatur",
+        "local_calibration_based": "Baseret på forskydning"
+      }
     }
   },
   "entity": {
@@ -195,6 +224,33 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (differentiel)"
+      },
+      "preset_eco": {
+        "name": "Temperatur for Eco-forvalg"
+      },
+      "preset_away": {
+        "name": "Temperatur for Ude-forvalg"
+      },
+      "preset_boost": {
+        "name": "Temperatur for Boost-forvalg"
+      },
+      "preset_comfort": {
+        "name": "Temperatur for Komfort-forvalg"
+      },
+      "preset_home": {
+        "name": "Temperatur for Hjemme-forvalg"
+      },
+      "preset_sleep": {
+        "name": "Temperatur for Søvn-forvalg"
+      },
+      "preset_activity": {
+        "name": "Temperatur for Aktivitet-forvalg"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: maksimal ventilåbning"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Maksimal ventilåbning"
       }
     },
     "switch": {
@@ -209,6 +265,38 @@
       },
       "child_lock_no_trv": {
         "name": "Børnesikring"
+      }
+    },
+    "sensor": {
+      "external_temp_ema": {
+        "name": "Temperatur-EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Temperatur-EMA (1 time)"
+      },
+      "temp_slope": {
+        "name": "Temperaturændring"
+      },
+      "heating_power": {
+        "name": "Varmeydelse"
+      },
+      "heat_loss": {
+        "name": "Varmetab"
+      },
+      "virtual_temp": {
+        "name": "Virtuel temperatur"
+      },
+      "mpc_gain": {
+        "name": "MPC-varmeforstærkning"
+      },
+      "mpc_loss": {
+        "name": "MPC-varmetab"
+      },
+      "mpc_ka": {
+        "name": "MPC-isolering (Ka)"
+      },
+      "solar_intensity": {
+        "name": "Solvarmetilskud"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/de.json
+++ b/custom_components/better_thermostat/translations/de.json
@@ -174,6 +174,35 @@
         "sleep": "Schlafen",
         "activity": "Aktivität"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Automatisch (alt)",
+        "auto": "Automatisch",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "KI zeitbasiert",
+        "default": "Nur externer Sensorversatz (Standard)",
+        "mpc_calibration": "MPC prädiktiv (Beta)",
+        "fix_calibration": "Aggressiv",
+        "tpi_calibration": "TPI-Regler",
+        "pid_calibration": "PID-Regler",
+        "no_calibration": "Keine Kalibrierung"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Direkte Ventilsteuerung",
+        "target_temp_based": "Zieltemperaturbasiert",
+        "local_calibration_based": "Versatzbasiert"
+      }
     }
   },
   "entity": {
@@ -195,6 +224,33 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (Differential)"
+      },
+      "preset_eco": {
+        "name": "Temperatur der Voreinstellung Eco"
+      },
+      "preset_away": {
+        "name": "Temperatur der Voreinstellung Abwesend"
+      },
+      "preset_boost": {
+        "name": "Temperatur der Voreinstellung Boost"
+      },
+      "preset_comfort": {
+        "name": "Temperatur der Voreinstellung Komfort"
+      },
+      "preset_home": {
+        "name": "Temperatur der Voreinstellung Zuhause"
+      },
+      "preset_sleep": {
+        "name": "Temperatur der Voreinstellung Schlafen"
+      },
+      "preset_activity": {
+        "name": "Temperatur der Voreinstellung Aktivität"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: maximale Ventilöffnung"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Maximale Ventilöffnung"
       }
     },
     "switch": {
@@ -209,6 +265,38 @@
       },
       "child_lock_no_trv": {
         "name": "Kindersicherung"
+      }
+    },
+    "sensor": {
+      "external_temp_ema": {
+        "name": "Temperatur-EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Temperatur-EMA (1 Stunde)"
+      },
+      "temp_slope": {
+        "name": "Temperaturänderung"
+      },
+      "heating_power": {
+        "name": "Heizleistung"
+      },
+      "heat_loss": {
+        "name": "Wärmeverlust"
+      },
+      "virtual_temp": {
+        "name": "Virtuelle Temperatur"
+      },
+      "mpc_gain": {
+        "name": "MPC-Heizverstärkung"
+      },
+      "mpc_loss": {
+        "name": "MPC-Wärmeverlust"
+      },
+      "mpc_ka": {
+        "name": "MPC-Isolierung (Ka)"
+      },
+      "solar_intensity": {
+        "name": "Solare Wärmeaufnahme"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/el.json
+++ b/custom_components/better_thermostat/translations/el.json
@@ -174,6 +174,35 @@
         "sleep": "Ύπνος",
         "activity": "Δραστηριότητα"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Αυτόματο (παλιό)",
+        "auto": "Αυτόματο",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "AI βάσει χρόνου",
+        "default": "Μόνο μετατόπιση εξωτερικού αισθητήρα (προεπιλογή)",
+        "mpc_calibration": "Προγνωστικό MPC (beta)",
+        "fix_calibration": "Επιθετικό",
+        "tpi_calibration": "Ελεγκτής TPI",
+        "pid_calibration": "Ελεγκτής PID",
+        "no_calibration": "Χωρίς βαθμονόμηση"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Άμεσος έλεγχος βαλβίδας",
+        "target_temp_based": "Βάσει επιθυμητής θερμοκρασίας",
+        "local_calibration_based": "Βάσει μετατόπισης"
+      }
     }
   },
   "entity": {
@@ -195,6 +224,33 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (διαφορικό)"
+      },
+      "preset_eco": {
+        "name": "Θερμοκρασία προρύθμισης Eco"
+      },
+      "preset_away": {
+        "name": "Θερμοκρασία προρύθμισης Απουσία"
+      },
+      "preset_boost": {
+        "name": "Θερμοκρασία προρύθμισης Boost"
+      },
+      "preset_comfort": {
+        "name": "Θερμοκρασία προρύθμισης Άνεση"
+      },
+      "preset_home": {
+        "name": "Θερμοκρασία προρύθμισης Σπίτι"
+      },
+      "preset_sleep": {
+        "name": "Θερμοκρασία προρύθμισης Ύπνος"
+      },
+      "preset_activity": {
+        "name": "Θερμοκρασία προρύθμισης Δραστηριότητα"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: μέγιστο άνοιγμα βαλβίδας"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Μέγιστο άνοιγμα βαλβίδας"
       }
     },
     "switch": {
@@ -209,6 +265,38 @@
       },
       "child_lock_no_trv": {
         "name": "Παιδικό κλείδωμα"
+      }
+    },
+    "sensor": {
+      "external_temp_ema": {
+        "name": "Θερμοκρασία EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Θερμοκρασία EMA (1 ώρα)"
+      },
+      "temp_slope": {
+        "name": "Ρυθμός μεταβολής θερμοκρασίας"
+      },
+      "heating_power": {
+        "name": "Ισχύς θέρμανσης"
+      },
+      "heat_loss": {
+        "name": "Απώλεια θερμότητας"
+      },
+      "virtual_temp": {
+        "name": "Εικονική θερμοκρασία"
+      },
+      "mpc_gain": {
+        "name": "Κέρδος θέρμανσης MPC"
+      },
+      "mpc_loss": {
+        "name": "Απώλεια θερμότητας MPC"
+      },
+      "mpc_ka": {
+        "name": "Μόνωση MPC (Ka)"
+      },
+      "solar_intensity": {
+        "name": "Ηλιακό θερμικό κέρδος"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/en.json
+++ b/custom_components/better_thermostat/translations/en.json
@@ -174,6 +174,35 @@
         "sleep": "Sleep",
         "activity": "Activity"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Auto (legacy)",
+        "auto": "Auto",
+        "step_0_1": "0.1 °C",
+        "step_0_2": "0.2 °C",
+        "step_0_25": "0.25 °C",
+        "step_0_5": "0.5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "(AI) Time based",
+        "default": "External sensor offset only (default)",
+        "mpc_calibration": "MPC predictive (beta)",
+        "fix_calibration": "Aggressive",
+        "tpi_calibration": "TPI controller",
+        "pid_calibration": "PID controller",
+        "no_calibration": "No calibration"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Direct valve control",
+        "target_temp_based": "Target temperature based",
+        "local_calibration_based": "Offset based"
+      }
     }
   },
   "entity": {
@@ -195,6 +224,33 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (Derivative)"
+      },
+      "preset_eco": {
+        "name": "Eco preset temperature"
+      },
+      "preset_away": {
+        "name": "Away preset temperature"
+      },
+      "preset_boost": {
+        "name": "Boost preset temperature"
+      },
+      "preset_comfort": {
+        "name": "Comfort preset temperature"
+      },
+      "preset_home": {
+        "name": "Home preset temperature"
+      },
+      "preset_sleep": {
+        "name": "Sleep preset temperature"
+      },
+      "preset_activity": {
+        "name": "Activity preset temperature"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name} maximum valve opening"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Maximum valve opening"
       }
     },
     "switch": {
@@ -209,6 +265,38 @@
       },
       "child_lock_no_trv": {
         "name": "Child Lock"
+      }
+    },
+    "sensor": {
+      "external_temp_ema": {
+        "name": "Temperature EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Temperature EMA (1 hour)"
+      },
+      "temp_slope": {
+        "name": "Temperature slope"
+      },
+      "heating_power": {
+        "name": "Heating power"
+      },
+      "heat_loss": {
+        "name": "Heat loss"
+      },
+      "virtual_temp": {
+        "name": "Virtual temperature"
+      },
+      "mpc_gain": {
+        "name": "MPC heating gain"
+      },
+      "mpc_loss": {
+        "name": "MPC heat loss"
+      },
+      "mpc_ka": {
+        "name": "MPC insulation (Ka)"
+      },
+      "solar_intensity": {
+        "name": "Solar heat gain"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/fr.json
+++ b/custom_components/better_thermostat/translations/fr.json
@@ -174,6 +174,35 @@
         "sleep": "Sommeil",
         "activity": "Activité"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Auto (ancien)",
+        "auto": "Auto",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "IA basée sur le temps",
+        "default": "Décalage du capteur externe uniquement (par défaut)",
+        "mpc_calibration": "MPC prédictif (bêta)",
+        "fix_calibration": "Agressif",
+        "tpi_calibration": "Contrôleur TPI",
+        "pid_calibration": "Contrôleur PID",
+        "no_calibration": "Sans étalonnage"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Commande directe de la vanne",
+        "target_temp_based": "Basé sur la température cible",
+        "local_calibration_based": "Basé sur le décalage"
+      }
     }
   },
   "entity": {
@@ -195,6 +224,33 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (dérivé)"
+      },
+      "preset_eco": {
+        "name": "Température du préréglage Éco"
+      },
+      "preset_away": {
+        "name": "Température du préréglage Absent"
+      },
+      "preset_boost": {
+        "name": "Température du préréglage Boost"
+      },
+      "preset_comfort": {
+        "name": "Température du préréglage Confort"
+      },
+      "preset_home": {
+        "name": "Température du préréglage Maison"
+      },
+      "preset_sleep": {
+        "name": "Température du préréglage Sommeil"
+      },
+      "preset_activity": {
+        "name": "Température du préréglage Activité"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name} : ouverture maximale de la vanne"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Ouverture maximale de la vanne"
       }
     },
     "switch": {
@@ -209,6 +265,38 @@
       },
       "child_lock_no_trv": {
         "name": "Sécurité enfant"
+      }
+    },
+    "sensor": {
+      "external_temp_ema": {
+        "name": "Température EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Température EMA (1 heure)"
+      },
+      "temp_slope": {
+        "name": "Variation de température"
+      },
+      "heating_power": {
+        "name": "Puissance de chauffage"
+      },
+      "heat_loss": {
+        "name": "Perte de chaleur"
+      },
+      "virtual_temp": {
+        "name": "Température virtuelle"
+      },
+      "mpc_gain": {
+        "name": "Gain de chauffage MPC"
+      },
+      "mpc_loss": {
+        "name": "Perte thermique MPC"
+      },
+      "mpc_ka": {
+        "name": "Isolation MPC (Ka)"
+      },
+      "solar_intensity": {
+        "name": "Apport de chaleur solaire"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/it.json
+++ b/custom_components/better_thermostat/translations/it.json
@@ -174,6 +174,35 @@
         "sleep": "Notte",
         "activity": "Attività"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Automatico (precedente)",
+        "auto": "Automatico",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "IA basata sul tempo",
+        "default": "Solo offset sensore esterno (predefinito)",
+        "mpc_calibration": "MPC predittivo (beta)",
+        "fix_calibration": "Aggressivo",
+        "tpi_calibration": "Controller TPI",
+        "pid_calibration": "Controller PID",
+        "no_calibration": "Nessuna calibrazione"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Controllo diretto della valvola",
+        "target_temp_based": "Basato sulla temperatura obiettivo",
+        "local_calibration_based": "Basato sull’offset"
+      }
     }
   },
   "entity": {
@@ -195,6 +224,33 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (derivativo)"
+      },
+      "preset_eco": {
+        "name": "Temperatura preimpostata Eco"
+      },
+      "preset_away": {
+        "name": "Temperatura preimpostata Assente"
+      },
+      "preset_boost": {
+        "name": "Temperatura preimpostata Boost"
+      },
+      "preset_comfort": {
+        "name": "Temperatura preimpostata Comfort"
+      },
+      "preset_home": {
+        "name": "Temperatura preimpostata Casa"
+      },
+      "preset_sleep": {
+        "name": "Temperatura preimpostata Sonno"
+      },
+      "preset_activity": {
+        "name": "Temperatura preimpostata Attività"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: apertura massima della valvola"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Apertura massima della valvola"
       }
     },
     "switch": {
@@ -209,6 +265,38 @@
       },
       "child_lock_no_trv": {
         "name": "Blocco bambini"
+      }
+    },
+    "sensor": {
+      "external_temp_ema": {
+        "name": "Temperatura EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Temperatura EMA (1 ora)"
+      },
+      "temp_slope": {
+        "name": "Variazione della temperatura"
+      },
+      "heating_power": {
+        "name": "Potenza di riscaldamento"
+      },
+      "heat_loss": {
+        "name": "Perdita di calore"
+      },
+      "virtual_temp": {
+        "name": "Temperatura virtuale"
+      },
+      "mpc_gain": {
+        "name": "Guadagno di riscaldamento MPC"
+      },
+      "mpc_loss": {
+        "name": "Perdita di calore MPC"
+      },
+      "mpc_ka": {
+        "name": "Isolamento MPC (Ka)"
+      },
+      "solar_intensity": {
+        "name": "Apporto di calore solare"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/pl.json
+++ b/custom_components/better_thermostat/translations/pl.json
@@ -174,6 +174,35 @@
         "sleep": "Sen",
         "activity": "Aktywność"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Automatycznie (stare)",
+        "auto": "Automatycznie",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "AI na podstawie czasu",
+        "default": "Tylko przesunięcie czujnika zewnętrznego (domyślne)",
+        "mpc_calibration": "Predykcyjne MPC (beta)",
+        "fix_calibration": "Agresywne",
+        "tpi_calibration": "Regulator TPI",
+        "pid_calibration": "Regulator PID",
+        "no_calibration": "Bez kalibracji"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Bezpośrednie sterowanie zaworem",
+        "target_temp_based": "Na podstawie temperatury docelowej",
+        "local_calibration_based": "Na podstawie przesunięcia"
+      }
     }
   },
   "entity": {
@@ -195,6 +224,33 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (różniczkujący)"
+      },
+      "preset_eco": {
+        "name": "Temperatura ustawienia Eco"
+      },
+      "preset_away": {
+        "name": "Temperatura ustawienia Poza domem"
+      },
+      "preset_boost": {
+        "name": "Temperatura ustawienia Boost"
+      },
+      "preset_comfort": {
+        "name": "Temperatura ustawienia Komfort"
+      },
+      "preset_home": {
+        "name": "Temperatura ustawienia Dom"
+      },
+      "preset_sleep": {
+        "name": "Temperatura ustawienia Sen"
+      },
+      "preset_activity": {
+        "name": "Temperatura ustawienia Aktywność"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: maksymalne otwarcie zaworu"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Maksymalne otwarcie zaworu"
       }
     },
     "switch": {
@@ -209,6 +265,38 @@
       },
       "child_lock_no_trv": {
         "name": "Blokada rodzicielska"
+      }
+    },
+    "sensor": {
+      "external_temp_ema": {
+        "name": "Temperatura EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Temperatura EMA (1 godzina)"
+      },
+      "temp_slope": {
+        "name": "Tempo zmian temperatury"
+      },
+      "heating_power": {
+        "name": "Moc grzewcza"
+      },
+      "heat_loss": {
+        "name": "Straty ciepła"
+      },
+      "virtual_temp": {
+        "name": "Temperatura wirtualna"
+      },
+      "mpc_gain": {
+        "name": "Wzmocnienie grzania MPC"
+      },
+      "mpc_loss": {
+        "name": "Straty ciepła MPC"
+      },
+      "mpc_ka": {
+        "name": "Izolacja MPC (Ka)"
+      },
+      "solar_intensity": {
+        "name": "Zysk ciepła od słońca"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/ru.json
+++ b/custom_components/better_thermostat/translations/ru.json
@@ -174,6 +174,35 @@
         "sleep": "Сон",
         "activity": "Активность"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Авто (старый режим)",
+        "auto": "Авто",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "ИИ на основе времени",
+        "default": "Только смещение по внешнему датчику (по умолчанию)",
+        "mpc_calibration": "Предиктивный MPC (бета)",
+        "fix_calibration": "Агрессивный",
+        "tpi_calibration": "TPI-регулятор",
+        "pid_calibration": "PID-регулятор",
+        "no_calibration": "Без калибровки"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Прямое управление клапаном",
+        "target_temp_based": "По целевой температуре",
+        "local_calibration_based": "По смещению"
+      }
     }
   },
   "entity": {
@@ -195,6 +224,33 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (дифференциальный коэффициент)"
+      },
+      "preset_eco": {
+        "name": "Температура предустановки «Эко»"
+      },
+      "preset_away": {
+        "name": "Температура предустановки «Вне дома»"
+      },
+      "preset_boost": {
+        "name": "Температура предустановки «Форсаж»"
+      },
+      "preset_comfort": {
+        "name": "Температура предустановки «Комфорт»"
+      },
+      "preset_home": {
+        "name": "Температура предустановки «Дома»"
+      },
+      "preset_sleep": {
+        "name": "Температура предустановки «Сон»"
+      },
+      "preset_activity": {
+        "name": "Температура предустановки «Активность»"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: максимальное открытие клапана"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Максимальное открытие клапана"
       }
     },
     "switch": {
@@ -209,6 +265,38 @@
       },
       "child_lock_no_trv": {
         "name": "Детский замок"
+      }
+    },
+    "sensor": {
+      "external_temp_ema": {
+        "name": "Сглаженная температура (EMA)"
+      },
+      "external_temp_ema_1h": {
+        "name": "Сглаженная температура (EMA, 1 час)"
+      },
+      "temp_slope": {
+        "name": "Скорость изменения температуры"
+      },
+      "heating_power": {
+        "name": "Мощность нагрева"
+      },
+      "heat_loss": {
+        "name": "Теплопотери"
+      },
+      "virtual_temp": {
+        "name": "Виртуальная температура"
+      },
+      "mpc_gain": {
+        "name": "Коэффициент нагрева MPC"
+      },
+      "mpc_loss": {
+        "name": "Коэффициент теплопотерь MPC"
+      },
+      "mpc_ka": {
+        "name": "Теплоизоляция MPC (Ka)"
+      },
+      "solar_intensity": {
+        "name": "Нагрев от солнечного излучения"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/sk.json
+++ b/custom_components/better_thermostat/translations/sk.json
@@ -174,6 +174,35 @@
         "sleep": "Spánok",
         "activity": "Aktivita"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Automaticky (staré)",
+        "auto": "Automaticky",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "AI podľa času",
+        "default": "Iba posun externého snímača (predvolené)",
+        "mpc_calibration": "Prediktívne MPC (beta)",
+        "fix_calibration": "Agresívne",
+        "tpi_calibration": "Regulátor TPI",
+        "pid_calibration": "Regulátor PID",
+        "no_calibration": "Bez kalibrácie"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Priame ovládanie ventilu",
+        "target_temp_based": "Podľa cieľovej teploty",
+        "local_calibration_based": "Podľa posunu"
+      }
     }
   },
   "entity": {
@@ -195,6 +224,33 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (Derivačné)"
+      },
+      "preset_eco": {
+        "name": "Teplota predvoľby Eco"
+      },
+      "preset_away": {
+        "name": "Teplota predvoľby Mimo domu"
+      },
+      "preset_boost": {
+        "name": "Teplota predvoľby Boost"
+      },
+      "preset_comfort": {
+        "name": "Teplota predvoľby Komfort"
+      },
+      "preset_home": {
+        "name": "Teplota predvoľby Doma"
+      },
+      "preset_sleep": {
+        "name": "Teplota predvoľby Spánok"
+      },
+      "preset_activity": {
+        "name": "Teplota predvoľby Aktivita"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: maximálne otvorenie ventilu"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Maximálne otvorenie ventilu"
       }
     },
     "switch": {
@@ -209,6 +265,38 @@
       },
       "child_lock_no_trv": {
         "name": "Detská poistka"
+      }
+    },
+    "sensor": {
+      "external_temp_ema": {
+        "name": "Teplota EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Teplota EMA (1 hodina)"
+      },
+      "temp_slope": {
+        "name": "Rýchlosť zmeny teploty"
+      },
+      "heating_power": {
+        "name": "Vykurovací výkon"
+      },
+      "heat_loss": {
+        "name": "Tepelná strata"
+      },
+      "virtual_temp": {
+        "name": "Virtuálna teplota"
+      },
+      "mpc_gain": {
+        "name": "Zisk vykurovania MPC"
+      },
+      "mpc_loss": {
+        "name": "Tepelná strata MPC"
+      },
+      "mpc_ka": {
+        "name": "Izolácia MPC (Ka)"
+      },
+      "solar_intensity": {
+        "name": "Solárny tepelný zisk"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/tr.json
+++ b/custom_components/better_thermostat/translations/tr.json
@@ -174,6 +174,35 @@
         "sleep": "Uyku",
         "activity": "Aktivite"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Otomatik (eski)",
+        "auto": "Otomatik",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "Zamana dayalı yapay zekâ",
+        "default": "Yalnızca harici sensör ofseti (varsayılan)",
+        "mpc_calibration": "MPC öngörülü (beta)",
+        "fix_calibration": "Agresif",
+        "tpi_calibration": "TPI denetleyici",
+        "pid_calibration": "PID denetleyici",
+        "no_calibration": "Kalibrasyon yok"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Doğrudan vana kontrolü",
+        "target_temp_based": "Hedef sıcaklığa dayalı",
+        "local_calibration_based": "Ofsete dayalı"
+      }
     }
   },
   "entity": {
@@ -195,6 +224,33 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (türevsel)"
+      },
+      "preset_eco": {
+        "name": "Eko ön ayar sıcaklığı"
+      },
+      "preset_away": {
+        "name": "Dışarıda ön ayar sıcaklığı"
+      },
+      "preset_boost": {
+        "name": "Takviye ön ayar sıcaklığı"
+      },
+      "preset_comfort": {
+        "name": "Konfor ön ayar sıcaklığı"
+      },
+      "preset_home": {
+        "name": "Ev ön ayar sıcaklığı"
+      },
+      "preset_sleep": {
+        "name": "Uyku ön ayar sıcaklığı"
+      },
+      "preset_activity": {
+        "name": "Etkinlik ön ayar sıcaklığı"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: maksimum vana açıklığı"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Maksimum vana açıklığı"
       }
     },
     "switch": {
@@ -209,6 +265,38 @@
       },
       "child_lock_no_trv": {
         "name": "Çocuk kilidi"
+      }
+    },
+    "sensor": {
+      "external_temp_ema": {
+        "name": "Sıcaklık EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Sıcaklık EMA (1 saat)"
+      },
+      "temp_slope": {
+        "name": "Sıcaklık değişim hızı"
+      },
+      "heating_power": {
+        "name": "Isıtma gücü"
+      },
+      "heat_loss": {
+        "name": "Isı kaybı"
+      },
+      "virtual_temp": {
+        "name": "Sanal sıcaklık"
+      },
+      "mpc_gain": {
+        "name": "MPC ısıtma kazancı"
+      },
+      "mpc_loss": {
+        "name": "MPC ısı kaybı"
+      },
+      "mpc_ka": {
+        "name": "MPC yalıtımı (Ka)"
+      },
+      "solar_intensity": {
+        "name": "Güneş ısı kazancı"
       }
     }
   },

--- a/project.inlang.json
+++ b/project.inlang.json
@@ -3,9 +3,13 @@
     "languageTags": [
         "da",
         "de",
+        "el",
         "en",
         "fr",
+        "it",
         "pl",
+        "ru",
+        "sk",
         "tr"
     ],
     "modules": [

--- a/tests/test_config_flow_localization.py
+++ b/tests/test_config_flow_localization.py
@@ -1,0 +1,29 @@
+"""Regression tests for localized config-flow selector values."""
+
+from custom_components.better_thermostat.config_flow import _normalize_user_submission
+from custom_components.better_thermostat.utils.const import CONF_TARGET_TEMP_STEP
+
+
+def test_new_auto_target_temperature_step_is_preserved():
+    """The translated Auto selector must persist the new empty-string value."""
+    normalized = _normalize_user_submission(
+        {CONF_TARGET_TEMP_STEP: "auto"}, mode="create"
+    )
+
+    assert normalized[CONF_TARGET_TEMP_STEP] == ""
+
+
+def test_legacy_auto_target_temperature_step_is_preserved():
+    """The legacy Auto selector must continue to persist 0.0."""
+    normalized = _normalize_user_submission(
+        {CONF_TARGET_TEMP_STEP: "auto_legacy"}, mode="create"
+    )
+
+    assert normalized[CONF_TARGET_TEMP_STEP] == "0.0"
+
+
+def test_missing_target_temperature_step_uses_legacy_default():
+    """A genuinely missing selector value must retain the existing fallback."""
+    normalized = _normalize_user_submission({}, mode="create")
+
+    assert normalized[CONF_TARGET_TEMP_STEP] == "0.0"

--- a/tests/test_config_flow_localization.py
+++ b/tests/test_config_flow_localization.py
@@ -27,3 +27,10 @@ def test_missing_target_temperature_step_uses_legacy_default():
     normalized = _normalize_user_submission({}, mode="create")
 
     assert normalized[CONF_TARGET_TEMP_STEP] == "0.0"
+
+
+def test_empty_target_temperature_step_uses_legacy_default():
+    """An explicit empty selector value must use the legacy fallback."""
+    normalized = _normalize_user_submission({CONF_TARGET_TEMP_STEP: ""}, mode="create")
+
+    assert normalized[CONF_TARGET_TEMP_STEP] == "0.0"

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -62,11 +62,16 @@ def _flatten(obj: dict, prefix: str = "") -> dict[str, object]:
     flat: dict[str, object] = {}
     for key, value in obj.items():
         path = f"{prefix}.{key}" if prefix else key
-        if isinstance(value, dict):
+        if isinstance(value, dict) and value:
             flat.update(_flatten(value, path))
         else:
             flat[path] = value
     return flat
+
+
+def test_flatten_preserves_empty_object_leaves():
+    """Empty catalog objects must remain visible to value validation."""
+    assert _flatten({"config": {"name": {}}}) == {"config.name": {}}
 
 
 def _load_json(path: Path) -> dict:

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,5 +1,8 @@
-"""Consistency checks for strings.json and the translation files."""
+"""Consistency checks for the Better Thermostat localization catalogs."""
 
+from __future__ import annotations
+
+import ast
 import json
 from pathlib import Path
 import re
@@ -7,28 +10,56 @@ import re
 import pytest
 import yaml
 
-COMPONENT = Path(__file__).parents[1] / "custom_components" / "better_thermostat"
+ROOT = Path(__file__).parents[1]
+COMPONENT = ROOT / "custom_components" / "better_thermostat"
 TRANSLATIONS = COMPONENT / "translations"
+PROJECT_INLANG = ROOT / "project.inlang.json"
 
-LANGUAGES = sorted(p.stem for p in TRANSLATIONS.glob("*.json") if p.stem != "en")
+ALL_LANGUAGES = sorted(path.stem for path in TRANSLATIONS.glob("*.json"))
+LANGUAGES = [language for language in ALL_LANGUAGES if language != "en"]
+
+ENTITY_TRANSLATION_KEYS = {
+    "sensor": {
+        "external_temp_ema",
+        "external_temp_ema_1h",
+        "temp_slope",
+        "heating_power",
+        "heat_loss",
+        "virtual_temp",
+        "mpc_gain",
+        "mpc_loss",
+        "mpc_ka",
+        "solar_intensity",
+    },
+    "number": {
+        "preset_eco",
+        "preset_away",
+        "preset_boost",
+        "preset_comfort",
+        "preset_home",
+        "preset_sleep",
+        "preset_activity",
+        "pid_kp",
+        "pid_ki",
+        "pid_kd",
+        "pid_kp_no_trv",
+        "pid_ki_no_trv",
+        "pid_kd_no_trv",
+        "valve_max_opening",
+        "valve_max_opening_no_trv",
+    },
+    "switch": {
+        "pid_auto_tune",
+        "pid_auto_tune_no_trv",
+        "child_lock",
+        "child_lock_no_trv",
+    },
+}
 
 
-def _flatten(obj: dict, prefix: str = "") -> dict[str, str]:
-    """Flatten nested dict values into dotted-key paths.
-
-    Parameters
-    ----------
-    obj : dict
-        Mapping to flatten.
-    prefix : str
-        Prefix for generated dotted paths.
-
-    Returns
-    -------
-    dict[str, str]
-        Flattened mapping where nested keys are represented as dotted paths.
-    """
-    flat: dict[str, str] = {}
+def _flatten(obj: dict, prefix: str = "") -> dict[str, object]:
+    """Flatten nested dictionary values into dotted-key paths."""
+    flat: dict[str, object] = {}
     for key, value in obj.items():
         path = f"{prefix}.{key}" if prefix else key
         if isinstance(value, dict):
@@ -38,79 +69,135 @@ def _flatten(obj: dict, prefix: str = "") -> dict[str, str]:
     return flat
 
 
-def _load(path: Path) -> dict[str, str]:
-    """Load a JSON file and flatten it into dotted-key paths.
-
-    Parameters
-    ----------
-    path : Path
-        JSON file path to read.
-
-    Returns
-    -------
-    dict[str, str]
-        Flattened JSON mapping for translation key comparisons.
-    """
-    return _flatten(json.loads(path.read_text(encoding="utf-8")))
+def _load_json(path: Path) -> dict:
+    """Load a JSON object from path."""
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict), f"{path} must contain a JSON object"
+    return value
 
 
-def _placeholders(text: str) -> list[str]:
-    """Return sorted placeholder tokens found in a string.
+def _load(path: Path) -> dict[str, object]:
+    """Load and flatten a translation catalog."""
+    return _flatten(_load_json(path))
 
-    Parameters
-    ----------
-    text : str
-        Input text that may contain placeholders such as ``{name}``.
 
-    Returns
-    -------
-    list[str]
-        Sorted placeholder tokens extracted from the text.
-    """
+def _placeholders(text: object) -> list[str]:
+    """Return sorted placeholder tokens found in a translation string."""
+    assert isinstance(text, str), f"translation value must be a string, got {text!r}"
     return sorted(re.findall(r"\{[^}]*\}", text))
 
 
 def test_strings_json_matches_en_json():
-    """strings.json (source) and translations/en.json must be identical."""
+    """The authoring source and runtime English catalog must be identical."""
     assert _load(COMPONENT / "strings.json") == _load(TRANSLATIONS / "en.json")
+
+
+def test_inlang_languages_match_translation_catalogs():
+    """Every catalog must be discoverable by the Inlang contributor tooling."""
+    project = _load_json(PROJECT_INLANG)
+
+    assert project["sourceLanguageTag"] == "en"
+    assert sorted(project["languageTags"]) == ALL_LANGUAGES
+    assert (
+        project["plugin.inlang.i18next"]["pathPattern"]
+        == "./custom_components/better_thermostat/translations/{languageTag}.json"
+    )
+
+
+@pytest.mark.parametrize("lang", ALL_LANGUAGES)
+def test_translation_values_are_non_empty_strings(lang: str):
+    """Catalog leaves must contain non-empty text rather than nulls or objects."""
+    invalid = {
+        key: value
+        for key, value in _load(TRANSLATIONS / f"{lang}.json").items()
+        if not isinstance(value, str) or not value.strip()
+    }
+    assert not invalid, f"{lang}.json has invalid translation values: {invalid}"
 
 
 @pytest.mark.parametrize("lang", LANGUAGES)
 def test_no_unknown_keys(lang: str):
-    """Translation files must not contain keys that do not exist in en.json."""
-    en = _load(TRANSLATIONS / "en.json")
+    """Translation files must not contain keys absent from English."""
+    english = _load(TRANSLATIONS / "en.json")
     translated = _load(TRANSLATIONS / f"{lang}.json")
-    unknown = sorted(key for key in translated if key not in en)
+    unknown = sorted(key for key in translated if key not in english)
     assert not unknown, f"{lang}.json has keys unknown to en.json: {unknown}"
 
 
 @pytest.mark.parametrize("lang", LANGUAGES)
 def test_all_keys_translated(lang: str):
-    """Translation files must cover every key of en.json."""
-    en = _load(TRANSLATIONS / "en.json")
+    """Every language must cover every runtime English key."""
+    english = _load(TRANSLATIONS / "en.json")
     translated = _load(TRANSLATIONS / f"{lang}.json")
-    missing = sorted(key for key in en if key not in translated)
+    missing = sorted(key for key in english if key not in translated)
     assert not missing, f"{lang}.json is missing keys: {missing}"
 
 
 @pytest.mark.parametrize("lang", LANGUAGES)
 def test_placeholders_match(lang: str):
-    """Shared keys must use exactly the same placeholders as en.json."""
-    en = _load(TRANSLATIONS / "en.json")
+    """Shared keys must preserve exactly the English placeholders."""
+    english = _load(TRANSLATIONS / "en.json")
     translated = _load(TRANSLATIONS / f"{lang}.json")
     mismatched = {
-        key: (en[key], translated[key])
-        for key in en.keys() & translated.keys()
-        if _placeholders(en[key]) != _placeholders(translated[key])
+        key: (english[key], translated[key])
+        for key in english.keys() & translated.keys()
+        if _placeholders(english[key]) != _placeholders(translated[key])
     }
     assert not mismatched, f"{lang}.json placeholder mismatch: {mismatched}"
 
 
+def test_entity_translation_catalog_covers_platform_keys():
+    """All stable translation keys used by entity platforms must be cataloged."""
+    english_entities = _load_json(TRANSLATIONS / "en.json").get("entity", {})
+
+    for platform, expected_keys in ENTITY_TRANSLATION_KEYS.items():
+        actual_keys = set(english_entities.get(platform, {}))
+        missing = expected_keys - actual_keys
+        assert not missing, f"entity.{platform} is missing translation keys: {missing}"
+
+
+def _is_attr_name_target(target: ast.expr) -> bool:
+    """Return whether an assignment target writes Home Assistant's name field."""
+    return (isinstance(target, ast.Name) and target.id == "_attr_name") or (
+        isinstance(target, ast.Attribute) and target.attr == "_attr_name"
+    )
+
+
+@pytest.mark.parametrize("platform", ["sensor.py", "number.py", "switch.py"])
+def test_entity_platforms_do_not_hardcode_natural_language_names(platform: str):
+    """Entity names must use translation keys instead of English Python text."""
+    source_path = COMPONENT / platform
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    hardcoded: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        targets: list[ast.expr] = []
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+
+        if value is None or not any(_is_attr_name_target(target) for target in targets):
+            continue
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            hardcoded.append((node.lineno, value.value))
+        elif isinstance(value, ast.JoinedStr):
+            hardcoded.append((node.lineno, ast.unparse(value)))
+
+    assert not hardcoded, (
+        f"{platform} hardcodes user-facing entity names instead of "
+        f"translation_key: {hardcoded}"
+    )
+
+
 def test_services_yaml_covered():
-    """Every service and service field in services.yaml has a translation."""
+    """Every service and service field in services.yaml has an English string."""
     services = yaml.safe_load((COMPONENT / "services.yaml").read_text(encoding="utf-8"))
-    en = json.loads((TRANSLATIONS / "en.json").read_text(encoding="utf-8"))
-    translated_services = en.get("services", {})
+    english = _load_json(TRANSLATIONS / "en.json")
+    translated_services = english.get("services", {})
 
     assert set(services) == set(translated_services)
     for name, spec in services.items():


### PR DESCRIPTION
## Motivation:

Several user-facing labels were still hardcoded in Python, including calibration selectors, target-temperature-step options, preset number names, valve limit names, and diagnostic sensor names. Those parts of the UI therefore remained in English even when Home Assistant used another language.

This change moves those labels to Home Assistant's native localization system, completes Russian coverage for them, and provides a documented and validated path for adding more languages without changing the integration's Python logic.

## Changes:

- Add translation-backed selector options for calibration mode, calibration type, presets, and target temperature step.
- Preserve existing stored target-temperature-step values through stable selector tokens.
- Replace hardcoded entity names with translation_key and translation placeholders.
- Complete Russian translations for the newly localizable selectors and entities.
- Keep every existing language catalog structurally complete.
- Synchronize the Inlang language list with the translation files in the repository.
- Add a contributor guide for adding BCP 47 language catalogs.
- Expand translation tests to validate catalog structure, placeholders, entity keys, English parity, and Inlang coverage.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2026.7.2 (custom integration tested in a live Home Assistant instance)
Zigbee2MQTT Version: Not applicable
TRV Hardware: Generic climate proxy / ESPHome servo; localization is device-independent

Automated checks:

- focused localization regression tests: 49 passed
- Ruff check for the changed Python files: passed
- Ruff format check for the changed Python files: passed
- Git diff whitespace check against origin/master: passed

The full Home Assistant pytest suite could not be collected on the Windows host because the Home Assistant test plugin imports the POSIX-only fcntl module. The translation and config-flow regression tests and lint checks completed successfully.

## New device mappings

- [x] I avoided any changes to other device mappings
- [x] There are no changes in climate.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Greek, Italian, Russian, and Slovak translation support.
  * Added translated labels for temperature steps, calibration options, presets, sensors, switches, and valve controls.
  * Improved localized names and placeholders across thermostat entities and configuration screens.

* **Documentation**
  * Updated translation contributor guidance with a dedicated guide link and clearer INLANG Editor instructions.

* **Bug Fixes**
  * Improved handling of localized temperature-step values, including legacy and automatic settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->