### PR TITLE
fix(trv): store the device-reported step as a Celsius delta

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1817,11 +1817,23 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             if cfg_step is not None:
                 trv_data.target_temp_step = cfg_step
             else:
-                trv_data.target_temp_step = convert_to_float(
+                _device_step = convert_to_float(
                     str(_attrs.get("target_temp_step", 0.5)),
                     self.device_name,
                     "startup",
                 )
+                # The device reports its step in its own unit, while every
+                # consumer of target_temp_step works in Celsius. A step is a
+                # delta, so it scales by the ratio alone.
+                if (
+                    _device_step is not None
+                    and state_temperature_unit(
+                        _attrs, self.hass.config.units.temperature_unit
+                    )
+                    == UnitOfTemperature.FAHRENHEIT
+                ):
+                    _device_step = round(_device_step * 5.0 / 9.0, 4)
+                trv_data.target_temp_step = _device_step
             trv_data.temperature = attr_to_celsius(
                 self, _s, "temperature", 5, "startup"
             )

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -542,6 +542,56 @@ class TestInitializeTrvCurrentTemperature:
         assert bt.real_trvs[TRV_ID].current_temperature is None
 
 
+class TestInitializeTrvTargetTempStep:
+    """The per-TRV step is stored in °C, whatever unit the device reports in.
+
+    Every consumer works in Celsius: the outbound rounding in
+    ``adapters.delegate.set_temperature``, the calibration math, and the
+    inbound echo comparison in ``events.trv``.
+    """
+
+    def _trv_only_bt(self, bt, attrs, unit="°C", cfg_step=None):
+        bt.real_trvs = {TRV_ID: Trv(entity_id=TRV_ID, calibration=1)}
+        bt.hass.config.units.temperature_unit = unit
+        bt.bt_target_temp_step = cfg_step
+        bt.hass.states.get.return_value = _make_trv_state(attrs=attrs)
+        return bt
+
+    async def _run(self, bt):
+        with (
+            patch("custom_components.better_thermostat.climate.init", AsyncMock()),
+            patch(
+                "custom_components.better_thermostat.climate.initial_tweak", AsyncMock()
+            ),
+            patch(
+                "custom_components.better_thermostat.climate.control_trv",
+                AsyncMock(return_value=True),
+            ),
+        ):
+            await BetterThermostat._initialize_trvs(bt)
+
+    @pytest.mark.asyncio
+    async def test_celsius_step_is_taken_as_reported(self, bt):
+        """On a Celsius system the reported step needs no scaling."""
+        bt = self._trv_only_bt(bt, {"target_temp_step": 0.5})
+        await self._run(bt)
+        assert bt.real_trvs[TRV_ID].target_temp_step == 0.5
+
+    @pytest.mark.asyncio
+    async def test_fahrenheit_step_is_scaled_to_a_celsius_delta(self, bt):
+        """A 1 °F step is a 0.5556 °C delta, not a 1 °C one."""
+        bt = self._trv_only_bt(bt, {"target_temp_step": 1.0}, unit="°F")
+        await self._run(bt)
+        assert bt.real_trvs[TRV_ID].target_temp_step == pytest.approx(0.5556, abs=1e-4)
+
+    @pytest.mark.asyncio
+    async def test_configured_step_is_used_unscaled(self, bt):
+        """A configured step is already in °C and is not scaled again."""
+        bt = self._trv_only_bt(bt, {"target_temp_step": 1.0}, unit="°F", cfg_step=0.5)
+        await self._run(bt)
+        assert bt.real_trvs[TRV_ID].target_temp_step == 0.5
+
+
 class TestRestoreState:
     """Tests for _restore_state."""
 


### PR DESCRIPTION
## Motivation:

The per-TRV `target_temp_step` is read straight from the device attributes at startup, which carry the device's own unit. Every consumer of it works in Celsius:

- `adapters/delegate.py` rounds the outbound setpoint with `round_by_step()`, and that setpoint is Celsius all the way from the controller
- `calibration.py` uses it in the calibration math
- `events/trv.py` uses it as the echo threshold for inbound setpoint changes

On a Fahrenheit system a device reporting a step of `1.0` was therefore treated as a 1 K delta instead of 0.5556 K. The visible effect is on the inbound path: a user turning the TRV dial by one notch moves the setpoint by less than the assumed step, so the change is classified as a device-side rounding echo and dropped.

The neighbouring attributes are already handled this way. `min_temp` and `max_temp` go through `attr_to_celsius()` two lines above, and the configured `bt_target_temp_step` is scaled at construction time. The device-reported step was the one that stayed raw.

## Changes:

`_initialize_trvs()` scales a device-reported step to a Celsius delta when the reporting state is in Fahrenheit. A step is a delta, so it scales by the ratio alone rather than through the offset conversion. The configured-step branch is untouched, since that value is already in Celsius.

Three tests cover the Celsius passthrough, the Fahrenheit scaling, and that a configured step is not scaled a second time.

## Related issue (check one):

- [x] There is no related issue ticket

## Checklist (check one):

- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: 2026.6.x (dev requirements)
Zigbee2MQTT Version: n/a
TRV Hardware: n/a (2139 tests, ruff, pyrefly)

## New device mappings

- [x] I avoided any changes to other device mappings