### PR TITLE
fix(cooler): survive an unknown cool target on a range-only cooler

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -134,6 +134,7 @@ from .utils.const import (
 )
 from .utils.controlling import control_queue, control_trv
 from .utils.helpers import (
+    COOLER_SETPOINT_KEYS,
     async_normalize_bt_entity_ids,
     attr_to_celsius,
     convert_to_float,
@@ -143,6 +144,7 @@ from .utils.helpers import (
     get_hvac_bt_mode,
     is_reasonable_temperature,
     normalize_hvac_mode,
+    read_setpoint_celsius,
     state_temperature_unit,
 )
 from .utils.hvac_action import (
@@ -1413,8 +1415,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 STATE_UNKNOWN,
                 None,
             ):
-                self.bt_target_cooltemp = attr_to_celsius(
-                    self, _cooler_state, "temperature", None, "startup()"
+                # A cooler that only supports TARGET_TEMPERATURE_RANGE reports
+                # ``temperature: None`` and carries its setpoint in
+                # ``target_temp_high``, so the same key precedence the event
+                # handler and control_cooler() use applies here too.
+                self.bt_target_cooltemp = read_setpoint_celsius(
+                    self, _cooler_state, COOLER_SETPOINT_KEYS, "startup()"
                 )
             # else: already logged warning above
 

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2822,6 +2822,34 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         )
         self.bt_target_cooltemp = adjusted
 
+    def _enforce_heat_below_cool(self) -> None:
+        """Keep the heating target strictly below the cooling target.
+
+        The counterpart to :meth:`_enforce_cool_above_heat`, for the case where
+        the cooling target is the value that was just set: the heating target
+        yields instead, down to one temperature step below the cooling target
+        and never below the configured minimum.
+        """
+        if (
+            self.hvac_mode != HVACMode.HEAT_COOL
+            or self.bt_target_cooltemp is None
+            or self.bt_target_temp is None
+            or self.bt_target_temp < self.bt_target_cooltemp
+        ):
+            return
+        step = self.bt_target_temp_step or 0.5
+        adjusted = self.bt_target_cooltemp - step
+        if self.bt_min_temp is not None:
+            adjusted = max(adjusted, self.bt_min_temp)
+        _LOGGER.warning(
+            "better_thermostat %s: heating target %.2f adjusted to %.2f to stay below cooling target %.2f",
+            self.device_name,
+            self.bt_target_temp,
+            adjusted,
+            self.bt_target_cooltemp,
+        )
+        self.bt_target_temp = adjusted
+
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""
         _LOGGER.debug(

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -77,8 +77,6 @@ async def trigger_cooler_change(self, event):
         keys=COOLER_SETPOINT_KEYS,
         known_values=(self.bt_target_cooltemp, self.last_sent_cooler_temp),
         step=_step,
-        device_label="Cooler",
-        entity_id=entity_id,
         log_source="trigger_cooler_change()",
     )
     if (
@@ -107,6 +105,13 @@ async def trigger_cooler_change(self, event):
             _new_cooling_setpoint.raw - _old_cooling_setpoint
         ) >= setpoint_echo_window(_step)
         if not _new_cooling_setpoint.is_echo and _reported_moved:
+            if _new_cooling_setpoint.clamped:
+                _LOGGER.warning(
+                    "better_thermostat %s: New Cooler %s setpoint outside of range, "
+                    "overwriting it",
+                    self.device_name,
+                    entity_id,
+                )
             self.bt_target_cooltemp = _new_cooling_setpoint.value
             self._enforce_heat_below_cool()
             _main_change = True

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -13,28 +13,12 @@ from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State, callback
 
 from custom_components.better_thermostat.utils.helpers import (
-    attr_to_celsius,
     convert_to_float,
+    get_cooler_setpoint,
     state_temperature_unit,
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _get_cooling_setpoint(self, state: State) -> float | None:
-    """Read the cooler's setpoint from a state and return it in °C.
-
-    A climate entity that supports both a single target and a target range
-    publishes ``temperature`` as None while it runs in range mode, so a
-    present-but-empty attribute must not stop the range key from being read.
-    """
-    for key in ("temperature", "target_temp_high"):
-        if state.attributes.get(key) is None:
-            continue
-        setpoint = attr_to_celsius(self, state, key, None, "trigger_cooler_change()")
-        if setpoint is not None:
-            return setpoint
-    return None
 
 
 def _get_cooler_step(self, state: State) -> float:
@@ -105,8 +89,12 @@ async def trigger_cooler_change(self, event):
         "better_thermostat %s: Cooler %s update received", self.device_name, entity_id
     )
 
-    _old_cooling_setpoint = _get_cooling_setpoint(self, old_state)
-    _new_cooling_setpoint = _get_cooling_setpoint(self, new_state)
+    _old_cooling_setpoint = get_cooler_setpoint(
+        self, old_state, "trigger_cooler_change()"
+    )
+    _new_cooling_setpoint = get_cooler_setpoint(
+        self, new_state, "trigger_cooler_change()"
+    )
     if (
         _new_cooling_setpoint is not None
         and _old_cooling_setpoint is not None

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -13,8 +13,12 @@ from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State, callback
 
 from custom_components.better_thermostat.utils.helpers import (
+    COOLER_SETPOINT_KEYS,
     convert_to_float,
-    get_cooler_setpoint,
+    normalize_step,
+    read_setpoint_celsius,
+    resolve_inbound_setpoint,
+    resolve_state_change_event,
     state_temperature_unit,
 )
 
@@ -38,9 +42,8 @@ def _get_cooler_step(self, state: State) -> float:
     ):
         step = round(step * 5.0 / 9.0, 4)
     if step is None or step <= 0:
-        fallback = self.bt_target_temp_step
-        step = fallback if isinstance(fallback, (int, float)) and fallback > 0 else 0.5
-    return float(step)
+        return normalize_step(self.bt_target_temp_step)
+    return step
 
 
 @callback
@@ -50,98 +53,52 @@ async def trigger_cooler_change(self, event):
         return
     if self.control_queue_task is None:
         return
-    _main_change = False
-    old_state = event.data.get("old_state")
-    new_state = event.data.get("new_state")
-    entity_id = event.data.get("entity_id")
 
-    if new_state is None or old_state is None:
-        _LOGGER.debug(
-            "better_thermostat %s: Cooler %s update contained not all "
-            "necessary data for processing, skipping",
-            self.device_name,
-            entity_id,
-        )
+    resolved_event = resolve_state_change_event(self, event, "Cooler")
+    if resolved_event is None:
         return
-
-    if not isinstance(new_state, State) or not isinstance(old_state, State):
-        _LOGGER.debug(
-            "better_thermostat %s: Cooler %s update contained not a State, skipping",
-            self.device_name,
-            entity_id,
-        )
-        return
-
-    if new_state.attributes is None:
-        _LOGGER.debug(
-            "better_thermostat %s: Cooler %s update had no attributes, skipping",
-            self.device_name,
-            entity_id,
-        )
-        return
-
-    # Skip updates that BT itself triggered: our own service calls carry
-    # self.context, so a matching context means this is an echo of our write.
-    if self.context == event.context:
-        return
+    old_state, new_state, entity_id = resolved_event
 
     _LOGGER.debug(
         "better_thermostat %s: Cooler %s update received", self.device_name, entity_id
     )
 
-    _old_cooling_setpoint = get_cooler_setpoint(
-        self, old_state, "trigger_cooler_change()"
+    _main_change = False
+    _step = _get_cooler_step(self, new_state)
+    # The previous state only answers whether the cooler was publishing a
+    # setpoint at all, so it is read without clamping or echo detection.
+    _old_cooling_setpoint = read_setpoint_celsius(
+        self, old_state, COOLER_SETPOINT_KEYS, "trigger_cooler_change()"
     )
-    _new_cooling_setpoint = get_cooler_setpoint(
-        self, new_state, "trigger_cooler_change()"
+    _new_cooling_setpoint = resolve_inbound_setpoint(
+        self,
+        new_state,
+        keys=COOLER_SETPOINT_KEYS,
+        known_values=(self.bt_target_cooltemp, self.last_sent_cooler_temp),
+        step=_step,
+        device_label="Cooler",
+        entity_id=entity_id,
+        log_source="trigger_cooler_change()",
     )
     if (
         _new_cooling_setpoint is not None
         and _old_cooling_setpoint is not None
         and self.bt_hvac_mode != HVACMode.OFF
     ):
-        _step = _get_cooler_step(self, new_state)
-        # Adopt only what a user set on the cooler itself. A value within one
-        # step of a setpoint BT wrote is the device reporting our own write
-        # back: rounded to its own grid, or delayed until a poll that carries a
-        # foreign context and therefore passes the context check above. User
-        # input moves the setpoint by at least one step.
-        _bt_known_values = (self.bt_target_cooltemp, self.last_sent_cooler_temp)
-        _is_echo = any(
-            isinstance(value, (int, float))
-            and abs(_new_cooling_setpoint - value) < _step
-            for value in _bt_known_values
-        )
         _LOGGER.debug(
             "better_thermostat %s: trigger_cooler_change / "
             "_old_cooling_setpoint: %s - _new_cooling_setpoint: %s - "
             "bt_target_cooltemp: %s - last_sent: %s - step: %s - echo: %s",
             self.device_name,
             _old_cooling_setpoint,
-            _new_cooling_setpoint,
+            _new_cooling_setpoint.value,
             self.bt_target_cooltemp,
             self.last_sent_cooler_temp,
             _step,
-            _is_echo,
+            _new_cooling_setpoint.is_echo,
         )
-        if not _is_echo:
-            if (
-                _new_cooling_setpoint < self.bt_min_temp
-                or self.bt_max_temp < _new_cooling_setpoint
-            ):
-                _LOGGER.warning(
-                    "better_thermostat %s: New Cooler %s setpoint outside of range, "
-                    "overwriting it",
-                    self.device_name,
-                    entity_id,
-                )
-
-                if _new_cooling_setpoint < self.bt_min_temp:
-                    _new_cooling_setpoint = self.bt_min_temp
-                else:
-                    _new_cooling_setpoint = self.bt_max_temp
-
-            self.bt_target_cooltemp = _new_cooling_setpoint
+        if not _new_cooling_setpoint.is_echo:
+            self.bt_target_cooltemp = _new_cooling_setpoint.value
             self._enforce_heat_below_cool()
             _main_change = True
 

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -19,6 +19,7 @@ from custom_components.better_thermostat.utils.helpers import (
     read_setpoint_celsius,
     resolve_inbound_setpoint,
     resolve_state_change_event,
+    setpoint_echo_window,
     state_temperature_unit,
 )
 
@@ -97,7 +98,15 @@ async def trigger_cooler_change(self, event):
             _step,
             _new_cooling_setpoint.is_echo,
         )
-        if not _new_cooling_setpoint.is_echo:
+        # The cooler handler has no device-side gate of its own, so an event
+        # that republishes the same setpoint — an attribute refresh, a mode
+        # change, a temperature push — must not be read as user intent: a
+        # stale report would otherwise revert a BT-side target that has not
+        # been written yet.
+        _reported_moved = abs(
+            _new_cooling_setpoint.raw - _old_cooling_setpoint
+        ) >= setpoint_echo_window(_step)
+        if not _new_cooling_setpoint.is_echo and _reported_moved:
             self.bt_target_cooltemp = _new_cooling_setpoint.value
             self._enforce_heat_below_cool()
             _main_change = True

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -9,11 +9,54 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State, callback
 
-from custom_components.better_thermostat.utils.helpers import convert_to_float
+from custom_components.better_thermostat.utils.helpers import (
+    attr_to_celsius,
+    convert_to_float,
+    state_temperature_unit,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _get_cooling_setpoint(self, state: State) -> float | None:
+    """Read the cooler's setpoint from a state and return it in °C.
+
+    A climate entity that supports both a single target and a target range
+    publishes ``temperature`` as None while it runs in range mode, so a
+    present-but-empty attribute must not stop the range key from being read.
+    """
+    for key in ("temperature", "target_temp_high"):
+        if state.attributes.get(key) is None:
+            continue
+        setpoint = attr_to_celsius(self, state, key, None, "trigger_cooler_change()")
+        if setpoint is not None:
+            return setpoint
+    return None
+
+
+def _get_cooler_step(self, state: State) -> float:
+    """Return the cooler's setpoint step as a °C delta."""
+    raw_step = state.attributes.get("target_temp_step")
+    step = (
+        convert_to_float(str(raw_step), self.device_name, "trigger_cooler_change()")
+        if raw_step is not None
+        else None
+    )
+    if (
+        step is not None
+        and state_temperature_unit(
+            state.attributes, self.hass.config.units.temperature_unit
+        )
+        == UnitOfTemperature.FAHRENHEIT
+    ):
+        step = round(step * 5.0 / 9.0, 4)
+    if step is None or step <= 0:
+        fallback = self.bt_target_temp_step
+        step = fallback if isinstance(fallback, (int, float)) and fallback > 0 else 0.5
+    return float(step)
 
 
 @callback
@@ -62,54 +105,57 @@ async def trigger_cooler_change(self, event):
         "better_thermostat %s: Cooler %s update received", self.device_name, entity_id
     )
 
-    def _get_cooling_setpoint(state):
-        """Extract cooling setpoint from state, checking both attribute keys."""
-        for key in ("temperature", "target_temp_high"):
-            if key in state.attributes:
-                return convert_to_float(
-                    str(state.attributes[key]),
-                    self.device_name,
-                    "trigger_cooler_change()",
-                )
-        return None
-
-    _old_cooling_setpoint = _get_cooling_setpoint(old_state)
-    _new_cooling_setpoint = _get_cooling_setpoint(new_state)
+    _old_cooling_setpoint = _get_cooling_setpoint(self, old_state)
+    _new_cooling_setpoint = _get_cooling_setpoint(self, new_state)
     if (
         _new_cooling_setpoint is not None
         and _old_cooling_setpoint is not None
         and self.bt_hvac_mode != HVACMode.OFF
     ):
+        _step = _get_cooler_step(self, new_state)
+        # Adopt only what a user set on the cooler itself. A value within one
+        # step of a setpoint BT wrote is the device reporting our own write
+        # back: rounded to its own grid, or delayed until a poll that carries a
+        # foreign context and therefore passes the context check above. User
+        # input moves the setpoint by at least one step.
+        _bt_known_values = (self.bt_target_cooltemp, self.last_sent_cooler_temp)
+        _is_echo = any(
+            isinstance(value, (int, float))
+            and abs(_new_cooling_setpoint - value) < _step
+            for value in _bt_known_values
+        )
         _LOGGER.debug(
             "better_thermostat %s: trigger_cooler_change / "
-            "_old_cooling_setpoint: %s - _new_cooling_setpoint: %s",
+            "_old_cooling_setpoint: %s - _new_cooling_setpoint: %s - "
+            "bt_target_cooltemp: %s - last_sent: %s - step: %s - echo: %s",
             self.device_name,
             _old_cooling_setpoint,
             _new_cooling_setpoint,
+            self.bt_target_cooltemp,
+            self.last_sent_cooler_temp,
+            _step,
+            _is_echo,
         )
-        if (
-            _new_cooling_setpoint < self.bt_min_temp
-            or self.bt_max_temp < _new_cooling_setpoint
-        ):
-            _LOGGER.warning(
-                "better_thermostat %s: New Cooler %s setpoint outside of range, "
-                "overwriting it",
-                self.device_name,
-                entity_id,
-            )
+        if not _is_echo:
+            if (
+                _new_cooling_setpoint < self.bt_min_temp
+                or self.bt_max_temp < _new_cooling_setpoint
+            ):
+                _LOGGER.warning(
+                    "better_thermostat %s: New Cooler %s setpoint outside of range, "
+                    "overwriting it",
+                    self.device_name,
+                    entity_id,
+                )
 
-            if _new_cooling_setpoint < self.bt_min_temp:
-                _new_cooling_setpoint = self.bt_min_temp
-            else:
-                _new_cooling_setpoint = self.bt_max_temp
+                if _new_cooling_setpoint < self.bt_min_temp:
+                    _new_cooling_setpoint = self.bt_min_temp
+                else:
+                    _new_cooling_setpoint = self.bt_max_temp
 
-        self.bt_target_cooltemp = _new_cooling_setpoint
-        if self.bt_target_temp >= self.bt_target_cooltemp:
-            self.bt_target_temp = max(
-                self.bt_target_cooltemp - max(self.bt_target_temp_step or 0.5, 0.5),
-                self.bt_min_temp,
-            )
-        _main_change = True
+            self.bt_target_cooltemp = _new_cooling_setpoint
+            self._enforce_heat_below_cool()
+            _main_change = True
 
     if _main_change is True:
         self.async_write_ha_state()

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -265,8 +265,6 @@ async def trigger_trv_change(self, event):
         keys=TRV_SETPOINT_KEYS,
         known_values=(self.bt_target_temp, trv.last_temperature),
         step=_step,
-        device_label="TRV",
-        entity_id=entity_id,
         log_source="trigger_trv_change()",
     )
     _is_no_off_device = advanced.get("no_off_system_mode", False)
@@ -298,6 +296,12 @@ async def trigger_trv_change(self, event):
             and not trv.ignore_trv_states
         )
         if _accept_user_setpoint:
