### PR TITLE
fix(cooler): guard the cool target against None and seed it from the range

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -155,6 +155,7 @@ from .utils.controlling import (
     reconcile_tick,
 )
 from .utils.helpers import (
+    COOLER_SETPOINT_KEYS,
     async_normalize_bt_entity_ids,
     attr_to_celsius,
     convert_to_float,
@@ -164,6 +165,7 @@ from .utils.helpers import (
     get_hvac_bt_mode,
     is_reasonable_temperature,
     normalize_hvac_mode,
+    read_setpoint_celsius,
     state_temperature_unit,
 )
 from .utils.hvac_action import (
@@ -1641,8 +1643,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 STATE_UNKNOWN,
                 None,
             ):
-                self.bt_target_cooltemp = attr_to_celsius(
-                    self, _cooler_state, "temperature", None, "startup()"
+                self.bt_target_cooltemp = read_setpoint_celsius(
+                    self, _cooler_state, COOLER_SETPOINT_KEYS, "startup()"
                 )
             # else: already logged warning above
 

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -333,11 +333,7 @@ async def trigger_trv_change(self, event):
                 _new_heating_setpoint,
             )
             self.bt_target_temp = _new_heating_setpoint
-            if self.cooler_entity_id is not None:
-                if self.bt_target_temp >= self.bt_target_cooltemp:
-                    self.bt_target_cooltemp = self.bt_target_temp + (
-                        self.bt_target_temp_step or 0.5
-                    )
+            self._enforce_cool_above_heat()
 
             _main_change = True
         elif _new_heating_setpoint != _old_heating_setpoint:

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -9,7 +9,12 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.climate.const import HVACMode
-from homeassistant.const import ATTR_TEMPERATURE, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    UnitOfTemperature,
+)
 from homeassistant.core import State
 import pytest
 
@@ -113,6 +118,16 @@ def _make_trv_state(entity_id=TRV_ID, state="heat", attrs=None):
 def _make_sensor_state(temp="21.5", state_val=None):
     """Build a sensor State."""
     return State(SENSOR_ID, state_val or temp)
+
+
+def _make_cooler_state(attrs, state="cool"):
+    """Build a cooler State with the given setpoint attributes."""
+    return State(COOLER_ID, state, attributes=attrs)
+
+
+def _install_states(bt, states):
+    """Route ``bt.hass.states.get`` to a per-entity mapping."""
+    bt.hass.states.get.side_effect = states.get
 
 
 # ---------------------------------------------------------------------------
@@ -482,6 +497,37 @@ class TestInitializeSensors:
         ):
             BetterThermostat._initialize_sensors(bt, sensor)
         assert bt.last_known_external_temp is not None
