### PR TITLE
fix(cooler): suppress the cooler while a window or door is open

### DIFF
--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -94,7 +94,8 @@ async def trigger_cooler_change(self, event):
         _LOGGER.debug(
             "better_thermostat %s: trigger_cooler_change / "
             "_old_cooling_setpoint: %s - _new_cooling_setpoint: %s - "
-            "bt_target_cooltemp: %s - last_sent: %s - step: %s - echo: %s",
+            "bt_target_cooltemp: %s - last_sent: %s - step: %s - echo: %s - "
+            "contact_open: %s",
             self.device_name,
             _old_cooling_setpoint,
             _new_cooling_setpoint.value,
@@ -102,6 +103,7 @@ async def trigger_cooler_change(self, event):
             _last_sent,
             _step,
             _new_cooling_setpoint.is_echo,
+            self.contact_open,
         )
         # The cooler handler has no device-side gate of its own, so an event
         # that republishes the same setpoint — an attribute refresh, a mode
@@ -111,9 +113,10 @@ async def trigger_cooler_change(self, event):
         _reported_moved = abs(
             _new_cooling_setpoint.raw - _old_cooling_setpoint
         ) >= setpoint_echo_window(_step)
-        # The TRV handler refuses a setpoint while a contact is open; the
-        # cooler does the same, so an event arriving mid-airing cannot install
-        # a target the suppression is about to override anyway.
+        # While a contact is open the cooler is held OFF and receives no
+        # setpoint, so nothing BT wrote explains a setpoint the device reports
+        # mid-airing; adopting it would let the airing move the user's cooling
+        # target. The TRV handler draws the same line.
         if (
             not _new_cooling_setpoint.is_echo
             and _reported_moved
@@ -129,6 +132,25 @@ async def trigger_cooler_change(self, event):
             self.bt_target_cooltemp = _new_cooling_setpoint.value
             self._enforce_heat_below_cool()
             _main_change = True
+        elif _reported_moved:
+            # A setpoint change arrived from the cooler but was not adopted as
+            # user intent. Record which guard suppressed it so intermittent
+            # "change ignored" reports can be diagnosed from a debug log
+            # instead of guesswork.
+            _LOGGER.debug(
+                "better_thermostat %s: Cooler %s setpoint change %s -> %s NOT "
+                "adopted (echo=%s contact_open=%s bt_target_cooltemp=%s "
+                "last_sent=%s step=%s)",
+                self.device_name,
+                entity_id,
+                _old_cooling_setpoint,
+                _new_cooling_setpoint.value,
+                _new_cooling_setpoint.is_echo,
+                self.contact_open,
+                self.bt_target_cooltemp,
+                _last_sent,
+                _step,
+            )
 
     if _main_change is True:
         self.async_write_ha_state()

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -111,7 +111,14 @@ async def trigger_cooler_change(self, event):
         _reported_moved = abs(
             _new_cooling_setpoint.raw - _old_cooling_setpoint
         ) >= setpoint_echo_window(_step)
-        if not _new_cooling_setpoint.is_echo and _reported_moved:
+        # The TRV handler refuses a setpoint while a contact is open; the
+        # cooler does the same, so an event arriving mid-airing cannot install
+        # a target the suppression is about to override anyway.
+        if (
+            not _new_cooling_setpoint.is_echo
+            and _reported_moved
+            and self.contact_open is False
+        ):
             if _new_cooling_setpoint.clamped:
                 _LOGGER.warning(
                     "better_thermostat %s: New Cooler %s setpoint outside of range, "

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -60,8 +60,8 @@ MIN_WRITE_INTERVAL_S = 30.0
 RECONCILE_TOLERANCE_K = 0.05
 # Resend throttle for the cooler path: cooler commands go straight to the
 # service call (no reconciler in between), so an identical command is
-# suppressed while the device's state feedback lags. A changed desired
-# value always sends immediately.
+# suppressed while the device's state feedback lags. A changed desired value
+# passes this throttle untouched; only the failure backoff below can hold it.
 #
 # An air conditioner protects its compressor by ignoring commands for
 # several minutes after a mode change, so re-asserting inside that window

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -62,6 +62,16 @@ RECONCILE_TOLERANCE_K = 0.05
 # suppressed while the device's state feedback lags. A changed desired
 # value always sends immediately.
 COOLER_RESEND_INTERVAL_S = 30.0
+# A rejected cooler command is not a completed send, so the resend throttle
+# cannot pace its retry. Consecutive failures on one channel are paced by
+# their own backoff instead: the first retry waits one resend interval, each
+# further one doubles the wait by this factor.
+COOLER_FAILURE_BACKOFF_FACTOR = 2.0
+# Ceiling of that backoff. It matches the slowest cadence at which Better
+# Thermostat re-evaluates on its own, so a device that stops rejecting
+# commands is picked up within one periodic control cycle no matter how long
+# it was failing.
+COOLER_FAILURE_BACKOFF_MAX_S = 300.0
 # A cooler may snap a received setpoint onto its own step grid (e.g. 0.5 °C,
 # or a whole-°F grid). A post-send reading within this distance of the sent
 # value counts as that device-side quantization, not as an unapplied command.
@@ -645,9 +655,10 @@ def cooler_send_cache(self) -> dict:
     """Return the cooler send-cache, creating it on first use.
 
     Holds the last successfully sent command per channel as
-    ``(value, monotonic_timestamp)`` for the resend throttle, plus the settled
-    reading of the temperature channel. Created lazily because only
-    cooler-equipped instances need it.
+    ``(value, monotonic_timestamp)`` for the resend throttle, the settled
+    reading of each written channel, and each channel's run of consecutive
+    send failures as ``(count, monotonic_timestamp)``. Created lazily because
+    only cooler-equipped instances need it.
     """
     last_sent = getattr(self, "_cooler_last_sent", None)
     if not isinstance(last_sent, dict):
@@ -660,6 +671,38 @@ def last_sent_cooler_temperature(self) -> float | None:
     """Return the cooling setpoint BT last wrote to the cooler, in °C."""
     value = cooler_send_cache(self).get("temperature", (None, None))[0]
     return value if isinstance(value, (int, float)) else None
+
+
+def _cooler_retry_paced(
+    last_sent: dict, channel: str, wanted, now_monotonic: float
+) -> bool:
+    """Whether a channel's backoff still bars the retry of a failed command.
+
+    A rejected command leaves no send timestamp behind, so the resend
+    throttle cannot pace it; this backoff does. The wait grows with the run
+    of consecutive failures, so a device that rejects every write — a cloud
+    air conditioner over its rate limit, for instance — is not retried harder
+    than one that merely lags. Only the identical command is paced: a value
+    BT has not put on the wire yet is a new command, not a retry.
+    """
+    failures, failed_at, failed_wanted = last_sent.get(
+        f"{channel}_failed", (0, None, None)
+    )
+    if not failures or failed_at is None or failed_wanted != wanted:
+        return False
+    wait = min(
+        COOLER_RESEND_INTERVAL_S * COOLER_FAILURE_BACKOFF_FACTOR ** (failures - 1),
+        COOLER_FAILURE_BACKOFF_MAX_S,
+    )
+    return (now_monotonic - failed_at) < wait
+
+
+def _record_cooler_failure(
+    last_sent: dict, channel: str, wanted, now_monotonic: float
+) -> None:
+    """Extend a channel's run of consecutive send failures."""
+    failures = last_sent.get(f"{channel}_failed", (0, None, None))[0]
+    last_sent[f"{channel}_failed"] = (failures + 1, now_monotonic, wanted)
 
 
 async def control_cooler(self, snapshot=None):
@@ -860,6 +903,25 @@ async def control_cooler(self, snapshot=None):
         )
         temp_to_send = None
 
+    # The command the payload would carry, in °C, as the failure backoff
+    # compares it: a rejected send leaves the send cache untouched, so the
+    # attempted command is what tells a retry from a new command.
+    _temp_wanted = None
+    if temp_to_send is not None:
+        _temp_wanted = (
+            temp_to_send,
+            cooler_low_bound(temp_to_send, target_temp) if _write_range else None,
+        )
+        if _cooler_retry_paced(last_sent, "temperature", _temp_wanted, now_monotonic):
+            _LOGGER.debug(
+                "better_thermostat %s: cooler %s deferring the set_temperature retry "
+                "after %s consecutive failures",
+                self.device_name,
+                self.cooler_entity_id,
+                last_sent["temperature_failed"][0],
+            )
+            temp_to_send = None
+
     if temp_to_send is not None:
         _LOGGER.debug(
             "better_thermostat %s: TO COOLER set_temperature: %s from: %s to: %s",
@@ -895,10 +957,11 @@ async def control_cooler(self, snapshot=None):
             _payload = {"entity_id": self.cooler_entity_id, "temperature": _temp_to_set}
         # Only prime the send-cache on success. A failed call must not look
         # like a completed send, otherwise the throttle would suppress the
-        # retry. Any exception from this one service call is isolated
-        # (cloud integrations propagate raw errors such as ConnectionError)
-        # so the hvac_mode command below still runs; CancelledError derives
-        # from BaseException and propagates.
+        # retry; its run of failures is recorded instead, which paces the
+        # retry without pretending the command arrived. Any exception from
+        # this one service call is isolated (cloud integrations propagate raw
+        # errors such as ConnectionError) so the hvac_mode command below still
+        # runs; CancelledError derives from BaseException and propagates.
         try:
             await self.hass.services.async_call(
                 "climate",
@@ -908,21 +971,25 @@ async def control_cooler(self, snapshot=None):
                 context=self.context,
             )
         except Exception as err:
+            _record_cooler_failure(
+                last_sent, "temperature", _temp_wanted, now_monotonic
+            )
             _LOGGER.warning(
                 "better_thermostat %s: set_temperature for cooler %s failed (%s); "
-                "will retry on the next cycle",
+                "will retry on a later cycle",
                 self.device_name,
                 self.cooler_entity_id,
                 err,
             )
         else:
             last_sent["temperature"] = (temp_to_send, now_monotonic)
+            last_sent.pop("temperature_failed", None)
             if _write_range:
                 last_sent["target_temp_low"] = (
                     cooler_low_bound(temp_to_send, target_temp),
                     now_monotonic,
                 )
-            # A fresh send invalidates the previously settled reading; the
+            # A fresh send invalidates the previously settled readings; the
             # device answers anew.
             last_sent.pop("temperature_settled", None)
 
@@ -947,6 +1014,20 @@ async def control_cooler(self, snapshot=None):
         )
         should_send_mode = False
 
+    # Same pacing as the temperature channel: a rejected mode command has no
+    # send timestamp, so its retry follows the failure backoff.
+    if should_send_mode and _cooler_retry_paced(
+        last_sent, "hvac_mode", desired_mode, now_monotonic
+    ):
+        _LOGGER.debug(
+            "better_thermostat %s: cooler %s deferring the set_hvac_mode retry "
+            "after %s consecutive failures",
+            self.device_name,
+            self.cooler_entity_id,
+            last_sent["hvac_mode_failed"][0],
+        )
+        should_send_mode = False
+
     if should_send_mode:
         _LOGGER.debug(
             "better_thermostat %s: TO COOLER set_hvac_mode: %s from: %s to: %s",
@@ -966,15 +1047,17 @@ async def control_cooler(self, snapshot=None):
                 context=self.context,
             )
         except Exception as err:
+            _record_cooler_failure(last_sent, "hvac_mode", desired_mode, now_monotonic)
             _LOGGER.warning(
                 "better_thermostat %s: set_hvac_mode for cooler %s failed (%s); "
-                "will retry on the next cycle",
+                "will retry on a later cycle",
                 self.device_name,
                 self.cooler_entity_id,
                 err,
             )
         else:
             last_sent["hvac_mode"] = (desired_mode, now_monotonic)
+            last_sent.pop("hvac_mode_failed", None)
 
 
 async def control_trv(self, heater_entity_id=None, cycle=None):

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -1090,15 +1090,17 @@ async def control_cooler(self, snapshot=None):
         else:
             last_sent["temperature"] = (temp_to_send, now_monotonic)
             last_sent.pop("temperature_failed", None)
+            # A fresh send invalidates the settled reading of the channels it
+            # carried; the device answers those anew. A single-setpoint
+            # payload carries no lower bound, so it says nothing about the
+            # bound's settled reading.
+            last_sent.pop("temperature_settled", None)
             if _write_range:
                 last_sent["target_temp_low"] = (
                     cooler_low_bound(temp_to_send, target_temp),
                     now_monotonic,
                 )
-            # A fresh send invalidates the previously settled readings; the
-            # device answers anew.
-            last_sent.pop("temperature_settled", None)
-            last_sent.pop("target_temp_low_settled", None)
+                last_sent.pop("target_temp_low_settled", None)
 
     # Decide whether an hvac_mode command is needed, throttling identical
     # resends the same way as temperature commands.

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -837,18 +837,43 @@ async def control_cooler(self, snapshot=None):
         _low_to_set = cooler_low_bound(desired_temp, target_temp)
         # A lower bound BT never wrote at this value is a new payload, not a
         # resend; one it already wrote and the device ignored is a retry.
-        _low_bound_changed = (
-            last_sent.get("target_temp_low", (None, None))[0] != _low_to_set
-        )
+        last_low = last_sent.get("target_temp_low", (None, None))[0]
+        _low_bound_changed = last_low != _low_to_set
         current_low = attr_to_celsius(
             self, cooler_state, "target_temp_low", None, "control_cooler()"
+        )
+        # The bound carries the same quantization latch as the temperature
+        # channel: the first post-send reading close to the written bound is
+        # the device's answer on its own grid, and while it holds and the
+        # wanted bound is unchanged the bound counts as applied. Without it a
+        # device that snaps both bounds is rewritten every resend interval
+        # for as long as it is configured.
+        settled_low = last_sent.get("target_temp_low_settled")
+        if (
+            not _low_bound_changed
+            and last_low is not None
+            and current_low is not None
+            and settled_low is None
+            and abs(current_low - last_low) <= COOLER_QUANTIZATION_TOLERANCE_K
+        ):
+            settled_low = current_low
+            last_sent["target_temp_low_settled"] = settled_low
+        _low_bound_settled = (
+            not _low_bound_changed
+            and settled_low is not None
+            and current_low is not None
+            and abs(current_low - settled_low) <= RECONCILE_TOLERANCE_K
         )
         # The device answers a written bound on its own grid, so the bound
         # carries the same per-device tolerance the TRV write-skip check uses.
         # A coarser answer than half a step is a bound the device did not
         # apply.
-        if current_low is not None and not matches_any_setpoint(
-            current_low, {_low_to_set}, _reconcile_tolerance(self, cooler_state)
+        if (
+            current_low is not None
+            and not _low_bound_settled
+            and not matches_any_setpoint(
+                current_low, {_low_to_set}, _reconcile_tolerance(self, cooler_state)
+            )
         ):
             _LOGGER.debug(
                 "better_thermostat %s: cooler %s lower bound %s differs from %s, "
@@ -992,6 +1017,7 @@ async def control_cooler(self, snapshot=None):
             # A fresh send invalidates the previously settled readings; the
             # device answers anew.
             last_sent.pop("temperature_settled", None)
+            last_sent.pop("target_temp_low_settled", None)
 
     # Decide whether an hvac_mode command is needed, throttling identical
     # resends the same way as temperature commands.

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import replace
 import logging
+import math
 
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfTemperature
@@ -91,6 +92,16 @@ COOLER_FAILURE_BACKOFF_FACTOR = 2.0
 # paced well beyond the resend interval; a device that starts working again
 # is picked up on the following attempt.
 COOLER_FAILURE_BACKOFF_MAX_S = 1800.0
+# Longest run the backoff can tell apart. Past it the wait is pinned at the
+# ceiling anyway, while the exponent would keep growing on a device that
+# rejects every write until the float power overflows and takes the whole
+# cooler cycle down with it.
+COOLER_FAILURE_BACKOFF_MAX_RUN = 1 + math.ceil(
+    math.log(
+        COOLER_FAILURE_BACKOFF_MAX_S / COOLER_FAILURE_BACKOFF_BASE_S,
+        COOLER_FAILURE_BACKOFF_FACTOR,
+    )
+)
 # A cooler may snap a received setpoint onto its own step grid (e.g. 0.5 °C,
 # or a whole-°F grid). A post-send reading within this distance of the sent
 # value counts as that device-side quantization, not as an unapplied command.
@@ -701,36 +712,57 @@ def last_sent_cooler_temperature(self) -> float | None:
     return value if isinstance(value, (int, float)) else None
 
 
-def _cooler_retry_paced(
+def _cooler_retry_deferred(
     last_sent: dict, channel: str, wanted, now_monotonic: float
 ) -> bool:
-    """Whether a channel's backoff still bars the retry of a failed command.
+    """Whether a channel's backoff still holds a command back.
 
     A rejected command leaves no send timestamp behind, so the resend
     throttle cannot pace it; this backoff does. The wait grows with the run
-    of consecutive failures, so a device that rejects every write — a cloud
-    air conditioner over its rate limit, for instance — is not retried harder
-    than one that merely lags. Only the identical command is paced: a value
-    BT has not put on the wire yet is a new command, not a retry.
+    of consecutive failures of that command, so a device that rejects every
+    write — a cloud air conditioner over its rate limit, for instance — is
+    not retried harder than one that merely lags.
+
+    A command other than the rejected one is a new command rather than a
+    retry, and waits the base only: it has to reach the device promptly, but
+    it must not hand a channel that is failing a fresh write budget at the
+    cycle rate either, which is what a desired value alternating between two
+    rejected commands would otherwise do.
     """
     failures, failed_at, failed_wanted = last_sent.get(
         f"{channel}_failed", (0, None, None)
     )
-    if not failures or failed_at is None or failed_wanted != wanted:
+    if not failures or failed_at is None:
         return False
-    wait = min(
-        COOLER_FAILURE_BACKOFF_BASE_S * COOLER_FAILURE_BACKOFF_FACTOR ** (failures - 1),
-        COOLER_FAILURE_BACKOFF_MAX_S,
-    )
+    if failed_wanted != wanted:
+        wait = COOLER_FAILURE_BACKOFF_BASE_S
+    else:
+        wait = min(
+            COOLER_FAILURE_BACKOFF_BASE_S
+            * COOLER_FAILURE_BACKOFF_FACTOR ** (failures - 1),
+            COOLER_FAILURE_BACKOFF_MAX_S,
+        )
     return (now_monotonic - failed_at) < wait
 
 
 def _record_cooler_failure(
     last_sent: dict, channel: str, wanted, now_monotonic: float
 ) -> None:
-    """Extend a channel's run of consecutive send failures."""
-    failures = last_sent.get(f"{channel}_failed", (0, None, None))[0]
-    last_sent[f"{channel}_failed"] = (failures + 1, now_monotonic, wanted)
+    """Extend a channel's run of consecutive failures of one command.
+
+    A run is a run of the same command; a different one that fails starts
+    its own, so the run the counter holds and the run the gate prices always
+    describe the same command. The count stops at the length the backoff can
+    still tell apart.
+    """
+    failures, _, failed_wanted = last_sent.get(f"{channel}_failed", (0, None, None))
+    if failed_wanted != wanted:
+        failures = 0
+    last_sent[f"{channel}_failed"] = (
+        min(failures + 1, COOLER_FAILURE_BACKOFF_MAX_RUN),
+        now_monotonic,
+        wanted,
+    )
 
 
 async def control_cooler(self, snapshot=None):
@@ -984,10 +1016,12 @@ async def control_cooler(self, snapshot=None):
             temp_to_send,
             cooler_low_bound(temp_to_send, target_temp) if _write_range else None,
         )
-        if _cooler_retry_paced(last_sent, "temperature", _temp_wanted, now_monotonic):
+        if _cooler_retry_deferred(
+            last_sent, "temperature", _temp_wanted, now_monotonic
+        ):
             _LOGGER.debug(
-                "better_thermostat %s: cooler %s deferring the set_temperature retry "
-                "after %s consecutive failures",
+                "better_thermostat %s: cooler %s deferring set_temperature at "
+                "failure-backoff step %s",
                 self.device_name,
                 self.cooler_entity_id,
                 last_sent["temperature_failed"][0],
@@ -1089,12 +1123,12 @@ async def control_cooler(self, snapshot=None):
 
     # Same pacing as the temperature channel: a rejected mode command has no
     # send timestamp, so its retry follows the failure backoff.
-    if should_send_mode and _cooler_retry_paced(
+    if should_send_mode and _cooler_retry_deferred(
         last_sent, "hvac_mode", desired_mode, now_monotonic
     ):
         _LOGGER.debug(
-            "better_thermostat %s: cooler %s deferring the set_hvac_mode retry "
-            "after %s consecutive failures",
+            "better_thermostat %s: cooler %s deferring set_hvac_mode at "
+            "failure-backoff step %s",
             self.device_name,
             self.cooler_entity_id,
             last_sent["hvac_mode_failed"][0],

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -61,17 +61,27 @@ RECONCILE_TOLERANCE_K = 0.05
 # service call (no reconciler in between), so an identical command is
 # suppressed while the device's state feedback lags. A changed desired
 # value always sends immediately.
-COOLER_RESEND_INTERVAL_S = 30.0
+#
+# An air conditioner protects its compressor by ignoring commands for
+# several minutes after a mode change, so re-asserting inside that window
+# cannot achieve anything: manufacturers state three minutes, and dedicated
+# thermostats hold the compressor off for four to five. The interval sits at
+# the top of that band, and stays below the reconcile and watchdog periods
+# so it never becomes the slowest timer in the system. A device that applies
+# what it is told never reaches it — the timestamp only advances on a send,
+# so a converged cooler leaves the window permanently open and a divergence
+# is still corrected on the next cycle.
+COOLER_RESEND_INTERVAL_S = 300.0
 # A rejected cooler command is not a completed send, so the resend throttle
 # cannot pace its retry. Consecutive failures on one channel are paced by
 # their own backoff instead: the first retry waits one resend interval, each
 # further one doubles the wait by this factor.
 COOLER_FAILURE_BACKOFF_FACTOR = 2.0
-# Ceiling of that backoff. It matches the slowest cadence at which Better
-# Thermostat re-evaluates on its own, so a device that stops rejecting
-# commands is picked up within one periodic control cycle no matter how long
-# it was failing.
-COOLER_FAILURE_BACKOFF_MAX_S = 300.0
+# Ceiling of that backoff, half an hour. A channel that has been rejected
+# this often is not going to accept the next command either, so the run is
+# paced well beyond the resend interval; a device that starts working again
+# is picked up on the following attempt.
+COOLER_FAILURE_BACKOFF_MAX_S = 1800.0
 # A cooler may snap a received setpoint onto its own step grid (e.g. 0.5 °C,
 # or a whole-°F grid). A post-send reading within this distance of the sent
 # value counts as that device-side quantization, not as an unapplied command.

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -76,6 +76,12 @@ COOLER_FAILURE_BACKOFF_MAX_S = 300.0
 # or a whole-°F grid). A post-send reading within this distance of the sent
 # value counts as that device-side quantization, not as an unapplied command.
 COOLER_QUANTIZATION_TOLERANCE_K = 0.5
+# Hysteresis band below the cooling switch-on point. Once BT has commanded
+# COOL the room has to fall this far below the switch-on point before OFF is
+# commanded, so a room temperature resting on the threshold does not flip the
+# decision — and produce a write — on every control cycle. Two steps of a
+# 0.1 °C room sensor.
+COOLER_MODE_HYSTERESIS_K = 0.2
 # Valve deviations below this are the device's own business.
 RECONCILE_VALVE_TOLERANCE_PCT = 5.0
 # Pause before re-queueing a cycle in which a TRV reported failure, so a
@@ -779,10 +785,21 @@ async def control_cooler(self, snapshot=None):
         desired_mode = HVACMode.OFF
     elif snapshot.hvac_mode == HVACMode.OFF:
         desired_mode = HVACMode.OFF
-    elif room_temp >= target_cooltemp - tolerance and room_temp > target_temp:
-        desired_mode = HVACMode.COOL
     else:
-        desired_mode = HVACMode.OFF
+        # Hysteresis around the switch-on point, so a room temperature
+        # resting on it does not flip the decision — and with it the write —
+        # on every cycle. The state is the mode BT last commanded: the
+        # device's own reported mode lags a command and can be changed
+        # externally, so it cannot carry the band. The heating target stays a
+        # hard floor; relaxing it would let the cooler run into the band the
+        # heater is working on.
+        _cool_on_at = target_cooltemp - tolerance
+        if last_sent.get("hvac_mode", (None, None))[0] == HVACMode.COOL:
+            _cool_on_at -= COOLER_MODE_HYSTERESIS_K
+        if room_temp >= _cool_on_at and room_temp > target_temp:
+            desired_mode = HVACMode.COOL
+        else:
+            desired_mode = HVACMode.OFF
 
     # Decide whether a temperature command is needed. When the current
     # temperature is unknown, only send if the desired value changed since

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -839,6 +839,14 @@ async def control_cooler(self, snapshot=None):
         desired_mode = HVACMode.OFF
     elif snapshot.hvac_mode == HVACMode.OFF:
         desired_mode = HVACMode.OFF
+    elif self.contact_open:
+        # An open window or door suppresses the cooler for the same reason it
+        # suppresses the TRVs: the room cannot reach its target, so the unit
+        # would run against an unbounded load. The kernel's window and door
+        # regions own the decision, debounce included; the cooler reads their
+        # combined verdict because the desired state carries no cooler intent
+        # for the kernel to suppress.
+        desired_mode = HVACMode.OFF
     else:
         # Hysteresis around the switch-on point, so a room temperature
         # resting on it does not flip the decision — and with it the write —

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -74,8 +74,13 @@ RECONCILE_TOLERANCE_K = 0.05
 COOLER_RESEND_INTERVAL_S = 300.0
 # A rejected cooler command is not a completed send, so the resend throttle
 # cannot pace its retry. Consecutive failures on one channel are paced by
-# their own backoff instead: the first retry waits one resend interval, each
-# further one doubles the wait by this factor.
+# their own backoff instead, starting at this base. The base is deliberately
+# shorter than the resend interval: a rejected command never reached the
+# device, so there is no compressor window to respect, and the wait exists
+# only to keep a rate-limited endpoint from being retried on every cycle.
+COOLER_FAILURE_BACKOFF_BASE_S = 30.0
+# Growth of that backoff: the first retry waits the base, each further one
+# doubles the wait by this factor.
 COOLER_FAILURE_BACKOFF_FACTOR = 2.0
 # Ceiling of that backoff, half an hour. A channel that has been rejected
 # this often is not going to accept the next command either, so the run is
@@ -707,7 +712,7 @@ def _cooler_retry_paced(
     if not failures or failed_at is None or failed_wanted != wanted:
         return False
     wait = min(
-        COOLER_RESEND_INTERVAL_S * COOLER_FAILURE_BACKOFF_FACTOR ** (failures - 1),
+        COOLER_FAILURE_BACKOFF_BASE_S * COOLER_FAILURE_BACKOFF_FACTOR ** (failures - 1),
         COOLER_FAILURE_BACKOFF_MAX_S,
     )
     return (now_monotonic - failed_at) < wait

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -1015,6 +1015,21 @@ async def control_cooler(self, snapshot=None):
         )
         temp_to_send = None
 
+    # An open contact suppresses the temperature channel alongside the mode,
+    # the way a suppressed TRV receives a mode command and no setpoint. The
+    # unit is held OFF and converges on nothing, so a setpoint written now
+    # would only overwrite whatever the user turned its own dial to. Nothing
+    # is attempted, so the failure backoff below records nothing either, and
+    # the channel resumes on the cycle the contact shuts.
+    if temp_to_send is not None and self.contact_open:
+        _LOGGER.debug(
+            "better_thermostat %s: cooler %s suppressed by an open contact, "
+            "skipping set_temperature",
+            self.device_name,
+            self.cooler_entity_id,
+        )
+        temp_to_send = None
+
     # The command the payload would carry, in °C, as the failure backoff
     # compares it: a rejected send leaves the send cache untouched, so the
     # attempted command is what tells a retry from a new command.

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -95,11 +95,13 @@ COOLER_FAILURE_BACKOFF_MAX_S = 1800.0
 # or a whole-°F grid). A post-send reading within this distance of the sent
 # value counts as that device-side quantization, not as an unapplied command.
 COOLER_QUANTIZATION_TOLERANCE_K = 0.5
-# Hysteresis band below the cooling switch-on point. Once BT has commanded
-# COOL the room has to fall this far below the switch-on point before OFF is
-# commanded, so a room temperature resting on the threshold does not flip the
+# Hysteresis band below the cooling switch-on point. Once BT has decided to
+# cool, the room has to fall this far below the switch-on point before OFF is
+# decided, so a room temperature resting on the threshold does not flip the
 # decision — and produce a write — on every control cycle. Two steps of a
-# 0.1 °C room sensor.
+# 0.1 °C room sensor, which is what the flip is made of; and well under the
+# 0.5 °C a cooling setpoint is set in, so the extra run time the band costs
+# is finer than the user can express in the target anyway.
 COOLER_MODE_HYSTERESIS_K = 0.2
 # Valve deviations below this are the device's own business.
 RECONCILE_VALVE_TOLERANCE_PCT = 5.0
@@ -681,9 +683,10 @@ def cooler_send_cache(self) -> dict:
 
     Holds the last successfully sent command per channel as
     ``(value, monotonic_timestamp)`` for the resend throttle, the settled
-    reading of each written channel, and each channel's run of consecutive
-    send failures as ``(count, monotonic_timestamp)``. Created lazily because
-    only cooler-equipped instances need it.
+    reading of each written channel, the mode the last cycle decided on for
+    the hysteresis band, and each channel's run of consecutive send failures
+    as ``(count, monotonic_timestamp, attempted_value)``. Created lazily
+    because only cooler-equipped instances need it.
     """
     last_sent = getattr(self, "_cooler_last_sent", None)
     if not isinstance(last_sent, dict):
@@ -807,18 +810,26 @@ async def control_cooler(self, snapshot=None):
     else:
         # Hysteresis around the switch-on point, so a room temperature
         # resting on it does not flip the decision — and with it the write —
-        # on every cycle. The state is the mode BT last commanded: the
-        # device's own reported mode lags a command and can be changed
-        # externally, so it cannot carry the band. The heating target stays a
+        # on every cycle. The band widens the COOL state only: entering it
+        # stays at the plain switch-on point the tolerance defines. The
+        # device's own reported mode cannot carry the band — it lags a
+        # command and can be changed externally. The heating target stays a
         # hard floor; relaxing it would let the cooler run into the band the
         # heater is working on.
         _cool_on_at = target_cooltemp - tolerance
-        if last_sent.get("hvac_mode", (None, None))[0] == HVACMode.COOL:
+        if last_sent.get("hvac_mode_decided") == HVACMode.COOL:
             _cool_on_at -= COOLER_MODE_HYSTERESIS_K
         if room_temp >= _cool_on_at and room_temp > target_temp:
             desired_mode = HVACMode.COOL
         else:
             desired_mode = HVACMode.OFF
+    # The band's state is the decision, not the send: a device that rejects
+    # every command would never advance a send-stamped state, and the
+    # decision would keep flipping between the two commands the device is
+    # refusing. Recorded for every branch above, so a cycle that fell into a
+    # guard leaves the band where that guard put it instead of on a stale
+    # value.
+    last_sent["hvac_mode_decided"] = desired_mode
 
     # Decide whether a temperature command is needed. When the current
     # temperature is unknown, only send if the desired value changed since

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -65,13 +65,17 @@ RECONCILE_TOLERANCE_K = 0.05
 # An air conditioner protects its compressor by ignoring commands for
 # several minutes after a mode change, so re-asserting inside that window
 # cannot achieve anything: manufacturers state three minutes, and dedicated
-# thermostats hold the compressor off for four to five. The interval sits at
-# the top of that band, and stays below the reconcile and watchdog periods
-# so it never becomes the slowest timer in the system. A device that applies
-# what it is told never reaches it — the timestamp only advances on a send,
-# so a converged cooler leaves the window permanently open and a divergence
-# is still corrected on the next cycle.
-COOLER_RESEND_INTERVAL_S = 300.0
+# thermostats hold the compressor off for four to five. The interval sits in
+# that band and strictly below the periodic ticks that drive a control cycle
+# — the five-minute reconcile and time triggers, the fifteen-minute watchdog
+# — because the throttle compares strictly and the clock is read partway
+# into a cycle: at exactly one tick period, scheduling jitter would decide
+# whether a tick counts, and the pacing would land anywhere between one and
+# two tick periods. A device that applies what it is told never reaches the
+# interval at all — the timestamp only advances on a send, so a converged
+# cooler leaves the window permanently open and a divergence appearing after
+# that convergence is corrected on the next cycle.
+COOLER_RESEND_INTERVAL_S = 240.0
 # A rejected cooler command is not a completed send, so the resend throttle
 # cannot pace its retry. Consecutive failures on one channel are paced by
 # their own backoff instead, starting at this base. The base is deliberately

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -29,6 +29,17 @@ def _mock_cooler_state(state=HVACMode.COOL):
     return mock_cooler_state
 
 
+def _mock_bt():
+    """Build a bare Better Thermostat mock with the contact pinned shut.
+
+    An attribute a ``Mock`` was never given is a truthy child mock, so
+    ``contact_open`` has to be pinned or every cycle reads as an airing.
+    """
+    mock_self = Mock()
+    mock_self.contact_open = False
+    return mock_self
+
+
 class TestControlCooler:
     """Test control_cooler function."""
 
@@ -49,7 +60,7 @@ class TestControlCooler:
         mock_cooler_state.attributes = {"temperature": None}
         mock_hass.states.get.return_value = mock_cooler_state
 
-        mock_self = Mock()
+        mock_self = _mock_bt()
         mock_self.hass = mock_hass
         mock_self.real_trvs = {}
         mock_self.clock = FakeClock()
@@ -59,8 +70,6 @@ class TestControlCooler:
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.bt_target_cooltemp = 24.0
         mock_self.context = None
-        # A bare Mock would hand out a truthy contact_open.
-        mock_self.contact_open = False
 
         await control_cooler(mock_self)
 
@@ -88,13 +97,11 @@ class TestControlCooler:
         mock_cooler_state.attributes = {"temperature": 24.0}
         mock_hass.states.get.return_value = mock_cooler_state
 
-        mock_self = Mock()
+        mock_self = _mock_bt()
         mock_self.hass = mock_hass
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.tolerance = 0.5
         mock_self.context = None
-        # A bare Mock would hand out a truthy contact_open.
-        mock_self.contact_open = False
 
         snapshot = make_snapshot(
             hvac_mode=CoreHvacMode.OFF, target_cooltemp=24.0, tolerance=0.5
@@ -117,7 +124,7 @@ class TestControlCooler:
         mock_hass.services.async_call = AsyncMock()
         mock_hass.states.get.return_value = _mock_cooler_state(HVACMode.OFF)
 
-        mock_self = Mock()
+        mock_self = _mock_bt()
         mock_self.hass = mock_hass
         mock_self.real_trvs = {}
         mock_self.clock = FakeClock()
@@ -126,8 +133,6 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
-        # A bare Mock would hand out a truthy contact_open.
-        mock_self.contact_open = False
         mock_self.cur_temp = 25.0
         mock_self.bt_target_cooltemp = 24.0
         mock_self.bt_target_temp = 20.0
@@ -162,7 +167,7 @@ class TestControlCooler:
         mock_hass.services.async_call = AsyncMock()
         mock_hass.states.get.return_value = _mock_cooler_state()
 
-        mock_self = Mock()
+        mock_self = _mock_bt()
         mock_self.hass = mock_hass
         mock_self.real_trvs = {}
         mock_self.clock = FakeClock()
@@ -171,8 +176,6 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
-        # A bare Mock would hand out a truthy contact_open.
-        mock_self.contact_open = False
         mock_self.cur_temp = 20.0  # Equal to bt_target_temp
         mock_self.bt_target_cooltemp = 24.0
         mock_self.bt_target_temp = 20.0
@@ -194,7 +197,7 @@ class TestControlCooler:
         mock_hass.services.async_call = AsyncMock()
         mock_hass.states.get.return_value = _mock_cooler_state()
 
-        mock_self = Mock()
+        mock_self = _mock_bt()
         mock_self.hass = mock_hass
         mock_self.real_trvs = {}
         mock_self.clock = FakeClock()
@@ -203,8 +206,6 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
-        # A bare Mock would hand out a truthy contact_open.
-        mock_self.contact_open = False
         mock_self.cur_temp = 23.0  # Below target_cooltemp - tolerance
         mock_self.bt_target_cooltemp = 24.0
         mock_self.bt_target_temp = 20.0
@@ -234,7 +235,7 @@ class TestControlCooler:
         mock_hass.services.async_call = AsyncMock()
         mock_hass.states.get.return_value = _mock_cooler_state(HVACMode.OFF)
 
-        mock_self = Mock()
+        mock_self = _mock_bt()
         mock_self.hass = mock_hass
         mock_self.real_trvs = {}
         mock_self.clock = FakeClock()
@@ -243,8 +244,6 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
-        # A bare Mock would hand out a truthy contact_open.
-        mock_self.contact_open = False
         mock_self.bt_target_cooltemp = 24.0
         mock_self.bt_target_temp = 20.0
         mock_self.tolerance = 0.5
@@ -270,7 +269,7 @@ class TestControlCooler:
         mock_context = Mock()
         mock_context.id = "test_context_id"
 
-        mock_self = Mock()
+        mock_self = _mock_bt()
         mock_self.hass = mock_hass
         mock_self.real_trvs = {}
         mock_self.clock = FakeClock()
@@ -294,7 +293,7 @@ class TestControlCooler:
         mock_hass.services.async_call = AsyncMock()
         mock_hass.states.get.return_value = _mock_cooler_state()
 
-        mock_self = Mock()
+        mock_self = _mock_bt()
         mock_self.hass = mock_hass
         mock_self.real_trvs = {}
         mock_self.clock = FakeClock()
@@ -303,8 +302,6 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
-        # A bare Mock would hand out a truthy contact_open.
-        mock_self.contact_open = False
         mock_self.cur_temp = 25.0
         mock_self.bt_target_cooltemp = 24.0
         mock_self.bt_target_temp = 20.0
@@ -329,7 +326,7 @@ class TestControlCooler:
         mock_hass.services.async_call = AsyncMock()
         mock_hass.states.get.return_value = _mock_cooler_state(HVACMode.OFF)
 
-        mock_self = Mock()
+        mock_self = _mock_bt()
         mock_self.hass = mock_hass
         mock_self.real_trvs = {}
         mock_self.clock = FakeClock()
@@ -338,8 +335,6 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
-        # A bare Mock would hand out a truthy contact_open.
-        mock_self.contact_open = False
         mock_self.bt_target_cooltemp = 24.0
         mock_self.bt_target_temp = 20.0
         mock_self.tolerance = 0.5
@@ -406,7 +401,7 @@ def _make_cooler_setup(
     )
     mock_hass.states.get.return_value = mock_cooler_state
 
-    mock_self = Mock()
+    mock_self = _mock_bt()
     mock_self.hass = mock_hass
     mock_self.real_trvs = {}
     mock_self.clock = FakeClock()
@@ -415,8 +410,6 @@ def _make_cooler_setup(
     mock_self.bt_hvac_mode = HVACMode.COOL
     mock_self.cooler_entity_id = "climate.cooler"
     mock_self.context = None
-    # A bare Mock would hand out a truthy contact_open.
-    mock_self.contact_open = False
     mock_self.cur_temp = cur_temp
     mock_self.bt_target_cooltemp = target_cooltemp
     mock_self.bt_target_temp = target_temp

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -1030,6 +1030,57 @@ class TestControlCoolerContactSuppression:
         modes = _service_calls(mock_hass, "set_hvac_mode")
         assert [c.args[2]["hvac_mode"] for c in modes] == [HVACMode.COOL]
 
+    @pytest.mark.asyncio
+    async def test_open_contact_writes_no_setpoint(self):
+        """A suppressed cooler receives no setpoint, so a dial turn survives."""
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.COOL, cooler_temp_attr=28.0, target_cooltemp=25.0
+        )
+        mock_self.contact_open = True
+
+        await control_cooler(mock_self)
+
+        assert _service_calls(mock_hass, "set_temperature") == []
+
+    @pytest.mark.asyncio
+    async def test_closed_contact_resumes_the_setpoint_write(self):
+        """The temperature channel comes back on the cycle the contact shuts."""
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.COOL, cooler_temp_attr=28.0, target_cooltemp=25.0
+        )
+        mock_self.contact_open = True
+        await control_cooler(mock_self)
+        assert _service_calls(mock_hass, "set_temperature") == []
+
+        mock_self.contact_open = False
+        await control_cooler(mock_self)
+
+        temps = _service_calls(mock_hass, "set_temperature")
+        assert [c.args[2]["temperature"] for c in temps] == [25.0]
+
+    @pytest.mark.asyncio
+    async def test_a_held_contact_commands_off_once_over_several_cycles(self):
+        """A whole airing is one command, not a write per cycle.
+
+        The clock passes the resend interval between cycles, so the quiet
+        that follows the first command is the suppression's doing and not
+        the throttle's.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.COOL, cooler_temp_attr=28.0, target_cooltemp=25.0
+        )
+        mock_self.contact_open = True
+
+        for _ in range(4):
+            await control_cooler(mock_self)
+            # The unit answers the command the way a real one would.
+            cooler_state.state = HVACMode.OFF
+            mock_self.clock.advance(COOLER_RESEND_INTERVAL_S + 1.0)
+
+        modes = _service_calls(mock_hass, "set_hvac_mode")
+        assert [c.args[2]["hvac_mode"] for c in modes] == [HVACMode.OFF]
+        assert _service_calls(mock_hass, "set_temperature") == []
+
 
 class TestControlCoolerModeHysteresis:
     """The COOL/OFF decision spans a band rather than a single threshold."""

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -59,6 +59,8 @@ class TestControlCooler:
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.bt_target_cooltemp = 24.0
         mock_self.context = None
+        # A bare Mock would hand out a truthy contact_open.
+        mock_self.contact_open = False
 
         await control_cooler(mock_self)
 
@@ -91,6 +93,8 @@ class TestControlCooler:
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.tolerance = 0.5
         mock_self.context = None
+        # A bare Mock would hand out a truthy contact_open.
+        mock_self.contact_open = False
 
         snapshot = make_snapshot(
             hvac_mode=CoreHvacMode.OFF, target_cooltemp=24.0, tolerance=0.5
@@ -122,6 +126,8 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
+        # A bare Mock would hand out a truthy contact_open.
+        mock_self.contact_open = False
         mock_self.cur_temp = 25.0
         mock_self.bt_target_cooltemp = 24.0
         mock_self.bt_target_temp = 20.0
@@ -165,6 +171,8 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
+        # A bare Mock would hand out a truthy contact_open.
+        mock_self.contact_open = False
         mock_self.cur_temp = 20.0  # Equal to bt_target_temp
         mock_self.bt_target_cooltemp = 24.0
         mock_self.bt_target_temp = 20.0
@@ -195,6 +203,8 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
+        # A bare Mock would hand out a truthy contact_open.
+        mock_self.contact_open = False
         mock_self.cur_temp = 23.0  # Below target_cooltemp - tolerance
         mock_self.bt_target_cooltemp = 24.0
         mock_self.bt_target_temp = 20.0
@@ -233,6 +243,8 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
+        # A bare Mock would hand out a truthy contact_open.
+        mock_self.contact_open = False
         mock_self.bt_target_cooltemp = 24.0
         mock_self.bt_target_temp = 20.0
         mock_self.tolerance = 0.5
@@ -291,6 +303,8 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
+        # A bare Mock would hand out a truthy contact_open.
+        mock_self.contact_open = False
         mock_self.cur_temp = 25.0
         mock_self.bt_target_cooltemp = 24.0
         mock_self.bt_target_temp = 20.0
@@ -324,6 +338,8 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
+        # A bare Mock would hand out a truthy contact_open.
+        mock_self.contact_open = False
         mock_self.bt_target_cooltemp = 24.0
         mock_self.bt_target_temp = 20.0
         mock_self.tolerance = 0.5
@@ -399,6 +415,8 @@ def _make_cooler_setup(
     mock_self.bt_hvac_mode = HVACMode.COOL
     mock_self.cooler_entity_id = "climate.cooler"
     mock_self.context = None
+    # A bare Mock would hand out a truthy contact_open.
+    mock_self.contact_open = False
     mock_self.cur_temp = cur_temp
     mock_self.bt_target_cooltemp = target_cooltemp
     mock_self.bt_target_temp = target_temp
@@ -983,6 +1001,41 @@ class TestControlCoolerSendCache:
 
         with pytest.raises(asyncio.CancelledError):
             await control_cooler(mock_self)
+
+
+class TestControlCoolerContactSuppression:
+    """An open window or door suppresses the cooler as it does the TRVs."""
+
+    @pytest.mark.asyncio
+    async def test_open_contact_turns_a_running_cooler_off(self):
+        """A room that cannot reach its target must not keep the unit running."""
+        mock_self, mock_hass, _ = _make_cooler_setup(cooler_state=HVACMode.COOL)
+        mock_self.contact_open = True
+
+        await control_cooler(mock_self)
+
+        modes = _service_calls(mock_hass, "set_hvac_mode")
+        assert [c.args[2]["hvac_mode"] for c in modes] == [HVACMode.OFF]
+
+    @pytest.mark.asyncio
+    async def test_open_contact_does_not_start_the_cooler(self):
+        """The suppression holds for a unit that is already off."""
+        mock_self, mock_hass, _ = _make_cooler_setup(cooler_state=HVACMode.OFF)
+        mock_self.contact_open = True
+
+        await control_cooler(mock_self)
+
+        assert _service_calls(mock_hass, "set_hvac_mode") == []
+
+    @pytest.mark.asyncio
+    async def test_closed_contact_still_cools(self):
+        """The gate must not swallow the normal demand."""
+        mock_self, mock_hass, _ = _make_cooler_setup(cooler_state=HVACMode.OFF)
+
+        await control_cooler(mock_self)
+
+        modes = _service_calls(mock_hass, "set_hvac_mode")
+        assert [c.args[2]["hvac_mode"] for c in modes] == [HVACMode.COOL]
 
 
 class TestControlCoolerModeHysteresis:

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -1077,6 +1077,74 @@ class TestControlCoolerTargetRange:
         assert self._set_temperature_payload(mock_hass) is None
 
     @pytest.mark.asyncio
+    async def test_quantizing_range_cooler_is_written_as_rarely_as_a_single_one(self):
+        """The lower bound carries the same quantization latch as the setpoint.
+
+        A cooler that snaps what it receives onto its own grid reports no
+        step to derive a tolerance from, so its bound never matches the
+        written one exactly. Without a latch on the bound the whole payload
+        goes out on every resend interval for as long as the cooler is
+        configured, while a single-setpoint cooler quantizing by the same
+        amount is written once.
+        """
+        quantization = 0.3
+        resend_intervals = 20
+
+        async def _writes(cooler_attributes):
+            mock_self, mock_hass, _ = _make_cooler_setup(
+                cooler_attributes=cooler_attributes,
+                target_cooltemp=24.0,
+                target_temp=20.0,
+            )
+            for _ in range(resend_intervals):
+                await control_cooler(mock_self)
+                mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+            return len(_service_calls(mock_hass, "set_temperature"))
+
+        single_setpoint = await _writes({"temperature": 24.0 - quantization})
+        target_range = await _writes(
+            _range_attributes(
+                target_temp_high=24.0 - quantization,
+                target_temp_low=20.0 - quantization,
+            )
+        )
+
+        assert single_setpoint == 1
+        assert target_range == single_setpoint
+
+    @pytest.mark.asyncio
+    async def test_settled_lower_bound_does_not_swallow_a_moved_heating_target(self):
+        """The latch answers for the bound BT wrote, not for a new one.
+
+        A heating target the user moved makes the bound a new command, so it
+        reaches the cooler on the next cycle regardless of what the device
+        settled at.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_attributes=_range_attributes(
+                target_temp_high=23.7, target_temp_low=19.7
+            ),
+            target_cooltemp=24.0,
+            target_temp=20.0,
+        )
+
+        await control_cooler(mock_self)
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+        mock_self.bt_target_temp = 21.0
+        await control_cooler(mock_self)
+
+        temp_calls = _service_calls(mock_hass, "set_temperature")
+        assert len(temp_calls) == 2
+        assert temp_calls[1].args[2] == {
+            "entity_id": "climate.cooler",
+            "target_temp_high": 24.0,
+            "target_temp_low": 21.0,
+        }
+
+    @pytest.mark.asyncio
     async def test_drifted_lower_bound_outlives_quantization_acceptance(self):
         """A settled upper bound does not vouch for the lower one.
 

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -921,7 +921,74 @@ class TestControlCoolerModeHysteresis:
         assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
 
     @pytest.mark.asyncio
-    async def test_the_band_follows_the_commanded_mode_not_the_reported_one(self):
+    async def test_the_band_does_not_delay_the_switch_on(self):
+        """The band widens the COOL state, it does not narrow the way into it.
+
+        A band applied in both directions would hold the cooler off until the
+        room had climbed a further band width past the switch-on point, which
+        is not the deadband the tolerance asks for.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        # Well below the band, so the decision the band reads is OFF.
+        mock_self.cur_temp = self.SWITCH_ON_AT - 1.0
+        await control_cooler(mock_self)
+        assert _service_calls(mock_hass, "set_hvac_mode") == []
+
+        # Exactly on the switch-on point.
+        mock_self.cur_temp = self.SWITCH_ON_AT
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 1
+        assert mode_calls[0].args[2]["hvac_mode"] == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_an_alternating_decision_is_not_written_every_cycle(self):
+        """A cooler in a mode BT never commands must not defeat the band.
+
+        ``dry`` is neither COOL nor OFF, so the device differs from whatever
+        BT decides and every cycle wants to write. A band that read the last
+        successful send would never move on a device that accepts nothing:
+        the room resting on the switch-on point would flip the decision every
+        cycle, and each flip would reach the retry gate as a new command
+        rather than as a retry.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state="dry", cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        attempts: list[float] = []
+
+        async def always_fail(domain, service, data, **kwargs):
+            if service == "set_hvac_mode":
+                attempts.append(mock_self.clock.monotonic_value)
+            raise ConnectionError("cloud rate limit reached")
+
+        mock_hass.services.async_call = AsyncMock(side_effect=always_fail)
+
+        cycles = 0
+        elapsed = 0.0
+        while elapsed < 3600.0:
+            mock_self.clock.monotonic_value = elapsed
+            mock_self.cur_temp = self.SWITCH_ON_AT + (
+                0.005 if cycles % 2 == 0 else -0.005
+            )
+            await control_cooler(mock_self)
+            elapsed += 5.0
+            cycles += 1
+
+        assert cycles == 720
+        # Paced by the failure backoff instead of by the control-cycle rate.
+        assert len(attempts) < 10
+        gaps = [b - a for a, b in zip(attempts, attempts[1:], strict=False)]
+        assert min(gaps) >= COOLER_FAILURE_BACKOFF_BASE_S
+
+    @pytest.mark.asyncio
+    async def test_the_band_follows_the_decided_mode_not_the_reported_one(self):
         """An externally switched-off cooler is put back into the band's state.
 
         The device's reported mode lags a command and can be changed from

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -12,6 +12,7 @@ from custom_components.better_thermostat.core.clock import FakeClock
 from custom_components.better_thermostat.core.snapshot import HvacMode as CoreHvacMode
 from custom_components.better_thermostat.utils.controlling import (
     COOLER_FAILURE_BACKOFF_BASE_S,
+    COOLER_FAILURE_BACKOFF_MAX_RUN,
     COOLER_FAILURE_BACKOFF_MAX_S,
     COOLER_RESEND_INTERVAL_S,
     control_cooler,
@@ -760,8 +761,14 @@ class TestControlCoolerSendCache:
         assert mode_calls[0].args[2]["hvac_mode"] == HVACMode.OFF
 
     @pytest.mark.asyncio
-    async def test_a_changed_target_bypasses_the_failure_backoff(self):
-        """A new setpoint is a new command, not a retry, and goes out at once."""
+    async def test_a_changed_target_only_waits_the_backoff_base(self):
+        """A new setpoint is a new command and skips the run's grown wait.
+
+        It does not skip the base, though: a channel whose last attempt was
+        rejected keeps its floor whatever the payload says, so a desired
+        value alternating between two rejected commands cannot buy itself a
+        write on every cycle.
+        """
         mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
 
         mock_hass.services.async_call = AsyncMock(
@@ -771,13 +778,71 @@ class TestControlCoolerSendCache:
             mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
             await control_cooler(mock_self)
 
+        # A run of four: the same setpoint would now wait eight bases.
         mock_hass.services.async_call = AsyncMock()
         mock_self.bt_target_cooltemp = 23.0
+        await control_cooler(mock_self)
+        assert _service_calls(mock_hass, "set_temperature") == []
+
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
         await control_cooler(mock_self)
 
         temp_calls = _service_calls(mock_hass, "set_temperature")
         assert len(temp_calls) == 1
         assert temp_calls[0].args[2]["temperature"] == 23.0
+
+    @pytest.mark.asyncio
+    async def test_a_different_rejected_command_starts_its_own_run(self):
+        """The counter counts the run the gate prices.
+
+        A command replacing the rejected one resets the run: the gate prices
+        the retry of that command as the first of a run, so a counter that
+        kept adding to the run before it would describe something else.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+        mock_hass.services.async_call = AsyncMock(
+            side_effect=HomeAssistantError("device rejected the command")
+        )
+
+        for _ in range(4):
+            mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+            await control_cooler(mock_self)
+
+        # A different setpoint is rejected once: a run of one, not of five.
+        mock_self.bt_target_cooltemp = 23.0
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
+        await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
+        await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_long_run_of_failures_cannot_overflow_the_backoff(self):
+        """The run stops counting before the exponent leaves float range.
+
+        The control queue swallows whatever control_cooler raises, so an
+        arithmetic error here would take cooler control out until the next
+        reload — and a device that rejects every write reaches the exponent
+        that overflows in about three weeks.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+        mock_hass.services.async_call = AsyncMock(
+            side_effect=HomeAssistantError("device rejected the command")
+        )
+
+        attempts = 1100
+        for _ in range(attempts):
+            mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+            await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_temperature")) == attempts
+        assert (
+            mock_self._cooler_last_sent["temperature_failed"][0]
+            == COOLER_FAILURE_BACKOFF_MAX_RUN
+        )
 
     @pytest.mark.asyncio
     async def test_a_successful_send_clears_the_failure_backoff(self):

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -11,6 +11,7 @@ import pytest
 from custom_components.better_thermostat.core.clock import FakeClock
 from custom_components.better_thermostat.core.snapshot import HvacMode as CoreHvacMode
 from custom_components.better_thermostat.utils.controlling import (
+    COOLER_FAILURE_BACKOFF_BASE_S,
     COOLER_FAILURE_BACKOFF_MAX_S,
     COOLER_RESEND_INTERVAL_S,
     control_cooler,
@@ -621,7 +622,7 @@ class TestControlCoolerSendCache:
         """A failed command leaves the cache empty and is retried once paced.
 
         The retry follows the failure backoff rather than the resend
-        throttle, so it goes out one resend interval later.
+        throttle, so it goes out one backoff base later.
         """
         mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
 
@@ -633,7 +634,11 @@ class TestControlCoolerSendCache:
         assert last_sent_cooler_temperature(mock_self) is None
 
         mock_hass.services.async_call = AsyncMock()
-        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S / 2
+        await control_cooler(mock_self)
+        assert _service_calls(mock_hass, "set_temperature") == []
+
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S / 2
         await control_cooler(mock_self)
 
         assert len(_service_calls(mock_hass, "set_temperature")) == 1
@@ -702,37 +707,57 @@ class TestControlCoolerSendCache:
 
         mock_hass.services.async_call = AsyncMock(side_effect=accept_once_then_fail)
 
+        # Two hours: long enough for the backoff to reach its ceiling and hold
+        # there for a full wait, so the ceiling is measured rather than assumed.
         elapsed = 0.0
-        while elapsed < 3600.0:
+        while elapsed < 7200.0:
             mock_self.clock.monotonic_value = elapsed
             await control_cooler(mock_self)
             elapsed += 5.0
 
-        # 720 cycles in the hour; the cooler never applies anything, so every
-        # one of them would otherwise carry both commands.
+        # 1440 cycles in the two hours. The resend throttle alone would pace
+        # the first of them and nothing after that: its timestamp advances on
+        # a successful send only, so once the device starts rejecting it stops
+        # moving and every later cycle finds the window open — 1428 calls per
+        # channel, measured with the backoff disabled.
         for service, stamps in attempts.items():
-            assert len(stamps) <= 20, service
+            assert len(stamps) <= 12, service
             gaps = [b - a for a, b in zip(stamps, stamps[1:], strict=False)]
-            assert min(gaps) >= COOLER_RESEND_INTERVAL_S, service
-            assert max(gaps) <= COOLER_FAILURE_BACKOFF_MAX_S, service
-            # The spacing grows rather than staying at the resend interval.
+            assert min(gaps) >= COOLER_FAILURE_BACKOFF_BASE_S, service
+            # The run is long enough to be pinned at the ceiling.
+            assert max(gaps) == COOLER_FAILURE_BACKOFF_MAX_S, service
+            # The spacing grows rather than staying at the base.
             assert gaps[-1] > gaps[0], service
 
     @pytest.mark.asyncio
-    async def test_a_single_failure_still_retries_within_the_resend_interval(self):
-        """One rejection must not push the retry beyond the normal pacing."""
-        mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+    async def test_one_transient_failure_does_not_defer_the_cooler_off(self):
+        """A hiccup on the way to OFF is retried well inside a resend interval.
+
+        The resend interval respects the compressor's protection window, and
+        a rejected command never reached the compressor: the backoff paces
+        the retry only so a rate-limited endpoint is not hammered, which is a
+        much shorter wait.
+        """
+        assert COOLER_FAILURE_BACKOFF_BASE_S < COOLER_RESEND_INTERVAL_S
+
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.COOL, cooler_temp_attr=24.0, cur_temp=20.0
+        )
+        mock_self.bt_hvac_mode = HVACMode.OFF
 
         mock_hass.services.async_call = AsyncMock(
             side_effect=HomeAssistantError("device rejected the command")
         )
         await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
 
         mock_hass.services.async_call = AsyncMock()
-        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
         await control_cooler(mock_self)
 
-        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 1
+        assert mode_calls[0].args[2]["hvac_mode"] == HVACMode.OFF
 
     @pytest.mark.asyncio
     async def test_a_changed_target_bypasses_the_failure_backoff(self):
@@ -790,21 +815,22 @@ class TestControlCoolerSendCache:
 
         mock_hass.services.async_call = AsyncMock(side_effect=fail_mode)
 
-        # Long enough for the backoff to double several times from the resend
-        # interval, and stepped far finer than the shortest wait.
-        window = COOLER_RESEND_INTERVAL_S * 8
-        step = COOLER_RESEND_INTERVAL_S / 10
+        # Long enough for the backoff to double several times from its base,
+        # and stepped far finer than the shortest wait.
+        window = COOLER_FAILURE_BACKOFF_BASE_S * 64
+        step = COOLER_FAILURE_BACKOFF_BASE_S / 5
         elapsed = 0.0
         while elapsed < window:
             mock_self.clock.monotonic_value = elapsed
             await control_cooler(mock_self)
             elapsed += step
 
-        # Without the backoff every one of those cycles would carry a command.
-        assert 1 < len(attempts) < window / COOLER_RESEND_INTERVAL_S
+        # The mode channel never gets a command through, so the resend
+        # throttle never starts: without the backoff every one of those
+        # cycles would carry a command.
+        assert 1 < len(attempts) < window / COOLER_FAILURE_BACKOFF_BASE_S
         gaps = [b - a for a, b in zip(attempts, attempts[1:], strict=False)]
-        assert min(gaps) >= COOLER_RESEND_INTERVAL_S
-        assert max(gaps) <= COOLER_FAILURE_BACKOFF_MAX_S
+        assert min(gaps) >= COOLER_FAILURE_BACKOFF_BASE_S
         assert gaps[-1] > gaps[0]
 
     @pytest.mark.asyncio

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -11,8 +11,10 @@ import pytest
 from custom_components.better_thermostat.core.clock import FakeClock
 from custom_components.better_thermostat.core.snapshot import HvacMode as CoreHvacMode
 from custom_components.better_thermostat.utils.controlling import (
+    COOLER_FAILURE_BACKOFF_MAX_S,
     COOLER_RESEND_INTERVAL_S,
     control_cooler,
+    last_sent_cooler_temperature,
 )
 from tests.factories import make_snapshot
 
@@ -616,7 +618,11 @@ class TestControlCoolerSendCache:
 
     @pytest.mark.asyncio
     async def test_failed_send_does_not_prime_the_send_cache(self):
-        """A failed command is retried on the next cycle despite the throttle."""
+        """A failed command leaves the cache empty and is retried once paced.
+
+        The retry follows the failure backoff rather than the resend
+        throttle, so it goes out one resend interval later.
+        """
         mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
 
         mock_hass.services.async_call = AsyncMock(
@@ -624,10 +630,14 @@ class TestControlCoolerSendCache:
         )
         await control_cooler(mock_self)
 
+        assert last_sent_cooler_temperature(mock_self) is None
+
         mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
         await control_cooler(mock_self)
 
         assert len(_service_calls(mock_hass, "set_temperature")) == 1
+        assert last_sent_cooler_temperature(mock_self) == 24.0
 
     @pytest.mark.asyncio
     async def test_connection_error_on_set_temperature_still_attempts_hvac_mode(self):
@@ -668,6 +678,123 @@ class TestControlCoolerSendCache:
         await control_cooler(mock_self)
 
         assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+    @pytest.mark.asyncio
+    async def test_run_of_failures_is_paced_by_an_exponential_backoff(self):
+        """A device rejecting every write is retried ever more slowly.
+
+        A rejected command primes no send timestamp, so the resend throttle
+        cannot pace it. Without a backoff of its own the retry would go out
+        on every control cycle — hammering exactly the cloud device whose
+        rate limit caused the rejection in the first place.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=20.0
+        )
+        accepted = set()
+        attempts: dict[str, list[float]] = {"set_temperature": [], "set_hvac_mode": []}
+
+        async def accept_once_then_fail(domain, service, data, **kwargs):
+            attempts[service].append(mock_self.clock.monotonic_value)
+            if service in accepted:
+                raise ConnectionError("cloud rate limit reached")
+            accepted.add(service)
+
+        mock_hass.services.async_call = AsyncMock(side_effect=accept_once_then_fail)
+
+        elapsed = 0.0
+        while elapsed < 3600.0:
+            mock_self.clock.monotonic_value = elapsed
+            await control_cooler(mock_self)
+            elapsed += 5.0
+
+        # 720 cycles in the hour; the cooler never applies anything, so every
+        # one of them would otherwise carry both commands.
+        for service, stamps in attempts.items():
+            assert len(stamps) <= 20, service
+            gaps = [b - a for a, b in zip(stamps, stamps[1:], strict=False)]
+            assert min(gaps) >= COOLER_RESEND_INTERVAL_S, service
+            assert max(gaps) <= COOLER_FAILURE_BACKOFF_MAX_S, service
+            # The spacing grows rather than staying at the resend interval.
+            assert gaps[-1] > gaps[0], service
+
+    @pytest.mark.asyncio
+    async def test_a_single_failure_still_retries_within_the_resend_interval(self):
+        """One rejection must not push the retry beyond the normal pacing."""
+        mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+
+        mock_hass.services.async_call = AsyncMock(
+            side_effect=HomeAssistantError("device rejected the command")
+        )
+        await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_changed_target_bypasses_the_failure_backoff(self):
+        """A new setpoint is a new command, not a retry, and goes out at once."""
+        mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+
+        mock_hass.services.async_call = AsyncMock(
+            side_effect=HomeAssistantError("device rejected the command")
+        )
+        for _ in range(4):
+            mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+            await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.bt_target_cooltemp = 23.0
+        await control_cooler(mock_self)
+
+        temp_calls = _service_calls(mock_hass, "set_temperature")
+        assert len(temp_calls) == 1
+        assert temp_calls[0].args[2]["temperature"] == 23.0
+
+    @pytest.mark.asyncio
+    async def test_a_successful_send_clears_the_failure_backoff(self):
+        """Recovery restores the plain resend pacing on the next cycle."""
+        mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+
+        mock_hass.services.async_call = AsyncMock(
+            side_effect=HomeAssistantError("device rejected the command")
+        )
+        for _ in range(4):
+            mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+            await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+        await control_cooler(mock_self)
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_temperature")) == 2
+
+    @pytest.mark.asyncio
+    async def test_failed_mode_command_is_paced_by_its_own_backoff(self):
+        """The mode channel carries the same backoff as the temperature one."""
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0
+        )
+
+        async def fail_mode(domain, service, data, **kwargs):
+            if service == "set_hvac_mode":
+                raise ConnectionError("cloud rate limit reached")
+
+        mock_hass.services.async_call = AsyncMock(side_effect=fail_mode)
+
+        elapsed = 0.0
+        while elapsed < 300.0:
+            mock_self.clock.monotonic_value = elapsed
+            await control_cooler(mock_self)
+            elapsed += 5.0
+
+        # Attempts at 0, 30, 90, 210 within the first 300 s.
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 4
 
     @pytest.mark.asyncio
     async def test_cancellation_during_service_call_propagates(self):

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -719,7 +719,7 @@ class TestControlCoolerSendCache:
         # 1440 cycles in the two hours. The resend throttle alone would pace
         # the first of them and nothing after that: its timestamp advances on
         # a successful send only, so once the device starts rejecting it stops
-        # moving and every later cycle finds the window open — 1428 calls per
+        # moving and every later cycle finds the window open — 1393 calls per
         # channel, measured with the backoff disabled.
         for service, stamps in attempts.items():
             assert len(stamps) <= 12, service
@@ -845,9 +845,81 @@ class TestControlCoolerSendCache:
         )
 
     @pytest.mark.asyncio
-    async def test_a_successful_send_clears_the_failure_backoff(self):
-        """Recovery restores the plain resend pacing on the next cycle."""
+    async def test_a_successful_temperature_send_clears_the_failure_run(self):
+        """Recovery makes the next failure the first of a new run.
+
+        A run that survived recovery would price the retry after the next
+        single failure at the wait the old run had grown to, so the fresh run
+        has to be measured while it is still short.
+        """
         mock_self, mock_hass, _ = _make_cooler_setup(cooler_temp_attr=20.0)
+
+        _fail = AsyncMock(side_effect=HomeAssistantError("device rejected the command"))
+        mock_hass.services.async_call = _fail
+        for _ in range(4):
+            mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+            await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+        # One rejection after the recovery: a run of one, so the retry waits
+        # a single base rather than the eight the cleared run had reached.
+        mock_hass.services.async_call = _fail
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
+        await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_successful_mode_send_clears_the_failure_run(self):
+        """The mode channel clears its run the same way the temperature does."""
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0
+        )
+
+        _fail = AsyncMock(side_effect=HomeAssistantError("device rejected the command"))
+        mock_hass.services.async_call = _fail
+        for _ in range(4):
+            mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+            await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+        mock_hass.services.async_call = _fail
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        mock_hass.services.async_call = AsyncMock()
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
+        await control_cooler(mock_self)
+
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+    @pytest.mark.asyncio
+    async def test_the_backoff_keys_on_both_bounds_of_a_range_payload(self):
+        """A range write carries the heating target, so the key must too.
+
+        The payload the device rejected and the payload a moved heating
+        target produces differ in the lower bound alone; a key blind to it
+        would price the second as a retry of the first.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_attributes=_range_attributes(
+                target_temp_high=20.0, target_temp_low=19.0
+            ),
+            target_cooltemp=24.0,
+            target_temp=20.0,
+        )
 
         mock_hass.services.async_call = AsyncMock(
             side_effect=HomeAssistantError("device rejected the command")
@@ -856,13 +928,15 @@ class TestControlCoolerSendCache:
             mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
             await control_cooler(mock_self)
 
+        # A run of four on (24.0, 20.0): that payload would wait eight bases.
         mock_hass.services.async_call = AsyncMock()
-        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_MAX_S
-        await control_cooler(mock_self)
-        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        mock_self.bt_target_temp = 21.0
+        mock_self.clock.monotonic_value += COOLER_FAILURE_BACKOFF_BASE_S
         await control_cooler(mock_self)
 
-        assert len(_service_calls(mock_hass, "set_temperature")) == 2
+        temp_calls = _service_calls(mock_hass, "set_temperature")
+        assert len(temp_calls) == 1
+        assert temp_calls[0].args[2]["target_temp_low"] == 21.0
 
     @pytest.mark.asyncio
     async def test_failed_mode_command_is_paced_by_its_own_backoff(self):
@@ -891,9 +965,9 @@ class TestControlCoolerSendCache:
             elapsed += step
 
         # The mode channel never gets a command through, so the resend
-        # throttle never starts: without the backoff every one of those
-        # cycles would carry a command.
-        assert 1 < len(attempts) < window / COOLER_FAILURE_BACKOFF_BASE_S
+        # throttle never starts and every one of the 320 cycles would carry a
+        # command; the backoff brings that down to a handful.
+        assert 1 < len(attempts) < 10
         gaps = [b - a for a, b in zip(attempts, attempts[1:], strict=False)]
         assert min(gaps) >= COOLER_FAILURE_BACKOFF_BASE_S
         assert gaps[-1] > gaps[0]
@@ -1410,6 +1484,45 @@ class TestControlCoolerTargetRange:
             "entity_id": "climate.cooler",
             "target_temp_high": 24.0,
             "target_temp_low": 21.0,
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_settled_lower_bound_that_moves_is_written_again(self):
+        """The latch answers for the reading it was taken at, not forever.
+
+        A bound that leaves the reading the device settled on was moved by
+        something other than Better Thermostat, so it is a divergence the
+        latch has no answer for.
+        """
+        mock_self, mock_hass, mock_cooler_state = _make_cooler_setup(
+            cooler_attributes=_range_attributes(
+                target_temp_high=23.7, target_temp_low=19.7
+            ),
+            target_cooltemp=24.0,
+            target_temp=20.0,
+        )
+
+        await control_cooler(mock_self)
+        # The device answered both bounds on its own grid; the latch takes.
+        mock_self.clock.monotonic_value += 1.0
+        await control_cooler(mock_self)
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_temperature")) == 1
+
+        # The lower bound leaves the reading it settled on.
+        mock_cooler_state.attributes = _range_attributes(
+            target_temp_high=23.7, target_temp_low=18.0
+        )
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        temp_calls = _service_calls(mock_hass, "set_temperature")
+        assert len(temp_calls) == 2
+        assert temp_calls[1].args[2] == {
+            "entity_id": "climate.cooler",
+            "target_temp_high": 24.0,
+            "target_temp_low": 20.0,
         }
 
     @pytest.mark.asyncio

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -781,20 +781,31 @@ class TestControlCoolerSendCache:
             cooler_state=HVACMode.OFF, cooler_temp_attr=24.0
         )
 
+        attempts: list[float] = []
+
         async def fail_mode(domain, service, data, **kwargs):
             if service == "set_hvac_mode":
+                attempts.append(mock_self.clock.monotonic_value)
                 raise ConnectionError("cloud rate limit reached")
 
         mock_hass.services.async_call = AsyncMock(side_effect=fail_mode)
 
+        # Long enough for the backoff to double several times from the resend
+        # interval, and stepped far finer than the shortest wait.
+        window = COOLER_RESEND_INTERVAL_S * 8
+        step = COOLER_RESEND_INTERVAL_S / 10
         elapsed = 0.0
-        while elapsed < 300.0:
+        while elapsed < window:
             mock_self.clock.monotonic_value = elapsed
             await control_cooler(mock_self)
-            elapsed += 5.0
+            elapsed += step
 
-        # Attempts at 0, 30, 90, 210 within the first 300 s.
-        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 4
+        # Without the backoff every one of those cycles would carry a command.
+        assert 1 < len(attempts) < window / COOLER_RESEND_INTERVAL_S
+        gaps = [b - a for a, b in zip(attempts, attempts[1:], strict=False)]
+        assert min(gaps) >= COOLER_RESEND_INTERVAL_S
+        assert max(gaps) <= COOLER_FAILURE_BACKOFF_MAX_S
+        assert gaps[-1] > gaps[0]
 
     @pytest.mark.asyncio
     async def test_cancellation_during_service_call_propagates(self):

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -809,6 +809,105 @@ class TestControlCoolerSendCache:
             await control_cooler(mock_self)
 
 
+class TestControlCoolerModeHysteresis:
+    """The COOL/OFF decision spans a band rather than a single threshold."""
+
+    # target_cooltemp - tolerance for the values _make_cooler_setup uses.
+    SWITCH_ON_AT = 23.5
+
+    @staticmethod
+    def _make_compliant(mock_hass, cooler_state):
+        """Let the fake cooler apply whatever it is commanded."""
+
+        async def apply(domain, service, data, **kwargs):
+            if service == "set_hvac_mode":
+                cooler_state.state = data["hvac_mode"]
+            else:
+                cooler_state.attributes = {"temperature": data["temperature"]}
+
+        mock_hass.services.async_call = AsyncMock(side_effect=apply)
+
+    @pytest.mark.asyncio
+    async def test_room_temp_resting_on_the_threshold_is_not_written_every_cycle(self):
+        """A hundredth of a degree of sensor noise must not drive the cooler.
+
+        A changed desired mode bypasses the resend throttle by design, so a
+        single threshold turns every flip into a write — and a fully
+        compliant device gets commanded at the whole control-cycle rate.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        cycles = 0
+        elapsed = 0.0
+        while elapsed < 3600.0:
+            mock_self.clock.monotonic_value = elapsed
+            mock_self.cur_temp = self.SWITCH_ON_AT + (
+                0.005 if cycles % 2 == 0 else -0.005
+            )
+            await control_cooler(mock_self)
+            elapsed += 5.0
+            cycles += 1
+
+        assert cycles == 720
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+    @pytest.mark.asyncio
+    async def test_cooling_stops_once_the_room_leaves_the_band(self):
+        """The band delays the switch-off, it does not prevent it."""
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        await control_cooler(mock_self)
+        assert (
+            _service_calls(mock_hass, "set_hvac_mode")[-1].args[2]["hvac_mode"]
+            == HVACMode.COOL
+        )
+
+        # Just below the switch-on point but still inside the band.
+        mock_self.cur_temp = self.SWITCH_ON_AT - 0.1
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+        # Below the band.
+        mock_self.cur_temp = self.SWITCH_ON_AT - 0.25
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 2
+        assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_the_band_follows_the_commanded_mode_not_the_reported_one(self):
+        """An externally switched-off cooler is put back into the band's state.
+
+        The device's reported mode lags a command and can be changed from
+        outside Better Thermostat, so reading the band's state off it would
+        abandon cooling inside the band.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        await control_cooler(mock_self)
+
+        cooler_state.state = HVACMode.OFF
+        mock_self.cur_temp = self.SWITCH_ON_AT - 0.1
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 2
+        assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.COOL
+
+
 class TestControlCoolerTargetRange:
     """Payload selection for coolers that only accept a target range."""
 

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -41,6 +41,8 @@ def mock_bt():
     bt.startup_running = False
     bt.control_queue_task = MagicMock()
     bt.context = MagicMock()  # unique context so != event.context
+    # A bare MagicMock would hand out a truthy contact_open.
+    bt.contact_open = False
     bt.async_write_ha_state = MagicMock()
     bt._enforce_heat_below_cool = lambda: BetterThermostat._enforce_heat_below_cool(bt)
     return bt
@@ -460,6 +462,23 @@ class TestEdgeCases:
 # ---------------------------------------------------------------------------
 # 6. Echo suppression
 # ---------------------------------------------------------------------------
+
+
+class TestContactOpenAdoption:
+    """A setpoint arriving while a contact is open is not adopted."""
+
+    @pytest.mark.asyncio
+    async def test_open_contact_refuses_the_reported_setpoint(self, mock_bt):
+        """Mid-airing the suppression owns the mode, so the target must hold."""
+        mock_bt.contact_open = True
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 27.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        mock_bt.control_queue_task.put_nowait.assert_not_called()
 
 
 class TestEchoSuppression:

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -468,17 +468,34 @@ class TestContactOpenAdoption:
     """A setpoint arriving while a contact is open is not adopted."""
 
     @pytest.mark.asyncio
-    async def test_open_contact_refuses_the_reported_setpoint(self, mock_bt):
+    async def test_open_contact_refuses_the_reported_setpoint(self, mock_bt, caplog):
         """Mid-airing the suppression owns the mode, so the target must hold."""
         mock_bt.contact_open = True
         old_state = _make_state(attributes={"temperature": 25.0})
         new_state = _make_state(attributes={"temperature": 27.0})
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
 
+        caplog.set_level(logging.DEBUG)
         await trigger_cooler_change(mock_bt, event)
 
         assert mock_bt.bt_target_cooltemp == 25.0
         mock_bt.control_queue_task.put_nowait.assert_not_called()
+        # The handler reached the adoption decision and named the guard that
+        # refused, so the change was weighed rather than missed on the way in.
+        assert "setpoint change 25.0 -> 27.0 NOT adopted" in caplog.text
+        assert "contact_open=True" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_closed_contact_adopts_the_same_setpoint(self, mock_bt):
+        """The contact is the only thing holding that event back."""
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 27.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 27.0
+        mock_bt.control_queue_task.put_nowait.assert_called_once()
 
 
 class TestEchoSuppression:


### PR DESCRIPTION
> Stacked on #2160. Review that one first; this branch adds one commit on top.

## Motivation

An open window or door turns every TRV off. The cooler keeps running.

The suppression lives in exactly one place, `decide()` in `core/decide.py`, and `DesiredState` carries only `call_for_heat` and `trvs` — there is no cooler intent for the kernel to suppress. `control_queue` hands `control_cooler()` the *snapshot* and discards the *desired state*, so the cooler path bypasses the kernel decision entirely. `snapshot.window_open` does exist, but it is documented as observation for the flight recorder and `control_cooler()` never reads it.

Reproduced on one instance in a single cycle, room 25.0 °C, cooling target 24.0, heating target 20.0, tolerance 0.5:

```
everything closed:  TRV desired hvac_mode=heat setpoint=20.0 suppression=None
                    cooler: set_hvac_mode {hvac_mode: cool}

window OPEN:        TRV desired hvac_mode=off  setpoint=None suppression=window
                    cooler: set_hvac_mode {hvac_mode: cool}      <-- unchanged

door OPEN:          TRV desired hvac_mode=off  setpoint=None suppression=door
                    cooler: set_hvac_mode {hvac_mode: cool}      <-- unchanged
```

It is worse than passive. `_announce_window_change()` requests a control cycle, so **opening the window actively triggers the cycle that re-affirms COOL** — and the logbook records that heating was turned off because a window was opened, while the air conditioner keeps going.

`develop` has the same hole through a different mechanism (`handle_contact_open()` inside `control_trv`, which the cooler likewise never reaches), so this is not a `v2` regression — the rewrite carried a long-standing gap across. No test on either branch covered window plus cooler, which is why nothing caught it.

## Severity

With the window open the room cannot reach its target, so the unit runs at full duty for as long as the window stays open — 0.5 to 1.5 kW electrical for a split unit — with no cooling benefit and the compressor never cycling off. The heating half of exactly this failure mode was considered worth a debounced FSM region and a suppression tier. The cooling half was unhandled, and the logbook tells the user the opposite of what is happening.

## Changes

`control_cooler()` reads the combined verdict of the window and door regions, so it inherits their debounce for free and the kernel keeps ownership of the decision.

`events/cooler.py` refuses a reported setpoint while a contact is open, for the same reason the TRV handler does: a target installed mid-airing would only be overridden by the suppression anyway. That guard was the one item from the TRV adoption gate that transfers cleanly — the device-OFF guard deliberately does not, because Better Thermostat parks the cooler in OFF most of the time and requiring a non-OFF device would make it deaf to the remote exactly when a user reaches for it.

## The proper fix, not done here

Giving `DesiredState` a cooler intent and letting `decide()` emit it is the architecturally correct home for this and would close the whole class of bug rather than this one instance. That is a much larger change than the defect warrants and belongs on the roadmap.

## Tests

`4101 passed`, ruff and pyrefly clean. Four new tests; the two that pin the suppression itself were confirmed to fail with the production hunk removed.

Both cooler fixtures now pin `contact_open = False`. They build bare mocks, which hand out a truthy attribute for anything unset — without the pin 28 existing tests fail for the wrong reason.

## Found alongside, filed separately

While tracing this I checked a second suspicion — that adopting a setpoint from the air conditioner's own remote can switch the unit off entirely. It reproduces (room 25 °C, user sets 28 on the remote, Better Thermostat adopts 28 and commands OFF), but it is **not** a defect: a target above the room temperature is no demand, and `decide()` already establishes "no demand ⇒ device OFF" as the kernel rule. What is missing there is only the annunciation — the TRV OFF carries a `Suppression` reason into the attributes and the flight recorder, the cooler OFF carries nothing, so the user cannot see why the unit stopped.

Three genuine but separate items came out of the same trace and want their own issues: the cooling deadband uses `target - tolerance`, which errs toward *more* energy where the heating band deliberately errs toward less; `_enforce_heat_below_cool()` lets an air-conditioner remote press pull the radiators' setpoint down; and a restart while the cooler is unavailable can leave `bt_target_cooltemp` at `None` indefinitely, which makes `control_cooler()` default to OFF until the user touches a slider.