+            if _setpoint.clamped:
+                _LOGGER.warning(
+                    "better_thermostat %s: New TRV %s setpoint outside of range, overwriting it",
+                    self.device_name,
+                    entity_id,
+                )
             _LOGGER.debug(
                 "better_thermostat %s: TRV %s decoded TRV target temp changed from %s to %s",
                 self.device_name,

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -311,10 +311,7 @@ async def trigger_trv_change(self, event):
             )
             self.bt_target_temp = _new_heating_setpoint
             if self.cooler_entity_id is not None:
-                if self.bt_target_temp >= self.bt_target_cooltemp:
-                    self.bt_target_cooltemp = self.bt_target_temp + (
-                        self.bt_target_temp_step or 0.5
-                    )
+                self._enforce_cool_above_heat()
 
             _main_change = True
         elif _new_heating_setpoint != _old_heating_setpoint:

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -28,12 +28,17 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.helpers import (
+    TRV_SETPOINT_KEYS,
     attr_to_celsius,
     convert_to_float,
     get_device_model,
     group_all_members_off,
     is_reasonable_temperature,
     mode_remap,
+    normalize_step,
+    read_setpoint_celsius,
+    resolve_inbound_setpoint,
+    resolve_state_change_event,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,32 +56,10 @@ async def trigger_trv_change(self, event):
     if self.bt_update_lock:
         return
     _main_change = False
-    old_state = event.data.get("old_state")
-    new_state = event.data.get("new_state")
-    entity_id = event.data.get("entity_id")
-
-    if new_state is None or old_state is None or new_state.attributes is None:
-        _LOGGER.debug(
-            "better_thermostat %s: TRV %s update contained not all necessary data for processing, skipping",
-            self.device_name,
-            entity_id,
-        )
+    resolved_event = resolve_state_change_event(self, event, "TRV")
+    if resolved_event is None:
         return
-
-    if not isinstance(new_state, State) or not isinstance(old_state, State):
-        _LOGGER.debug(
-            "better_thermostat %s: TRV %s update contained not a State, skipping",
-            self.device_name,
-            entity_id,
-        )
-        return
-
-    # Skip updates that BT itself triggered: our own service calls carry
-    # self.context, so a matching context means this is an echo of our write.
-    if self.context == event.context:
-        return
-
-    # _LOGGER.debug(f"better_thermostat {self.device_name}: TRV {entity_id} update received")
+    old_state, new_state, entity_id = resolved_event
 
     _org_trv_state = self.hass.states.get(entity_id)
     if _org_trv_state is None:
@@ -267,19 +250,28 @@ async def trigger_trv_change(self, event):
             ):
                 self.bt_hvac_mode = mapped_state
 
