### PR TITLE
fix(cooler): bound the cooler write rate and derive the resend interval

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -60,8 +60,8 @@ MIN_WRITE_INTERVAL_S = 30.0
 RECONCILE_TOLERANCE_K = 0.05
 # Resend throttle for the cooler path: cooler commands go straight to the
 # service call (no reconciler in between), so an identical command is
-# suppressed while the device's state feedback lags. A changed desired
-# value always sends immediately.
+# suppressed while the device's state feedback lags. A changed desired value
+# passes this throttle untouched; only the failure backoff below can hold it.
 #
 # An air conditioner protects its compressor by ignoring commands for
 # several minutes after a mode change, so re-asserting inside that window

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -62,6 +62,16 @@ RECONCILE_TOLERANCE_K = 0.05
 # suppressed while the device's state feedback lags. A changed desired
 # value always sends immediately.
 COOLER_RESEND_INTERVAL_S = 30.0
+# A rejected cooler command is not a completed send, so the resend throttle
+# cannot pace its retry. Consecutive failures on one channel are paced by
+# their own backoff instead: the first retry waits one resend interval, each
+# further one doubles the wait by this factor.
+COOLER_FAILURE_BACKOFF_FACTOR = 2.0
+# Ceiling of that backoff. It matches the slowest cadence at which Better
+# Thermostat re-evaluates on its own, so a device that stops rejecting
+# commands is picked up within one periodic control cycle no matter how long
+# it was failing.
+COOLER_FAILURE_BACKOFF_MAX_S = 300.0
 # A cooler may snap a received setpoint onto its own step grid (e.g. 0.5 °C,
 # or a whole-°F grid). A post-send reading within this distance of the sent
 # value counts as that device-side quantization, not as an unapplied command.
@@ -645,9 +655,10 @@ def cooler_send_cache(self) -> dict:
     """Return the cooler send-cache, creating it on first use.
 
     Holds the last successfully sent command per channel as
-    ``(value, monotonic_timestamp)`` for the resend throttle, plus the settled
-    reading of the temperature channel. Created lazily because only
-    cooler-equipped instances need it.
+    ``(value, monotonic_timestamp)`` for the resend throttle, the settled
+    reading of each written channel, and each channel's run of consecutive
+    send failures as ``(count, monotonic_timestamp)``. Created lazily because
+    only cooler-equipped instances need it.
     """
     last_sent = getattr(self, "_cooler_last_sent", None)
     if not isinstance(last_sent, dict):
@@ -660,6 +671,38 @@ def last_sent_cooler_temperature(self) -> float | None:
     """Return the cooling setpoint BT last wrote to the cooler, in °C."""
     value = cooler_send_cache(self).get("temperature", (None, None))[0]
     return value if isinstance(value, (int, float)) else None
+
+
+def _cooler_retry_paced(
+    last_sent: dict, channel: str, wanted, now_monotonic: float
+) -> bool:
+    """Whether a channel's backoff still bars the retry of a failed command.
+
+    A rejected command leaves no send timestamp behind, so the resend
+    throttle cannot pace it; this backoff does. The wait grows with the run
+    of consecutive failures, so a device that rejects every write — a cloud
+    air conditioner over its rate limit, for instance — is not retried harder
+    than one that merely lags. Only the identical command is paced: a value
+    BT has not put on the wire yet is a new command, not a retry.
+    """
+    failures, failed_at, failed_wanted = last_sent.get(
+        f"{channel}_failed", (0, None, None)
+    )
+    if not failures or failed_at is None or failed_wanted != wanted:
+        return False
+    wait = min(
+        COOLER_RESEND_INTERVAL_S * COOLER_FAILURE_BACKOFF_FACTOR ** (failures - 1),
+        COOLER_FAILURE_BACKOFF_MAX_S,
+    )
+    return (now_monotonic - failed_at) < wait
+
+
+def _record_cooler_failure(
+    last_sent: dict, channel: str, wanted, now_monotonic: float
+) -> None:
+    """Extend a channel's run of consecutive send failures."""
+    failures = last_sent.get(f"{channel}_failed", (0, None, None))[0]
+    last_sent[f"{channel}_failed"] = (failures + 1, now_monotonic, wanted)
 
 
 async def control_cooler(self, snapshot=None):
@@ -860,6 +903,25 @@ async def control_cooler(self, snapshot=None):
         )
         temp_to_send = None
 
+    # The command the payload would carry, in °C, as the failure backoff
+    # compares it: a rejected send leaves the send cache untouched, so the
+    # attempted command is what tells a retry from a new command.
+    _temp_wanted = None
+    if temp_to_send is not None:
+        _temp_wanted = (
+            temp_to_send,
+            cooler_low_bound(temp_to_send, target_temp) if _write_range else None,
+        )
+        if _cooler_retry_paced(last_sent, "temperature", _temp_wanted, now_monotonic):
+            _LOGGER.debug(
+                "better_thermostat %s: cooler %s deferring the set_temperature retry "
+                "after %s consecutive failures",
+                self.device_name,
+                self.cooler_entity_id,
+                last_sent["temperature_failed"][0],
+            )
+            temp_to_send = None
+
     if temp_to_send is not None:
         _LOGGER.debug(
             "better_thermostat %s: TO COOLER set_temperature: %s from: %s to: %s",
@@ -895,10 +957,11 @@ async def control_cooler(self, snapshot=None):
             _payload = {"entity_id": self.cooler_entity_id, "temperature": _temp_to_set}
         # Only prime the send-cache on success. A failed call must not look
         # like a completed send, otherwise the throttle would suppress the
-        # retry. Any exception from this one service call is isolated
-        # (cloud integrations propagate raw errors such as ConnectionError)
-        # so the hvac_mode command below still runs; CancelledError derives
-        # from BaseException and propagates.
+        # retry; its run of failures is recorded instead, which paces the
+        # retry without pretending the command arrived. Any exception from
+        # this one service call is isolated (cloud integrations propagate raw
+        # errors such as ConnectionError) so the hvac_mode command below still
+        # runs; CancelledError derives from BaseException and propagates.
         try:
             await self.hass.services.async_call(
                 "climate",
@@ -908,21 +971,25 @@ async def control_cooler(self, snapshot=None):
                 context=self.context,
             )
         except Exception as err:
+            _record_cooler_failure(
+                last_sent, "temperature", _temp_wanted, now_monotonic
+            )
             _LOGGER.warning(
                 "better_thermostat %s: set_temperature for cooler %s failed (%s); "
-                "will retry on the next cycle",
+                "will retry on a later cycle",
                 self.device_name,
                 self.cooler_entity_id,
                 err,
             )
         else:
             last_sent["temperature"] = (temp_to_send, now_monotonic)
+            last_sent.pop("temperature_failed", None)
             if _write_range:
                 last_sent["target_temp_low"] = (
                     cooler_low_bound(temp_to_send, target_temp),
                     now_monotonic,
                 )
-            # A fresh send invalidates the previously settled reading; the
+            # A fresh send invalidates the previously settled readings; the
             # device answers anew.
             last_sent.pop("temperature_settled", None)
 
@@ -947,6 +1014,20 @@ async def control_cooler(self, snapshot=None):
         )
         should_send_mode = False
 
+    # Same pacing as the temperature channel: a rejected mode command has no
+    # send timestamp, so its retry follows the failure backoff.
+    if should_send_mode and _cooler_retry_paced(
+        last_sent, "hvac_mode", desired_mode, now_monotonic
+    ):
+        _LOGGER.debug(
+            "better_thermostat %s: cooler %s deferring the set_hvac_mode retry "
+            "after %s consecutive failures",
+            self.device_name,
+            self.cooler_entity_id,
+            last_sent["hvac_mode_failed"][0],
+        )
+        should_send_mode = False
+
     if should_send_mode:
         _LOGGER.debug(
             "better_thermostat %s: TO COOLER set_hvac_mode: %s from: %s to: %s",
@@ -966,15 +1047,17 @@ async def control_cooler(self, snapshot=None):
                 context=self.context,
             )
         except Exception as err:
+            _record_cooler_failure(last_sent, "hvac_mode", desired_mode, now_monotonic)
             _LOGGER.warning(
                 "better_thermostat %s: set_hvac_mode for cooler %s failed (%s); "
-                "will retry on the next cycle",
+                "will retry on a later cycle",
                 self.device_name,
                 self.cooler_entity_id,
                 err,
             )
         else:
             last_sent["hvac_mode"] = (desired_mode, now_monotonic)
+            last_sent.pop("hvac_mode_failed", None)
 
 
 async def control_trv(self, heater_entity_id=None, cycle=None):

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -1090,15 +1090,17 @@ async def control_cooler(self, snapshot=None):
         else:
             last_sent["temperature"] = (temp_to_send, now_monotonic)
             last_sent.pop("temperature_failed", None)
+            # A fresh send invalidates the settled reading of the channels it
+            # carried; the device answers those anew. A single-setpoint
+            # payload carries no lower bound, so it says nothing about the
+            # bound's settled reading.
+            last_sent.pop("temperature_settled", None)
             if _write_range:
                 last_sent["target_temp_low"] = (
                     cooler_low_bound(temp_to_send, target_temp),
                     now_monotonic,
                 )
-            # A fresh send invalidates the previously settled readings; the
-            # device answers anew.
-            last_sent.pop("temperature_settled", None)
-            last_sent.pop("target_temp_low_settled", None)
+                last_sent.pop("target_temp_low_settled", None)
 
     # Decide whether an hvac_mode command is needed, throttling identical
     # resends the same way as temperature commands.

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -837,18 +837,43 @@ async def control_cooler(self, snapshot=None):
         _low_to_set = cooler_low_bound(desired_temp, target_temp)
         # A lower bound BT never wrote at this value is a new payload, not a
         # resend; one it already wrote and the device ignored is a retry.
-        _low_bound_changed = (
-            last_sent.get("target_temp_low", (None, None))[0] != _low_to_set
-        )
+        last_low = last_sent.get("target_temp_low", (None, None))[0]
+        _low_bound_changed = last_low != _low_to_set
         current_low = attr_to_celsius(
             self, cooler_state, "target_temp_low", None, "control_cooler()"
+        )
+        # The bound carries the same quantization latch as the temperature
+        # channel: the first post-send reading close to the written bound is
+        # the device's answer on its own grid, and while it holds and the
+        # wanted bound is unchanged the bound counts as applied. Without it a
+        # device that snaps both bounds is rewritten every resend interval
+        # for as long as it is configured.
+        settled_low = last_sent.get("target_temp_low_settled")
+        if (
+            not _low_bound_changed
+            and last_low is not None
+            and current_low is not None
+            and settled_low is None
+            and abs(current_low - last_low) <= COOLER_QUANTIZATION_TOLERANCE_K
+        ):
+            settled_low = current_low
+            last_sent["target_temp_low_settled"] = settled_low
+        _low_bound_settled = (
+            not _low_bound_changed
+            and settled_low is not None
+            and current_low is not None
+            and abs(current_low - settled_low) <= RECONCILE_TOLERANCE_K
         )
         # The device answers a written bound on its own grid, so the bound
         # carries the same per-device tolerance the TRV write-skip check uses.
         # A coarser answer than half a step is a bound the device did not
         # apply.