+
+    def test_single_setpoint_cooler_seeds_cool_target(self, bt):
+        """A cooler driven through a single setpoint is read from temperature."""
+        bt.cooler_entity_id = COOLER_ID
+        bt.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: 24.0})})
+        BetterThermostat._initialize_sensors(bt, _make_sensor_state("21.5"))
+        assert bt.bt_target_cooltemp == 24.0
+
+    def test_range_only_cooler_seeds_cool_target_from_range_high(self, bt):
+        """A range-only cooler publishes an empty temperature and a range.
+
+        Its setpoint sits in target_temp_high, so reading only temperature
+        would leave the cool target unset for the whole session.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+        _install_states(
+            bt,
+            {
+                COOLER_ID: _make_cooler_state(
+                    {
+                        ATTR_TEMPERATURE: None,
+                        "target_temp_low": 19.0,
+                        "target_temp_high": 25.5,
+                    }
+                )
+            },
+        )
+        BetterThermostat._initialize_sensors(bt, _make_sensor_state("21.5"))
+        assert bt.bt_target_cooltemp == 25.5
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -14,6 +14,7 @@ from homeassistant.core import State
 from homeassistant.util import dt as dt_util
 import pytest
 
+from custom_components.better_thermostat.climate import BetterThermostat
 from custom_components.better_thermostat.events.trv import (
     convert_inbound_states,
     convert_outbound_states,
@@ -41,6 +42,7 @@ def mock_bt():
     bt.hass = MagicMock()
     bt.device_name = "Test Thermostat"
     bt.bt_hvac_mode = HVACMode.HEAT
+    bt.hvac_mode = HVACMode.HEAT
     bt.bt_target_temp = 19.0
     bt.bt_min_temp = 5.0
     bt.bt_max_temp = 30.0
@@ -58,6 +60,7 @@ def mock_bt():
     bt.context = MagicMock()  # unique context so != event.context
     bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
     bt.async_write_ha_state = MagicMock()
+    bt._enforce_cool_above_heat = lambda: BetterThermostat._enforce_cool_above_heat(bt)
 
     bt.all_trvs = [{"advanced": {CONF_HOMEMATICIP: False}}]
 
@@ -1038,9 +1041,10 @@ class TestTargetTempAdoption:
         assert mock_bt.bt_target_temp == 22.0
 
     @pytest.mark.asyncio
-    async def test_cooler_sync_logic_bug(self, mock_bt):
-        """Cooler-sync always sets cooltemp to target - step regardless of initial value."""
+    async def test_cooler_sync_keeps_cooltemp_above_target(self, mock_bt):
+        """A cool target already above the adopted heat target stays untouched."""
         mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_target_cooltemp = 25.0
         mock_bt.bt_target_temp_step = 0.5
 
@@ -1071,6 +1075,7 @@ class TestTargetTempAdoption:
     async def test_cooler_sync_pushes_cooltemp_above_target(self, mock_bt):
         """Cooltemp is pushed to target + step when equal to target."""
         mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_target_cooltemp = 22.0  # equal to new target
         mock_bt.bt_target_temp_step = 0.5
 
@@ -1101,6 +1106,7 @@ class TestTargetTempAdoption:
     async def test_cooler_sync_always_overwrites(self, mock_bt):
         """Cooltemp is pushed to target + step even when already below target."""
         mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_target_cooltemp = 15.0
         mock_bt.bt_target_temp_step = 0.5
 
@@ -1126,6 +1132,44 @@ class TestTargetTempAdoption:
             await trigger_trv_change(mock_bt, event)
 
         assert mock_bt.bt_target_cooltemp == 22.0 + 0.5
+
+    @pytest.mark.asyncio
+    async def test_cooler_sync_survives_unset_cooltemp(self, mock_bt):
+        """An unset cool target does not break adoption of the heat target.
+
+        A cooler that has not reported a setpoint yet leaves
+        ``bt_target_cooltemp`` at None, and the handler runs in a background
+        task where an exception would abandon the adoption half-done.
+        """
+        mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_cooltemp = None
+        mock_bt.bt_target_temp_step = 0.5
+
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 22.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 22.0},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].last_temperature = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 22.0
+        assert mock_bt.bt_target_cooltemp is None
+        mock_bt.control_queue_task.put_nowait.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_no_off_system_mode_sets_off_at_min(self, mock_bt):


### PR DESCRIPTION
## Motivation

The same two defects that #2154 fixes on `develop` survive on `v2`: `events/trv.py:337` and `climate.py:1644` came through the `v2` merge untouched.

A cooler that only advertises `TARGET_TEMPERATURE_RANGE` publishes `temperature: None` and carries its setpoint under `target_temp_high`, so `_initialize_sensors()` leaves `bt_target_cooltemp` at `None` — as does a cooler that is unavailable at startup. `events/trv.py` then compares `self.bt_target_temp >= self.bt_target_cooltemp` guarded only by `if self.cooler_entity_id is not None:`, and the first user setpoint change on a TRV raises `TypeError` inside a background event handler, after `bt_target_temp` has already been mutated. No `async_write_ha_state`, no control cycle, adoption lost.

The review of #2148 surfaced this and its scope check correctly refused it there: the lines are pre-existing on `v2` and that pull request did not touch them. Hence this follow-up.

## Changes

`events/trv.py` calls `self._enforce_cool_above_heat()`, mirroring the `self._enforce_heat_below_cool()` the cooler handler already calls — so the asymmetry between the two handlers goes away with the crash.

Two behaviour deltas, both deliberate:

- The helper is gated on `hvac_mode == HVACMode.HEAT_COOL`. With a cooler configured, `_hvac_list` becomes `[OFF, HEAT_COOL]` and `map_on_hvac_mode` becomes `HEAT_COOL`, so the property returns `HEAT_COOL` for `bt_hvac_mode` of both `HEAT` and `HEAT_COOL`; without a cooler it can never be `HEAT_COOL`. The guard is therefore equivalent to "a cooler is configured" for every non-OFF mode. The one narrowing is `bt_hvac_mode == OFF`, which the inline block still bumped — reachable, since the adoption gate checks the valve's mode, not BT's. Not moving a cooling target while BT is off matches what the cooler side already does.
- The comparison is identical, not merely similar: the inline block bumped on `bt_target_temp >= bt_target_cooltemp`, the helper early-returns on `bt_target_cooltemp > bt_target_temp` and bumps otherwise. Same predicate, same `or 0.5` step. The only added side effect is a WARNING where the inline block adjusted silently.

`_initialize_sensors()` now reads the cool target through `read_setpoint_celsius(self, _cooler_state, COOLER_SETPOINT_KEYS, "startup()")`, so startup, `control_cooler()` and the cooler event handler all resolve the setpoint through one key precedence.

## Tests

`4060 passed` (baseline 4057), ruff and pyrefly clean. Two regression tests confirmed to fail without their fix — `TypeError` at `events/trv.py:337`, and `assert None == 25.5` for the range-only cooler at startup. A third pins the single-setpoint path and passes either way by design.

The `mock_bt` fixture wires the real `_enforce_cool_above_heat`, the same pattern `test_cooler_events.py` already uses for its mirror; without it the mock would swallow the call and three existing assertions would go vacuous.
