### PR TITLE
fix(degraded-mode): watch the door sensor and correct the repair text

### DIFF
--- a/custom_components/better_thermostat/strings.json
+++ b/custom_components/better_thermostat/strings.json
@@ -128,7 +128,7 @@
     },
     "degraded_mode": {
       "title": "BT: {name} - sensor error: {sensors} running in degraded mode",
-      "description": "Better Thermostat is running in degraded mode because some sensors are unavailable: {sensors}\n\nThe thermostat will continue to operate with reduced functionality. For example:\n- If the room temperature sensor is unavailable, the TRV's internal sensor will be used instead.\n- If window sensors are unavailable, windows are assumed to be closed.\n- If outdoor/weather sensors are unavailable, heating will always be enabled.\n\nCheck if the affected devices have battery issues or connectivity problems."
+      "description": "Better Thermostat is running in degraded mode because some sensors are unavailable: {sensors}\n\nThe thermostat will continue to operate with reduced functionality. For example:\n- If the room temperature sensor is unavailable, the TRV's internal sensor will be used instead.\n- If a window or door sensor is unavailable, its last known state stays in effect: a contact that was closed keeps heating enabled, a contact that was open keeps heating suppressed until the sensor reports closed again. Only at startup is an unavailable contact sensor treated as closed.\n- If outdoor/weather sensors are unavailable, heating will always be enabled.\n\nCheck if the affected devices have battery issues or connectivity problems."
     },
     "invalid_window_state": {
       "title": "BT: {name} - invalid window sensor state",

--- a/custom_components/better_thermostat/translations/en.json
+++ b/custom_components/better_thermostat/translations/en.json
@@ -128,7 +128,7 @@
     },
     "degraded_mode": {
       "title": "BT: {name} - sensor error: {sensors} running in degraded mode",
-      "description": "Better Thermostat is running in degraded mode because some sensors are unavailable: {sensors}\n\nThe thermostat will continue to operate with reduced functionality. For example:\n- If the room temperature sensor is unavailable, the TRV's internal sensor will be used instead.\n- If window sensors are unavailable, windows are assumed to be closed.\n- If outdoor/weather sensors are unavailable, heating will always be enabled.\n\nCheck if the affected devices have battery issues or connectivity problems."
+      "description": "Better Thermostat is running in degraded mode because some sensors are unavailable: {sensors}\n\nThe thermostat will continue to operate with reduced functionality. For example:\n- If the room temperature sensor is unavailable, the TRV's internal sensor will be used instead.\n- If a window or door sensor is unavailable, its last known state stays in effect: a contact that was closed keeps heating enabled, a contact that was open keeps heating suppressed until the sensor reports closed again. Only at startup is an unavailable contact sensor treated as closed.\n- If outdoor/weather sensors are unavailable, heating will always be enabled.\n\nCheck if the affected devices have battery issues or connectivity problems."
     },
     "invalid_window_state": {
       "title": "BT: {name} - invalid window sensor state",

--- a/custom_components/better_thermostat/utils/watcher.py
+++ b/custom_components/better_thermostat/utils/watcher.py
@@ -3,8 +3,9 @@
 This module contains utility functions to verify entities, check batteries,
 and raise Home Assistant issues if an entity is missing or unavailable.
 
-Supports degraded mode operation where optional sensors (window, humidity,
-outdoor, weather) can be unavailable without blocking thermostat operation.
+Supports degraded mode operation where optional sensors (window, door,
+humidity, outdoor, weather) can be unavailable without blocking thermostat
+operation.
 """
 
 from __future__ import annotations
@@ -161,6 +162,8 @@ def get_optional_sensors(self) -> list:
     optional = []
     if getattr(self, "window_id", None):
         optional.append(self.window_id)
+    if getattr(self, "door_id", None):
+        optional.append(self.door_id)
     if getattr(self, "humidity_sensor_entity_id", None):
         optional.append(self.humidity_sensor_entity_id)
     if getattr(self, "outdoor_sensor", None):
@@ -282,10 +285,11 @@ async def await_optional_sensors(
 ) -> list[str]:
     """Wait for optional sensors to become available with increasing delays.
 
-    After a reboot, optional sensors (outdoor, weather, window, humidity)
-    frequently need a few seconds to initialise.  This helper retries with
-    increasing intervals so that ``check_and_update_degraded_mode`` is not
-    called while sensors are still starting up.
+    After a reboot, optional sensors (outdoor, weather, window, door,
+    humidity) frequently need a few seconds to initialise.  This helper
+    retries with increasing intervals so that
+    ``check_and_update_degraded_mode`` is not called while sensors are still
+    starting up.
 
     Parameters
     ----------

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -40,6 +40,9 @@ def mock_bt_instance(mock_hass):
     bt.device_name = "Test Thermostat"
     bt.sensor_entity_id = "sensor.room_temp"
     bt.window_id = "binary_sensor.window"
+    # MagicMock would auto-create a truthy attribute; the default fixture has
+    # no door sensor configured.
+    bt.door_id = None
     bt.humidity_sensor_entity_id = "sensor.humidity"
     bt.outdoor_sensor = "sensor.outdoor_temp"
     bt.weather_entity = "weather.home"
@@ -175,6 +178,36 @@ class TestGetOptionalSensors:
         result = get_optional_sensors(mock_bt_instance)
 
         assert result == []
+
+    def test_includes_door_sensor_when_configured(self, mock_bt_instance):
+        """A configured door sensor is watched like the other optional sensors."""
+        from custom_components.better_thermostat.utils.watcher import (
+            get_optional_sensors,
+        )
+
+        mock_bt_instance.door_id = "binary_sensor.door"
+
+        result = get_optional_sensors(mock_bt_instance)
+
+        assert "binary_sensor.door" in result
+        assert len(result) == 5
+
+    def test_excludes_door_sensor_when_not_configured(self, mock_bt_instance):
+        """Without a door sensor the optional list stays unchanged."""
+        from custom_components.better_thermostat.utils.watcher import (
+            get_optional_sensors,
+        )
+
+        mock_bt_instance.door_id = None
+
+        result = get_optional_sensors(mock_bt_instance)
+
+        assert result == [
+            "binary_sensor.window",
+            "sensor.humidity",
+            "sensor.outdoor_temp",
+            "weather.home",
+        ]
 
 
 class TestGetCriticalEntities:
@@ -478,6 +511,52 @@ class TestCheckAndUpdateDegradedMode:
         assert "binary_sensor.window" in mock_bt_instance.unavailable_sensors
 
     @pytest.mark.anyio
+    async def test_sets_degraded_mode_when_door_sensor_unavailable(
+        self, mock_bt_instance
+    ):
+        """A dead door sensor reaches degraded mode and raises the repair issue."""
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        mock_bt_instance.door_id = "binary_sensor.door"
+
+        def mock_get(entity_id):
+            state = MagicMock()
+            state.state = "unavailable" if entity_id == "binary_sensor.door" else "20.0"
+            return state
+
+        mock_bt_instance.hass.states.get.side_effect = mock_get
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            result = await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert result is True
+        assert mock_bt_instance.degraded_mode is True
+        assert "binary_sensor.door" in mock_bt_instance.unavailable_sensors
+        assert mock_ir.async_create_issue.called
+
+    @pytest.mark.anyio
+    async def test_no_degraded_mode_when_door_sensor_not_configured(
+        self, mock_bt_instance
+    ):
+        """An unconfigured door sensor never counts as unavailable."""
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        mock_bt_instance.door_id = None
+        mock_state = MagicMock()
+        mock_state.state = "20.0"
+        mock_bt_instance.hass.states.get.return_value = mock_state
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir"):
+            result = await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert result is False
+        assert mock_bt_instance.unavailable_sensors == []
+
+    @pytest.mark.anyio
     async def test_no_degraded_mode_when_all_sensors_available(self, mock_bt_instance):
         """Test that degraded_mode is False when all sensors are available."""
         from custom_components.better_thermostat.utils.watcher import (
@@ -767,6 +846,35 @@ class TestAwaitOptionalSensors:
 
         assert result == []
         assert sleep_calls == []
+
+    def test_waits_for_door_sensor(self, mock_bt_instance):
+        """A door sensor that never comes online is reported as pending."""
+        from custom_components.better_thermostat.utils.watcher import (
+            await_optional_sensors,
+        )
+
+        # Only the door sensor is configured, and it stays unavailable.
+        mock_bt_instance.window_id = None
+        mock_bt_instance.door_id = "binary_sensor.door"
+        mock_bt_instance.humidity_sensor_entity_id = None
+        mock_bt_instance.outdoor_sensor = None
+        mock_bt_instance.weather_entity = None
+
+        mock_state = MagicMock()
+        mock_state.state = "unavailable"
+        mock_bt_instance.hass.states.get.return_value = mock_state
+
+        sleep_calls = []
+
+        async def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+
+        result = self._run(
+            await_optional_sensors(mock_bt_instance, delays=(2, 4), _sleep=fake_sleep)
+        )
+
+        assert result == ["binary_sensor.door"]
+        assert sleep_calls == [2, 4]
 
     def test_retries_until_sensor_comes_online(self, mock_bt_instance):
         """Sensor unavailable on first check, available on second → one sleep."""


### PR DESCRIPTION
## Motivation

Door sensors are a fully wired, configurable feature: `CONF_SENSOR_DOOR` in `utils/const.py`, an entity selector in both config-flow schemas, `door_id` / `door_delay` / `door_delay_after` on the entity, a `door_queue_task`, a state-change listener, `contact_open = window_open or door_open`, and `events/door.py` bound to the shared `events/contact.py`.

But `get_optional_sensors()` lists the window sensor and not the door. So a door sensor that dies — typically a flat battery — never reaches degraded mode, never raises the repair issue and never appears in the `unavailable_sensors` attribute. `climate.py` does append `door_id` to `self.all_entities`, but that list is consumed only by the battery-discovery loop; `check_all_entities()`, the one function that would raise `missing_entity` for it, has no caller anywhere in the repository.

At startup the sensor is simply assumed closed and heating continues, logged at DEBUG. That is the whole symptom.

## Changes

`get_optional_sensors()` gains the door branch, in the same shape as the window one. Both consumers were traced: `await_optional_sensors()` only passes the id to `is_entity_available()`, and `check_and_update_degraded_mode()` passes it to `is_entity_available()` and `get_battery_status()`, which guards with `if entity in self.devices_states` — and the door entity is in `devices_states`. The not-configured case falls out of `self.door_id = door_id or None`.

The module docstring and `await_optional_sensors` listed the optional sensors by name without the door; both now match the code.

## The repair text was wrong, but not in the way it first looked

The description told users "windows are assumed to be closed" when a window sensor is unavailable. That is true only on the startup path (`_detect_contact_open_at_startup`).

`events/contact.py` puts `"unknown"` and `"unavailable"` into `_OPEN_STATES`, which reads like "a dead sensor is treated as an open contact and heating is suppressed". Tracing it, that is **not** the general runtime behaviour: the only runtime entry point is `_trigger_contact_change`, which gates on `is_entity_available()`, and that returns False for both sentinels. So when a contact sensor dies the handler is never invoked, nothing is queued, no logbook entry fires, and `window_open` / `door_open` keep their last value. `_OPEN_STATES` bites only in a narrow race inside `contact_queue()`: if the sensor dies while an event is already in flight, the post-delay re-read maps `unavailable` to open, so a pending OPEN gets confirmed and a pending CLOSE fails to confirm. Both race outcomes point away from "assumed closed".

The new bullet therefore says what the code does — the last known state stays in effect, and only a restart assumes closed — and covers both contact kinds. The debounce race is deliberately not in user-facing repair text. `strings.json` and `translations/en.json` only; the other nine locales are left to translators.

## `check_all_entities()` is dead

`grep -rn check_all_entities` across `custom_components/`, `tests/` and `docs/` returns exactly one hit: its own definition. Left untouched — wiring it up would raise a second `missing_entity` issue for every optional sensor on top of the `degraded_mode` issue and duplicate the signal. Worth its own decision.

## Tests

`2141 passed` (baseline 2136), ruff and pyrefly clean. Three of the five new tests fail without the fix, including the actual defect end to end: a dead door sensor now sets degraded mode, lands in `unavailable_sensors` and raises the repair issue. Two more guard the not-configured case.

The fixture in `test_watcher.py` builds a bare `MagicMock`, so `getattr(bt, "door_id", None)` returned a truthy auto-attribute; it now pins `bt.door_id = None`. Without that pin, seven pre-existing tests break for the wrong reason — verified by removing it temporarily (7 failed, 49 passed). With it, no pre-existing test changed its count or its assertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved degraded-mode guidance for unavailable window and door sensors, including last-known-state behavior.
  * Door sensors are now correctly recognized when determining degraded operation.
  * Thermostat startup and retry handling now properly account for unavailable door sensors.

* **Tests**
  * Added coverage for configured and unconfigured door sensors, degraded mode, and sensor availability waiting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->