### PR TITLE
fix(climate): give every child its own setpoint step

### DIFF
--- a/custom_components/better_thermostat/adapters/delegate.py
+++ b/custom_components/better_thermostat/adapters/delegate.py
@@ -103,15 +103,16 @@ async def set_temperature(self, entity_id, temperature):
     # Initialize step with default value
     step = 0.5
     try:
-        # Step precedence: per-TRV (usually from config) > global config > device attribute > default 0.5
+        # Step precedence: per-TRV > global config > default 0.5. Both sources
+        # hold a Celsius step, matching the Celsius temperature being rounded;
+        # the device's raw attribute carries the device's unit and is therefore
+        # not a candidate here.
         trv = self.real_trvs.get(entity_id)
         per_trv_step = trv.target_temp_step if trv is not None else None
         global_cfg_step = getattr(self, "bt_target_temp_step", None)
         if global_cfg_step in (0, 0.0):
             global_cfg_step = None
-        state = self.hass.states.get(entity_id)
-        device_step = state.attributes.get("target_temp_step") if state else None
-        step = per_trv_step or global_cfg_step or device_step or 0.5
+        step = per_trv_step or global_cfg_step or 0.5
         rounded = round_by_step(float(t), float(step))
     except Exception:
         rounded = float(t)

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -316,6 +316,27 @@ def _detect_contact_open_at_startup(self, entity_id: str | None, kind: str) -> b
     return is_open
 
 
+def _target_temp_step_celsius(
+    state: State | None, device_name: str, system_unit: str | None
+) -> float | None:
+    """Read a child's own setpoint step and return it as a Celsius delta.
+
+    A child publishes its step in its own unit, so a Fahrenheit child's step is
+    scaled as a temperature difference (5/9) rather than run through the
+    absolute Fahrenheit-to-Celsius conversion.
+    """
+    attributes = state.attributes if state is not None else {}
+    raw_step = attributes.get(ATTR_TARGET_TEMP_STEP)
+    if raw_step is None:
+        return None
+    step = convert_to_float(str(raw_step), device_name, "_target_temp_step_celsius")
+    if step is None:
+        return None
+    if state_temperature_unit(attributes, system_unit) == UnitOfTemperature.FAHRENHEIT:
+        return round(step * 5.0 / 9.0, 4)
+    return step
+
+
 class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
     """Representation of a Better Thermostat device."""
 
@@ -597,6 +618,14 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             and unit == UnitOfTemperature.FAHRENHEIT
         ):
             self.bt_target_temp_step = round(self.bt_target_temp_step * 5.0 / 9.0, 4)
+        # ``bt_target_temp_step`` also absorbs the step derived from the child
+        # entities, so the explicitly configured value is kept apart: it is the
+        # only step that may override a device's own grid.
+        self._configured_target_temp_step: float | None = (
+            self.bt_target_temp_step
+            if self.bt_target_temp_step and self.bt_target_temp_step > 0.0
+            else None
+        )
         self.bt_min_temp: float | None = DEFAULT_MIN_TEMP
         self.bt_max_temp: float | None = DEFAULT_MAX_TEMP
         self.bt_target_temp = DEFAULT_TARGET_TEMP
@@ -1260,16 +1289,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 )
                 if _c is not None:
                     max_temps.append(_c)
-            _raw_step = s.attributes.get(ATTR_TARGET_TEMP_STEP)
-            if _raw_step is not None:
-                _sf = convert_to_float(
-                    str(_raw_step), self.device_name, "_resolve_temperature_range(step)"
-                )
-                if _sf is not None:
-                    # Convert step as a temperature delta if child uses °F
-                    if _unit == UnitOfTemperature.FAHRENHEIT:
-                        _sf = round(_sf * 5.0 / 9.0, 4)
-                    steps.append(_sf)
+            _sf = _target_temp_step_celsius(
+                s, self.device_name, self.hass.config.units.temperature_unit
+            )
+            if _sf is not None:
+                steps.append(_sf)
         self.bt_min_temp = max(min_temps) if min_temps else None
         self.bt_max_temp = min(max_temps) if max_temps else None
 
@@ -1808,20 +1832,23 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             )
             trv_data.max_temp = attr_to_celsius(self, _s, "max_temp", 30, "startup")
             trv_data.min_temp = attr_to_celsius(self, _s, "min_temp", 5, "startup")