-        if current_low is not None and not matches_any_setpoint(
-            current_low, {_low_to_set}, _reconcile_tolerance(self, cooler_state)
+        if (
+            current_low is not None
+            and not _low_bound_settled
+            and not matches_any_setpoint(
+                current_low, {_low_to_set}, _reconcile_tolerance(self, cooler_state)
+            )
         ):
             _LOGGER.debug(
                 "better_thermostat %s: cooler %s lower bound %s differs from %s, "
@@ -992,6 +1017,7 @@ async def control_cooler(self, snapshot=None):
             # A fresh send invalidates the previously settled readings; the
             # device answers anew.
             last_sent.pop("temperature_settled", None)
+            last_sent.pop("target_temp_low_settled", None)
 
     # Decide whether an hvac_mode command is needed, throttling identical
     # resends the same way as temperature commands.

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import replace
 import logging
+import math
 
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfTemperature
@@ -91,6 +92,16 @@ COOLER_FAILURE_BACKOFF_FACTOR = 2.0
 # paced well beyond the resend interval; a device that starts working again
 # is picked up on the following attempt.
 COOLER_FAILURE_BACKOFF_MAX_S = 1800.0
+# Longest run the backoff can tell apart. Past it the wait is pinned at the
+# ceiling anyway, while the exponent would keep growing on a device that
+# rejects every write until the float power overflows and takes the whole
+# cooler cycle down with it.
+COOLER_FAILURE_BACKOFF_MAX_RUN = 1 + math.ceil(
+    math.log(
+        COOLER_FAILURE_BACKOFF_MAX_S / COOLER_FAILURE_BACKOFF_BASE_S,
+        COOLER_FAILURE_BACKOFF_FACTOR,
+    )
+)
 # A cooler may snap a received setpoint onto its own step grid (e.g. 0.5 °C,
 # or a whole-°F grid). A post-send reading within this distance of the sent
 # value counts as that device-side quantization, not as an unapplied command.
@@ -701,36 +712,57 @@ def last_sent_cooler_temperature(self) -> float | None:
     return value if isinstance(value, (int, float)) else None
 
 
-def _cooler_retry_paced(
+def _cooler_retry_deferred(
     last_sent: dict, channel: str, wanted, now_monotonic: float
 ) -> bool:
-    """Whether a channel's backoff still bars the retry of a failed command.
+    """Whether a channel's backoff still holds a command back.
 
     A rejected command leaves no send timestamp behind, so the resend
     throttle cannot pace it; this backoff does. The wait grows with the run
-    of consecutive failures, so a device that rejects every write — a cloud
-    air conditioner over its rate limit, for instance — is not retried harder
-    than one that merely lags. Only the identical command is paced: a value
-    BT has not put on the wire yet is a new command, not a retry.
+    of consecutive failures of that command, so a device that rejects every
+    write — a cloud air conditioner over its rate limit, for instance — is
+    not retried harder than one that merely lags.
+
+    A command other than the rejected one is a new command rather than a
+    retry, and waits the base only: it has to reach the device promptly, but
+    it must not hand a channel that is failing a fresh write budget at the
+    cycle rate either, which is what a desired value alternating between two
+    rejected commands would otherwise do.
     """
     failures, failed_at, failed_wanted = last_sent.get(
         f"{channel}_failed", (0, None, None)
     )
-    if not failures or failed_at is None or failed_wanted != wanted:
+    if not failures or failed_at is None:
         return False
-    wait = min(
-        COOLER_FAILURE_BACKOFF_BASE_S * COOLER_FAILURE_BACKOFF_FACTOR ** (failures - 1),
-        COOLER_FAILURE_BACKOFF_MAX_S,
-    )
+    if failed_wanted != wanted:
+        wait = COOLER_FAILURE_BACKOFF_BASE_S
+    else:
+        wait = min(
+            COOLER_FAILURE_BACKOFF_BASE_S
+            * COOLER_FAILURE_BACKOFF_FACTOR ** (failures - 1),
+            COOLER_FAILURE_BACKOFF_MAX_S,
+        )
     return (now_monotonic - failed_at) < wait
 
 
 def _record_cooler_failure(
     last_sent: dict, channel: str, wanted, now_monotonic: float
 ) -> None:
-    """Extend a channel's run of consecutive send failures."""
-    failures = last_sent.get(f"{channel}_failed", (0, None, None))[0]
-    last_sent[f"{channel}_failed"] = (failures + 1, now_monotonic, wanted)
+    """Extend a channel's run of consecutive failures of one command.
+
+    A run is a run of the same command; a different one that fails starts
+    its own, so the run the counter holds and the run the gate prices always
+    describe the same command. The count stops at the length the backoff can
+    still tell apart.
+    """
+    failures, _, failed_wanted = last_sent.get(f"{channel}_failed", (0, None, None))
+    if failed_wanted != wanted:
+        failures = 0
+    last_sent[f"{channel}_failed"] = (
+        min(failures + 1, COOLER_FAILURE_BACKOFF_MAX_RUN),
+        now_monotonic,
+        wanted,
+    )
 
 
 async def control_cooler(self, snapshot=None):
@@ -984,10 +1016,12 @@ async def control_cooler(self, snapshot=None):
             temp_to_send,
             cooler_low_bound(temp_to_send, target_temp) if _write_range else None,
         )
-        if _cooler_retry_paced(last_sent, "temperature", _temp_wanted, now_monotonic):
+        if _cooler_retry_deferred(
+            last_sent, "temperature", _temp_wanted, now_monotonic
+        ):
             _LOGGER.debug(
-                "better_thermostat %s: cooler %s deferring the set_temperature retry "
-                "after %s consecutive failures",
+                "better_thermostat %s: cooler %s deferring set_temperature at "
+                "failure-backoff step %s",
                 self.device_name,
                 self.cooler_entity_id,
                 last_sent["temperature_failed"][0],
@@ -1089,12 +1123,12 @@ async def control_cooler(self, snapshot=None):
 
     # Same pacing as the temperature channel: a rejected mode command has no
     # send timestamp, so its retry follows the failure backoff.
-    if should_send_mode and _cooler_retry_paced(
+    if should_send_mode and _cooler_retry_deferred(
         last_sent, "hvac_mode", desired_mode, now_monotonic
     ):
         _LOGGER.debug(
-            "better_thermostat %s: cooler %s deferring the set_hvac_mode retry "
-            "after %s consecutive failures",
+            "better_thermostat %s: cooler %s deferring set_hvac_mode at "
+            "failure-backoff step %s",
             self.device_name,
             self.cooler_entity_id,
             last_sent["hvac_mode_failed"][0],

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -61,17 +61,27 @@ RECONCILE_TOLERANCE_K = 0.05
 # service call (no reconciler in between), so an identical command is
 # suppressed while the device's state feedback lags. A changed desired
 # value always sends immediately.
-COOLER_RESEND_INTERVAL_S = 30.0
+#
+# An air conditioner protects its compressor by ignoring commands for
+# several minutes after a mode change, so re-asserting inside that window
+# cannot achieve anything: manufacturers state three minutes, and dedicated
+# thermostats hold the compressor off for four to five. The interval sits at
+# the top of that band, and stays below the reconcile and watchdog periods
+# so it never becomes the slowest timer in the system. A device that applies
+# what it is told never reaches it — the timestamp only advances on a send,
+# so a converged cooler leaves the window permanently open and a divergence
+# is still corrected on the next cycle.
+COOLER_RESEND_INTERVAL_S = 300.0
 # A rejected cooler command is not a completed send, so the resend throttle
 # cannot pace its retry. Consecutive failures on one channel are paced by
 # their own backoff instead: the first retry waits one resend interval, each
 # further one doubles the wait by this factor.
 COOLER_FAILURE_BACKOFF_FACTOR = 2.0
-# Ceiling of that backoff. It matches the slowest cadence at which Better
-# Thermostat re-evaluates on its own, so a device that stops rejecting
-# commands is picked up within one periodic control cycle no matter how long
-# it was failing.
-COOLER_FAILURE_BACKOFF_MAX_S = 300.0
+# Ceiling of that backoff, half an hour. A channel that has been rejected
+# this often is not going to accept the next command either, so the run is
+# paced well beyond the resend interval; a device that starts working again
+# is picked up on the following attempt.
+COOLER_FAILURE_BACKOFF_MAX_S = 1800.0
 # A cooler may snap a received setpoint onto its own step grid (e.g. 0.5 °C,
 # or a whole-°F grid). A post-send reading within this distance of the sent
 # value counts as that device-side quantization, not as an unapplied command.

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -76,6 +76,12 @@ COOLER_FAILURE_BACKOFF_MAX_S = 300.0
 # or a whole-°F grid). A post-send reading within this distance of the sent
 # value counts as that device-side quantization, not as an unapplied command.
 COOLER_QUANTIZATION_TOLERANCE_K = 0.5
+# Hysteresis band below the cooling switch-on point. Once BT has commanded
+# COOL the room has to fall this far below the switch-on point before OFF is
+# commanded, so a room temperature resting on the threshold does not flip the
+# decision — and produce a write — on every control cycle. Two steps of a
+# 0.1 °C room sensor.
+COOLER_MODE_HYSTERESIS_K = 0.2
 # Valve deviations below this are the device's own business.
 RECONCILE_VALVE_TOLERANCE_PCT = 5.0
 # Pause before re-queueing a cycle in which a TRV reported failure, so a
@@ -779,10 +785,21 @@ async def control_cooler(self, snapshot=None):
         desired_mode = HVACMode.OFF
     elif snapshot.hvac_mode == HVACMode.OFF:
         desired_mode = HVACMode.OFF
-    elif room_temp >= target_cooltemp - tolerance and room_temp > target_temp:
-        desired_mode = HVACMode.COOL
     else:
-        desired_mode = HVACMode.OFF
+        # Hysteresis around the switch-on point, so a room temperature
+        # resting on it does not flip the decision — and with it the write —
+        # on every cycle. The state is the mode BT last commanded: the
+        # device's own reported mode lags a command and can be changed
+        # externally, so it cannot carry the band. The heating target stays a
+        # hard floor; relaxing it would let the cooler run into the band the
+        # heater is working on.
+        _cool_on_at = target_cooltemp - tolerance
+        if last_sent.get("hvac_mode", (None, None))[0] == HVACMode.COOL:
+            _cool_on_at -= COOLER_MODE_HYSTERESIS_K
+        if room_temp >= _cool_on_at and room_temp > target_temp:
+            desired_mode = HVACMode.COOL
+        else:
+            desired_mode = HVACMode.OFF
 
     # Decide whether a temperature command is needed. When the current
     # temperature is unknown, only send if the desired value changed since

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -74,8 +74,13 @@ RECONCILE_TOLERANCE_K = 0.05
 COOLER_RESEND_INTERVAL_S = 300.0
 # A rejected cooler command is not a completed send, so the resend throttle
 # cannot pace its retry. Consecutive failures on one channel are paced by
-# their own backoff instead: the first retry waits one resend interval, each
-# further one doubles the wait by this factor.
+# their own backoff instead, starting at this base. The base is deliberately
+# shorter than the resend interval: a rejected command never reached the
+# device, so there is no compressor window to respect, and the wait exists
+# only to keep a rate-limited endpoint from being retried on every cycle.
+COOLER_FAILURE_BACKOFF_BASE_S = 30.0
+# Growth of that backoff: the first retry waits the base, each further one
+# doubles the wait by this factor.
 COOLER_FAILURE_BACKOFF_FACTOR = 2.0
 # Ceiling of that backoff, half an hour. A channel that has been rejected
 # this often is not going to accept the next command either, so the run is
@@ -707,7 +712,7 @@ def _cooler_retry_paced(
     if not failures or failed_at is None or failed_wanted != wanted:
         return False
     wait = min(
-        COOLER_RESEND_INTERVAL_S * COOLER_FAILURE_BACKOFF_FACTOR ** (failures - 1),
+        COOLER_FAILURE_BACKOFF_BASE_S * COOLER_FAILURE_BACKOFF_FACTOR ** (failures - 1),
         COOLER_FAILURE_BACKOFF_MAX_S,
     )
     return (now_monotonic - failed_at) < wait

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -95,11 +95,13 @@ COOLER_FAILURE_BACKOFF_MAX_S = 1800.0
 # or a whole-°F grid). A post-send reading within this distance of the sent
 # value counts as that device-side quantization, not as an unapplied command.
 COOLER_QUANTIZATION_TOLERANCE_K = 0.5
-# Hysteresis band below the cooling switch-on point. Once BT has commanded
-# COOL the room has to fall this far below the switch-on point before OFF is
-# commanded, so a room temperature resting on the threshold does not flip the
+# Hysteresis band below the cooling switch-on point. Once BT has decided to
+# cool, the room has to fall this far below the switch-on point before OFF is
+# decided, so a room temperature resting on the threshold does not flip the
 # decision — and produce a write — on every control cycle. Two steps of a
-# 0.1 °C room sensor.
+# 0.1 °C room sensor, which is what the flip is made of; and well under the
+# 0.5 °C a cooling setpoint is set in, so the extra run time the band costs
+# is finer than the user can express in the target anyway.
 COOLER_MODE_HYSTERESIS_K = 0.2
 # Valve deviations below this are the device's own business.
 RECONCILE_VALVE_TOLERANCE_PCT = 5.0
@@ -681,9 +683,10 @@ def cooler_send_cache(self) -> dict:
 
     Holds the last successfully sent command per channel as
     ``(value, monotonic_timestamp)`` for the resend throttle, the settled
-    reading of each written channel, and each channel's run of consecutive
-    send failures as ``(count, monotonic_timestamp)``. Created lazily because
-    only cooler-equipped instances need it.
+    reading of each written channel, the mode the last cycle decided on for
+    the hysteresis band, and each channel's run of consecutive send failures
+    as ``(count, monotonic_timestamp, attempted_value)``. Created lazily
+    because only cooler-equipped instances need it.
     """
     last_sent = getattr(self, "_cooler_last_sent", None)
     if not isinstance(last_sent, dict):
@@ -807,18 +810,26 @@ async def control_cooler(self, snapshot=None):
     else:
         # Hysteresis around the switch-on point, so a room temperature
         # resting on it does not flip the decision — and with it the write —
-        # on every cycle. The state is the mode BT last commanded: the
-        # device's own reported mode lags a command and can be changed
-        # externally, so it cannot carry the band. The heating target stays a
+        # on every cycle. The band widens the COOL state only: entering it
+        # stays at the plain switch-on point the tolerance defines. The
+        # device's own reported mode cannot carry the band — it lags a
+        # command and can be changed externally. The heating target stays a
         # hard floor; relaxing it would let the cooler run into the band the
         # heater is working on.
         _cool_on_at = target_cooltemp - tolerance
-        if last_sent.get("hvac_mode", (None, None))[0] == HVACMode.COOL:
+        if last_sent.get("hvac_mode_decided") == HVACMode.COOL:
             _cool_on_at -= COOLER_MODE_HYSTERESIS_K
         if room_temp >= _cool_on_at and room_temp > target_temp:
             desired_mode = HVACMode.COOL
         else:
             desired_mode = HVACMode.OFF
+    # The band's state is the decision, not the send: a device that rejects
+    # every command would never advance a send-stamped state, and the
+    # decision would keep flipping between the two commands the device is
+    # refusing. Recorded for every branch above, so a cycle that fell into a
+    # guard leaves the band where that guard put it instead of on a stale
+    # value.
+    last_sent["hvac_mode_decided"] = desired_mode
 
     # Decide whether a temperature command is needed. When the current
     # temperature is unknown, only send if the desired value changed since

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -65,13 +65,17 @@ RECONCILE_TOLERANCE_K = 0.05
 # An air conditioner protects its compressor by ignoring commands for
 # several minutes after a mode change, so re-asserting inside that window
 # cannot achieve anything: manufacturers state three minutes, and dedicated
-# thermostats hold the compressor off for four to five. The interval sits at
-# the top of that band, and stays below the reconcile and watchdog periods
-# so it never becomes the slowest timer in the system. A device that applies
-# what it is told never reaches it — the timestamp only advances on a send,
-# so a converged cooler leaves the window permanently open and a divergence
-# is still corrected on the next cycle.
-COOLER_RESEND_INTERVAL_S = 300.0
+# thermostats hold the compressor off for four to five. The interval sits in
+# that band and strictly below the periodic ticks that drive a control cycle
+# — the five-minute reconcile and time triggers, the fifteen-minute watchdog
+# — because the throttle compares strictly and the clock is read partway
+# into a cycle: at exactly one tick period, scheduling jitter would decide
+# whether a tick counts, and the pacing would land anywhere between one and
+# two tick periods. A device that applies what it is told never reaches the
+# interval at all — the timestamp only advances on a send, so a converged
+# cooler leaves the window permanently open and a divergence appearing after
+# that convergence is corrected on the next cycle.
+COOLER_RESEND_INTERVAL_S = 240.0
 # A rejected cooler command is not a completed send, so the resend throttle
 # cannot pace its retry. Consecutive failures on one channel are paced by
 # their own backoff instead, starting at this base. The base is deliberately

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -1077,6 +1077,74 @@ class TestControlCoolerTargetRange:
         assert self._set_temperature_payload(mock_hass) is None
 
     @pytest.mark.asyncio
+    async def test_quantizing_range_cooler_is_written_as_rarely_as_a_single_one(self):
+        """The lower bound carries the same quantization latch as the setpoint.
+
+        A cooler that snaps what it receives onto its own grid reports no
+        step to derive a tolerance from, so its bound never matches the
+        written one exactly. Without a latch on the bound the whole payload
+        goes out on every resend interval for as long as the cooler is
+        configured, while a single-setpoint cooler quantizing by the same
+        amount is written once.
+        """
+        quantization = 0.3
+        resend_intervals = 20
+
+        async def _writes(cooler_attributes):
+            mock_self, mock_hass, _ = _make_cooler_setup(
+                cooler_attributes=cooler_attributes,
+                target_cooltemp=24.0,
+                target_temp=20.0,
+            )
+            for _ in range(resend_intervals):
+                await control_cooler(mock_self)
+                mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+            return len(_service_calls(mock_hass, "set_temperature"))
+
+        single_setpoint = await _writes({"temperature": 24.0 - quantization})
+        target_range = await _writes(
+            _range_attributes(
+                target_temp_high=24.0 - quantization,
+                target_temp_low=20.0 - quantization,
+            )
+        )
+
+        assert single_setpoint == 1
+        assert target_range == single_setpoint
+
+    @pytest.mark.asyncio
+    async def test_settled_lower_bound_does_not_swallow_a_moved_heating_target(self):
+        """The latch answers for the bound BT wrote, not for a new one.
+
+        A heating target the user moved makes the bound a new command, so it
+        reaches the cooler on the next cycle regardless of what the device
+        settled at.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_attributes=_range_attributes(
+                target_temp_high=23.7, target_temp_low=19.7
+            ),
+            target_cooltemp=24.0,
+            target_temp=20.0,
+        )
+
+        await control_cooler(mock_self)
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+        mock_self.bt_target_temp = 21.0
+        await control_cooler(mock_self)
+
+        temp_calls = _service_calls(mock_hass, "set_temperature")
+        assert len(temp_calls) == 2
+        assert temp_calls[1].args[2] == {
+            "entity_id": "climate.cooler",
+            "target_temp_high": 24.0,
+            "target_temp_low": 21.0,
+        }
+
+    @pytest.mark.asyncio
     async def test_drifted_lower_bound_outlives_quantization_acceptance(self):
         """A settled upper bound does not vouch for the lower one.
 

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -921,7 +921,74 @@ class TestControlCoolerModeHysteresis:
         assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
 
     @pytest.mark.asyncio
-    async def test_the_band_follows_the_commanded_mode_not_the_reported_one(self):
+    async def test_the_band_does_not_delay_the_switch_on(self):
+        """The band widens the COOL state, it does not narrow the way into it.
+
+        A band applied in both directions would hold the cooler off until the
+        room had climbed a further band width past the switch-on point, which
+        is not the deadband the tolerance asks for.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        # Well below the band, so the decision the band reads is OFF.
+        mock_self.cur_temp = self.SWITCH_ON_AT - 1.0
+        await control_cooler(mock_self)
+        assert _service_calls(mock_hass, "set_hvac_mode") == []
+
+        # Exactly on the switch-on point.
+        mock_self.cur_temp = self.SWITCH_ON_AT
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 1
+        assert mode_calls[0].args[2]["hvac_mode"] == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_an_alternating_decision_is_not_written_every_cycle(self):
+        """A cooler in a mode BT never commands must not defeat the band.
+
+        ``dry`` is neither COOL nor OFF, so the device differs from whatever
+        BT decides and every cycle wants to write. A band that read the last
+        successful send would never move on a device that accepts nothing:
+        the room resting on the switch-on point would flip the decision every
+        cycle, and each flip would reach the retry gate as a new command
+        rather than as a retry.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state="dry", cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        attempts: list[float] = []
+
+        async def always_fail(domain, service, data, **kwargs):
+            if service == "set_hvac_mode":
+                attempts.append(mock_self.clock.monotonic_value)
+            raise ConnectionError("cloud rate limit reached")
+
+        mock_hass.services.async_call = AsyncMock(side_effect=always_fail)
+
+        cycles = 0
+        elapsed = 0.0
+        while elapsed < 3600.0:
+            mock_self.clock.monotonic_value = elapsed
+            mock_self.cur_temp = self.SWITCH_ON_AT + (
+                0.005 if cycles % 2 == 0 else -0.005
+            )
+            await control_cooler(mock_self)
+            elapsed += 5.0
+            cycles += 1
+
+        assert cycles == 720
+        # Paced by the failure backoff instead of by the control-cycle rate.
+        assert len(attempts) < 10
+        gaps = [b - a for a, b in zip(attempts, attempts[1:], strict=False)]
+        assert min(gaps) >= COOLER_FAILURE_BACKOFF_BASE_S
+
+    @pytest.mark.asyncio
+    async def test_the_band_follows_the_decided_mode_not_the_reported_one(self):
         """An externally switched-off cooler is put back into the band's state.
 
         The device's reported mode lags a command and can be changed from

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -12,6 +12,7 @@ from custom_components.better_thermostat.core.clock import FakeClock
 from custom_components.better_thermostat.core.snapshot import HvacMode as CoreHvacMode
 from custom_components.better_thermostat.utils.controlling import (
     COOLER_FAILURE_BACKOFF_BASE_S,
+    COOLER_FAILURE_BACKOFF_MAX_RUN,
     COOLER_FAILURE_BACKOFF_MAX_S,
     COOLER_RESEND_INTERVAL_S,
     control_cooler,
@@ -760,8 +761,14 @@ class TestControlCoolerSendCache:
         assert mode_calls[0].args[2]["hvac_mode"] == HVACMode.OFF
 
     @pytest.mark.asyncio
-    async def test_a_changed_target_bypasses_the_failure_backoff(self):
-        """A new setpoint is a new command, not a retry, and goes out at once."""
+    async def test_a_changed_target_only_waits_the_backoff_base(self):
+        """A new setpoint is a new command and skips the run's grown wait.
+
+        It does not skip the base, though: a channel whose last attempt was
+        rejected keeps its floor whatever the payload says, so a desired
+        value alternating between two rejected commands cannot buy itself a
+        write on every cycle.
+        """
         mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
 
         mock_hass.services.async_call = AsyncMock(
@@ -771,13 +778,71 @@ class TestControlCoolerSendCache:
             mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
             await control_cooler(mock_self)
 
+        # A run of four: the same setpoint would now wait eight bases.
         mock_hass.services.async_call = AsyncMock()
         mock_self.bt_target_cooltemp = 23.0
+        await control_cooler(mock_self)
+        assert _service_calls(mock_hass, "set_temperature") == []
+
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
         await control_cooler(mock_self)
 
         temp_calls = _service_calls(mock_hass, "set_temperature")
         assert len(temp_calls) == 1
         assert temp_calls[0].args[2]["temperature"] == 23.0
+
+    @pytest.mark.asyncio
+    async def test_a_different_rejected_command_starts_its_own_run(self):
+        """The counter counts the run the gate prices.
+
+        A command replacing the rejected one resets the run: the gate prices
+        the retry of that command as the first of a run, so a counter that
+        kept adding to the run before it would describe something else.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+        mock_hass.services.async_call = AsyncMock(
+            side_effect=HomeAssistantError("device rejected the command")
+        )
+
+        for _ in range(4):
+            mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+            await control_cooler(mock_self)
+
+        # A different setpoint is rejected once: a run of one, not of five.
+        mock_self.bt_target_cooltemp = 23.0
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
+        await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
+        await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_long_run_of_failures_cannot_overflow_the_backoff(self):
+        """The run stops counting before the exponent leaves float range.
+
+        The control queue swallows whatever control_cooler raises, so an
+        arithmetic error here would take cooler control out until the next
+        reload — and a device that rejects every write reaches the exponent
+        that overflows in about three weeks.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+        mock_hass.services.async_call = AsyncMock(
+            side_effect=HomeAssistantError("device rejected the command")
+        )
+
+        attempts = 1100
+        for _ in range(attempts):
+            mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+            await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_temperature")) == attempts
+        assert (
+            mock_self._cooler_last_sent["temperature_failed"][0]
+            == COOLER_FAILURE_BACKOFF_MAX_RUN
+        )
 
     @pytest.mark.asyncio
     async def test_a_successful_send_clears_the_failure_backoff(self):

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -11,6 +11,7 @@ import pytest
 from custom_components.better_thermostat.core.clock import FakeClock
 from custom_components.better_thermostat.core.snapshot import HvacMode as CoreHvacMode
 from custom_components.better_thermostat.utils.controlling import (
+    COOLER_FAILURE_BACKOFF_BASE_S,
     COOLER_FAILURE_BACKOFF_MAX_S,
     COOLER_RESEND_INTERVAL_S,
     control_cooler,
@@ -621,7 +622,7 @@ class TestControlCoolerSendCache:
         """A failed command leaves the cache empty and is retried once paced.
 
         The retry follows the failure backoff rather than the resend
-        throttle, so it goes out one resend interval later.
+        throttle, so it goes out one backoff base later.
         """
         mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
 
@@ -633,7 +634,11 @@ class TestControlCoolerSendCache:
         assert last_sent_cooler_temperature(mock_self) is None
 
         mock_hass.services.async_call = AsyncMock()
-        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S / 2
+        await control_cooler(mock_self)
+        assert _service_calls(mock_hass, "set_temperature") == []
+
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S / 2
         await control_cooler(mock_self)
 
         assert len(_service_calls(mock_hass, "set_temperature")) == 1
@@ -702,37 +707,57 @@ class TestControlCoolerSendCache:
 
         mock_hass.services.async_call = AsyncMock(side_effect=accept_once_then_fail)
 
+        # Two hours: long enough for the backoff to reach its ceiling and hold
+        # there for a full wait, so the ceiling is measured rather than assumed.
         elapsed = 0.0
-        while elapsed < 3600.0:
+        while elapsed < 7200.0:
             mock_self.clock.monotonic_value = elapsed
             await control_cooler(mock_self)
             elapsed += 5.0
 
-        # 720 cycles in the hour; the cooler never applies anything, so every
-        # one of them would otherwise carry both commands.
+        # 1440 cycles in the two hours. The resend throttle alone would pace
+        # the first of them and nothing after that: its timestamp advances on
+        # a successful send only, so once the device starts rejecting it stops
+        # moving and every later cycle finds the window open — 1428 calls per
+        # channel, measured with the backoff disabled.
         for service, stamps in attempts.items():
-            assert len(stamps) <= 20, service
+            assert len(stamps) <= 12, service
             gaps = [b - a for a, b in zip(stamps, stamps[1:], strict=False)]
-            assert min(gaps) >= COOLER_RESEND_INTERVAL_S, service
-            assert max(gaps) <= COOLER_FAILURE_BACKOFF_MAX_S, service
-            # The spacing grows rather than staying at the resend interval.
+            assert min(gaps) >= COOLER_FAILURE_BACKOFF_BASE_S, service
+            # The run is long enough to be pinned at the ceiling.
+            assert max(gaps) == COOLER_FAILURE_BACKOFF_MAX_S, service
+            # The spacing grows rather than staying at the base.
             assert gaps[-1] > gaps[0], service
 
     @pytest.mark.asyncio
-    async def test_a_single_failure_still_retries_within_the_resend_interval(self):
-        """One rejection must not push the retry beyond the normal pacing."""
-        mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+    async def test_one_transient_failure_does_not_defer_the_cooler_off(self):
+        """A hiccup on the way to OFF is retried well inside a resend interval.
+
+        The resend interval respects the compressor's protection window, and
+        a rejected command never reached the compressor: the backoff paces
+        the retry only so a rate-limited endpoint is not hammered, which is a
+        much shorter wait.
+        """
+        assert COOLER_FAILURE_BACKOFF_BASE_S < COOLER_RESEND_INTERVAL_S
+
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.COOL, cooler_temp_attr=24.0, cur_temp=20.0
+        )
+        mock_self.bt_hvac_mode = HVACMode.OFF
 
         mock_hass.services.async_call = AsyncMock(
             side_effect=HomeAssistantError("device rejected the command")
         )
         await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
 
         mock_hass.services.async_call = AsyncMock()
-        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
         await control_cooler(mock_self)
 
-        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 1
+        assert mode_calls[0].args[2]["hvac_mode"] == HVACMode.OFF
 
     @pytest.mark.asyncio
     async def test_a_changed_target_bypasses_the_failure_backoff(self):
@@ -790,21 +815,22 @@ class TestControlCoolerSendCache:
 
         mock_hass.services.async_call = AsyncMock(side_effect=fail_mode)
 
-        # Long enough for the backoff to double several times from the resend
-        # interval, and stepped far finer than the shortest wait.
-        window = COOLER_RESEND_INTERVAL_S * 8
-        step = COOLER_RESEND_INTERVAL_S / 10
+        # Long enough for the backoff to double several times from its base,
+        # and stepped far finer than the shortest wait.
+        window = COOLER_FAILURE_BACKOFF_BASE_S * 64
+        step = COOLER_FAILURE_BACKOFF_BASE_S / 5
         elapsed = 0.0
         while elapsed < window:
             mock_self.clock.monotonic_value = elapsed
             await control_cooler(mock_self)
             elapsed += step
 
-        # Without the backoff every one of those cycles would carry a command.
-        assert 1 < len(attempts) < window / COOLER_RESEND_INTERVAL_S
+        # The mode channel never gets a command through, so the resend
+        # throttle never starts: without the backoff every one of those
+        # cycles would carry a command.
+        assert 1 < len(attempts) < window / COOLER_FAILURE_BACKOFF_BASE_S
         gaps = [b - a for a, b in zip(attempts, attempts[1:], strict=False)]
-        assert min(gaps) >= COOLER_RESEND_INTERVAL_S
-        assert max(gaps) <= COOLER_FAILURE_BACKOFF_MAX_S
+        assert min(gaps) >= COOLER_FAILURE_BACKOFF_BASE_S
         assert gaps[-1] > gaps[0]
 
     @pytest.mark.asyncio

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -11,8 +11,10 @@ import pytest
 from custom_components.better_thermostat.core.clock import FakeClock
 from custom_components.better_thermostat.core.snapshot import HvacMode as CoreHvacMode
 from custom_components.better_thermostat.utils.controlling import (
+    COOLER_FAILURE_BACKOFF_MAX_S,
     COOLER_RESEND_INTERVAL_S,
     control_cooler,
+    last_sent_cooler_temperature,
 )
 from tests.factories import make_snapshot
 
@@ -616,7 +618,11 @@ class TestControlCoolerSendCache:
 
     @pytest.mark.asyncio
     async def test_failed_send_does_not_prime_the_send_cache(self):
-        """A failed command is retried on the next cycle despite the throttle."""
+        """A failed command leaves the cache empty and is retried once paced.
+
+        The retry follows the failure backoff rather than the resend
+        throttle, so it goes out one resend interval later.
+        """
         mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
 
         mock_hass.services.async_call = AsyncMock(
@@ -624,10 +630,14 @@ class TestControlCoolerSendCache:
         )
         await control_cooler(mock_self)
 
+        assert last_sent_cooler_temperature(mock_self) is None
+
         mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
         await control_cooler(mock_self)
 
         assert len(_service_calls(mock_hass, "set_temperature")) == 1
+        assert last_sent_cooler_temperature(mock_self) == 24.0
 
     @pytest.mark.asyncio
     async def test_connection_error_on_set_temperature_still_attempts_hvac_mode(self):
@@ -668,6 +678,123 @@ class TestControlCoolerSendCache:
         await control_cooler(mock_self)
 
         assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+    @pytest.mark.asyncio
+    async def test_run_of_failures_is_paced_by_an_exponential_backoff(self):
+        """A device rejecting every write is retried ever more slowly.
+
+        A rejected command primes no send timestamp, so the resend throttle
+        cannot pace it. Without a backoff of its own the retry would go out
+        on every control cycle — hammering exactly the cloud device whose
+        rate limit caused the rejection in the first place.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=20.0
+        )
+        accepted = set()
+        attempts: dict[str, list[float]] = {"set_temperature": [], "set_hvac_mode": []}
+
+        async def accept_once_then_fail(domain, service, data, **kwargs):
+            attempts[service].append(mock_self.clock.monotonic_value)
+            if service in accepted:
+                raise ConnectionError("cloud rate limit reached")
+            accepted.add(service)
+
+        mock_hass.services.async_call = AsyncMock(side_effect=accept_once_then_fail)
+
+        elapsed = 0.0
+        while elapsed < 3600.0:
+            mock_self.clock.monotonic_value = elapsed
+            await control_cooler(mock_self)
+            elapsed += 5.0
+
+        # 720 cycles in the hour; the cooler never applies anything, so every
+        # one of them would otherwise carry both commands.
+        for service, stamps in attempts.items():
+            assert len(stamps) <= 20, service
+            gaps = [b - a for a, b in zip(stamps, stamps[1:], strict=False)]
+            assert min(gaps) >= COOLER_RESEND_INTERVAL_S, service
+            assert max(gaps) <= COOLER_FAILURE_BACKOFF_MAX_S, service
+            # The spacing grows rather than staying at the resend interval.
+            assert gaps[-1] > gaps[0], service
+
+    @pytest.mark.asyncio
+    async def test_a_single_failure_still_retries_within_the_resend_interval(self):
+        """One rejection must not push the retry beyond the normal pacing."""
+        mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+
+        mock_hass.services.async_call = AsyncMock(
+            side_effect=HomeAssistantError("device rejected the command")
+        )
+        await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_changed_target_bypasses_the_failure_backoff(self):
+        """A new setpoint is a new command, not a retry, and goes out at once."""
+        mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+
+        mock_hass.services.async_call = AsyncMock(
+            side_effect=HomeAssistantError("device rejected the command")
+        )
+        for _ in range(4):
+            mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+            await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.bt_target_cooltemp = 23.0
+        await control_cooler(mock_self)
+
+        temp_calls = _service_calls(mock_hass, "set_temperature")
+        assert len(temp_calls) == 1
+        assert temp_calls[0].args[2]["temperature"] == 23.0
+
+    @pytest.mark.asyncio
+    async def test_a_successful_send_clears_the_failure_backoff(self):
+        """Recovery restores the plain resend pacing on the next cycle."""
+        mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+
+        mock_hass.services.async_call = AsyncMock(
+            side_effect=HomeAssistantError("device rejected the command")
+        )
+        for _ in range(4):
+            mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+            await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+        await control_cooler(mock_self)
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_temperature")) == 2
+
+    @pytest.mark.asyncio
+    async def test_failed_mode_command_is_paced_by_its_own_backoff(self):
+        """The mode channel carries the same backoff as the temperature one."""
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0
+        )
+
+        async def fail_mode(domain, service, data, **kwargs):
+            if service == "set_hvac_mode":
+                raise ConnectionError("cloud rate limit reached")
+
+        mock_hass.services.async_call = AsyncMock(side_effect=fail_mode)
+
+        elapsed = 0.0
+        while elapsed < 300.0:
+            mock_self.clock.monotonic_value = elapsed
+            await control_cooler(mock_self)
+            elapsed += 5.0
+
+        # Attempts at 0, 30, 90, 210 within the first 300 s.
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 4
 
     @pytest.mark.asyncio
     async def test_cancellation_during_service_call_propagates(self):

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -719,7 +719,7 @@ class TestControlCoolerSendCache:
         # 1440 cycles in the two hours. The resend throttle alone would pace
         # the first of them and nothing after that: its timestamp advances on
         # a successful send only, so once the device starts rejecting it stops
-        # moving and every later cycle finds the window open — 1428 calls per
+        # moving and every later cycle finds the window open — 1393 calls per
         # channel, measured with the backoff disabled.
         for service, stamps in attempts.items():
             assert len(stamps) <= 12, service
@@ -845,9 +845,81 @@ class TestControlCoolerSendCache:
         )
 
     @pytest.mark.asyncio
-    async def test_a_successful_send_clears_the_failure_backoff(self):
-        """Recovery restores the plain resend pacing on the next cycle."""
+    async def test_a_successful_temperature_send_clears_the_failure_run(self):
+        """Recovery makes the next failure the first of a new run.
+
+        A run that survived recovery would price the retry after the next
+        single failure at the wait the old run had grown to, so the fresh run
+        has to be measured while it is still short.
+        """
         mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+
+        _fail = AsyncMock(side_effect=HomeAssistantError("device rejected the command"))
+        mock_hass.services.async_call = _fail
+        for _ in range(4):
+            mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+            await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+        # One rejection after the recovery: a run of one, so the retry waits
+        # a single base rather than the eight the cleared run had reached.
+        mock_hass.services.async_call = _fail
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
+        await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_successful_mode_send_clears_the_failure_run(self):
+        """The mode channel clears its run the same way the temperature does."""
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0
+        )
+
+        _fail = AsyncMock(side_effect=HomeAssistantError("device rejected the command"))
+        mock_hass.services.async_call = _fail
+        for _ in range(4):
+            mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+            await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+        mock_hass.services.async_call = _fail
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
+        await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+    @pytest.mark.asyncio
+    async def test_the_backoff_keys_on_both_bounds_of_a_range_payload(self):
+        """A range write carries the heating target, so the key must too.
+
+        The payload the device rejected and the payload a moved heating
+        target produces differ in the lower bound alone; a key blind to it
+        would price the second as a retry of the first.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_attributes=_range_attributes(
+                target_temp_high=20.0, target_temp_low=19.0
+            ),
+            target_cooltemp=24.0,
+            target_temp=20.0,
+        )
 
         mock_hass.services.async_call = AsyncMock(
             side_effect=HomeAssistantError("device rejected the command")
@@ -856,13 +928,15 @@ class TestControlCoolerSendCache:
             mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
             await control_cooler(mock_self)
 
+        # A run of four on (24.0, 20.0): that payload would wait eight bases.
         mock_hass.services.async_call = AsyncMock()
-        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
-        await control_cooler(mock_self)
-        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        mock_self.bt_target_temp = 21.0
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
         await control_cooler(mock_self)
 
-        assert len(_service_calls(mock_hass, "set_temperature")) == 2
+        temp_calls = _service_calls(mock_hass, "set_temperature")
+        assert len(temp_calls) == 1
+        assert temp_calls[0].args[2]["target_temp_low"] == 21.0
 
     @pytest.mark.asyncio
     async def test_failed_mode_command_is_paced_by_its_own_backoff(self):
@@ -891,9 +965,9 @@ class TestControlCoolerSendCache:
             elapsed += step
 
         # The mode channel never gets a command through, so the resend
-        # throttle never starts: without the backoff every one of those
-        # cycles would carry a command.
-        assert 1 < len(attempts) < window / COOLER_FAILURE_BACKOFF_BASE_S
+        # throttle never starts and every one of the 320 cycles would carry a
+        # command; the backoff brings that down to a handful.
+        assert 1 < len(attempts) < 10
         gaps = [b - a for a, b in zip(attempts, attempts[1:], strict=False)]
         assert min(gaps) >= COOLER_FAILURE_BACKOFF_BASE_S
         assert gaps[-1] > gaps[0]
@@ -1410,6 +1484,45 @@ class TestControlCoolerTargetRange:
             "entity_id": "climate.cooler",
             "target_temp_high": 24.0,
             "target_temp_low": 21.0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_settled_lower_bound_that_moves_is_written_again(self):
+        """The latch answers for the reading it was taken at, not forever.
+
+        A bound that leaves the reading the device settled on was moved by
+        something other than Better Thermostat, so it is a divergence the
+        latch has no answer for.
+        """
+        mock_self, mock_hass, mock_cooler_state = _make_cooler_setup(
+            cooler_attributes=_range_attributes(
+                target_temp_high=23.7, target_temp_low=19.7
+            ),
+            target_cooltemp=24.0,
+            target_temp=20.0,
+        )
+
+        await control_cooler(mock_self)
+        # The device answered both bounds on its own grid; the latch takes.
+        mock_self.clock.monotonic_value += 1.0
+        await control_cooler(mock_self)
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+        # The lower bound leaves the reading it settled on.
+        mock_cooler_state.attributes = _range_attributes(
+            target_temp_high=23.7, target_temp_low=18.0
+        )
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        temp_calls = _service_calls(mock_hass, "set_temperature")
+        assert len(temp_calls) == 2
+        assert temp_calls[1].args[2] == {
+            "entity_id": "climate.cooler",
+            "target_temp_high": 24.0,
+            "target_temp_low": 20.0,
         }
 
     @pytest.mark.asyncio

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -781,20 +781,31 @@ class TestControlCoolerSendCache:
             cooler_state=HVACMode.OFF, cooler_temp_attr=24.0
         )
 
+        attempts: list[float] = []
+
         async def fail_mode(domain, service, data, **kwargs):
             if service == "set_hvac_mode":
+                attempts.append(mock_self.clock.monotonic_value)
                 raise ConnectionError("cloud rate limit reached")
 
         mock_hass.services.async_call = AsyncMock(side_effect=fail_mode)
 
+        # Long enough for the backoff to double several times from the resend
+        # interval, and stepped far finer than the shortest wait.
+        window = COOLER_RESEND_INTERVAL_S * 8
+        step = COOLER_RESEND_INTERVAL_S / 10
         elapsed = 0.0
-        while elapsed < 300.0:
+        while elapsed < window:
             mock_self.clock.monotonic_value = elapsed
             await control_cooler(mock_self)
-            elapsed += 5.0
+            elapsed += step
 
-        # Attempts at 0, 30, 90, 210 within the first 300 s.
-        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 4
+        # Without the backoff every one of those cycles would carry a command.
+        assert 1 < len(attempts) < window / COOLER_RESEND_INTERVAL_S
+        gaps = [b - a for a, b in zip(attempts, attempts[1:], strict=False)]
+        assert min(gaps) >= COOLER_RESEND_INTERVAL_S
+        assert max(gaps) <= COOLER_FAILURE_BACKOFF_MAX_S
+        assert gaps[-1] > gaps[0]
 
     @pytest.mark.asyncio
     async def test_cancellation_during_service_call_propagates(self):

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -809,6 +809,105 @@ class TestControlCoolerSendCache:
             await control_cooler(mock_self)
 
 
+class TestControlCoolerModeHysteresis:
+    """The COOL/OFF decision spans a band rather than a single threshold."""
+
+    # target_cooltemp - tolerance for the values _make_cooler_setup uses.
+    SWITCH_ON_AT = 23.5
+
+    @staticmethod
+    def _make_compliant(mock_hass, cooler_state):
+        """Let the fake cooler apply whatever it is commanded."""
+
+        async def apply(domain, service, data, **kwargs):
+            if service == "set_hvac_mode":
+                cooler_state.state = data["hvac_mode"]
+            else:
+                cooler_state.attributes = {"temperature": data["temperature"]}
+
+        mock_hass.services.async_call = AsyncMock(side_effect=apply)
+
+    @pytest.mark.asyncio
+    async def test_room_temp_resting_on_the_threshold_is_not_written_every_cycle(self):
+        """A hundredth of a degree of sensor noise must not drive the cooler.
+
+        A changed desired mode bypasses the resend throttle by design, so a
+        single threshold turns every flip into a write — and a fully
+        compliant device gets commanded at the whole control-cycle rate.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        cycles = 0
+        elapsed = 0.0
+        while elapsed < 3600.0:
+            mock_self.clock.monotonic_value = elapsed
+            mock_self.cur_temp = self.SWITCH_ON_AT + (
+                0.005 if cycles % 2 == 0 else -0.005
+            )
+            await control_cooler(mock_self)
+            elapsed += 5.0
+            cycles += 1
+
+        assert cycles == 720
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+    @pytest.mark.asyncio
+    async def test_cooling_stops_once_the_room_leaves_the_band(self):
+        """The band delays the switch-off, it does not prevent it."""
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        await control_cooler(mock_self)
+        assert (
+            _service_calls(mock_hass, "set_hvac_mode")[-1].args[2]["hvac_mode"]
+            == HVACMode.COOL
+        )
+
+        # Just below the switch-on point but still inside the band.
+        mock_self.cur_temp = self.SWITCH_ON_AT - 0.1
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+        # Below the band.
+        mock_self.cur_temp = self.SWITCH_ON_AT - 0.25
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 2
+        assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_the_band_follows_the_commanded_mode_not_the_reported_one(self):
+        """An externally switched-off cooler is put back into the band's state.
+
+        The device's reported mode lags a command and can be changed from
+        outside Better Thermostat, so reading the band's state off it would
+        abandon cooling inside the band.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        await control_cooler(mock_self)
+
+        cooler_state.state = HVACMode.OFF
+        mock_self.cur_temp = self.SWITCH_ON_AT - 0.1
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 2
+        assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.COOL
+
+
 class TestControlCoolerTargetRange:
     """Payload selection for coolers that only accept a target range."""
 


### PR DESCRIPTION
## Motivation

Three ways the cooler can be written far more often than the resend throttle is supposed to allow, plus the interval itself, which was never derived from anything.

All numbers below are measurements: the real `control_cooler()` driven against the fixtures in `tests/unit/controlling/test_control_cooler.py`, before and after each change.

## A failed command removed all pacing

Both channels stamp the send-cache only in the `else:` of their `try`. The comment says why — "a failed call must not look like a completed send, otherwise the throttle would suppress the retry" — and that is right for one failure. For a run of them there is nothing left: `last_temp_ts` stays stale or `None`, the throttle cannot fire, and every control cycle retries immediately.

The consequence is perverse. A cloud air conditioner that starts rejecting writes *because its rate limit was hit* is then hammered harder than one that is merely lagging.

Device accepts one write per channel and raises on every later one, one simulated hour:

| cycle cadence | before | after |
|---|---|---|
| 15 s | 239 / 239 | **16 / 16** |
| 5 s | 715 / 715 | **16 / 16** |

Consecutive failures are now paced per channel by their own backoff, starting at the resend interval and doubling to a ceiling; a success clears the run. The pacing keys off the **attempted** command rather than the last successful one. Reusing the existing `temp_changed_since_last_send` would have left the hole open: a device that never accepts a single write keeps `last_temp` at `None`, so every cycle looks like a changed value and nothing is paced — measured, that variant stayed at 720 calls. A genuinely new command still goes out at once.

## A range cooler's lower bound had no settled reading

The temperature channel latches the first post-send reading within `COOLER_QUANTIZATION_TOLERANCE_K` of the sent value and treats the command as converged while it holds. The lower bound of a range write had no equivalent, so a cooler that snaps `target_temp_low` onto its own grid kept `_low_bound_drifted` true forever — which both armed the send and exempted it from the temperature latch.

Same 0.3 K quantization, same day, the only difference is the write mode:

| cooler | before | after |
|---|---|---|
| single-setpoint | 1 | 1 |
| range | **2880** | **1** |

Both existing tests that pin opposing behaviour here still assert exactly what they did, unedited: `test_drifted_lower_bound_outlives_quantization_acceptance` puts the bound 1.0 K out, beyond the latch tolerance, so the drift stays correctable; `test_lower_bound_drift_is_not_throttled_as_a_resend` has no cached bound at all, so the latch's guard does not engage and a new payload still bypasses the throttle.

## The COOL/OFF decision had no hysteresis

A single threshold, so a room temperature resting on it flipped the decision every cycle — and because the mode throttle exempts a *changed* desired mode, every flip was written immediately. A perfectly compliant device was commanded at the full cycle rate.

Room alternating 23.505 / 23.495 against a 23.5 switch-on point, one hour:

| cadence | before | after |
|---|---|---|
| 5 s (the room-sensor debounce floor) | 720 | **1** |
| 15 s | 240 | **1** |

The band uses the mode BT last commanded as its state, not the device's reported mode, which lags a command and can be changed externally. The heating target stays a hard floor — relaxing that conjunct would let the cooler run into the band the heater is working on.

For a normal installation the compressor runs **0.2 °C longer per cooling cycle**: having switched on at 23.5 °C it keeps cooling to 23.3 °C instead of stopping at 23.5 °C. Well inside the tolerance the user already configured, and switch-on is unaffected.

## The interval: 30 s → 300 s

The 30 s was copied from `MIN_WRITE_INTERVAL_S`, the TRV write budget, which exists because TRVs are battery- and radio-constrained. A cooler's constraint is different and physical: an air conditioner ignores commands for several minutes after a mode change to protect its compressor. Manufacturers state three minutes; dedicated thermostats hold the compressor off for four to five and will not let the user go below four. At 30 s Better Thermostat re-asserted five or six times inside a window in which the device is designed not to react.

**It costs a working installation nothing.** The send timestamp only advances on a successful send, so a converged cooler leaves the throttle window permanently open and a divergence appearing later is corrected on the very next cycle. Driving a compliant cooler through a simulated day suppresses **zero** sends at 30 s, 300 s and 1800 s alike, and the wrong-mode dwell time is identical. Startup is unaffected for the same reason — the cache is empty, so the first cycle is never paced, measured identical at all three.

What changes is the retry cadence of a device that is not applying what it is told: 120 commands per hour per channel become 12. The cost is that a cooler which was dropping commands and starts working again idles up to five minutes instead of half a minute (mean 2.4 min against 14 s).

1800 s was considered and rejected. It exceeds the 5-minute reconcile tick and the 900 s watchdog, which would make it the only binding timer in every installation, and it stretches that idle to half an hour — mean 15.9 min. It also produces the haunted-house case: a user switches the unit off by hand, walks away satisfied, and it restarts itself up to half an hour later for no visible reason.

The interval is deliberately **not** sized against a cloud API budget. That cannot be done with a constant: the strictest documented limit is 200 calls per day shared across an entire account and its own polling, which no interval a control loop can use would fit inside. A device that refuses a setpoint indefinitely wants a give-up, not slower pacing.

The failure backoff ceiling moves to half an hour so a run of rejections still de-escalates past the resend interval instead of collapsing onto it.

## Tests

`4097 passed` (baseline 4087), ruff and pyrefly clean. Ten new tests; each was confirmed to fail with its production hunk neutralised and to pass after restore.

One existing test changed: `test_failed_send_does_not_prime_the_send_cache` asserted the retry goes out on the very next cycle at the same instant, which is precisely the behaviour the backoff removes. Its actual subject is kept — the cache is still asserted empty right after the failure, then one resend interval is advanced and the retry is asserted to go out.

`test_failed_mode_command_is_paced_by_its_own_backoff` had the backoff schedule written out as literals derived from the old interval. It now derives its window and step from the constants and asserts the gaps rather than the instants, so it survives the next change to the value.

## Not in this pull request

While measuring this I found that an open window or door does **not** suppress the cooler — `DesiredState` carries no cooler intent, so `decide()`'s window suppression reaches the TRVs only, and the air conditioner keeps running at full duty into an open window. That is a separate, user-visible behaviour change and gets its own pull request.