-    _main_key = "temperature"
-    if "temperature" not in old_state.attributes:
-        _main_key = "target_temp_low"
-
-    _old_heating_setpoint = attr_to_celsius(
-        self, old_state, _main_key, None, "trigger_trv_change()"
+    # The previous state only answers whether the TRV was publishing a setpoint
+    # at all, so it is read without clamping or echo detection.
+    _old_heating_setpoint = read_setpoint_celsius(
+        self, old_state, TRV_SETPOINT_KEYS, "trigger_trv_change()"
     )
-    _new_heating_setpoint = attr_to_celsius(
-        self, new_state, _main_key, None, "trigger_trv_change()"
+    # Compare only against values BT itself wrote. ``_old_heating_setpoint`` is
+    # the TRV's previously published state and is not necessarily a BT-written
+    # value, so it does not belong in the echo-suppression set.
+    _step = normalize_step(trv.target_temp_step or self.bt_target_temp_step)
+    _setpoint = resolve_inbound_setpoint(
+        self,
+        new_state,
+        keys=TRV_SETPOINT_KEYS,
+        known_values=(self.bt_target_temp, trv.last_temperature),
+        step=_step,
+        device_label="TRV",
+        entity_id=entity_id,
+        log_source="trigger_trv_change()",
     )
     _is_no_off_device = advanced.get("no_off_system_mode", False)
     if (
-        _new_heating_setpoint is not None
+        _setpoint is not None
         and _old_heating_setpoint is not None
         and (self.bt_hvac_mode != HVACMode.OFF or _is_no_off_device)
     ):
@@ -287,47 +279,15 @@ async def trigger_trv_change(self, event):
             "better_thermostat %s: trigger_trv_change / _old_heating_setpoint: %s - _new_heating_setpoint: %s - _last_temperature: %s",
             self.device_name,
             _old_heating_setpoint,
-            _new_heating_setpoint,
+            _setpoint.value,
             trv.last_temperature,
         )
-        # Preserve the device's raw reported setpoint before range clamping;
-        # no_off OFF detection must compare against the device's true min_temp,
-        # not a value the clamp may have raised into [bt_min_temp, bt_max_temp].
-        _raw_heating_setpoint = _new_heating_setpoint
-        if (
-            _new_heating_setpoint < self.bt_min_temp
-            or self.bt_max_temp < _new_heating_setpoint
-        ):
-            _LOGGER.warning(
-                "better_thermostat %s: New TRV %s setpoint outside of range, overwriting it",
-                self.device_name,
-                entity_id,
-            )
-
-            if _new_heating_setpoint < self.bt_min_temp:
-                _new_heating_setpoint = self.bt_min_temp
-            else:
-                _new_heating_setpoint = self.bt_max_temp
-
-        # Step-aware echo detection: changes strictly smaller than the device
-        # step are treated as device-side rounding echoes of a BT-written
-        # value, not as user input. User input on a TRV display moves the
-        # setpoint by at least one step.
-        _step_raw = trv.target_temp_step or self.bt_target_temp_step or 0.5
-        try:
-            _step = float(_step_raw)
-        except TypeError, ValueError:
-            _step = 0.5
-        if _step <= 0:
-            _step = 0.5
-        # Compare only against values BT itself wrote. ``_old_heating_setpoint``
-        # is the TRV's previously published state and is not necessarily a
-        # BT-written value, so it does not belong in the echo-suppression set.
-        _bt_known_values = (self.bt_target_temp, trv.last_temperature)
-        _is_echo = any(
-            v is not None and abs(_new_heating_setpoint - v) < _step
-            for v in _bt_known_values
-        )
+        # The no_off OFF detection compares against the device's true min_temp,
+        # so it uses the reported value, not one the clamp may have raised into
+        # [bt_min_temp, bt_max_temp].
+        _raw_heating_setpoint = _setpoint.raw
+        _new_heating_setpoint = _setpoint.value
+        _is_echo = _setpoint.is_echo
         _accept_user_setpoint = (
             not _is_echo
             and not child_lock

--- a/custom_components/better_thermostat/model_fixes/BTH-RM.py
+++ b/custom_components/better_thermostat/model_fixes/BTH-RM.py
@@ -10,7 +10,7 @@ import logging
 
 from custom_components.better_thermostat.utils.helpers import (
     celsius_to_system_temperature,
-    trv_supports_temperature_range,
+    supports_temperature_range,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -85,7 +85,7 @@ async def override_set_temperature(self, entity_id, temperature):
         )
         return True
 
-    _supports_range = trv_supports_temperature_range(state)
+    _supports_range = supports_temperature_range(state)
 
     _LOGGER.debug(
         f"better_thermostat {self.device_name}: TRV {entity_id} device quirk bth-rm "

--- a/custom_components/better_thermostat/model_fixes/BTH-RM230Z.py
+++ b/custom_components/better_thermostat/model_fixes/BTH-RM230Z.py
@@ -10,7 +10,7 @@ import logging
 
 from custom_components.better_thermostat.utils.helpers import (
     celsius_to_system_temperature,
-    trv_supports_temperature_range,
+    supports_temperature_range,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -88,7 +88,7 @@ async def override_set_temperature(self, entity_id, temperature):
         )
         return True
 
-    _supports_range = trv_supports_temperature_range(state)
+    _supports_range = supports_temperature_range(state)
 
     _LOGGER.debug(
         "better_thermostat %s: TRV %s device quirk bth-rm230z "

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -28,6 +28,7 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.helpers import (
+    attr_to_celsius,
     convert_to_float,
     get_cooler_setpoint,
     get_current_set_temperatures,
@@ -285,7 +286,7 @@ async def control_cooler(self):
 
     # A cooler that only advertises the range feature rejects a "temperature"
     # payload with a ServiceValidationError, so it never receives a setpoint.
-    # Devices that advertise neither bit keep the single-setpoint payload.
+    # Devices that advertise neither bit use the single-setpoint payload.
     _write_range = not supports_single_target_temperature(
         cooler_state
     ) and trv_supports_temperature_range(cooler_state)
@@ -295,6 +296,18 @@ async def control_cooler(self):
 
     # Determine desired state based on current conditions
     desired_temp = self.bt_target_cooltemp
+
+    # A range write needs both bounds, and Home Assistant rejects a low bound
+    # above the high one. The heating target is the natural lower bound; it can
+    # only exceed the cooling target while the two are out of sync, so it is
+    # capped at the value being written.
+    _low_to_set = desired_temp
+    if (
+        _write_range
+        and desired_temp is not None
+        and isinstance(self.bt_target_temp, (int, float))
+    ):
+        _low_to_set = min(float(self.bt_target_temp), desired_temp)
 
     if any(
         v is None
@@ -352,6 +365,29 @@ async def control_cooler(self):
     elif current_temp != desired_temp:
         should_send_temp = True
 
+    # A range write carries both bounds, so a lower bound that drifted away
+    # from the heating target needs a send of its own: the cooling target can
+    # stay unchanged for as long as the user only moves the heating side.
+    if _write_range and desired_temp is not None and not should_send_temp:
+        current_low = attr_to_celsius(
+            self, cooler_state, "target_temp_low", None, "control_cooler()"
+        )
+        # The reported bound comes back on convert_to_float's 0.01 grid while
+        # _low_to_set is BT's raw value, so the two are compared with the same
+        # tolerance the TRV write-skip check uses.
+        if current_low is not None and not matches_any_setpoint(
+            current_low, {_low_to_set}
+        ):
+            _LOGGER.debug(
+                "better_thermostat %s: cooler %s lower bound %s differs from %s, "
+                "sending both bounds",
+                self.device_name,
+                self.cooler_entity_id,
+                current_low,
+                _low_to_set,
+            )
+            should_send_temp = True
+
     # Throttle identical resends when the state feedback lags behind.
     if (
         should_send_temp
@@ -378,13 +414,6 @@ async def control_cooler(self):
             desired_temp,
         )
         _temp_to_set = desired_temp
-        # A range write needs both bounds, and Home Assistant rejects a low
-        # bound above the high one. The heating target is the natural lower
-        # bound; it can only exceed the cooling target while the two are out
-        # of sync, so it is capped at the value being written.
-        _low_to_set = desired_temp
-        if _write_range and isinstance(self.bt_target_temp, (int, float)):
-            _low_to_set = min(float(self.bt_target_temp), desired_temp)
         if self.hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             _temp_to_set = round(
                 TemperatureConverter.convert(

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -28,11 +28,13 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.helpers import (
+    SETPOINT_MATCH_TOLERANCE,
     attr_to_celsius,
     convert_to_float,
     get_cooler_setpoint,
     get_current_set_temperatures,
     matches_any_setpoint,
+    state_temperature_unit,
     supports_single_target_temperature,
     supports_temperature_range,
 )
@@ -261,6 +263,33 @@ async def control_queue(self):
             self.ignore_states = False
 
 
+def _device_setpoint_tolerance(self, state) -> float:
+    """Return the tolerance for comparing a commanded setpoint to a reported one.
+
+    A device snaps a written setpoint onto its own step grid, so a snapped
+    value sits at most half a step away from the value that was commanded.
+    SETPOINT_MATCH_TOLERANCE is the floor: it covers the read-back grid for
+    devices that report no usable step.
+    """
+    raw_step = state.attributes.get("target_temp_step")
+    step = (
+        convert_to_float(str(raw_step), self.device_name, "control_cooler()")
+        if raw_step is not None
+        else None
+    )
+    if step is None or step <= 0:
+        return SETPOINT_MATCH_TOLERANCE
+    if (
+        state_temperature_unit(
+            state.attributes, self.hass.config.units.temperature_unit
+        )
+        == UnitOfTemperature.FAHRENHEIT
+    ):
+        step = round(step * 5.0 / 9.0, 4)
+    # Slack against float noise when the difference is exactly half a step.
+    return max(SETPOINT_MATCH_TOLERANCE, step / 2.0 + 1e-6)
+
+
 async def control_cooler(self):
     """Control the cooler entity based on current temperature and cooling setpoint.
 
@@ -350,9 +379,11 @@ async def control_cooler(self):
     # Decide whether a temperature command is needed. When the current
     # temperature is unknown, only send if the desired value changed since the
     # last successful command; otherwise send when it differs from current.
-    # The reported value comes back on convert_to_float's 0.01 grid, and on a
-    # Fahrenheit system through a unit conversion on top, so it is compared
-    # with the same tolerance as the lower bound below.
+    # The reported value comes back on convert_to_float's 0.01 grid, on a
+    # Fahrenheit system through a unit conversion on top, and snapped onto the
+    # device's own step grid, so both bounds are compared with the tolerance
+    # that grid allows.
+    _match_tolerance = _device_setpoint_tolerance(self, cooler_state)
     temp_changed_since_last_send = self.last_sent_cooler_temp != desired_temp
     should_send_temp = False
     if desired_temp is None:
@@ -372,21 +403,22 @@ async def control_cooler(self):
                 self.cooler_entity_id,
                 desired_temp,
             )
-    elif not matches_any_setpoint(current_temp, {desired_temp}):
+    elif not matches_any_setpoint(current_temp, {desired_temp}, _match_tolerance):
         should_send_temp = True
 
     # A range write carries both bounds, so a lower bound that drifted away
     # from the heating target needs a send of its own: the cooling target can
     # stay unchanged for as long as the user only moves the heating side.
+    _low_bound_drifted = False
     if _write_range and desired_temp is not None and not should_send_temp:
         current_low = attr_to_celsius(
             self, cooler_state, "target_temp_low", None, "control_cooler()"
         )
-        # The reported bound comes back on convert_to_float's 0.01 grid while
-        # _low_to_set is BT's raw value, so the two are compared with the same
-        # tolerance the TRV write-skip check uses.
+        # The reported bound comes back on the device's grid while _low_to_set
+        # is BT's raw value, so the two are compared with the same tolerance
+        # the upper bound uses.
         if current_low is not None and not matches_any_setpoint(
-            current_low, {_low_to_set}
+            current_low, {_low_to_set}, _match_tolerance
         ):
             _LOGGER.debug(
                 "better_thermostat %s: cooler %s lower bound %s differs from %s, "
@@ -397,12 +429,17 @@ async def control_cooler(self):
                 _low_to_set,
             )
             should_send_temp = True
+            _low_bound_drifted = True
 
     # Throttle identical resends when the state feedback lags behind.
+    # last_sent_cooler_temp tracks the upper bound alone, so a send armed by
+    # the lower bound carries a payload that was never written before and is
+    # not a resend.
     if (
         should_send_temp
         and min_resend_interval_s > 0
         and not temp_changed_since_last_send
+        and not _low_bound_drifted
     ):
         last_temp_ts = self.last_sent_cooler_temp_ts
         if last_temp_ts is not None and (now_ts - last_temp_ts) < min_resend_interval_s:

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -287,9 +287,16 @@ async def control_cooler(self):
     # A cooler that only advertises the range feature rejects a "temperature"
     # payload with a ServiceValidationError, so it never receives a setpoint.
     # Devices that advertise neither bit use the single-setpoint payload.
-    _write_range = not supports_single_target_temperature(
-        cooler_state
-    ) and supports_temperature_range(cooler_state)
+    # A cooler advertising both publishes the channel it does not drive as
+    # None, so the write follows the channel the reading came from: writing
+    # the other one leaves the two sides permanently out of sync.
+    _write_range = supports_temperature_range(cooler_state) and (
+        not supports_single_target_temperature(cooler_state)
+        or (
+            cooler_state.attributes.get("temperature") is None
+            and cooler_state.attributes.get("target_temp_high") is not None
+        )
+    )
 
     min_resend_interval_s = self.min_cooler_resend_interval_s
     now_ts = monotonic()

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -28,12 +28,13 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.helpers import (
+    COOLER_SETPOINT_KEYS,
     SETPOINT_MATCH_TOLERANCE,
     attr_to_celsius,
     convert_to_float,
-    get_cooler_setpoint,
     get_current_set_temperatures,
     matches_any_setpoint,
+    read_setpoint_celsius,
     state_temperature_unit,
     supports_single_target_temperature,
     supports_temperature_range,
@@ -311,7 +312,9 @@ async def control_cooler(self):
     # Resolve the cooler's reported setpoint to Celsius before comparing it
     # against the Celsius desired value; on a Fahrenheit system the raw
     # attribute would never match and defeat the redundant-send dedup.
-    current_temp = get_cooler_setpoint(self, cooler_state, "control_cooler()")
+    current_temp = read_setpoint_celsius(
+        self, cooler_state, COOLER_SETPOINT_KEYS, "control_cooler()"
+    )
 
     # A cooler that only advertises the range feature rejects a "temperature"
     # payload with a ServiceValidationError, so it never receives a setpoint.

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -343,6 +343,9 @@ async def control_cooler(self):
     # Decide whether a temperature command is needed. When the current
     # temperature is unknown, only send if the desired value changed since the
     # last successful command; otherwise send when it differs from current.
+    # The reported value comes back on convert_to_float's 0.01 grid, and on a
+    # Fahrenheit system through a unit conversion on top, so it is compared
+    # with the same tolerance as the lower bound below.
     temp_changed_since_last_send = self.last_sent_cooler_temp != desired_temp
     should_send_temp = False
     if desired_temp is None:
@@ -362,7 +365,7 @@ async def control_cooler(self):
                 self.cooler_entity_id,
                 desired_temp,
             )
-    elif current_temp != desired_temp:
+    elif not matches_any_setpoint(current_temp, {desired_temp}):
         should_send_temp = True
 
     # A range write carries both bounds, so a lower bound that drifted away

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -28,10 +28,12 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.helpers import (
-    attr_to_celsius,
     convert_to_float,
+    get_cooler_setpoint,
     get_current_set_temperatures,
     matches_any_setpoint,
+    supports_single_target_temperature,
+    trv_supports_temperature_range,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -279,9 +281,14 @@ async def control_cooler(self):
     # Resolve the cooler's reported setpoint to Celsius before comparing it
     # against the Celsius desired value; on a Fahrenheit system the raw
     # attribute would never match and defeat the redundant-send dedup.
-    current_temp = attr_to_celsius(
-        self, cooler_state, "temperature", None, "control_cooler()"
-    )
+    current_temp = get_cooler_setpoint(self, cooler_state, "control_cooler()")
+
+    # A cooler that only advertises the range feature rejects a "temperature"
+    # payload with a ServiceValidationError, so it never receives a setpoint.
+    # Devices that advertise neither bit keep the single-setpoint payload.
+    _write_range = not supports_single_target_temperature(
+        cooler_state
+    ) and trv_supports_temperature_range(cooler_state)
 
     min_resend_interval_s = self.min_cooler_resend_interval_s
     now_ts = monotonic()
@@ -371,18 +378,43 @@ async def control_cooler(self):
             desired_temp,
         )
         _temp_to_set = desired_temp
+        # A range write needs both bounds, and Home Assistant rejects a low
+        # bound above the high one. The heating target is the natural lower
+        # bound; it can only exceed the cooling target while the two are out
+        # of sync, so it is capped at the value being written.
+        _low_to_set = desired_temp
+        if _write_range and isinstance(self.bt_target_temp, (int, float)):
+            _low_to_set = min(float(self.bt_target_temp), desired_temp)
         if self.hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
-            _temp_to_set = TemperatureConverter.convert(
-                desired_temp, UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT
+            _temp_to_set = round(
+                TemperatureConverter.convert(
+                    desired_temp,
+                    UnitOfTemperature.CELSIUS,
+                    UnitOfTemperature.FAHRENHEIT,
+                ),
+                1,
             )
-            _temp_to_set = round(_temp_to_set, 1)
+            _low_to_set = round(
+                TemperatureConverter.convert(
+                    _low_to_set, UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT
+                ),
+                1,
+            )
+        if _write_range:
+            _payload = {
+                "entity_id": self.cooler_entity_id,
+                "target_temp_high": _temp_to_set,
+                "target_temp_low": _low_to_set,
+            }
+        else:
+            _payload = {"entity_id": self.cooler_entity_id, "temperature": _temp_to_set}
         # Only prime the send-cache on success. A failed call must not look like
         # a completed send, otherwise the nil-guard would suppress the retry.
         try:
             await self.hass.services.async_call(
                 "climate",
                 "set_temperature",
-                {"entity_id": self.cooler_entity_id, "temperature": _temp_to_set},
+                _payload,
                 blocking=True,
                 context=self.context,
             )

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -34,7 +34,7 @@ from custom_components.better_thermostat.utils.helpers import (
     get_current_set_temperatures,
     matches_any_setpoint,
     supports_single_target_temperature,
-    trv_supports_temperature_range,
+    supports_temperature_range,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -289,7 +289,7 @@ async def control_cooler(self):
     # Devices that advertise neither bit use the single-setpoint payload.
     _write_range = not supports_single_target_temperature(
         cooler_state
-    ) and trv_supports_temperature_range(cooler_state)
+    ) and supports_temperature_range(cooler_state)
 
     min_resend_interval_s = self.min_cooler_resend_interval_s
     now_ts = monotonic()

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -685,6 +685,27 @@ def normalize_step(value: float | int | str | None, fallback: float = 0.5) -> fl
     return step
 
 
+def setpoint_echo_window(step: float) -> float:
+    """Return the distance below which a setpoint difference is grid noise.
+
+    A reported value carries the rounding of ``convert_to_float``'s 0.01 grid
+    while the device's step and the values BT wrote sit on the device's own
+    grid, so one full step of movement can land a hair below ``step``. The
+    window shrinks by that noise and stays positive for a tiny step.
+
+    Parameters
+    ----------
+    step : float
+            the device's setpoint step in °C
+
+    Returns
+    -------
+    float
+            the largest difference that still counts as the same setpoint
+    """
+    return max(step - SETPOINT_MATCH_TOLERANCE, SETPOINT_MATCH_TOLERANCE)
+
+
 def resolve_inbound_setpoint(
     self,
     state: State | None,
@@ -717,7 +738,9 @@ def resolve_inbound_setpoint(
     known_values : tuple[float | None, ...]
             the values BT itself wrote, in °C; non-numeric entries are ignored
     step : float
-            the device's setpoint step in °C
+            the device's setpoint step as a Celsius delta; a step read from a
+            device attribute carries that device's unit and has to be converted
+            before it is passed
     device_label : str
             role of the device in log messages, e.g. ``"TRV"`` or ``"Cooler"``
     entity_id : str | None
@@ -752,8 +775,9 @@ def resolve_inbound_setpoint(
             entity_id,
         )
 
+    echo_window = setpoint_echo_window(step)
     is_echo = any(
-        isinstance(known, (int, float)) and abs(value - known) < step
+        isinstance(known, (int, float)) and abs(value - known) < echo_window
         for known in known_values
     )
     return InboundSetpoint(raw=raw, value=value, clamped=clamped, is_echo=is_echo)

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -582,6 +582,64 @@ def trv_supports_temperature_range(state: State | None) -> bool:
     return bool(supported_features & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE)
 
 
+def supports_single_target_temperature(state: State | None) -> bool:
+    """Check whether a climate state advertises TARGET_TEMPERATURE.
+
+    The counterpart to :func:`trv_supports_temperature_range`. Home Assistant
+    rejects a ``set_temperature`` call carrying ``temperature`` when the entity
+    does not advertise this feature, so write paths need both bits to pick the
+    payload a device accepts.
+
+    Parameters
+    ----------
+    state : State | None
+            the climate entity state to inspect
+
+    Returns
+    -------
+    bool
+            True if the single-setpoint feature bit is set, False otherwise
+            (including when state is None)
+    """
+    if state is None:
+        return False
+    supported_features = state.attributes.get("supported_features", 0)
+    return bool(supported_features & ClimateEntityFeature.TARGET_TEMPERATURE)
+
+
+def get_cooler_setpoint(self, state: State | None, log_source: str) -> float | None:
+    """Read the cooler's setpoint from a state and return it in °C.
+
+    A climate entity that supports both a single target and a target range
+    publishes ``temperature`` as None while it runs in range mode, so a
+    present-but-empty attribute must not stop the range key from being read.
+
+    Parameters
+    ----------
+    self :
+            the Better Thermostat instance, supplying ``hass`` and ``device_name``
+    state : State | None
+            the cooler entity state to inspect, or None when unavailable
+    log_source : str
+            caller name, forwarded to attr_to_celsius for logging context
+
+    Returns
+    -------
+    float | None
+            the cooling setpoint in Celsius, or None when neither key holds a
+            usable value
+    """
+    if state is None:
+        return None
+    for key in ("temperature", "target_temp_high"):
+        if state.attributes.get(key) is None:
+            continue
+        setpoint = attr_to_celsius(self, state, key, None, log_source)
+        if setpoint is not None:
+            return setpoint
+    return None
+
+
 def attr_to_celsius(
     self,
     state: State | None,

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -759,13 +759,15 @@ def resolve_inbound_setpoint(
         return None
 
     # A bound stays None until a child entity reports one, so each side is
-    # enforced only once it is known.
+    # enforced only once it is known. Non-overlapping heater and cooler ranges
+    # leave bt_min_temp above bt_max_temp, so the two bounds are applied in
+    # sequence rather than exclusively and the upper one decides.
     value = raw
     clamped = False
     if self.bt_min_temp is not None and value < self.bt_min_temp:
         value = self.bt_min_temp
         clamped = True
-    elif self.bt_max_temp is not None and self.bt_max_temp < value:
+    if self.bt_max_temp is not None and self.bt_max_temp < value:
         value = self.bt_max_temp
         clamped = True
 

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -713,18 +713,18 @@ def resolve_inbound_setpoint(
     keys: tuple[str, ...],
     known_values: tuple[float | None, ...],
     step: float,
-    device_label: str,
-    entity_id: str | None,
     log_source: str,
 ) -> InboundSetpoint | None:
     """Prepare a setpoint reported by a controlled device for adoption.
 
-    The single inbound boundary for setpoints BT does not own: it resolves the
-    value to °C, clamps it into BT's range, and decides whether it is BT's own
-    write coming back. A device settles a written value on its own grid and
-    republishes it, sometimes from a later poll whose context is not BT's, so
-    anything within one device step of a value BT wrote is an echo.
-    User input moves a setpoint by at least one step.
+    The shared adoption gate for setpoints BT does not own: it resolves the
+    value to °C via :func:`read_setpoint_celsius`, clamps it into BT's range,
+    and decides whether it is BT's own write coming back. A device settles a
+    written value on its own grid and republishes it, sometimes from a later
+    poll whose context is not BT's, so anything within one device step of a
+    value BT wrote is an echo. User input moves a setpoint by at least one
+    step. Answering rather than logging keeps the caller free to decide
+    whether a clamp is worth reporting.
 
     Parameters
     ----------
@@ -741,10 +741,6 @@ def resolve_inbound_setpoint(
             the device's setpoint step as a Celsius delta; a step read from a
             device attribute carries that device's unit and has to be converted
             before it is passed
-    device_label : str
-            role of the device in log messages, e.g. ``"TRV"`` or ``"Cooler"``
-    entity_id : str | None
-            the reporting entity, for log messages
     log_source : str
             caller name, forwarded for logging context
 
@@ -767,13 +763,6 @@ def resolve_inbound_setpoint(
     elif self.bt_max_temp is not None and self.bt_max_temp < value:
         value = self.bt_max_temp
         clamped = True
-    if clamped:
-        _LOGGER.warning(
-            "better_thermostat %s: New %s %s setpoint outside of range, overwriting it",
-            self.device_name,
-            device_label,
-            entity_id,
-        )
 
     echo_window = setpoint_echo_window(step)
     is_echo = any(
@@ -789,8 +778,9 @@ def resolve_state_change_event(
     """Return the states of a device event worth acting on, or None.
 
     Shared prologue of the device event handlers: an event is actionable when
-    it carries both states, both are States with attributes, and it was not
-    caused by BT's own service call — those carry ``self.context``.
+    it carries both states, both are States with attributes, it names an
+    entity, and it was not caused by BT's own service call — those carry
+    ``self.context``.
 
     Parameters
     ----------
@@ -804,7 +794,8 @@ def resolve_state_change_event(
     Returns
     -------
     tuple[State, State, str] | None
-            (old_state, new_state, entity_id) when actionable, else None
+            (old_state, new_state, entity_id) when actionable, with the entity
+            id guaranteed to be a string, else None
     """
     old_state = event.data.get("old_state")
     new_state = event.data.get("new_state")

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -557,7 +557,7 @@ def celsius_to_system_temperature(hass: HomeAssistant, temperature: float) -> fl
     return temperature
 
 
-def trv_supports_temperature_range(state: State | None) -> bool:
+def supports_temperature_range(state: State | None) -> bool:
     """Check whether a climate state advertises TARGET_TEMPERATURE_RANGE.
 
     Centralizes the supported_features bitmask check so write paths
@@ -585,7 +585,7 @@ def trv_supports_temperature_range(state: State | None) -> bool:
 def supports_single_target_temperature(state: State | None) -> bool:
     """Check whether a climate state advertises TARGET_TEMPERATURE.
 
-    The counterpart to :func:`trv_supports_temperature_range`. Home Assistant
+    The counterpart to :func:`supports_temperature_range`. Home Assistant
     rejects a ``set_temperature`` call carrying ``temperature`` when the entity
     does not advertise this feature, so write paths need both bits to pick the
     payload a device accepts.
@@ -722,7 +722,7 @@ def get_current_set_temperatures(
     single = attr_to_celsius(self, state, "temperature", None, log_source)
     range_low = (
         attr_to_celsius(self, state, "target_temp_low", None, log_source)
-        if trv_supports_temperature_range(state)
+        if supports_temperature_range(state)
         else None
     )
     return {v for v in (single, range_low) if v is not None}

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import logging
 import math
 import re
-from typing import Any
+from typing import Any, NamedTuple
 
 from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
 from homeassistant.config_entries import ConfigEntry
@@ -607,37 +607,225 @@ def supports_single_target_temperature(state: State | None) -> bool:
     return bool(supported_features & ClimateEntityFeature.TARGET_TEMPERATURE)
 
 
-def get_cooler_setpoint(self, state: State | None, log_source: str) -> float | None:
-    """Read the cooler's setpoint from a state and return it in °C.
+# The attribute a device publishes its setpoint under depends on the role it
+# plays: BT drives a TRV towards the lower bound of a range and a cooler
+# towards the upper one. The single-setpoint key comes first in both cases,
+# because a device that offers it is driven through it.
+TRV_SETPOINT_KEYS = ("temperature", "target_temp_low")
+COOLER_SETPOINT_KEYS = ("temperature", "target_temp_high")
+
+
+class InboundSetpoint(NamedTuple):
+    """A setpoint reported by a controlled device, prepared for adoption.
+
+    Attributes
+    ----------
+    raw : float
+            the reported value in °C, before range clamping
+    value : float
+            the reported value in °C after clamping into BT's range
+    clamped : bool
+            whether clamping changed the value
+    is_echo : bool
+            whether the value is BT's own write coming back
+    """
+
+    raw: float
+    value: float
+    clamped: bool
+    is_echo: bool
+
+
+def read_setpoint_celsius(
+    self, state: State | None, keys: tuple[str, ...], log_source: str
+) -> float | None:
+    """Read the first usable setpoint attribute from a state and return it in °C.
 
     A climate entity that supports both a single target and a target range
-    publishes ``temperature`` as None while it runs in range mode, so a
-    present-but-empty attribute must not stop the range key from being read.
+    publishes the key it does not currently drive as None, so a
+    present-but-empty attribute must not stop the next key from being read.
 
     Parameters
     ----------
     self :
             the Better Thermostat instance, supplying ``hass`` and ``device_name``
     state : State | None
-            the cooler entity state to inspect, or None when unavailable
+            the climate entity state to inspect, or None when unavailable
+    keys : tuple[str, ...]
+            the attribute names to try, in order of precedence
     log_source : str
             caller name, forwarded to attr_to_celsius for logging context
 
     Returns
     -------
     float | None
-            the cooling setpoint in Celsius, or None when neither key holds a
-            usable value
+            the setpoint in Celsius, or None when no key holds a usable value
     """
     if state is None:
         return None
-    for key in ("temperature", "target_temp_high"):
+    for key in keys:
         if state.attributes.get(key) is None:
             continue
         setpoint = attr_to_celsius(self, state, key, None, log_source)
         if setpoint is not None:
             return setpoint
     return None
+
+
+def normalize_step(value: float | int | str | None, fallback: float = 0.5) -> float:
+    """Coerce a reported temperature step to a usable positive float."""
+    if value is None:
+        return fallback
+    try:
+        step = float(value)
+    except TypeError, ValueError:
+        return fallback
+    if step <= 0:
+        return fallback
+    return step
+
+
+def resolve_inbound_setpoint(
+    self,
+    state: State | None,
+    *,
+    keys: tuple[str, ...],
+    known_values: tuple[float | None, ...],
+    step: float,
+    device_label: str,
+    entity_id: str | None,
+    log_source: str,
+) -> InboundSetpoint | None:
+    """Prepare a setpoint reported by a controlled device for adoption.
+
+    The single inbound boundary for setpoints BT does not own: it resolves the
+    value to °C, clamps it into BT's range, and decides whether it is BT's own
+    write coming back. A device settles a written value on its own grid and
+    republishes it, sometimes from a later poll whose context is not BT's, so
+    anything within one device step of a value BT wrote is an echo.
+    User input moves a setpoint by at least one step.
+
+    Parameters
+    ----------
+    self :
+            the Better Thermostat instance, supplying ``hass``, ``device_name``
+            and the configured range
+    state : State | None
+            the device state carrying the reported setpoint
+    keys : tuple[str, ...]
+            the attribute names to try, in order of precedence
+    known_values : tuple[float | None, ...]
+            the values BT itself wrote, in °C; non-numeric entries are ignored
+    step : float
+            the device's setpoint step in °C
+    device_label : str
+            role of the device in log messages, e.g. ``"TRV"`` or ``"Cooler"``
+    entity_id : str | None
+            the reporting entity, for log messages
+    log_source : str
+            caller name, forwarded for logging context
+
+    Returns
+    -------
+    InboundSetpoint | None
+            the resolved setpoint, or None when the state holds no usable value
+    """
+    raw = read_setpoint_celsius(self, state, keys, log_source)
+    if raw is None:
+        return None
+
+    # A bound stays None until a child entity reports one, so each side is
+    # enforced only once it is known.
+    value = raw
+    clamped = False
+    if self.bt_min_temp is not None and value < self.bt_min_temp:
+        value = self.bt_min_temp
+        clamped = True
+    elif self.bt_max_temp is not None and self.bt_max_temp < value:
+        value = self.bt_max_temp
+        clamped = True
+    if clamped:
+        _LOGGER.warning(
+            "better_thermostat %s: New %s %s setpoint outside of range, overwriting it",
+            self.device_name,
+            device_label,
+            entity_id,
+        )
+
+    is_echo = any(
+        isinstance(known, (int, float)) and abs(value - known) < step
+        for known in known_values
+    )
+    return InboundSetpoint(raw=raw, value=value, clamped=clamped, is_echo=is_echo)
+
+
+def resolve_state_change_event(
+    self, event, device_label: str
+) -> tuple[State, State, str] | None:
+    """Return the states of a device event worth acting on, or None.
+
+    Shared prologue of the device event handlers: an event is actionable when
+    it carries both states, both are States with attributes, and it was not
+    caused by BT's own service call — those carry ``self.context``.
+
+    Parameters
+    ----------
+    self :
+            the Better Thermostat instance, supplying ``context`` and ``device_name``
+    event :
+            the state change event to inspect
+    device_label : str
+            role of the device in log messages, e.g. ``"TRV"`` or ``"Cooler"``
+
+    Returns
+    -------
+    tuple[State, State, str] | None
+            (old_state, new_state, entity_id) when actionable, else None
+    """
+    old_state = event.data.get("old_state")
+    new_state = event.data.get("new_state")
+    entity_id = event.data.get("entity_id")
+
+    if new_state is None or old_state is None:
+        _LOGGER.debug(
+            "better_thermostat %s: %s %s update contained not all necessary data "
+            "for processing, skipping",
+            self.device_name,
+            device_label,
+            entity_id,
+        )
+        return None
+
+    if not isinstance(new_state, State) or not isinstance(old_state, State):
+        _LOGGER.debug(
+            "better_thermostat %s: %s %s update contained not a State, skipping",
+            self.device_name,
+            device_label,
+            entity_id,
+        )
+        return None
+
+    if new_state.attributes is None:
+        _LOGGER.debug(
+            "better_thermostat %s: %s %s update had no attributes, skipping",
+            self.device_name,
+            device_label,
+            entity_id,
+        )
+        return None
+
+    if not isinstance(entity_id, str):
+        _LOGGER.debug(
+            "better_thermostat %s: %s update without an entity id, skipping",
+            self.device_name,
+            device_label,
+        )
+        return None
+
+    if self.context == event.context:
+        return None
+
+    return old_state, new_state, entity_id
 
 
 def attr_to_celsius(

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -673,14 +673,19 @@ def read_setpoint_celsius(
 
 
 def normalize_step(value: float | int | str | None, fallback: float = 0.5) -> float:
-    """Coerce a reported temperature step to a usable positive float."""
+    """Coerce a reported temperature step to a usable positive float.
+
+    NaN and infinity survive ``float()`` and pass a ``<= 0`` test, so they are
+    rejected explicitly: a NaN step makes every echo comparison false, an
+    infinite one makes them all true.
+    """
     if value is None:
         return fallback
     try:
         step = float(value)
     except TypeError, ValueError:
         return fallback
-    if step <= 0:
+    if not math.isfinite(step) or step <= 0:
         return fallback
     return step
 

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -460,22 +460,30 @@ class TestControlCoolerFahrenheit:
         assert "set_temperature" not in service_names
 
 
+_ATTRIBUTE_ABSENT = object()
+
+
 def _make_range_cooler_state(
     state=HVACMode.COOL,
     target_temp_high=None,
     target_temp_low=None,
     supported_features=ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
+    temperature=_ATTRIBUTE_ABSENT,
 ):
-    """Build a cooler State that advertises a target range."""
-    return State(
-        "climate.cooler",
-        str(state),
-        {
-            "target_temp_high": target_temp_high,
-            "target_temp_low": target_temp_low,
-            "supported_features": int(supported_features),
-        },
-    )
+    """Build a cooler State that advertises a target range.
+
+    ``temperature`` defaults to an absent attribute; pass None to model a
+    dual-feature cooler running in range mode and a value to model one
+    driving its single setpoint.
+    """
+    attributes = {
+        "target_temp_high": target_temp_high,
+        "target_temp_low": target_temp_low,
+        "supported_features": int(supported_features),
+    }
+    if temperature is not _ATTRIBUTE_ABSENT:
+        attributes["temperature"] = temperature
+    return State("climate.cooler", str(state), attributes)
 
 
 class TestControlCoolerTargetRange:
@@ -540,11 +548,12 @@ class TestControlCoolerTargetRange:
 
     @pytest.mark.asyncio
     async def test_cooler_supporting_both_features_keeps_single_setpoint(self):
-        """A cooler that also accepts "temperature" gets the single payload."""
+        """A dual-feature cooler driving "temperature" gets the single payload."""
         mock_hass = self._hass()
         mock_hass.states.get.return_value = _make_range_cooler_state(
-            target_temp_high=28.0,
-            target_temp_low=19.0,
+            temperature=28.0,
+            target_temp_high=None,
+            target_temp_low=None,
             supported_features=ClimateEntityFeature.TARGET_TEMPERATURE
             | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
         )
@@ -555,6 +564,36 @@ class TestControlCoolerTargetRange:
 
         payload = self._set_temperature_payload(mock_hass)
         assert payload == {"entity_id": "climate.cooler", "temperature": 24.0}
+
+    @pytest.mark.asyncio
+    async def test_cooler_supporting_both_features_in_range_mode_gets_both_bounds(self):
+        """A dual-feature cooler in range mode is written via both bounds.
+
+        It publishes the channel it does not drive as None, so the setpoint is
+        read from target_temp_high and the write has to follow that channel;
+        writing "temperature" leaves the two sides permanently out of sync.
+        """
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            temperature=None,
+            target_temp_high=28.0,
+            target_temp_low=19.0,
+            supported_features=ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload == {
+            "entity_id": "climate.cooler",
+            "target_temp_high": 24.0,
+            "target_temp_low": 20.0,
+        }
 
     @pytest.mark.asyncio
     async def test_cooler_without_feature_flags_keeps_single_setpoint(self):

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -511,7 +511,7 @@ class TestControlCoolerTargetRange:
 
     @pytest.mark.asyncio
     async def test_cooler_supporting_both_features_keeps_single_setpoint(self):
-        """A cooler that also accepts "temperature" keeps the single payload."""
+        """A cooler that also accepts "temperature" gets the single payload."""
         mock_hass = self._hass()
         mock_hass.states.get.return_value = _make_range_cooler_state(
             target_temp_high=28.0,
@@ -529,7 +529,7 @@ class TestControlCoolerTargetRange:
 
     @pytest.mark.asyncio
     async def test_cooler_without_feature_flags_keeps_single_setpoint(self):
-        """Without advertised features the established payload is used."""
+        """Without advertised features the single-setpoint payload is used."""
         mock_hass = self._hass()
         mock_hass.states.get.return_value = _make_cooler_state(temperature=28.0)
 
@@ -564,6 +564,85 @@ class TestControlCoolerTargetRange:
         mock_hass = self._hass()
         mock_hass.states.get.return_value = _make_range_cooler_state(
             target_temp_high=24.0, target_temp_low=20.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        assert self._set_temperature_payload(mock_hass) is None
+
+    @pytest.mark.asyncio
+    async def test_changed_lower_bound_alone_triggers_a_send(self):
+        """A heating target that moved is written even when cooling is unchanged.
+
+        Both bounds travel in one call, so a lower bound left behind on the
+        device would persist until the cooling target happens to change.
+        """
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=24.0, target_temp_low=19.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=21.0
+        )
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload == {
+            "entity_id": "climate.cooler",
+            "target_temp_high": 24.0,
+            "target_temp_low": 21.0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_matching_bounds_are_not_resent(self):
+        """Both bounds in sync means nothing is written."""
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=24.0, target_temp_low=20.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        assert self._set_temperature_payload(mock_hass) is None
+
+    @pytest.mark.asyncio
+    async def test_lower_bound_within_read_tolerance_is_not_resent(self):
+        """A bound that only differs by the read-back grid is unchanged.
+
+        The device reports on convert_to_float's 0.01 grid while BT holds the
+        raw value, so exact inequality would resend on every cycle.
+        """
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=24.0, target_temp_low=20.005
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        assert self._set_temperature_payload(mock_hass) is None
+
+    @pytest.mark.asyncio
+    async def test_lower_bound_is_ignored_for_single_setpoint_coolers(self):
+        """A single-setpoint cooler has no lower bound to keep in sync."""
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = State(
+            "climate.cooler",
+            str(HVACMode.COOL),
+            {"temperature": 24.0, "target_temp_low": 15.0},
         )
 
         mock_self = _make_mock_self(

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -44,9 +44,12 @@ def _make_mock_self(
     return mock_self
 
 
-def _make_cooler_state(state=HVACMode.COOL, temperature=None):
+def _make_cooler_state(state=HVACMode.COOL, temperature=None, target_temp_step=None):
     """Build a Home Assistant State for the cooler entity in control_cooler tests."""
-    return State("climate.cooler", str(state), {"temperature": temperature})
+    attributes = {"temperature": temperature}
+    if target_temp_step is not None:
+        attributes["target_temp_step"] = target_temp_step
+    return State("climate.cooler", str(state), attributes)
 
 
 class TestControlCooler:
@@ -431,18 +434,19 @@ class TestControlCoolerFahrenheit:
         assert "set_temperature" not in service_names
 
     @pytest.mark.asyncio
-    async def test_reported_temp_within_read_tolerance_is_not_resent(self):
-        """A setpoint that only differs by the read-back grid is unchanged.
+    async def test_reported_temp_within_the_device_step_is_not_resent(self):
+        """A setpoint snapped onto the device's °F step is unchanged.
 
-        The device reports on convert_to_float's 0.01 grid while BT holds the
-        raw value, so exact inequality would resend on every cycle.
+        The device step is a °F interval, so it is worth 0.56 K: 75 °F is
+        23.89 °C, which is the grid position the commanded 24.0 °C snaps to
+        and not a setpoint of its own.
         """
         mock_hass = Mock()
-        mock_hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+        mock_hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
         mock_hass.services = Mock()
         mock_hass.services.async_call = AsyncMock()
         mock_hass.states.get.return_value = _make_cooler_state(
-            state=HVACMode.COOL, temperature=24.005
+            state=HVACMode.COOL, temperature=75, target_temp_step=1
         )
 
         mock_self = _make_mock_self(
@@ -459,6 +463,37 @@ class TestControlCoolerFahrenheit:
         ]
         assert "set_temperature" not in service_names
 
+    @pytest.mark.asyncio
+    async def test_setpoint_change_beyond_the_device_step_is_written(self):
+        """A setpoint the device cannot be holding is written immediately.
+
+        The step tolerance only absorbs the device's own snapping; a genuine
+        change has to reach the cooler on the first cycle.
+        """
+        mock_hass = Mock()
+        mock_hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock()
+        mock_hass.states.get.return_value = _make_cooler_state(
+            state=HVACMode.COOL, temperature=75, target_temp_step=1
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass,
+            bt_hvac_mode=HVACMode.COOL,
+            cur_temp=25.0,
+            bt_target_cooltemp=22.0,
+        )
+
+        await control_cooler(mock_self)
+
+        payload = next(
+            c.args[2]
+            for c in mock_hass.services.async_call.call_args_list
+            if c.args[1] == "set_temperature"
+        )
+        assert payload == {"entity_id": "climate.cooler", "temperature": 71.6}
+
 
 _ATTRIBUTE_ABSENT = object()
 
@@ -469,6 +504,7 @@ def _make_range_cooler_state(
     target_temp_low=None,
     supported_features=ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
     temperature=_ATTRIBUTE_ABSENT,
+    target_temp_step=None,
 ):
     """Build a cooler State that advertises a target range.
 
@@ -483,6 +519,8 @@ def _make_range_cooler_state(
     }
     if temperature is not _ATTRIBUTE_ABSENT:
         attributes["temperature"] = temperature
+    if target_temp_step is not None:
+        attributes["target_temp_step"] = target_temp_step
     return State("climate.cooler", str(state), attributes)
 
 
@@ -687,12 +725,14 @@ class TestControlCoolerTargetRange:
     async def test_lower_bound_within_read_tolerance_is_not_resent(self):
         """A bound that only differs by the read-back grid is unchanged.
 
-        The device reports on convert_to_float's 0.01 grid while BT holds the
-        raw value, so exact inequality would resend on every cycle.
+        The cooler advertises no step, so the comparison falls back to the
+        base tolerance: the device reports on convert_to_float's 0.01 grid
+        while BT holds the raw value, and exact inequality would resend on
+        every cycle.
         """
         mock_hass = self._hass()
         mock_hass.states.get.return_value = _make_range_cooler_state(
-            target_temp_high=24.0, target_temp_low=20.005
+            target_temp_high=24.0, target_temp_low=19.99
         )
 
         mock_self = _make_mock_self(
@@ -702,6 +742,57 @@ class TestControlCoolerTargetRange:
         await control_cooler(mock_self)
 
         assert self._set_temperature_payload(mock_hass) is None
+
+    @pytest.mark.asyncio
+    async def test_lower_bound_within_the_device_step_is_not_resent(self):
+        """A lower bound snapped onto the device's step is unchanged.
+
+        The cooler holds its bounds on a 0.5 K grid, so 20.5 is where the
+        commanded 20.3 lands and rewriting it would change nothing.
+        """
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=24.0, target_temp_low=20.5, target_temp_step=0.5
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.3
+        )
+
+        await control_cooler(mock_self)
+
+        assert self._set_temperature_payload(mock_hass) is None
+
+    @pytest.mark.asyncio
+    async def test_lower_bound_drift_is_not_throttled_as_a_resend(self):
+        """A lower bound left behind is written despite the resend interval.
+
+        last_sent_cooler_temp tracks the upper bound alone, so a payload armed
+        by the lower bound is not an identical resend and the interval must
+        not delay the user's heating-target change.
+        """
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=24.0, target_temp_low=19.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass,
+            bt_target_cooltemp=24.0,
+            bt_target_temp=21.0,
+            last_sent_cooler_temp=24.0,
+            last_sent_cooler_temp_ts=monotonic(),
+            min_cooler_resend_interval_s=300,
+        )
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload == {
+            "entity_id": "climate.cooler",
+            "target_temp_high": 24.0,
+            "target_temp_low": 21.0,
+        }
 
     @pytest.mark.asyncio
     async def test_lower_bound_is_ignored_for_single_setpoint_coolers(self):

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -430,6 +430,35 @@ class TestControlCoolerFahrenheit:
         ]
         assert "set_temperature" not in service_names
 
+    @pytest.mark.asyncio
+    async def test_reported_temp_within_read_tolerance_is_not_resent(self):
+        """A setpoint that only differs by the read-back grid is unchanged.
+
+        The device reports on convert_to_float's 0.01 grid while BT holds the
+        raw value, so exact inequality would resend on every cycle.
+        """
+        mock_hass = Mock()
+        mock_hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock()
+        mock_hass.states.get.return_value = _make_cooler_state(
+            state=HVACMode.COOL, temperature=24.005
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass,
+            bt_hvac_mode=HVACMode.COOL,
+            cur_temp=25.0,
+            bt_target_cooltemp=24.0,
+        )
+
+        await control_cooler(mock_self)
+
+        service_names = [
+            c.args[1] for c in mock_hass.services.async_call.call_args_list
+        ]
+        assert "set_temperature" not in service_names
+
 
 def _make_range_cooler_state(
     state=HVACMode.COOL,

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -3,7 +3,7 @@
 from time import monotonic
 from unittest.mock import AsyncMock, Mock
 
-from homeassistant.components.climate.const import HVACMode
+from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
@@ -429,3 +429,147 @@ class TestControlCoolerFahrenheit:
             c.args[1] for c in mock_hass.services.async_call.call_args_list
         ]
         assert "set_temperature" not in service_names
+
+
+def _make_range_cooler_state(
+    state=HVACMode.COOL,
+    target_temp_high=None,
+    target_temp_low=None,
+    supported_features=ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
+):
+    """Build a cooler State that advertises a target range."""
+    return State(
+        "climate.cooler",
+        str(state),
+        {
+            "target_temp_high": target_temp_high,
+            "target_temp_low": target_temp_low,
+            "supported_features": int(supported_features),
+        },
+    )
+
+
+class TestControlCoolerTargetRange:
+    """Payload selection for coolers that only accept a target range."""
+
+    @staticmethod
+    def _hass(unit=UnitOfTemperature.CELSIUS):
+        mock_hass = Mock()
+        mock_hass.config.units.temperature_unit = unit
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock()
+        return mock_hass
+
+    @staticmethod
+    def _set_temperature_payload(mock_hass):
+        for call in mock_hass.services.async_call.call_args_list:
+            if call.args[1] == "set_temperature":
+                return call.args[2]
+        return None
+
+    @pytest.mark.asyncio
+    async def test_range_only_cooler_receives_both_bounds(self):
+        """A range-only cooler is written via target_temp_high/low.
+
+        Home Assistant rejects a "temperature" payload for such an entity, so
+        it would never receive a setpoint at all.
+        """
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=28.0, target_temp_low=19.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload == {
+            "entity_id": "climate.cooler",
+            "target_temp_high": 24.0,
+            "target_temp_low": 20.0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_low_bound_never_exceeds_the_high_bound(self):
+        """A heating target above the cooling target is capped at it."""
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=28.0, target_temp_low=19.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=26.0
+        )
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload["target_temp_low"] == payload["target_temp_high"] == 24.0
+
+    @pytest.mark.asyncio
+    async def test_cooler_supporting_both_features_keeps_single_setpoint(self):
+        """A cooler that also accepts "temperature" keeps the single payload."""
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=28.0,
+            target_temp_low=19.0,
+            supported_features=ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
+        )
+
+        mock_self = _make_mock_self(mock_hass, bt_target_cooltemp=24.0)
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload == {"entity_id": "climate.cooler", "temperature": 24.0}
+
+    @pytest.mark.asyncio
+    async def test_cooler_without_feature_flags_keeps_single_setpoint(self):
+        """Without advertised features the established payload is used."""
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_cooler_state(temperature=28.0)
+
+        mock_self = _make_mock_self(mock_hass, bt_target_cooltemp=24.0)
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload == {"entity_id": "climate.cooler", "temperature": 24.0}
+
+    @pytest.mark.asyncio
+    async def test_range_payload_is_converted_to_fahrenheit(self):
+        """Both bounds are converted on a °F system."""
+        mock_hass = self._hass(UnitOfTemperature.FAHRENHEIT)
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=82.4, target_temp_low=66.2
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        payload = self._set_temperature_payload(mock_hass)
+        assert payload["target_temp_high"] == 75.2  # 24.0 °C
+        assert payload["target_temp_low"] == 68.0  # 20.0 °C
+
+    @pytest.mark.asyncio
+    async def test_matching_range_setpoint_is_not_resent(self):
+        """The dedup reads the range key, so no redundant write is sent."""
+        mock_hass = self._hass()
+        mock_hass.states.get.return_value = _make_range_cooler_state(
+            target_temp_high=24.0, target_temp_low=20.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_target_cooltemp=24.0, bt_target_temp=20.0
+        )
+
+        await control_cooler(mock_self)
+
+        assert self._set_temperature_payload(mock_hass) is None

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -1225,3 +1225,76 @@ class TestEnforceCoolAboveHeat:
         mock_bt.bt_target_cooltemp = None
         self._call(mock_bt)
         assert mock_bt.bt_target_cooltemp is None
+
+
+# ===========================================================================
+# 8. TestEnforceHeatBelowCool
+# ===========================================================================
+
+
+class TestEnforceHeatBelowCool:
+    """_enforce_heat_below_cool keeps the heat target strictly below the cool target."""
+
+    def _call(self, bt):
+        return BetterThermostat._enforce_heat_below_cool(bt)
+
+    def test_not_heat_cool_mode_is_noop(self, mock_bt):
+        """Outside HEAT_COOL the heat target is left untouched even if above cool."""
+        mock_bt.hvac_mode = HVACMode.HEAT
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_cooltemp = 20.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 22.0
+
+    def test_heat_below_cool_is_noop(self, mock_bt):
+        """A heat target already below the cool target is unchanged."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 20.0
+        mock_bt.bt_target_cooltemp = 24.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 20.0
+
+    def test_heat_above_cool_is_pushed_down_by_step(self, mock_bt):
+        """A heat target above the cool target drops one step below it."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 24.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 21.5
+
+    def test_heat_equal_cool_is_pushed_down(self, mock_bt):
+        """A heat target equal to the cool target is pushed below it."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 21.5
+
+    def test_step_falls_back_to_half_degree(self, mock_bt):
+        """A missing/zero step falls back to 0.5."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 21.5
+
+    def test_result_is_clamped_to_min_temp(self, mock_bt):
+        """The heat target never drops below the configured minimum."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 6.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_cooltemp = 5.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 5.0
+
+    def test_none_heat_target_is_noop(self, mock_bt):
+        """A None heat target does not raise and stays None."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = None
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp is None

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -462,6 +462,28 @@ class TestInitializeSensors:
         BetterThermostat._initialize_sensors(bt, sensor)
         assert bt.door_open is False
 
+    def test_single_setpoint_cooler_sets_cooltemp(self, bt):
+        """A cooler exposing ``temperature`` seeds the cool target from it."""
+        bt.cooler_entity_id = COOLER_ID
+        sensor = _make_sensor_state("20.0")
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, "cool", {"temperature": 24.0}
+        )
+        BetterThermostat._initialize_sensors(bt, sensor)
+        assert bt.bt_target_cooltemp == 24.0
+
+    def test_range_only_cooler_sets_cooltemp_from_target_temp_high(self, bt):
+        """A range-only cooler seeds the cool target from ``target_temp_high``."""
+        bt.cooler_entity_id = COOLER_ID
+        sensor = _make_sensor_state("20.0")
+        bt.hass.states.get.return_value = State(
+            COOLER_ID,
+            "cool",
+            {"temperature": None, "target_temp_low": 19.0, "target_temp_high": 26.0},
+        )
+        BetterThermostat._initialize_sensors(bt, sensor)
+        assert bt.bt_target_cooltemp == 26.0
+
     def test_humidity_sensor_initialized(self, bt):
         """Test Humidity sensor initialized."""
         bt.humidity_sensor_entity_id = HUMIDITY_ID

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -1,15 +1,17 @@
 """Tests for events/cooler.py – Cooler event handler.
 
-Covers guard clauses, setpoint adoption, clamping, heat-target sync,
-and control-queue triggering.
+Covers guard clauses, setpoint adoption, echo suppression, unit handling,
+clamping, heat-target sync, and control-queue triggering.
 """
 
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
 import pytest
 
+from custom_components.better_thermostat.climate import BetterThermostat
 from custom_components.better_thermostat.events.cooler import trigger_cooler_change
 
 ENTITY_ID = "climate.test_cooler"
@@ -25,17 +27,21 @@ def mock_bt():
     """Create a mock BetterThermostat instance with sensible defaults."""
     bt = MagicMock()
     bt.hass = MagicMock()
+    bt.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
     bt.device_name = "Test Thermostat"
     bt.bt_hvac_mode = HVACMode.HEAT_COOL
+    bt.hvac_mode = HVACMode.HEAT_COOL
     bt.bt_target_temp = 20.0
     bt.bt_target_cooltemp = 25.0
     bt.bt_target_temp_step = 0.5
     bt.bt_min_temp = 5.0
     bt.bt_max_temp = 30.0
+    bt.last_sent_cooler_temp = None
     bt.startup_running = False
     bt.control_queue_task = AsyncMock()
     bt.context = MagicMock()  # unique context so != event.context
     bt.async_write_ha_state = MagicMock()
+    bt._enforce_heat_below_cool = lambda: BetterThermostat._enforce_heat_below_cool(bt)
     return bt
 
 
@@ -265,6 +271,7 @@ class TestHeatTargetSync:
     async def test_heat_target_pushed_down_when_equal(self, mock_bt):
         """When cooltemp == heat target, heat target is pushed down by step."""
         mock_bt.bt_target_temp = 25.0
+        mock_bt.bt_target_cooltemp = 27.0
         old_state = _make_state(attributes={"temperature": 27.0})
         new_state = _make_state(attributes={"temperature": 25.0})
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
@@ -302,11 +309,10 @@ class TestHeatTargetSync:
 
     @pytest.mark.asyncio
     async def test_heat_target_sync_not_checked_below_min(self, mock_bt):
-        """Heat-target sync should still work correctly after clamping to min.
+        """Heat-target sync keeps the heat target inside the configured range.
 
-        If cooltemp is clamped to min (5.0), and heat target is >= 5.0,
-        heat target should be pushed down to 4.5. But 4.5 < bt_min_temp!
-        The code does NOT clamp the heat target — potential invariant violation.
+        With the cool target clamped to the minimum there is no room for a full
+        step below it, so the heat target stops at bt_min_temp.
         """
         mock_bt.bt_target_temp = 6.0
         mock_bt.bt_min_temp = 5.0
@@ -316,19 +322,14 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
-        # cooltemp clamped to 5.0, heat target >= cooltemp → pushed to 4.5
         assert mock_bt.bt_target_cooltemp == 5.0
-        # BUG: heat target pushed below min_temp without clamping
         assert mock_bt.bt_target_temp >= mock_bt.bt_min_temp
 
     @pytest.mark.asyncio
     async def test_heat_target_sync_with_zero_step(self, mock_bt):
-        """When step is 0, heat-target sync produces cooltemp - 0 = cooltemp.
-
-        This means heat target == cooltemp, which violates the invariant
-        that heat < cool. The >= check would trigger again next time.
-        """
+        """A zero step falls back to 0.5 so heat stays below cool."""
         mock_bt.bt_target_temp = 25.0
+        mock_bt.bt_target_cooltemp = 27.0
         mock_bt.bt_target_temp_step = 0.0
         old_state = _make_state(attributes={"temperature": 27.0})
         new_state = _make_state(attributes={"temperature": 25.0})
@@ -336,8 +337,6 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
-        # With step=0: bt_target_temp = cooltemp - 0 = cooltemp
-        # This should maintain heat < cool invariant
         assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
 
@@ -407,12 +406,11 @@ class TestEdgeCases:
     async def test_main_key_mismatch_old_has_temp_new_has_target_temp_high(
         self, mock_bt
     ):
-        """Key selection uses old_state only to pick the temperature attribute key.
+        """Each state picks its own attribute key.
 
-        If old has 'temperature' but new only has 'target_temp_high', the new
-        setpoint reads from the wrong key. The _main_key is determined from
-        old_state.attributes — if the cooler switches attribute schema between
-        events, new_state is read with the wrong key → None → no adoption.
+        A cooler that switches between single-setpoint and range attributes
+        between two events is read correctly, because the key is resolved per
+        state.
         """
         old_state = _make_state(attributes={"temperature": 25.0})
         # new_state has target_temp_high but NOT temperature
@@ -425,7 +423,166 @@ class TestEdgeCases:
 
         await trigger_cooler_change(mock_bt, event)
 
-        # _main_key is "temperature" (from old_state), but new_state has
-        # no "temperature" → convert_to_float("None") → None → no adoption
-        # The 28.0 setpoint is silently lost
         assert mock_bt.bt_target_cooltemp == 28.0
+
+
+# ---------------------------------------------------------------------------
+# 6. Echo suppression
+# ---------------------------------------------------------------------------
+
+
+class TestEchoSuppression:
+    """Only user input on the cooler is adopted, not BT's own writes."""
+
+    @pytest.mark.asyncio
+    async def test_unchanged_setpoint_is_not_re_adopted(self, mock_bt):
+        """A cooler update without a setpoint change runs no control cycle."""
+        old_state = _make_state(
+            attributes={"temperature": 25.0, "current_temperature": 26.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 25.0, "current_temperature": 26.1}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_echo_of_last_sent_setpoint_is_not_adopted(self, mock_bt):
+        """A write BT sent is not adopted when it returns with a foreign context.
+
+        Cloud and MQTT backed coolers publish the new setpoint from a later poll
+        or broker message whose context is not BT's, so the context check alone
+        does not catch it.
+        """
+        mock_bt.bt_target_cooltemp = 25.0
+        mock_bt.last_sent_cooler_temp = 22.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 22.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_device_rounding_of_own_write_is_not_adopted(self, mock_bt):
+        """A device rounding BT's write to its own grid is not user input."""
+        mock_bt.bt_target_cooltemp = 24.4
+        mock_bt.last_sent_cooler_temp = 24.4
+        old_state = _make_state(
+            attributes={"temperature": 26.0, "target_temp_step": 1.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 24.0, "target_temp_step": 1.0}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 24.4
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_user_change_of_one_full_step_is_adopted(self, mock_bt):
+        """A change of at least one device step is user input."""
+        mock_bt.bt_target_cooltemp = 24.0
+        mock_bt.last_sent_cooler_temp = 24.0
+        old_state = _make_state(
+            attributes={"temperature": 24.0, "target_temp_step": 1.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 25.0, "target_temp_step": 1.0}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        mock_bt.control_queue_task.put.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 7. Unit handling
+# ---------------------------------------------------------------------------
+
+
+class TestCoolerUnitHandling:
+    """Setpoints arrive in the system unit and are stored in °C."""
+
+    @pytest.mark.asyncio
+    async def test_fahrenheit_setpoint_is_converted_to_celsius(self, mock_bt):
+        """On a °F system the reported setpoint is converted, not taken as °C."""
+        mock_bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        mock_bt.bt_target_temp = 18.0
+        old_state = _make_state(attributes={"temperature": 75.0})
+        new_state = _make_state(attributes={"temperature": 68.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 20.0
+        mock_bt.control_queue_task.put.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fahrenheit_step_is_converted_to_a_celsius_delta(self, mock_bt):
+        """The device step is a °F delta on a °F system and must be scaled."""
+        mock_bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        mock_bt.bt_target_cooltemp = 21.11  # 70 °F
+        mock_bt.last_sent_cooler_temp = 21.11
+        old_state = _make_state(
+            attributes={"temperature": 70.0, "target_temp_step": 2.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 71.0, "target_temp_step": 2.0}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        # 1 °F is below the 2 °F device step, so this is a rounding echo.
+        assert mock_bt.bt_target_cooltemp == 21.11
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# 8. Range mode
+# ---------------------------------------------------------------------------
+
+
+class TestRangeModeCooler:
+    """Coolers running in range mode publish an empty single setpoint."""
+
+    @pytest.mark.asyncio
+    async def test_empty_temperature_falls_back_to_target_temp_high(self, mock_bt):
+        """A present-but-empty 'temperature' does not hide 'target_temp_high'."""
+        old_state = State(
+            ENTITY_ID,
+            "heat_cool",
+            attributes={
+                "temperature": None,
+                "target_temp_high": 24.0,
+                "target_temp_low": 19.0,
+            },
+        )
+        new_state = State(
+            ENTITY_ID,
+            "heat_cool",
+            attributes={
+                "temperature": None,
+                "target_temp_high": 26.0,
+                "target_temp_low": 19.0,
+            },
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 26.0
+        mock_bt.control_queue_task.put.assert_awaited_once()

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -529,6 +529,30 @@ class TestCoolerUnitHandling:
         mock_bt.control_queue_task.put.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_one_fahrenheit_press_is_adopted(self, mock_bt):
+        """A single press on a 1 °F cooler moves the cool target.
+
+        75 °F and 76 °F read back as 23.89 °C and 24.44 °C, 0.55 apart, while
+        the converted step is 0.5556 — a full step of user input lands below
+        the step itself.
+        """
+        mock_bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        mock_bt.bt_target_cooltemp = 23.89
+        mock_bt.last_sent_cooler_temp = 23.89
+        old_state = _make_state(
+            attributes={"temperature": 75.0, "target_temp_step": 1.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 76.0, "target_temp_step": 1.0}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 24.44
+        mock_bt.control_queue_task.put.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_fahrenheit_step_is_converted_to_a_celsius_delta(self, mock_bt):
         """The device step is a °F delta on a °F system and must be scaled."""
         mock_bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -308,7 +308,7 @@ class TestHeatTargetSync:
         assert mock_bt.bt_target_temp == 20.0  # unchanged
 
     @pytest.mark.asyncio
-    async def test_heat_target_sync_not_checked_below_min(self, mock_bt):
+    async def test_heat_target_sync_respects_min_temp(self, mock_bt):
         """Heat-target sync keeps the heat target inside the configured range.
 
         With the cool target clamped to the minimum there is no room for a full
@@ -403,9 +403,7 @@ class TestEdgeCases:
         mock_bt.control_queue_task.put.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_main_key_mismatch_old_has_temp_new_has_target_temp_high(
-        self, mock_bt
-    ):
+    async def test_setpoint_key_is_resolved_per_state(self, mock_bt):
         """Each state picks its own attribute key.
 
         A cooler that switches between single-setpoint and range attributes
@@ -540,15 +538,16 @@ class TestCoolerUnitHandling:
             attributes={"temperature": 70.0, "target_temp_step": 2.0}
         )
         new_state = _make_state(
-            attributes={"temperature": 71.0, "target_temp_step": 2.0}
+            attributes={"temperature": 73.0, "target_temp_step": 2.0}
         )
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
 
         await trigger_cooler_change(mock_bt, event)
 
-        # 1 °F is below the 2 °F device step, so this is a rounding echo.
-        assert mock_bt.bt_target_cooltemp == 21.11
-        mock_bt.control_queue_task.put.assert_not_awaited()
+        # 3 °F is 1.67 K, above the converted step of 1.11 K and below the
+        # 2.0 the raw attribute would give, so only a converted step adopts it.
+        assert mock_bt.bt_target_cooltemp == 22.78
+        mock_bt.control_queue_task.put.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -488,6 +488,29 @@ class TestEchoSuppression:
         mock_bt.control_queue_task.put.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_report_of_an_unchanged_setpoint_does_not_revert_bt(self, mock_bt):
+        """A cooler republishing its old setpoint does not undo a BT-side change.
+
+        The send cache is written only after a successful service call, so
+        between a BT-side target change and that write it still holds the
+        previous value. Only a setpoint the cooler itself moved is user input.
+        """
+        mock_bt.bt_target_cooltemp = 27.0
+        mock_bt.last_sent_cooler_temp = None
+        old_state = _make_state(
+            attributes={"temperature": 25.0, "current_temperature": 26.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 25.0, "current_temperature": 26.5}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 27.0
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_user_change_of_one_full_step_is_adopted(self, mock_bt):
         """A change of at least one device step is user input."""
         mock_bt.bt_target_cooltemp = 24.0

--- a/tests/unit/test_helpers_inbound_setpoint.py
+++ b/tests/unit/test_helpers_inbound_setpoint.py
@@ -4,14 +4,17 @@ from unittest.mock import Mock
 
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import Context, State
+from homeassistant.util.unit_conversion import TemperatureDeltaConverter
 
 from custom_components.better_thermostat.utils.helpers import (
     COOLER_SETPOINT_KEYS,
+    SETPOINT_MATCH_TOLERANCE,
     TRV_SETPOINT_KEYS,
     normalize_step,
     read_setpoint_celsius,
     resolve_inbound_setpoint,
     resolve_state_change_event,
+    setpoint_echo_window,
 )
 
 ENTITY_ID = "climate.device"
@@ -98,6 +101,18 @@ class TestNormalizeStep:
     def test_custom_fallback_is_used(self):
         """The caller can supply its own fallback."""
         assert normalize_step(None, fallback=1.0) == 1.0
+
+
+class TestSetpointEchoWindow:
+    """The distance below which a setpoint difference is grid noise."""
+
+    def test_window_is_a_step_less_the_read_grid(self):
+        """A reported value carries the read grid, so the window shrinks by it."""
+        assert setpoint_echo_window(0.5) == 0.5 - SETPOINT_MATCH_TOLERANCE
+
+    def test_window_stays_positive_for_a_tiny_step(self):
+        """A step at or below the read grid still separates two setpoints."""
+        assert setpoint_echo_window(0.005) == SETPOINT_MATCH_TOLERANCE
 
 
 class TestResolveInboundSetpoint:
@@ -189,6 +204,60 @@ class TestResolveInboundSetpoint:
             log_source="t",
         )
         assert result.is_echo is False
+
+    def test_a_full_step_off_a_non_dyadic_grid_is_user_input(self):
+        """One press on a 2 °F device lands a hair below a full step.
+
+        21.11 °C and 22.22 °C are the read-back values of 70 °F and 72 °F, and
+        their difference is 1.1099999999999994 against a step of 1.1111.
+        """
+        result = resolve_inbound_setpoint(
+            _fake_self(),
+            _state({"temperature": 22.22}),
+            keys=TRV_SETPOINT_KEYS,
+            known_values=(21.11,),
+            step=1.1111,
+            device_label="TRV",
+            entity_id=ENTITY_ID,
+            log_source="t",
+        )
+        assert result.is_echo is False
+
+    def test_every_fahrenheit_step_is_user_input(self):
+        """On a °F system one press of the up button is never an echo.
+
+        The reported values pass through convert_to_float's 0.01 grid while
+        the step sits on the device grid, so a genuine single-step move can
+        land a hair below one full step.
+        """
+        mock_self = _fake_self(UnitOfTemperature.FAHRENHEIT)
+        # The whole grid has to stay inside the configured range, so that the
+        # clamp cannot pull a reported value onto the previous one.
+        mock_self.bt_max_temp = 35.0
+        step = round(
+            TemperatureDeltaConverter.convert(
+                1.0, UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS
+            ),
+            4,
+        )
+        for fahrenheit in range(50, 90):
+            known = read_setpoint_celsius(
+                mock_self,
+                _state({"temperature": float(fahrenheit)}),
+                TRV_SETPOINT_KEYS,
+                "t",
+            )
+            result = resolve_inbound_setpoint(
+                mock_self,
+                _state({"temperature": float(fahrenheit + 1)}),
+                keys=TRV_SETPOINT_KEYS,
+                known_values=(known,),
+                step=step,
+                device_label="TRV",
+                entity_id=ENTITY_ID,
+                log_source="t",
+            )
+            assert result.is_echo is False, f"{fahrenheit} °F -> {fahrenheit + 1} °F"
 
     def test_non_numeric_known_values_are_ignored(self):
         """Uninitialised known values do not raise."""

--- a/tests/unit/test_helpers_inbound_setpoint.py
+++ b/tests/unit/test_helpers_inbound_setpoint.py
@@ -102,6 +102,12 @@ class TestNormalizeStep:
         """The caller can supply its own fallback."""
         assert normalize_step(None, fallback=1.0) == 1.0
 
+    def test_non_finite_falls_back(self):
+        """NaN and infinity pass a ``<= 0`` test but cannot separate setpoints."""
+        assert normalize_step(float("nan")) == 0.5
+        assert normalize_step(float("inf")) == 0.5
+        assert normalize_step(float("-inf")) == 0.5
+
 
 class TestSetpointEchoWindow:
     """The distance below which a setpoint difference is grid noise."""

--- a/tests/unit/test_helpers_inbound_setpoint.py
+++ b/tests/unit/test_helpers_inbound_setpoint.py
@@ -290,6 +290,26 @@ class TestResolveInboundSetpoint:
         )
         assert (result.value, result.clamped) == (5.0, True)
 
+    def test_inverted_range_never_yields_a_value_above_the_maximum(self):
+        """Non-overlapping heater and cooler ranges still clamp to the maximum.
+
+        A configuration whose members do not overlap leaves bt_min_temp above
+        bt_max_temp, and a value the lower bound raises must not end up above
+        the upper one.
+        """
+        mock_self = _fake_self()
+        mock_self.bt_min_temp = 25.0
+        mock_self.bt_max_temp = 20.0
+        result = resolve_inbound_setpoint(
+            mock_self,
+            _state({"temperature": 18.0}),
+            keys=TRV_SETPOINT_KEYS,
+            known_values=(),
+            step=0.5,
+            log_source="t",
+        )
+        assert (result.value, result.clamped) == (20.0, True)
+
     def test_echo_is_judged_after_clamping(self):
         """A value the clamp pulls onto a known value is an echo, not input."""
         result = resolve_inbound_setpoint(

--- a/tests/unit/test_helpers_inbound_setpoint.py
+++ b/tests/unit/test_helpers_inbound_setpoint.py
@@ -128,8 +128,6 @@ class TestResolveInboundSetpoint:
                 keys=TRV_SETPOINT_KEYS,
                 known_values=(),
                 step=0.5,
-                device_label="TRV",
-                entity_id=ENTITY_ID,
                 log_source="t",
             )
             is None
@@ -143,8 +141,6 @@ class TestResolveInboundSetpoint:
             keys=TRV_SETPOINT_KEYS,
             known_values=(),
             step=0.5,
-            device_label="TRV",
-            entity_id=ENTITY_ID,
             log_source="t",
         )
         assert (result.raw, result.value, result.clamped) == (21.0, 21.0, False)
@@ -157,8 +153,6 @@ class TestResolveInboundSetpoint:
             keys=TRV_SETPOINT_KEYS,
             known_values=(),
             step=0.5,
-            device_label="TRV",
-            entity_id=ENTITY_ID,
             log_source="t",
         )
         assert (result.raw, result.value, result.clamped) == (35.0, 30.0, True)
@@ -171,8 +165,6 @@ class TestResolveInboundSetpoint:
             keys=TRV_SETPOINT_KEYS,
             known_values=(),
             step=0.5,
-            device_label="TRV",
-            entity_id=ENTITY_ID,
             log_source="t",
         )
         assert (result.raw, result.value, result.clamped) == (2.0, 5.0, True)
@@ -185,8 +177,6 @@ class TestResolveInboundSetpoint:
             keys=TRV_SETPOINT_KEYS,
             known_values=(None, 21.5),
             step=0.5,
-            device_label="TRV",
-            entity_id=ENTITY_ID,
             log_source="t",
         )
         assert result.is_echo is True
@@ -199,8 +189,6 @@ class TestResolveInboundSetpoint:
             keys=TRV_SETPOINT_KEYS,
             known_values=(21.5,),
             step=0.5,
-            device_label="TRV",
-            entity_id=ENTITY_ID,
             log_source="t",
         )
         assert result.is_echo is False
@@ -217,8 +205,6 @@ class TestResolveInboundSetpoint:
             keys=TRV_SETPOINT_KEYS,
             known_values=(21.11,),
             step=1.1111,
-            device_label="TRV",
-            entity_id=ENTITY_ID,
             log_source="t",
         )
         assert result.is_echo is False
@@ -253,8 +239,6 @@ class TestResolveInboundSetpoint:
                 keys=TRV_SETPOINT_KEYS,
                 known_values=(known,),
                 step=step,
-                device_label="TRV",
-                entity_id=ENTITY_ID,
                 log_source="t",
             )
             assert result.is_echo is False, f"{fahrenheit} °F -> {fahrenheit + 1} °F"
@@ -267,8 +251,6 @@ class TestResolveInboundSetpoint:
             keys=TRV_SETPOINT_KEYS,
             known_values=(None, "unset"),
             step=0.5,
-            device_label="TRV",
-            entity_id=ENTITY_ID,
             log_source="t",
         )
         assert result.is_echo is False
@@ -284,8 +266,6 @@ class TestResolveInboundSetpoint:
             keys=TRV_SETPOINT_KEYS,
             known_values=(),
             step=0.5,
-            device_label="TRV",
-            entity_id=ENTITY_ID,
             log_source="t",
         )
         assert (result.value, result.clamped) == (21.0, False)
@@ -300,8 +280,6 @@ class TestResolveInboundSetpoint:
             keys=TRV_SETPOINT_KEYS,
             known_values=(),
             step=0.5,
-            device_label="TRV",
-            entity_id=ENTITY_ID,
             log_source="t",
         )
         assert (result.value, result.clamped) == (5.0, True)
@@ -314,8 +292,6 @@ class TestResolveInboundSetpoint:
             keys=TRV_SETPOINT_KEYS,
             known_values=(30.0,),
             step=0.5,
-            device_label="TRV",
-            entity_id=ENTITY_ID,
             log_source="t",
         )
         assert (result.value, result.is_echo) == (30.0, True)

--- a/tests/unit/test_helpers_inbound_setpoint.py
+++ b/tests/unit/test_helpers_inbound_setpoint.py
@@ -1,0 +1,315 @@
+"""Tests for the shared inbound-setpoint boundary in utils/helpers.py."""
+
+from unittest.mock import Mock
+
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import Context, State
+
+from custom_components.better_thermostat.utils.helpers import (
+    COOLER_SETPOINT_KEYS,
+    TRV_SETPOINT_KEYS,
+    normalize_step,
+    read_setpoint_celsius,
+    resolve_inbound_setpoint,
+    resolve_state_change_event,
+)
+
+ENTITY_ID = "climate.device"
+
+
+def _fake_self(unit=UnitOfTemperature.CELSIUS):
+    """Create a minimal BetterThermostat mock for the inbound helpers."""
+    mock_self = Mock()
+    mock_self.device_name = "test_thermostat"
+    mock_self.hass.config.units.temperature_unit = unit
+    mock_self.bt_min_temp = 5.0
+    mock_self.bt_max_temp = 30.0
+    mock_self.context = Context()
+    return mock_self
+
+
+def _state(attributes, entity_id=ENTITY_ID, state="heat"):
+    return State(entity_id, state, attributes)
+
+
+class TestReadSetpointCelsius:
+    """Reading a setpoint from a foreign climate state."""
+
+    def test_missing_state_returns_none(self):
+        """A missing state holds no setpoint."""
+        assert read_setpoint_celsius(_fake_self(), None, TRV_SETPOINT_KEYS, "t") is None
+
+    def test_first_key_wins(self):
+        """The single-setpoint key takes precedence over the range key."""
+        state = _state({"temperature": 21.0, "target_temp_low": 19.0})
+        assert (
+            read_setpoint_celsius(_fake_self(), state, TRV_SETPOINT_KEYS, "t") == 21.0
+        )
+
+    def test_empty_first_key_falls_through(self):
+        """A present-but-empty key does not hide the next one."""
+        state = _state({"temperature": None, "target_temp_low": 19.0})
+        assert (
+            read_setpoint_celsius(_fake_self(), state, TRV_SETPOINT_KEYS, "t") == 19.0
+        )
+
+    def test_cooler_keys_read_the_upper_bound(self):
+        """The cooler is driven towards the upper bound of a range."""
+        state = _state({"temperature": None, "target_temp_high": 26.0})
+        assert (
+            read_setpoint_celsius(_fake_self(), state, COOLER_SETPOINT_KEYS, "t")
+            == 26.0
+        )
+
+    def test_unusable_value_falls_through(self):
+        """A non-numeric value does not stop the next key from being read."""
+        state = _state({"temperature": "unavailable", "target_temp_low": 19.0})
+        assert (
+            read_setpoint_celsius(_fake_self(), state, TRV_SETPOINT_KEYS, "t") == 19.0
+        )
+
+    def test_value_is_converted_from_the_system_unit(self):
+        """On a °F system the reported value is converted to °C."""
+        mock_self = _fake_self(UnitOfTemperature.FAHRENHEIT)
+        state = _state({"temperature": 68.0})
+        assert read_setpoint_celsius(mock_self, state, TRV_SETPOINT_KEYS, "t") == 20.0
+
+
+class TestNormalizeStep:
+    """Coercing a reported step to a usable value."""
+
+    def test_valid_step_is_kept(self):
+        """A positive step passes through."""
+        assert normalize_step(0.1) == 0.1
+
+    def test_none_falls_back(self):
+        """A missing step falls back."""
+        assert normalize_step(None) == 0.5
+
+    def test_zero_and_negative_fall_back(self):
+        """A non-positive step cannot separate user input from an echo."""
+        assert normalize_step(0) == 0.5
+        assert normalize_step(-1.0) == 0.5
+
+    def test_unconvertible_falls_back(self):
+        """A non-numeric step falls back."""
+        assert normalize_step("unavailable") == 0.5
+
+    def test_custom_fallback_is_used(self):
+        """The caller can supply its own fallback."""
+        assert normalize_step(None, fallback=1.0) == 1.0
+
+
+class TestResolveInboundSetpoint:
+    """Clamping and echo detection on a reported setpoint."""
+
+    def test_missing_value_returns_none(self):
+        """A state without a usable setpoint resolves to nothing."""
+        state = _state({"current_temperature": 20.0})
+        assert (
+            resolve_inbound_setpoint(
+                _fake_self(),
+                state,
+                keys=TRV_SETPOINT_KEYS,
+                known_values=(),
+                step=0.5,
+                device_label="TRV",
+                entity_id=ENTITY_ID,
+                log_source="t",
+            )
+            is None
+        )
+
+    def test_value_inside_range_is_untouched(self):
+        """A value inside the configured range is passed through."""
+        result = resolve_inbound_setpoint(
+            _fake_self(),
+            _state({"temperature": 21.0}),
+            keys=TRV_SETPOINT_KEYS,
+            known_values=(),
+            step=0.5,
+            device_label="TRV",
+            entity_id=ENTITY_ID,
+            log_source="t",
+        )
+        assert (result.raw, result.value, result.clamped) == (21.0, 21.0, False)
+
+    def test_value_above_range_is_clamped_and_raw_kept(self):
+        """Clamping records the reported value, which callers still need."""
+        result = resolve_inbound_setpoint(
+            _fake_self(),
+            _state({"temperature": 35.0}),
+            keys=TRV_SETPOINT_KEYS,
+            known_values=(),
+            step=0.5,
+            device_label="TRV",
+            entity_id=ENTITY_ID,
+            log_source="t",
+        )
+        assert (result.raw, result.value, result.clamped) == (35.0, 30.0, True)
+
+    def test_value_below_range_is_clamped(self):
+        """A value below the minimum is raised to it."""
+        result = resolve_inbound_setpoint(
+            _fake_self(),
+            _state({"temperature": 2.0}),
+            keys=TRV_SETPOINT_KEYS,
+            known_values=(),
+            step=0.5,
+            device_label="TRV",
+            entity_id=ENTITY_ID,
+            log_source="t",
+        )
+        assert (result.raw, result.value, result.clamped) == (2.0, 5.0, True)
+
+    def test_value_within_a_step_of_a_known_value_is_an_echo(self):
+        """A device settling BT's write on its own grid is not user input."""
+        result = resolve_inbound_setpoint(
+            _fake_self(),
+            _state({"temperature": 21.4}),
+            keys=TRV_SETPOINT_KEYS,
+            known_values=(None, 21.5),
+            step=0.5,
+            device_label="TRV",
+            entity_id=ENTITY_ID,
+            log_source="t",
+        )
+        assert result.is_echo is True
+
+    def test_a_full_step_away_is_user_input(self):
+        """A change of at least one step is adopted."""
+        result = resolve_inbound_setpoint(
+            _fake_self(),
+            _state({"temperature": 22.0}),
+            keys=TRV_SETPOINT_KEYS,
+            known_values=(21.5,),
+            step=0.5,
+            device_label="TRV",
+            entity_id=ENTITY_ID,
+            log_source="t",
+        )
+        assert result.is_echo is False
+
+    def test_non_numeric_known_values_are_ignored(self):
+        """Uninitialised known values do not raise."""
+        result = resolve_inbound_setpoint(
+            _fake_self(),
+            _state({"temperature": 22.0}),
+            keys=TRV_SETPOINT_KEYS,
+            known_values=(None, "unset"),
+            step=0.5,
+            device_label="TRV",
+            entity_id=ENTITY_ID,
+            log_source="t",
+        )
+        assert result.is_echo is False
+
+    def test_unknown_bounds_do_not_raise(self):
+        """A range BT does not know yet cannot clamp, but must not crash."""
+        mock_self = _fake_self()
+        mock_self.bt_min_temp = None
+        mock_self.bt_max_temp = None
+        result = resolve_inbound_setpoint(
+            mock_self,
+            _state({"temperature": 21.0}),
+            keys=TRV_SETPOINT_KEYS,
+            known_values=(),
+            step=0.5,
+            device_label="TRV",
+            entity_id=ENTITY_ID,
+            log_source="t",
+        )
+        assert (result.value, result.clamped) == (21.0, False)
+
+    def test_known_bound_is_still_enforced_alone(self):
+        """One known bound clamps even while the other is unknown."""
+        mock_self = _fake_self()
+        mock_self.bt_max_temp = None
+        result = resolve_inbound_setpoint(
+            mock_self,
+            _state({"temperature": 2.0}),
+            keys=TRV_SETPOINT_KEYS,
+            known_values=(),
+            step=0.5,
+            device_label="TRV",
+            entity_id=ENTITY_ID,
+            log_source="t",
+        )
+        assert (result.value, result.clamped) == (5.0, True)
+
+    def test_echo_is_judged_after_clamping(self):
+        """A value the clamp pulls onto a known value is an echo, not input."""
+        result = resolve_inbound_setpoint(
+            _fake_self(),
+            _state({"temperature": 32.0}),
+            keys=TRV_SETPOINT_KEYS,
+            known_values=(30.0,),
+            step=0.5,
+            device_label="TRV",
+            entity_id=ENTITY_ID,
+            log_source="t",
+        )
+        assert (result.value, result.is_echo) == (30.0, True)
+
+
+class TestResolveStateChangeEvent:
+    """The shared guard prologue of the device event handlers."""
+
+    @staticmethod
+    def _event(mock_self, old_state, new_state, context=None):
+        event = Mock()
+        event.data = {
+            "old_state": old_state,
+            "new_state": new_state,
+            "entity_id": ENTITY_ID,
+        }
+        event.context = context if context is not None else Context()
+        return event
+
+    def test_actionable_event_returns_states(self):
+        """A complete foreign event yields both states and the entity id."""
+        mock_self = _fake_self()
+        old_state = _state({"temperature": 20.0})
+        new_state = _state({"temperature": 21.0})
+        resolved = resolve_state_change_event(
+            mock_self, self._event(mock_self, old_state, new_state), "TRV"
+        )
+        assert resolved == (old_state, new_state, ENTITY_ID)
+
+    def test_missing_new_state_is_skipped(self):
+        """An event without a new state carries nothing to act on."""
+        mock_self = _fake_self()
+        event = self._event(mock_self, _state({"temperature": 20.0}), None)
+        assert resolve_state_change_event(mock_self, event, "TRV") is None
+
+    def test_missing_old_state_is_skipped(self):
+        """An event without an old state carries nothing to compare against."""
+        mock_self = _fake_self()
+        event = self._event(mock_self, None, _state({"temperature": 20.0}))
+        assert resolve_state_change_event(mock_self, event, "TRV") is None
+
+    def test_non_state_payload_is_skipped(self):
+        """A payload that is not a State is skipped."""
+        mock_self = _fake_self()
+        event = self._event(mock_self, _state({"temperature": 20.0}), "not-a-state")
+        assert resolve_state_change_event(mock_self, event, "TRV") is None
+
+    def test_event_without_entity_id_is_skipped(self):
+        """Without an entity id there is no device to attribute the change to."""
+        mock_self = _fake_self()
+        event = self._event(
+            mock_self, _state({"temperature": 20.0}), _state({"temperature": 21.0})
+        )
+        event.data["entity_id"] = None
+        assert resolve_state_change_event(mock_self, event, "TRV") is None
+
+    def test_own_context_is_skipped(self):
+        """An event caused by BT's own service call is not user input."""
+        mock_self = _fake_self()
+        event = self._event(
+            mock_self,
+            _state({"temperature": 20.0}),
+            _state({"temperature": 21.0}),
+            context=mock_self.context,
+        )
+        assert resolve_state_change_event(mock_self, event, "TRV") is None

--- a/tests/unit/test_helpers_setpoint_range.py
+++ b/tests/unit/test_helpers_setpoint_range.py
@@ -12,7 +12,7 @@ from custom_components.better_thermostat.utils.helpers import (
     get_current_set_temperatures,
     matches_any_setpoint,
     round_by_step,
-    trv_supports_temperature_range,
+    supports_temperature_range,
 )
 
 RANGE_BIT = int(ClimateEntityFeature.TARGET_TEMPERATURE_RANGE)
@@ -26,27 +26,27 @@ def _fake_self():
     return mock_self
 
 
-class TestTrvSupportsTemperatureRange:
+class TestSupportsTemperatureRange:
     """Feature detection reads the supported_features bitmask."""
 
     def test_none_state_returns_false(self):
         """Report no range support when the TRV state is missing."""
-        assert trv_supports_temperature_range(None) is False
+        assert supports_temperature_range(None) is False
 
     def test_missing_attribute_returns_false(self):
         """Report no range support when supported_features is absent."""
         state = State("climate.trv", "heat", {})
-        assert trv_supports_temperature_range(state) is False
+        assert supports_temperature_range(state) is False
 
     def test_bit_not_set_returns_false(self):
         """Report no range support when the range bit is not set."""
         state = State("climate.trv", "heat", {"supported_features": 0})
-        assert trv_supports_temperature_range(state) is False
+        assert supports_temperature_range(state) is False
 
     def test_bit_set_returns_true(self):
         """Report range support when the range bit is set."""
         state = State("climate.trv", "heat", {"supported_features": RANGE_BIT})
-        assert trv_supports_temperature_range(state) is True
+        assert supports_temperature_range(state) is True
 
 
 class TestGetCurrentSetTemperatures:

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -879,6 +879,44 @@ class TestTargetTempAdoption:
         assert mock_bt.bt_target_temp == 22.0
 
     @pytest.mark.asyncio
+    async def test_setpoint_falls_back_when_temperature_is_empty(self, mock_bt):
+        """An empty 'temperature' does not hide 'target_temp_low'.
+
+        A TRV running in range mode publishes the key it does not drive as
+        None, so the fallback has to survive a present-but-empty attribute.
+        """
+        old_state = State(
+            ENTITY_ID,
+            "heat",
+            attributes={
+                "temperature": None,
+                "target_temp_low": 19.0,
+                "current_temperature": 18.0,
+            },
+        )
+        new_state = State(
+            ENTITY_ID,
+            "heat",
+            attributes={
+                "temperature": None,
+                "target_temp_low": 22.0,
+                "current_temperature": 18.0,
+            },
+        )
+        mock_bt.hass.states.get.return_value = new_state
+        mock_bt.real_trvs[ENTITY_ID].last_temperature = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 22.0
+
+    @pytest.mark.asyncio
     async def test_cooler_sync_logic_bug(self, mock_bt):
         """Cooler-sync always sets cooltemp to target - step regardless of initial value."""
         mock_bt.cooler_entity_id = "climate.cooler"

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -13,6 +13,7 @@ from homeassistant.core import State
 from homeassistant.util import dt as dt_util
 import pytest
 
+from custom_components.better_thermostat.climate import BetterThermostat
 from custom_components.better_thermostat.events.trv import (
     convert_inbound_states,
     convert_outbound_states,
@@ -40,6 +41,7 @@ def mock_bt():
     bt.hass = MagicMock()
     bt.device_name = "Test Thermostat"
     bt.bt_hvac_mode = HVACMode.HEAT
+    bt.hvac_mode = HVACMode.HEAT
     bt.bt_target_temp = 19.0
     bt.bt_min_temp = 5.0
     bt.bt_max_temp = 30.0
@@ -57,6 +59,7 @@ def mock_bt():
     bt.context = MagicMock()  # unique context so != event.context
     bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
     bt.async_write_ha_state = MagicMock()
+    bt._enforce_cool_above_heat = lambda: BetterThermostat._enforce_cool_above_heat(bt)
 
     bt.all_trvs = [{"advanced": {CONF_HOMEMATICIP: False}}]
 
@@ -917,9 +920,10 @@ class TestTargetTempAdoption:
         assert mock_bt.bt_target_temp == 22.0
 
     @pytest.mark.asyncio
-    async def test_cooler_sync_logic_bug(self, mock_bt):
-        """Cooler-sync always sets cooltemp to target - step regardless of initial value."""
+    async def test_cooler_sync_keeps_cooltemp_above_target(self, mock_bt):
+        """A cooltemp already above the new target is left untouched."""
         mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_target_cooltemp = 25.0
         mock_bt.bt_target_temp_step = 0.5
 
@@ -950,6 +954,7 @@ class TestTargetTempAdoption:
     async def test_cooler_sync_pushes_cooltemp_above_target(self, mock_bt):
         """Cooltemp is pushed to target + step when equal to target."""
         mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_target_cooltemp = 22.0  # equal to new target
         mock_bt.bt_target_temp_step = 0.5
 
@@ -980,6 +985,7 @@ class TestTargetTempAdoption:
     async def test_cooler_sync_always_overwrites(self, mock_bt):
         """Cooltemp is pushed to target + step even when already below target."""
         mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_target_cooltemp = 15.0
         mock_bt.bt_target_temp_step = 0.5
 
@@ -1005,6 +1011,40 @@ class TestTargetTempAdoption:
             await trigger_trv_change(mock_bt, event)
 
         assert mock_bt.bt_target_cooltemp == 22.0 + 0.5
+
+    @pytest.mark.asyncio
+    async def test_cooler_sync_with_unknown_cooltemp_adopts_setpoint(self, mock_bt):
+        """An unknown cool target does not abort the heating-setpoint adoption."""
+        mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_cooltemp = None
+        mock_bt.bt_target_temp_step = 0.5
+
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 22.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 22.0},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].last_temperature = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 22.0
+        assert mock_bt.bt_target_cooltemp is None
+        mock_bt.async_write_ha_state.assert_called()
+        mock_bt.control_queue_task.put.assert_awaited_with(mock_bt)
 
     @pytest.mark.asyncio
     async def test_no_off_system_mode_sets_off_at_min(self, mock_bt):


### PR DESCRIPTION
> Rebased onto #2147, so this now sits on top of the cooler stack and merges after it. The inline key fallback that the first version carried has been folded into `read_setpoint_celsius()`, as the note below said it should be.

## Motivation

A cooler that only advertises `TARGET_TEMPERATURE_RANGE` publishes `temperature: None` and carries its setpoint under `target_temp_high`. `_initialize_sensors()` read only the `temperature` key, so `bt_target_cooltemp` stayed `None` for exactly that device class — and `None` is also what it holds when the cooler is unavailable at startup.

That arms a crash. `events/trv.py` compared `self.bt_target_temp >= self.bt_target_cooltemp` guarded only by `if self.cooler_entity_id is not None:`, so the first user setpoint change on a TRV raised `TypeError: '>=' not supported between instances of 'float' and 'NoneType'` inside a background event handler — *after* `bt_target_temp` had already been mutated. `_main_change` was never acted on: no `async_write_ha_state`, no control cycle. The adoption is lost and the entity keeps showing the old target.

## Changes

`events/trv.py` calls `self._enforce_cool_above_heat()` instead of carrying its own copy of the bump. The extracted method is the None-safe version of the same predicate, and `async_set_temperature` and `async_set_preset_mode` already go through it.

Two behaviour deltas, both deliberate:

- The helper is gated on `hvac_mode == HVACMode.HEAT_COOL`. With a cooler configured, `_hvac_list` becomes `[OFF, HEAT_COOL]` and `map_on_hvac_mode` becomes `HEAT_COOL`, so the property returns `HEAT_COOL` for `bt_hvac_mode` of both `HEAT` and `HEAT_COOL` — the guard is equivalent to "a cooler is configured" for every non-OFF mode. The one real narrowing is `bt_hvac_mode == OFF`, which the inline block still bumped. That path is reachable, because the adoption gate checks the *valve's* mode, not BT's. Not moving a cooling target while BT is off is the correct behaviour and matches what the cooler side does.
- The helper logs a WARNING where the inline block adjusted silently, so turning a TRV dial up past the cooling target now produces a log line. Consistent with the other call sites, but it is new log volume.

`_initialize_sensors()` reads the cool target through `read_setpoint_celsius(self, _cooler_state, COOLER_SETPOINT_KEYS, "startup()")`, so startup, `control_cooler()` and the cooler event handler all resolve the setpoint through one key precedence. That precedence is **value**-based, not presence-based: a range-only cooler does publish a `temperature` key, with `None` in it, so a presence check would stop at the first key and never reach `target_temp_high`.

Related and **not** fixed here: `events/cooler.py` still carries the mirror bump inline (`self.bt_target_temp >= self.bt_target_cooltemp`), which is `None`-fragile in the other direction — `bt_target_temp` being `None` raises the same `TypeError`. The `_enforce_heat_below_cool()` counterpart that would replace it does not exist on this line; it lives on `v2`.

## Tests

`2204 passed`, ruff and pyrefly clean. Two regression tests, both confirmed to fail without their fix — including against the folded implementation: a TRV setpoint change with `bt_target_cooltemp is None` (raises `TypeError` before) and a range-only cooler at startup (`assert None == 26.0` before). A third test pins the `temperature` path so the shared key precedence cannot break the primary read unnoticed.

The `mock_bt` fixture in `test_trv_events.py` binds the real `_enforce_cool_above_heat`; without that the MagicMock would swallow the call and the three existing cooler-sync assertions would have gone vacuous. `test_cooler_sync_logic_bug` is renamed to `test_cooler_sync_keeps_cooltemp_above_target` — its old name and docstring claimed the opposite of its own assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cooler and TRV setpoint parsing and fallback when only partial attributes are available.
  - Enhanced stepped setpoint handling with unit-aware conversions and tolerance-based resend suppression.
  - Improved echo suppression behavior and warnings when overwriting out-of-range values.
  - Added stronger enforcement to keep heating strictly below cooling in combined heat/cool mode.
  - Fixed cooler synchronization edge cases so updates are applied only when truly needed.
- **Tests**
  - Expanded unit test coverage for startup initialization, cooler/heat-cool enforcement, and inbound setpoint helper behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->