-            # Prefer configured step over device-reported step
-            cfg_step = (
-                self.bt_target_temp_step
-                if self.bt_target_temp_step and self.bt_target_temp_step > 0.0
-                else None
+            # This step is the grid the device rounds to: it sizes the echo
+            # window for inbound setpoints and the rounding of outbound ones,
+            # so it must be this device's own step and not the coarsest step
+            # across all children in ``bt_target_temp_step``. An explicitly
+            # configured step still overrides the device, and the aggregate
+            # only fills in for a device that publishes no usable step.
+            _device_step = _target_temp_step_celsius(
+                _s, self.device_name, self.hass.config.units.temperature_unit
             )
-            if cfg_step is not None:
-                trv_data.target_temp_step = cfg_step
+            if self._configured_target_temp_step is not None:
+                trv_data.target_temp_step = self._configured_target_temp_step
+            elif _device_step is not None and _device_step > 0.0:
+                trv_data.target_temp_step = _device_step
+            elif self.bt_target_temp_step and self.bt_target_temp_step > 0.0:
+                trv_data.target_temp_step = self.bt_target_temp_step
             else:
-                trv_data.target_temp_step = convert_to_float(
-                    str(_attrs.get("target_temp_step", 0.5)),
-                    self.device_name,
-                    "startup",
-                )
+                trv_data.target_temp_step = 0.5
             trv_data.temperature = attr_to_celsius(
                 self, _s, "temperature", 5, "startup"
             )

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -427,6 +427,10 @@ def convert_to_float(
 ) -> float | None:
     """Convert value to float or print error message.
 
+    Non-finite readings fail the conversion and yield None: the step rounding
+    goes through an integer number of steps, so ``inf`` raises ``OverflowError``
+    and ``nan`` raises ``ValueError``.
+
     Parameters
     ----------
     value : str | int | float | None
@@ -448,7 +452,7 @@ def convert_to_float(
         # Rounding to 0.1 can turn 19.97 into 20.0, leading to incorrect
         # HVAC action decisions.
         return round_by_step(float(value), 0.01)
-    except ValueError, TypeError, AttributeError, KeyError:
+    except ValueError, TypeError, AttributeError, KeyError, OverflowError:
         _LOGGER.debug(
             "better thermostat %s: Could not convert '%s' to float in %s",
             instance_name,

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -60,6 +60,7 @@ def bt():
     mock.bt_max_temp = 30.0
     mock.bt_target_temp = 21.0
     mock.bt_target_temp_step = None
+    mock._configured_target_temp_step = None
     mock.bt_target_cooltemp = None
     mock.bt_hvac_mode = None
     mock.cur_temp = None

--- a/tests/unit/test_delegate_set_temperature.py
+++ b/tests/unit/test_delegate_set_temperature.py
@@ -1,0 +1,55 @@
+"""Rounding in the delegate's set_temperature stays in Celsius.
+
+The temperature handed to the delegate is Celsius, so every step it may round
+by has to be a Celsius step. The step a device publishes in its state is in the
+device's own unit and is therefore not one of them.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.adapters.delegate import set_temperature
+from custom_components.better_thermostat.trv import Trv
+
+ENTITY_ID = "climate.trv"
+
+
+@pytest.fixture
+def bt():
+    """Mock thermostat whose TRV carries no step of its own."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.hass = MagicMock()
+    mock.bt_target_temp_step = None
+    trv = Trv(entity_id=ENTITY_ID, min_temp=5.0, max_temp=30.0)
+    trv.adapter = MagicMock()
+    trv.adapter.set_temperature = AsyncMock(return_value=True)
+    mock.real_trvs = {ENTITY_ID: trv}
+    mock.hass.states.get.return_value = State(
+        ENTITY_ID, "heat", attributes={"target_temp_step": 1.0}
+    )
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_device_step_attribute_is_not_used_for_celsius_rounding(bt):
+    """With no Celsius step known, the 0.5 default rounds, not the attribute."""
+    await set_temperature(bt, ENTITY_ID, 21.3)
+
+    bt.real_trvs[ENTITY_ID].adapter.set_temperature.assert_awaited_once_with(
+        bt, ENTITY_ID, pytest.approx(21.5)
+    )
+
+
+@pytest.mark.asyncio
+async def test_per_trv_step_rounds_the_setpoint(bt):
+    """The TRV's own Celsius step rounds the outbound setpoint."""
+    bt.real_trvs[ENTITY_ID].target_temp_step = 0.1
+
+    await set_temperature(bt, ENTITY_ID, 21.34)
+
+    bt.real_trvs[ENTITY_ID].adapter.set_temperature.assert_awaited_once_with(
+        bt, ENTITY_ID, pytest.approx(21.3)
+    )

--- a/tests/unit/test_helpers_normalize.py
+++ b/tests/unit/test_helpers_normalize.py
@@ -5,6 +5,7 @@ which are critical for handling user input and TRV state conversions.
 """
 
 from homeassistant.components.climate.const import HVACMode
+import pytest
 
 from custom_components.better_thermostat.utils.const import CalibrationMode
 from custom_components.better_thermostat.utils.helpers import (
@@ -234,6 +235,20 @@ class TestConvertToFloat:
         result = convert_to_float("1.5e-3", "test", "temperature")
         # Expected behavior: 0.0015 rounded to 0.0 due to 0.01 step
         assert result == 0.0
+
+    @pytest.mark.parametrize("value", ["inf", "-inf", float("inf"), float("-inf")])
+    def test_returns_none_for_infinity(self, value):
+        """Infinite readings degrade to None instead of raising.
+
+        The 0.01 step rounding converts to an integer number of steps, which
+        rejects infinity with OverflowError rather than ValueError.
+        """
+        assert convert_to_float(value, "test", "temperature") is None
+
+    @pytest.mark.parametrize("value", ["nan", float("nan")])
+    def test_returns_none_for_nan(self, value):
+        """NaN readings degrade to None instead of raising."""
+        assert convert_to_float(value, "test", "temperature") is None
 
 
 class TestIsReasonableTemperature:

--- a/tests/unit/test_per_trv_target_temp_step.py
+++ b/tests/unit/test_per_trv_target_temp_step.py
@@ -1,0 +1,184 @@
+"""The per-device setpoint step stays the device's own grid.
+
+``bt_target_temp_step`` is the coarsest step across all children — every TRV
+plus the cooler — and is what the integration exposes as its own
+``target_temperature_step``. Handing that aggregate to each child would size
+the inbound echo window by the coarsest device, so a user turning a
+fine-grained TRV by less than the coarse step would have the change
+classified as an echo of a Better Thermostat write and dropped.
+"""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.climate.const import ATTR_TARGET_TEMP_STEP, HVACMode
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.core import State
+from homeassistant.util import dt as dt_util
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+from custom_components.better_thermostat.events.trv import trigger_trv_change
+from custom_components.better_thermostat.trv import Trv
+from custom_components.better_thermostat.utils.const import (
+    CONF_HOMEMATICIP,
+    CalibrationMode,
+    CalibrationType,
+)
+
+TRV_ID = "climate.fine_trv"
+COOLER_ID = "climate.coarse_ac"
+
+FINE_STEP = 0.1
+COARSE_STEP = 1.0
+
+
+def _child_state(
+    entity_id, step, temperature=21.0, current=20.0, min_t=5.0, max_t=30.0, unit=None
+):
+    """Build a climate child state, publishing its own step when given."""
+    attrs = {
+        "min_temp": min_t,
+        "max_temp": max_t,
+        ATTR_TEMPERATURE: temperature,
+        "current_temperature": current,
+    }
+    if step is not None:
+        attrs[ATTR_TARGET_TEMP_STEP] = step
+    if unit is not None:
+        attrs["temperature_unit"] = unit
+    return State(entity_id, "heat", attributes=attrs)
+
+
+@pytest.fixture
+def bt():
+    """Mock thermostat wired to one fine TRV and one coarse cooler."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.hass = MagicMock()
+    mock.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+    mock.all_entities = []
+    mock.cooler_entity_id = COOLER_ID
+    mock.bt_min_temp = None
+    mock.bt_max_temp = None
+    mock.bt_target_temp_step = None
+    mock._configured_target_temp_step = None
+    mock.bt_target_temp = 21.0
+    mock.bt_target_cooltemp = 25.0
+    mock.bt_hvac_mode = HVACMode.HEAT
+    mock.cur_temp = 20.0
+    mock.tolerance = 0.3
+    mock.startup_running = False
+    mock.bt_update_lock = False
+    mock.ignore_states = False
+    mock.contact_open = False
+    mock.window_open = False
+    mock.control_queue_task = AsyncMock()
+    mock.context = MagicMock()
+    mock.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
+    mock.all_trvs = [{"advanced": {CONF_HOMEMATICIP: False}}]
+    mock.real_trvs = {
+        TRV_ID: Trv(
+            entity_id=TRV_ID,
+            calibration=1,
+            model="SomeModel",
+            hvac_mode=HVACMode.HEAT,
+            last_hvac_mode=HVACMode.HEAT,
+            last_temperature=21.0,
+            advanced={
+                "calibration": CalibrationType.TARGET_TEMP_BASED,
+                "calibration_mode": CalibrationMode.DEFAULT,
+                "child_lock": False,
+                "no_off_system_mode": False,
+                "heat_auto_swapped": False,
+            },
+        )
+    }
+    return mock
+
+
+async def _run_startup(bt, trv_state):
+    """Resolve the temperature range and initialize the TRV."""
+    BetterThermostat._resolve_temperature_range(
+        bt, [trv_state, _child_state(COOLER_ID, COARSE_STEP)]
+    )
+    bt.hass.states.get.return_value = trv_state
+    with (
+        patch("custom_components.better_thermostat.climate.init", AsyncMock()),
+        patch("custom_components.better_thermostat.climate.initial_tweak", AsyncMock()),
+        patch(
+            "custom_components.better_thermostat.climate.control_trv",
+            AsyncMock(return_value=True),
+        ),
+    ):
+        await BetterThermostat._initialize_trvs(bt)
+
+
+@pytest.mark.asyncio
+async def test_fine_trv_keeps_its_own_step_next_to_a_coarse_cooler(bt):
+    """The TRV gets its own 0.1 step while the entity exposes the coarse 1.0."""
+    await _run_startup(bt, _child_state(TRV_ID, FINE_STEP))
+
+    assert bt.bt_target_temp_step == pytest.approx(COARSE_STEP)
+    assert bt.real_trvs[TRV_ID].target_temp_step == pytest.approx(FINE_STEP)
+
+
+@pytest.mark.asyncio
+async def test_half_degree_user_change_on_a_fine_trv_is_adopted(bt):
+    """A 0.5 K turn is below the cooler's step but several of the TRV's own."""
+    await _run_startup(bt, _child_state(TRV_ID, FINE_STEP))
+
+    old_state = _child_state(TRV_ID, FINE_STEP, temperature=21.0)
+    new_state = _child_state(TRV_ID, FINE_STEP, temperature=21.5)
+    bt.hass.states.get.return_value = new_state
+    event = MagicMock()
+    event.context = MagicMock()
+    event.data = {"old_state": old_state, "new_state": new_state, "entity_id": TRV_ID}
+
+    with patch(
+        "custom_components.better_thermostat.events.trv.convert_inbound_states",
+        return_value=HVACMode.HEAT,
+    ):
+        await trigger_trv_change(bt, event)
+
+    assert bt.bt_target_temp == pytest.approx(21.5)
+
+
+@pytest.mark.asyncio
+async def test_configured_step_overrides_the_device_step(bt):
+    """An explicitly configured step is the user's decision and wins."""
+    bt.bt_target_temp_step = 0.25
+    bt._configured_target_temp_step = 0.25
+
+    await _run_startup(bt, _child_state(TRV_ID, FINE_STEP))
+
+    assert bt.real_trvs[TRV_ID].target_temp_step == pytest.approx(0.25)
+
+
+@pytest.mark.asyncio
+async def test_fahrenheit_device_step_converts_as_a_delta(bt):
+    """A child's step is a temperature difference, not an absolute reading."""
+    await _run_startup(
+        bt,
+        _child_state(
+            TRV_ID,
+            1.0,
+            temperature=70.0,
+            current=68.0,
+            min_t=41.0,
+            max_t=86.0,
+            unit=UnitOfTemperature.FAHRENHEIT,
+        ),
+    )
+
+    assert bt.real_trvs[TRV_ID].target_temp_step == pytest.approx(
+        round(1.0 * 5.0 / 9.0, 4)
+    )
+
+
+@pytest.mark.asyncio
+async def test_device_without_a_step_falls_back_to_the_aggregate(bt):
+    """A child publishing no step inherits the entity-level step."""
+    await _run_startup(bt, _child_state(TRV_ID, None))
+
+    assert bt.real_trvs[TRV_ID].target_temp_step == pytest.approx(COARSE_STEP)


### PR DESCRIPTION
## Motivation

`_resolve_temperature_range()` collects a `target_temp_step` from every child — all TRVs **and the cooler** — and stores `max(steps)` in `bt_target_temp_step`. `_initialize_trvs()` then hands that single aggregate to every TRV as its own `target_temp_step`, and `events/trv.py` uses that value as the echo window for inbound setpoints.

So a 0.1 K TRV paired with a 1.0 K air conditioner gets a 1.0 K echo window. A user turning that TRV up by 0.5 K has the change classified as BT's own write coming back and silently discarded — no adoption, no control cycle, no log above DEBUG.

`max()` is the right answer for the step the integration exposes as its own `target_temperature_step`; it is the wrong answer for a per-device grid.

## Changes

**`climate.py`** — the aggregate stays for the entity property, and each child keeps its own step. The precedence needed untangling first: `cfg_step` was never purely the configured value, because `_resolve_temperature_range` writes the aggregate into the same `bt_target_temp_step` field that `_initialize_trvs` reads. Preserving "a configured step wins over the device's" therefore required separating the two, hence `_configured_target_temp_step`. A user who types a step into the config entry is correcting a device that misreports its grid, so that override has to keep working.

The °F→°C delta conversion moves into one module-level helper used by both `_resolve_temperature_range` and `_initialize_trvs`. The old raw-attribute fallback in `_initialize_trvs` never converted at all; it was near-unreachable, so latent rather than live.

**`adapters/delegate.py`** — `set_temperature` had `device_step` (the raw attribute, in the device's unit) as the third term of a precedence chain whose first two terms are Celsius, and rounded a Celsius value with it. The term is dropped: the function's own tail indexes `self.real_trvs[entity_id]`, so it is only ever called for entities that have a per-TRV step.

**`utils/helpers.py`** — `convert_to_float` documents "the converted value, or None if conversion failed" but `round_by_step(inf, 0.01)` raises `OverflowError`, which is not in the except tuple. It is called on raw foreign attributes throughout startup, so an entity publishing `inf` aborted startup or an event handler instead of degrading to `None`. NaN already returned `None` — `round()` rejects it with `ValueError`, which was caught.

## Blast radius worth knowing

`real_trvs[...].target_temp_step` also feeds `adapters/delegate.set_temperature` (rounding of every **outbound** setpoint) and `calibration.py`. In a mixed setup those now see the device's own finer step instead of the group's coarsest. That is the correct semantics and it is what makes the change worth having, but it does change what gets written to fine-grained TRVs. A real-hardware soak on a heater+cooler setup is the honest confirmation, and I have not done one.

`_configured_target_temp_step` is only written in `__init__`. Nothing mutates `bt_target_temp_step` from config at runtime — `SIGNAL_BT_CONFIG_CHANGED` is declared but has no sender or listener, and options changes go through an entry reload — so the two cannot drift. If a live config-update path is ever added, both fields must be updated together.

## Tests

`2149 passed` (baseline 2136), ruff and pyrefly clean. Three tests confirmed to fail without the fix: a 0.5 K user change on a fine TRV next to a coarse cooler being adopted, the per-device/aggregate split asserted explicitly, and a °F child's step converting as a delta. Two further tests pin behaviour that must **not** change (configured step still wins; a device without a step still inherits the aggregate) and pass either way by design. The `convert_to_float` infinity cases are parametrized and all four fail without the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat temperature-step selection across individual devices and global settings.
  * Correctly handles Celsius and Fahrenheit step values, including device-specific and user-configured overrides.
  * Uses a reliable 0.5°C fallback when no valid step is available.
  * Prevents invalid values such as `NaN` and infinity from causing conversion errors.
* **Tests**
  * Added coverage for temperature rounding, overrides, unit conversion, fallback behavior, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->