### PR TITLE
fix(controlling): drop the deprecated interval converter

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -290,10 +290,9 @@ def _reconcile_tolerance(self, state) -> float:
     unit = state_temperature_unit(
         state.attributes, self.hass.config.units.temperature_unit
     )
-    if unit is not None and unit != UnitOfTemperature.CELSIUS:
-        step = TemperatureConverter.convert_interval(
-            step, unit, UnitOfTemperature.CELSIUS
-        )
+    # A Kelvin interval equals a Celsius one, so only Fahrenheit scales.
+    if unit == UnitOfTemperature.FAHRENHEIT:
+        step = step * 5.0 / 9.0
     # Slack against float noise when the difference is exactly half a step.
     return max(RECONCILE_TOLERANCE_K, step / 2.0 + 1e-6)
 

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -14,6 +14,7 @@ import asyncio
 from unittest.mock import MagicMock, Mock
 
 from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
+from homeassistant.const import UnitOfTemperature
 import pytest
 
 from custom_components.better_thermostat.trv import Trv
@@ -22,7 +23,9 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.controlling import (
+    RECONCILE_TOLERANCE_K,
     _get_valve_control,
+    _reconcile_tolerance,
     check_system_mode,
     check_target_temperature,
 )
@@ -572,3 +575,48 @@ class TestGetValveControlBoostMaxOpening:
             CalibrationType.DIRECT_VALVE_BASED,
         )
         assert bal == {"valve_percent": 100, "apply_valve": True}
+
+
+class TestReconcileTolerance:
+    """Tests for _reconcile_tolerance()."""
+
+    @staticmethod
+    def _mock_self(system_unit=UnitOfTemperature.CELSIUS):
+        mock_self = MagicMock()
+        mock_self.device_name = "Test"
+        mock_self.hass.config.units.temperature_unit = system_unit
+        return mock_self
+
+    @staticmethod
+    def _state(attributes):
+        state = Mock()
+        state.attributes = attributes
+        return state
+
+    def test_no_reported_step_falls_back_to_the_base_tolerance(self):
+        """Without a usable step there is no grid to derive a tolerance from."""
+        tolerance = _reconcile_tolerance(self._mock_self(), self._state({}))
+        assert tolerance == RECONCILE_TOLERANCE_K
+
+    def test_celsius_step_yields_half_a_step(self):
+        """A snapped value sits at most half a step from the commanded one."""
+        tolerance = _reconcile_tolerance(
+            self._mock_self(), self._state({"target_temp_step": 0.5})
+        )
+        assert tolerance == pytest.approx(0.25, abs=1e-5)
+
+    def test_fahrenheit_step_scales_as_an_interval(self):
+        """A 1 °F step is 0.5556 K, so the tolerance is half of that."""
+        tolerance = _reconcile_tolerance(
+            self._mock_self(UnitOfTemperature.FAHRENHEIT),
+            self._state({"target_temp_step": 1.0}),
+        )
+        assert tolerance == pytest.approx(1.0 * 5.0 / 9.0 / 2.0, abs=1e-5)
+
+    def test_kelvin_step_is_not_scaled(self):
+        """A Kelvin interval equals a Celsius one."""
+        tolerance = _reconcile_tolerance(
+            self._mock_self(UnitOfTemperature.KELVIN),
+            self._state({"target_temp_step": 0.5}),
+        )
+        assert tolerance == pytest.approx(0.25, abs=1e-5)


### PR DESCRIPTION
## Motivation

`_reconcile_tolerance()` scales a device-reported step through `TemperatureConverter.convert_interval()`. Home Assistant marks that method `@deprecated_function` with `breaks_in_ha_version="2026.12.0"`, and the decorator calls `_print_deprecation_warning` on **every** invocation — so a custom integration calling it gets

```
The deprecated function convert_interval was called. It will be removed in HA Core 2026.12.0. Use TemperatureDeltaConverter.convert instead
```

in the user's log each time, not once.

Until recently the only caller was `desired_diverges()`, on the reconcile tick. #2148 added a second one in `control_cooler()`, for the lower-bound comparison, which runs on every control cycle. On a Fahrenheit installation with a range-mode cooler that turns into one warning line per cycle — so this went from a slow-burning deprecation to visible log noise the moment that fix landed.

## Changes

A Kelvin interval equals a Celsius one, so only Fahrenheit needs scaling, and the factor is the same `5/9` the rest of the integration already uses for a delta (`events/cooler.py::_get_cooler_step`, and the step resolution in `climate.py`). The guard narrows from `unit != CELSIUS` to `unit == FAHRENHEIT` accordingly — that is not a behaviour change, it is what `convert_interval` was computing.

`TemperatureDeltaConverter.convert` is Home Assistant's suggested replacement and is available in the pinned 2026.7.2, but `hacs.json` declares a minimum of 2025.12.0 and I could not confirm the symbol that far back. The arithmetic is one multiplication and is used in this form elsewhere in the integration, so it avoids the version question entirely.

`TemperatureConverter` stays imported: the two absolute conversions further down `control_cooler()` use `TemperatureConverter.convert`, which is not deprecated.

## Tests

New `TestReconcileTolerance` in `tests/unit/controlling/test_helpers.py`, which the helper had no direct coverage for at all: the base tolerance for a device reporting no step, half a step for Celsius, the 5/9 scaling for Fahrenheit, and Kelvin explicitly **not** scaled — the case a naive `* 5/9` without the unit guard would get wrong.

`4061 passed`, ruff and pyrefly clean. `convert_interval` no longer appears anywhere under `custom_components/`.
