### PR TITLE
fix(cooler): delay the cooling switch-on by the tolerance

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -750,11 +750,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.accum_dir = 0
         self.pending_temp = None
         self.pending_since = None
-        # Cooler send-cache (anti-spam for cloud-backed coolers)
+        # Cooler send-cache (anti-spam for cloud-backed coolers).
+        # last_cooler_mode_decided is not part of the send-cache: it latches the
+        # decision itself so the cooling tolerance band keeps its two edges even
+        # when a command never reaches the device.
         self.last_sent_cooler_temp: float | None = None
         self.last_sent_cooler_hvac_mode: str | None = None
         self.last_sent_cooler_temp_ts: float | None = None
         self.last_sent_cooler_hvac_mode_ts: float | None = None
+        self.last_cooler_mode_decided: str | None = None
 
     async def async_added_to_hass(self):
         """Run when entity about to be added.

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -39,8 +39,20 @@ from custom_components.better_thermostat.utils.helpers import (
     supports_single_target_temperature,
     supports_temperature_range,
 )
+from custom_components.better_thermostat.utils.hvac_action import (
+    should_cool_with_tolerance,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+# Minimum width of the cooling decision band. A tolerance narrower than this
+# leaves the room temperature resting on an edge, where it flips the decision —
+# and produces a write — on every control cycle; the missing width is taken
+# from below the cooling target to keep the switch-on edge where the tolerance
+# puts it. Two steps of a 0.1 °C room sensor, which is what the flip is made
+# of; and well under the 0.5 °C a cooling setpoint is set in, so the extra run
+# time the band costs is finer than the user can express in the target anyway.
+COOLER_MODE_HYSTERESIS_K = 0.2
 
 
 def _is_boost_heating_active(self) -> bool:
@@ -294,9 +306,13 @@ def _device_setpoint_tolerance(self, state) -> float:
 async def control_cooler(self):
     """Control the cooler entity based on current temperature and cooling setpoint.
 
-    Activates cooling when current temperature exceeds target cooling temperature
-    minus tolerance and is above heating target. Deactivates cooling when
-    temperature drops below cooling target minus tolerance or when BT HVAC mode is OFF.
+    Activates cooling when the current temperature reaches the cooling target plus
+    tolerance and is above the heating target, so a configured tolerance delays the
+    switch-on instead of running the room below the cooling target. Deactivates
+    cooling when the temperature falls back below the cooling target — or below the
+    cooling target minus the width ``COOLER_MODE_HYSTERESIS_K`` borrows from
+    underneath it whenever the tolerance is narrower than that minimum band — or
+    when BT HVAC mode is OFF.
     """
     # Get current cooler state to avoid sending redundant commands
     cooler_state = self.hass.states.get(self.cooler_entity_id)
@@ -371,13 +387,55 @@ async def control_cooler(self):
         desired_mode = HVACMode.OFF
     elif self.bt_hvac_mode == HVACMode.OFF:
         desired_mode = HVACMode.OFF
-    elif (
-        self.cur_temp >= self.bt_target_cooltemp - self.tolerance
-        and self.cur_temp > self.bt_target_temp
-    ):
-        desired_mode = HVACMode.COOL
     else:
-        desired_mode = HVACMode.OFF
+        # The tolerance delays the switch-on instead of advancing it: cooling
+        # starts only once the room reaches cool_target + tolerance and then
+        # runs down to cool_target, so the room settles at or above the cooling
+        # target rather than below it. A band narrower than
+        # COOLER_MODE_HYSTERESIS_K takes the missing width from below the
+        # target, because a room resting on an edge would otherwise flip the
+        # decision — and with it the write — on every cycle; the switch-on edge
+        # never moves for that guard, which buys decision stability and not a
+        # colder room. The heating target stays a hard floor: cooling below it
+        # would fight the TRVs.
+        #
+        # The latch carries the band, and it is unset only while BT has not
+        # decided a cooler mode of its own — the state a restart or a
+        # config-entry reload leaves behind. Seeding the hold edge from the
+        # cooler's own reported mode there keeps a unit that is already running
+        # inside the band running, instead of stopping it and letting the room
+        # warm all the way back up to the switch-on edge. As soon as the latch
+        # holds a decision it wins, because the reported mode lags a command by
+        # a state update and can be changed externally, either of which would
+        # drop the hold edge mid-band.
+        _previously_cooling = (
+            self.last_cooler_mode_decided == HVACMode.COOL
+            if self.last_cooler_mode_decided is not None
+            else current_hvac_mode == HVACMode.COOL
+        )
+        _cool_wanted = should_cool_with_tolerance(
+            self.cur_temp,
+            self.bt_target_cooltemp,
+            self.tolerance,
+            _previously_cooling,
+            min_band=COOLER_MODE_HYSTERESIS_K,
+        )
+        if _cool_wanted and self.cur_temp > self.bt_target_temp:
+            desired_mode = HVACMode.COOL
+        else:
+            desired_mode = HVACMode.OFF
+
+    # The band's state is the decision, not the send: last_sent_cooler_hvac_mode
+    # is written only after a successful service call, so a device that rejects
+    # every command would keep the hold edge unreachable and make the decision
+    # flap between the two commands the device is refusing. Recorded for every
+    # branch above, so a cycle that fell into a guard leaves the band where that
+    # guard put it instead of on a stale value. Each of those guards stops the
+    # cooler outright, so the run ends there and the way back in is the
+    # switch-on edge — the same contract the heating hysteresis in
+    # compute_hvac_action applies to its own guards, where a missing reading and
+    # a mode of OFF each return the band to IDLE.
+    self.last_cooler_mode_decided = desired_mode
 
     # Decide whether a temperature command is needed. When the current
     # temperature is unknown, only send if the desired value changed since the

--- a/custom_components/better_thermostat/utils/hvac_action.py
+++ b/custom_components/better_thermostat/utils/hvac_action.py
@@ -76,6 +76,28 @@ def should_heat_with_tolerance(
     return cur_temp < heat_on_threshold
 
 
+def should_cool_with_tolerance(
+    cur_temp: float,
+    cool_target: float,
+    tolerance: float,
+    previously_cooling: bool,
+    min_band: float = 0.0,
+) -> bool:
+    """Determine whether cooling should be active based on hysteresis.
+
+    Band: ``[cool_target, cool_target + tolerance]``
+    * Start cooling when ``cur_temp >= cool_target + tolerance``.
+    * Continue cooling (if already cooling) until ``cur_temp < cool_target``.
+    * A band narrower than ``min_band`` takes the missing width from below
+      ``cool_target``, so a room temperature resting on an edge cannot flip
+      the decision on every cycle. The switch-on edge never moves for it.
+    """
+    tolerance = max(0.0, tolerance)
+    if previously_cooling:
+        return cur_temp >= cool_target - max(0.0, min_band - tolerance)
+    return cur_temp >= cool_target + tolerance
+
+
 _VALVE_THRESH = 0.0
 
 

--- a/docs/Configuration/configuration.md
+++ b/docs/Configuration/configuration.md
@@ -50,7 +50,7 @@ group:
 
 **The outdoor temperature threshold** This is an optional field. If you have an outdoor sensor or a weather entity, you can set a threshold. If the outdoor temperature is higher than the threshold, the thermostat will be turned off. If the outdoor temperature is lower than the threshold, the thermostat will be turned on. If you don't have an outdoor sensor or a weather entity, this field will be ignored.
 
-**Tolerance** This is an optional field. It helps prevent the thermostat from turning on and off too often. Here is an example of how it works: If you set the target temperature to 20.0 and the tolerance to 0.3 for example. Then BT will heat to 20.0 and then go to idle until the temperature drops again to 19.7 and then it will heat again to 20.0.
+**Tolerance** This is an optional field. It helps prevent the thermostat from turning on and off too often. Here is an example of how it works: If you set the target temperature to 20.0 and the tolerance to 0.3 for example. Then BT will heat to 20.0 and then go to idle until the temperature drops again to 19.7 and then it will heat again to 20.0. If you configured a cooler, the tolerance delays the switch-on instead of advancing it: with a cooling target of 24.0 and a tolerance of 0.3, BT starts cooling once the temperature reaches 24.3 and keeps cooling until it is back below 24.0. The cooling band is never narrower than 0.2, so with a tolerance of 0.1 cooling still starts at 24.1, but it keeps running until the temperature is back below 23.9.
 
 ## Second step
 

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -9,7 +9,11 @@ from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
 import pytest
 
-from custom_components.better_thermostat.utils.controlling import control_cooler
+from custom_components.better_thermostat.climate import BetterThermostat
+from custom_components.better_thermostat.utils.controlling import (
+    COOLER_MODE_HYSTERESIS_K,
+    control_cooler,
+)
 
 
 def _make_mock_self(
@@ -24,6 +28,7 @@ def _make_mock_self(
     last_sent_cooler_hvac_mode=None,
     last_sent_cooler_temp_ts=None,
     last_sent_cooler_hvac_mode_ts=None,
+    last_cooler_mode_decided=None,
     min_cooler_resend_interval_s=0,
 ):
     """Build a minimal mock BetterThermostat instance for control_cooler tests."""
@@ -40,6 +45,9 @@ def _make_mock_self(
     mock_self.last_sent_cooler_hvac_mode = last_sent_cooler_hvac_mode
     mock_self.last_sent_cooler_temp_ts = last_sent_cooler_temp_ts
     mock_self.last_sent_cooler_hvac_mode_ts = last_sent_cooler_hvac_mode_ts
+    # A bare Mock() would never equal HVACMode.COOL, which silently sends every
+    # hold-edge case down the switch-on branch, so the latch is pinned explicitly.
+    mock_self.last_cooler_mode_decided = last_cooler_mode_decided
     mock_self.min_cooler_resend_interval_s = min_cooler_resend_interval_s
     return mock_self
 
@@ -83,7 +91,7 @@ class TestControlCooler:
 
     @pytest.mark.asyncio
     async def test_cooling_needed_above_target(self):
-        """Test cooling turns on when temp >= target_cooltemp - tolerance AND > bt_target_temp."""
+        """Test cooling turns on when temp >= target_cooltemp + tolerance AND > bt_target_temp."""
         mock_hass = Mock()
         mock_hass.services = Mock()
         mock_hass.services.async_call = AsyncMock()
@@ -117,7 +125,7 @@ class TestControlCooler:
     async def test_cooling_not_needed_when_temp_below_bt_target(self):
         """Test cooling doesn't turn on if cur_temp <= bt_target_temp.
 
-        The condition requires BOTH cur_temp >= target_cooltemp - tolerance
+        The condition requires BOTH cur_temp >= target_cooltemp + tolerance
         AND cur_temp > bt_target_temp. If cur_temp <= bt_target_temp, goes to else.
         """
         mock_hass = Mock()
@@ -142,7 +150,7 @@ class TestControlCooler:
 
     @pytest.mark.asyncio
     async def test_stop_cooling_below_threshold(self):
-        """Test cooling stops when temp <= target_cooltemp - tolerance."""
+        """Test cooling stops when temp < target_cooltemp."""
         mock_hass = Mock()
         mock_hass.services = Mock()
         mock_hass.services.async_call = AsyncMock()
@@ -151,9 +159,12 @@ class TestControlCooler:
             state=HVACMode.COOL, temperature=20.0
         )
 
-        # cur_temp (23.0) <= bt_target_cooltemp (24.0) - tolerance (0.5) = 23.5
+        # cur_temp (23.0) < bt_target_cooltemp (24.0), the hold edge
         mock_self = _make_mock_self(
-            mock_hass, bt_hvac_mode=HVACMode.COOL, cur_temp=23.0
+            mock_hass,
+            bt_hvac_mode=HVACMode.COOL,
+            cur_temp=23.0,
+            last_cooler_mode_decided=HVACMode.COOL,
         )
 
         await control_cooler(mock_self)
@@ -168,10 +179,10 @@ class TestControlCooler:
     async def test_hysteresis_behavior(self):
         """Test hysteresis behavior between cooling thresholds.
 
-        Temperature in the zone between (target_cooltemp - tolerance) and
-        target_cooltemp, but still above bt_target_temp. The first condition
-        requires cur_temp >= (target_cooltemp - tolerance), so at 23.7 >= 23.5,
-        AND cur_temp > bt_target_temp (23.7 > 20.0), so it should COOL.
+        Temperature inside the band between target_cooltemp and
+        (target_cooltemp + tolerance) and above bt_target_temp. The cooler
+        reports OFF and BT holds no cooling decision, so the switch-on edge at
+        24.5 has not been reached and the band must not be entered from below.
         """
         mock_hass = Mock()
         mock_hass.services = Mock()
@@ -181,16 +192,21 @@ class TestControlCooler:
             state=HVACMode.OFF, temperature=20.0
         )
 
-        # cur_temp (23.7) >= (24.0 - 0.5 = 23.5) AND cur_temp (23.7) > 20.0
-        # -> first branch: COOL
+        # cur_temp (24.3) < (24.0 + 0.5 = 24.5) -> stays OFF
         mock_self = _make_mock_self(
-            mock_hass, bt_hvac_mode=HVACMode.COOL, cur_temp=23.7
+            mock_hass, bt_hvac_mode=HVACMode.COOL, cur_temp=24.3
         )
 
         await control_cooler(mock_self)
 
-        calls = mock_hass.services.async_call.call_args_list
-        assert calls[-1].args[2]["hvac_mode"] == HVACMode.COOL
+        mode_calls = [
+            c
+            for c in mock_hass.services.async_call.call_args_list
+            if c.args[1] == "set_hvac_mode"
+        ]
+        # The cooler already reports OFF, so a decision of OFF sends nothing.
+        assert mode_calls == []
+        assert mock_self.last_cooler_mode_decided == HVACMode.OFF
 
     @pytest.mark.asyncio
     async def test_context_passed_to_service_calls(self):
@@ -240,8 +256,8 @@ class TestControlCooler:
     async def test_edge_case_exactly_at_threshold(self):
         """Test behavior when temperature is exactly at threshold.
 
-        cur_temp (23.5) >= (24.0 - 0.5 = 23.5) -> True
-        cur_temp (23.5) > bt_target_temp (20.0) -> True
+        cur_temp (24.5) >= (24.0 + 0.5 = 24.5) -> True
+        cur_temp (24.5) > bt_target_temp (20.0) -> True
         -> first branch: COOL
         """
         mock_hass = Mock()
@@ -252,16 +268,591 @@ class TestControlCooler:
             state=HVACMode.OFF, temperature=20.0
         )
 
-        # Exactly at target_cooltemp - tolerance AND above bt_target_temp
+        # Exactly at target_cooltemp + tolerance AND above bt_target_temp
         mock_self = _make_mock_self(
-            mock_hass, bt_hvac_mode=HVACMode.COOL, cur_temp=23.5
+            mock_hass, bt_hvac_mode=HVACMode.COOL, cur_temp=24.5
         )
 
         await control_cooler(mock_self)
 
         calls = mock_hass.services.async_call.call_args_list
-        # cur_temp (23.5) >= 23.5 AND cur_temp (23.5) > 20.0 -> COOL
+        # cur_temp (24.5) >= 24.5 AND cur_temp (24.5) > 20.0 -> COOL
         assert calls[-1].args[2]["hvac_mode"] == HVACMode.COOL
+
+
+class TestControlCoolerToleranceBand:
+    """The cooling band [cool_target, cool_target + tolerance] and its latch."""
+
+    @staticmethod
+    async def _decide(
+        cur_temp,
+        *,
+        tolerance=0.5,
+        last_cooler_mode_decided=None,
+        cooler_mode=HVACMode.OFF,
+    ):
+        """Run control_cooler once and report the decided mode.
+
+        Returns the decided mode together with the mock instance. The reported
+        cooler mode is a parameter because it seeds the hold edge while BT holds
+        no decision; it defaults to OFF so the latch alone drives the band. A
+        decision differing from the reported mode always produces a
+        set_hvac_mode call, and no call means the cooler already reports it.
+        """
+        mock_hass = Mock()
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock()
+        mock_hass.states.get.return_value = _make_cooler_state(
+            state=cooler_mode, temperature=24.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass,
+            bt_hvac_mode=HVACMode.COOL,
+            cur_temp=cur_temp,
+            bt_target_cooltemp=24.0,
+            bt_target_temp=20.0,
+            tolerance=tolerance,
+            last_cooler_mode_decided=last_cooler_mode_decided,
+        )
+
+        await control_cooler(mock_self)
+
+        mode_call = next(
+            (
+                c
+                for c in mock_hass.services.async_call.call_args_list
+                if c.args[1] == "set_hvac_mode"
+            ),
+            None,
+        )
+        # No command means the cooler already reports the decided mode.
+        decided = mode_call.args[2]["hvac_mode"] if mode_call else cooler_mode
+        return decided, mock_self
+
+    @pytest.mark.asyncio
+    async def test_enters_band_at_cool_target_plus_tolerance(self):
+        """The tolerance delays the switch-on to cool_target + tolerance."""
+        mode, _ = await self._decide(24.5)
+        assert mode == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_no_entry_just_below_the_switch_on_edge(self):
+        """Just below the switch-on edge the cooler stays off."""
+        mode, _ = await self._decide(24.49)
+        assert mode == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_holds_inside_the_band_once_cooling(self):
+        """Once COOL was decided, cooling continues down through the band."""
+        mode, _ = await self._decide(24.2, last_cooler_mode_decided=HVACMode.COOL)
+        assert mode == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_holds_at_the_cooling_target(self):
+        """The cooling target itself is still inside the hold band."""
+        mode, _ = await self._decide(24.0, last_cooler_mode_decided=HVACMode.COOL)
+        assert mode == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_releases_below_the_cooling_target(self):
+        """Below the cooling target the cooler is released — never cool past it."""
+        mode, _ = await self._decide(23.9, last_cooler_mode_decided=HVACMode.COOL)
+        assert mode == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_default_tolerance_switches_on_at_the_cooling_target(self):
+        """With the default tolerance of 0.0 the switch-on edge sits on the target."""
+        mode, _ = await self._decide(24.0, tolerance=0.0)
+        assert mode == HVACMode.COOL
+
+        mode, _ = await self._decide(23.99, tolerance=0.0)
+        assert mode == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_latch_records_the_decision(self):
+        """A COOL decision arms the latch so the next cycle uses the hold edge."""
+        _, mock_self = await self._decide(24.5)
+        assert mock_self.last_cooler_mode_decided == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_latch_is_released_by_an_off_decision(self):
+        """An OFF decision clears the latch so the band is re-entered from above."""
+        _, mock_self = await self._decide(23.9, last_cooler_mode_decided=HVACMode.COOL)
+        assert mock_self.last_cooler_mode_decided == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_running_cooler_seeds_the_hold_edge(self):
+        """A cooler already running keeps running while BT holds no decision.
+
+        This is the state a restart or a config-entry reload leaves behind, and
+        stopping the unit there would cost a compressor cycle and let the room
+        warm back up to the switch-on edge.
+        """
+        mode, mock_self = await self._decide(24.3, cooler_mode=HVACMode.COOL)
+        assert mode == HVACMode.COOL
+        assert mock_self.last_cooler_mode_decided == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_running_cooler_is_still_released_below_the_hold_edge(self):
+        """Seeding from the reported mode never cools past the cooling target."""
+        mode, _ = await self._decide(23.9, cooler_mode=HVACMode.COOL)
+        assert mode == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_own_decision_wins_over_the_reported_mode(self):
+        """An externally started cooler does not reopen a band BT decided closed.
+
+        Once the latch holds a decision, the reported mode is ignored: it lags a
+        command by a state update and can be changed behind BT's back.
+        """
+        mode, _ = await self._decide(
+            24.3, last_cooler_mode_decided=HVACMode.OFF, cooler_mode=HVACMode.COOL
+        )
+        assert mode == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "reported_mode",
+        [HVACMode.HEAT_COOL, HVACMode.AUTO, HVACMode.DRY, HVACMode.FAN_ONLY],
+    )
+    async def test_only_a_reported_cool_seeds_the_hold_edge(self, reported_mode):
+        """A cooler not reporting cool is not on a run BT could take over.
+
+        heat_cool, auto, dry and fan_only are all modes other than off, and
+        none of them is a cooling run: at 24.1 — inside the band but below the
+        switch-on edge at 24.5 — there is no hold edge to seed, so the band is
+        entered from above like any fresh start.
+        """
+        mode, mock_self = await self._decide(24.1, cooler_mode=reported_mode)
+        assert mode == HVACMode.OFF
+        assert mock_self.last_cooler_mode_decided == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_a_reported_cool_seeds_the_hold_edge_at_the_same_temperature(self):
+        """The very same room temperature holds once the cooler reports cool.
+
+        The counterpart to the modes above: only cool distinguishes a running
+        unit BT should keep running from one it should leave alone.
+        """
+        mode, mock_self = await self._decide(24.1, cooler_mode=HVACMode.COOL)
+        assert mode == HVACMode.COOL
+        assert mock_self.last_cooler_mode_decided == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_latch_survives_a_rejected_command(self):
+        """A device rejecting every command must not unlatch the band.
+
+        The latch tracks the decision, not the send, so the hold edge stays
+        reachable while the cooler keeps raising errors.
+        """
+        mock_hass = Mock()
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock(
+            side_effect=HomeAssistantError("cooler offline")
+        )
+        mock_hass.states.get.return_value = _make_cooler_state(
+            state=HVACMode.OFF, temperature=20.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass, bt_hvac_mode=HVACMode.COOL, cur_temp=24.5
+        )
+
+        await control_cooler(mock_self)
+
+        assert mock_self.last_sent_cooler_hvac_mode is None
+        assert mock_self.last_cooler_mode_decided == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_heating_target_stays_a_hard_floor(self):
+        """The heating target overrides the hold edge: cooling never fights the TRVs."""
+        mock_hass = Mock()
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock()
+        mock_hass.states.get.return_value = _make_cooler_state(
+            state=HVACMode.COOL, temperature=20.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass,
+            bt_hvac_mode=HVACMode.COOL,
+            cur_temp=24.0,
+            bt_target_cooltemp=24.0,
+            bt_target_temp=24.0,
+            last_cooler_mode_decided=HVACMode.COOL,
+        )
+
+        await control_cooler(mock_self)
+
+        calls = mock_hass.services.async_call.call_args_list
+        assert calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_none_value_guard_commands_off_and_clears_the_latch(self):
+        """A missing input ends the run: it commands OFF and drops the hold edge.
+
+        The guard stops the cooler outright, so the run is over and the way
+        back in is the switch-on edge, not the hold edge the interrupted run
+        was using.
+        """
+        mock_hass = Mock()
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock()
+        mock_hass.states.get.return_value = _make_cooler_state(
+            state=HVACMode.COOL, temperature=24.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass,
+            bt_hvac_mode=HVACMode.COOL,
+            cur_temp=None,
+            last_cooler_mode_decided=HVACMode.COOL,
+        )
+
+        await control_cooler(mock_self)
+
+        calls = mock_hass.services.async_call.call_args_list
+        assert calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
+        assert mock_self.last_cooler_mode_decided == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_a_missed_reading_costs_one_band_excursion(self):
+        """A blind cycle ends the run, and the room has to climb back to re-enter.
+
+        The single OFF command the guard sends is the whole cost: the next
+        cycles decide OFF again rather than flapping the cooler back on inside
+        the band, and cooling resumes at the switch-on edge.
+        """
+        _, first = await self._decide(24.5)
+        assert first.last_cooler_mode_decided == HVACMode.COOL
+
+        blind_mode, blind = await self._decide(
+            None,
+            last_cooler_mode_decided=first.last_cooler_mode_decided,
+            cooler_mode=HVACMode.COOL,
+        )
+        assert blind_mode == HVACMode.OFF
+        assert blind.last_cooler_mode_decided == HVACMode.OFF
+
+        # Back inside the band with the readings restored: the run does not
+        # resume, because the hold edge went with the run that the guard ended.
+        not_resumed, still_off = await self._decide(
+            24.2, last_cooler_mode_decided=blind.last_cooler_mode_decided
+        )
+        assert not_resumed == HVACMode.OFF
+        assert still_off.last_cooler_mode_decided == HVACMode.OFF
+
+        # The switch-on edge is what lets it back in.
+        resumed, _ = await self._decide(
+            24.5, last_cooler_mode_decided=still_off.last_cooler_mode_decided
+        )
+        assert resumed == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_bt_switched_off_clears_the_latch(self):
+        """BT going OFF is a decision of its own, so the next start is a fresh one.
+
+        A deliberate stop leaves the cooler off and the room warming, which is
+        the situation the switch-on edge is written for.
+        """
+        mock_hass = Mock()
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock()
+        mock_hass.states.get.return_value = _make_cooler_state(
+            state=HVACMode.COOL, temperature=24.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass,
+            bt_hvac_mode=HVACMode.OFF,
+            cur_temp=24.3,
+            last_cooler_mode_decided=HVACMode.COOL,
+        )
+
+        await control_cooler(mock_self)
+
+        assert mock_self.last_cooler_mode_decided == HVACMode.OFF
+
+        resumed, _ = await self._decide(
+            24.2, last_cooler_mode_decided=mock_self.last_cooler_mode_decided
+        )
+        assert resumed == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("tolerance", "switch_on", "lowest_holding"),
+        [(0.3, 24.3, 24.0), (0.1, 24.1, 23.9)],
+    )
+    async def test_the_documented_example_decides_the_documented_edges(
+        self, tolerance, switch_on, lowest_holding
+    ):
+        """The cooling example in docs/Configuration/configuration.md, executed.
+
+        With a cooling target of 24.0, a tolerance of 0.3 starts cooling at 24.3
+        and keeps cooling until the room is back below 24.0. A tolerance of 0.1
+        is narrower than the minimum band, so the hold edge moves to 23.9 while
+        the switch-on edge stays at 24.1.
+        """
+        entered, _ = await self._decide(switch_on, tolerance=tolerance)
+        assert entered == HVACMode.COOL
+
+        below_edge, _ = await self._decide(
+            round(switch_on - 0.01, 2), tolerance=tolerance
+        )
+        assert below_edge == HVACMode.OFF
+
+        holding, _ = await self._decide(
+            lowest_holding, tolerance=tolerance, last_cooler_mode_decided=HVACMode.COOL
+        )
+        assert holding == HVACMode.COOL
+
+        released, _ = await self._decide(
+            round(lowest_holding - 0.01, 2),
+            tolerance=tolerance,
+            last_cooler_mode_decided=HVACMode.COOL,
+        )
+        assert released == HVACMode.OFF
+
+
+class TestControlCoolerLatchOfAFreshThermostat:
+    """The first cooling decision a newly constructed BetterThermostat makes.
+
+    The tests above hand the latch to control_cooler; these take it from a real
+    BetterThermostat instead, so the value its constructor installs is the one
+    under test. That value decides what happens on the first cycle after a
+    restart or a config-entry reload, when BT has made no decision yet and the
+    only evidence about the cooler is what the cooler itself reports.
+    """
+
+    @staticmethod
+    def _make_thermostat(hass, *, tolerance=0.3):
+        """Build a real BetterThermostat and wire it for a cooling cycle.
+
+        Everything control_cooler reads is set except the cooler latch, which
+        keeps the value the constructor gave it.
+        """
+        thermostat = BetterThermostat(
+            name="cooler band",
+            heater_entity_id=[],
+            sensor_entity_id=None,
+            humidity_sensor_entity_id=None,
+            window_id=None,
+            window_delay=0,
+            window_delay_after=0,
+            door_id=None,
+            door_delay=0,
+            door_delay_after=0,
+            weather_entity=None,
+            outdoor_sensor=None,
+            off_temperature=None,
+            tolerance=tolerance,
+            target_temp_step=None,
+            model="generic",
+            cooler_entity_id="climate.cooler",
+            min_cooler_resend_interval=0,
+            enabled_presets=None,
+            unit=UnitOfTemperature.CELSIUS,
+            unique_id="cooler_band",
+            device_class=None,
+            state_class=None,
+        )
+        thermostat.hass = hass
+        thermostat.bt_hvac_mode = HVACMode.COOL
+        thermostat.bt_target_cooltemp = 24.0
+        thermostat.bt_target_temp = 20.0
+        return thermostat
+
+    @staticmethod
+    def _make_hass(reported_mode):
+        """Build a hass whose cooler reports a mode and BT's own setpoint."""
+        mock_hass = Mock()
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock()
+        mock_hass.states.get.return_value = _make_cooler_state(
+            state=reported_mode, temperature=24.0
+        )
+        return mock_hass
+
+    @staticmethod
+    def _mode_calls(mock_hass):
+        """Return the set_hvac_mode calls the cooler received."""
+        return [
+            call
+            for call in mock_hass.services.async_call.call_args_list
+            if call.args[1] == "set_hvac_mode"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_running_cooler_keeps_running_through_the_first_cycle(self):
+        """A reload mid-band leaves a cooling unit cooling.
+
+        At 24.1 the room is inside the band but below the switch-on edge at
+        24.3, so the run only survives because the hold edge is seeded from the
+        reported cool. A constructor that started the latch on a mode would make
+        that first cycle read as a decision of BT's own, stop the unit and let
+        the room warm back up to the switch-on edge.
+        """
+        mock_hass = self._make_hass(HVACMode.COOL)
+        thermostat = self._make_thermostat(mock_hass)
+        thermostat.cur_temp = 24.1
+
+        await control_cooler(thermostat)
+
+        assert thermostat.last_cooler_mode_decided == HVACMode.COOL
+        assert self._mode_calls(mock_hass) == []
+
+    @pytest.mark.asyncio
+    async def test_a_stopped_cooler_stays_stopped_through_the_first_cycle(self):
+        """The same first cycle starts nothing while the cooler reports off.
+
+        Seeding follows the cooler, so at the same 24.1 — short of the switch-on
+        edge — a unit that is not running is left alone until the room reaches
+        it.
+        """
+        mock_hass = self._make_hass(HVACMode.OFF)
+        thermostat = self._make_thermostat(mock_hass)
+        thermostat.cur_temp = 24.1
+
+        await control_cooler(thermostat)
+
+        assert thermostat.last_cooler_mode_decided == HVACMode.OFF
+        assert self._mode_calls(mock_hass) == []
+
+
+class TestControlCoolerMinimumBand:
+    """COOLER_MODE_HYSTERESIS_K keeps the decision band wide enough to be stable."""
+
+    @staticmethod
+    def _setup(*, tolerance, reported=HVACMode.COOL, latch=HVACMode.COOL, target=20.0):
+        """Build a cooler that applies every mode it is commanded.
+
+        The reported mode follows the commands, so a stable decision produces no
+        writes at all and every flip of the decision produces one.
+        """
+        mock_hass = Mock()
+        mock_hass.services = Mock()
+        state = {"mode": reported}
+        mock_hass.states.get.side_effect = lambda _entity_id: _make_cooler_state(
+            state=state["mode"], temperature=24.0
+        )
+
+        async def apply(_domain, service, data, **_kwargs):
+            """Record a commanded mode as the cooler's reported mode."""
+            if service == "set_hvac_mode":
+                state["mode"] = data["hvac_mode"]
+
+        mock_hass.services.async_call = AsyncMock(side_effect=apply)
+
+        mock_self = _make_mock_self(
+            mock_hass,
+            bt_hvac_mode=HVACMode.COOL,
+            cur_temp=24.0,
+            bt_target_cooltemp=24.0,
+            bt_target_temp=target,
+            tolerance=tolerance,
+            last_cooler_mode_decided=latch,
+        )
+        return mock_self, mock_hass
+
+    @staticmethod
+    def _mode_calls(mock_hass):
+        """Return the set_hvac_mode calls the cooler received."""
+        return [
+            call
+            for call in mock_hass.services.async_call.call_args_list
+            if call.args[1] == "set_hvac_mode"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_tolerance_under_the_minimum_band_still_holds(self):
+        """A room dithering one sensor step around the target must not be written.
+
+        A changed desired mode bypasses the resend throttle by design, so a band
+        only as wide as the tolerance turns every step across the cooling target
+        into a genuine write, at whatever rate the room sensor updates. The
+        cooling target is exactly where a working air conditioner parks the room.
+        """
+        mock_self, mock_hass = self._setup(tolerance=0.1)
+        assert mock_self.tolerance < COOLER_MODE_HYSTERESIS_K
+
+        for _ in range(5):
+            for room_temp in (24.0, 24.1, 24.0, 23.9):
+                mock_self.cur_temp = room_temp
+                await control_cooler(mock_self)
+
+        assert self._mode_calls(mock_hass) == []
+
+    @pytest.mark.asyncio
+    async def test_a_fahrenheit_tolerance_under_the_minimum_band_still_holds(self):
+        """A tolerance configured in Fahrenheit reaches the band as Celsius.
+
+        A configured 0.1 °F arrives as 0.0556 K, well inside the minimum band.
+        """
+        mock_self, mock_hass = self._setup(tolerance=round(0.1 * 5.0 / 9.0, 4))
+        assert mock_self.tolerance < COOLER_MODE_HYSTERESIS_K
+
+        for _ in range(5):
+            for room_temp in (24.0, 24.1, 24.0, 23.9):
+                mock_self.cur_temp = room_temp
+                await control_cooler(mock_self)
+
+        assert self._mode_calls(mock_hass) == []
+
+    @pytest.mark.asyncio
+    async def test_the_default_tolerance_borrows_the_hold_edge_from_below(self):
+        """Without a configured tolerance the band collapses onto the target.
+
+        The minimum band still applies below the target, so the decision is
+        stable, but it buys decision stability and not a colder room: the
+        switch-on edge stays on the cooling target.
+        """
+        mock_self, mock_hass = self._setup(
+            tolerance=0.0, reported=HVACMode.OFF, latch=None
+        )
+
+        mock_self.cur_temp = 23.99
+        await control_cooler(mock_self)
+        assert self._mode_calls(mock_hass) == []
+
+        mock_self.cur_temp = 24.0
+        await control_cooler(mock_self)
+        assert self._mode_calls(mock_hass)[-1].args[2]["hvac_mode"] == HVACMode.COOL
+
+        # Inside the minimum band the hold edge is borrowed from below the target.
+        mock_self.cur_temp = 23.9
+        await control_cooler(mock_self)
+        assert len(self._mode_calls(mock_hass)) == 1
+
+        mock_self.cur_temp = 23.7
+        await control_cooler(mock_self)
+        mode_calls = self._mode_calls(mock_hass)
+        assert len(mode_calls) == 2
+        assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_the_heating_target_ends_the_hold_inside_the_borrowed_band(self):
+        """The heating target outranks the borrowed hold edge as well as the entry.
+
+        The borrowed width reaches below the cooling target, so a heat/cool gap
+        narrower than COOLER_MODE_HYSTERESIS_K puts the hold edge inside the
+        range the TRVs are heating towards.
+        """
+        mock_self, mock_hass = self._setup(
+            tolerance=0.0, reported=HVACMode.OFF, latch=None, target=23.9
+        )
+
+        mock_self.cur_temp = 24.0
+        await control_cooler(mock_self)
+        assert self._mode_calls(mock_hass)[-1].args[2]["hvac_mode"] == HVACMode.COOL
+
+        # Still above the borrowed hold edge at 23.8, but no longer above the
+        # heating target.
+        mock_self.cur_temp = 23.85
+        await control_cooler(mock_self)
+        mode_calls = self._mode_calls(mock_hass)
+        assert len(mode_calls) == 2
+        assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
 
 
 class TestControlCoolerSendCache:

--- a/tests/unit/test_hvac_action.py
+++ b/tests/unit/test_hvac_action.py
@@ -2,6 +2,7 @@
 
 Covers:
   - should_heat_with_tolerance  (hysteresis helper)
+  - should_cool_with_tolerance  (hysteresis helper)
   - to_pct                      (valve normalisation)
   - compute_hvac_action         (main FSM, TRV overrides, idempotency)
   - Hysteresis state transitions
@@ -14,6 +15,7 @@ from custom_components.better_thermostat.utils.hvac_action import (
     ToleranceHysteresis,
     TrvSnapshot,
     compute_hvac_action,
+    should_cool_with_tolerance,
     should_heat_with_tolerance,
     to_pct,
 )
@@ -82,6 +84,68 @@ class TestShouldHeatWithTolerance:
         """None previous_action treated as non-HEATING → strict threshold."""
         assert should_heat_with_tolerance(20.4, 21.0, 0.5, None) is True
         assert should_heat_with_tolerance(20.7, 21.0, 0.5, None) is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Group 1b: should_cool_with_tolerance
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestShouldCoolWithTolerance:
+    """Tests for should cool with tolerance."""
+
+    def test_starts_at_upper_edge(self):
+        """Cooling starts when temp reaches cool_target + tolerance."""
+        assert should_cool_with_tolerance(24.5, 24.0, 0.5, False) is True
+
+    def test_no_start_in_band_when_idle(self):
+        """No start inside (cool_target, cool_target + tolerance) when idle."""
+        assert should_cool_with_tolerance(24.4, 24.0, 0.5, False) is False
+
+    def test_continues_in_band_when_cooling(self):
+        """Continue cooling inside the band when already cooling."""
+        assert should_cool_with_tolerance(24.1, 24.0, 0.5, True) is True
+
+    def test_holds_at_cool_target(self):
+        """Test Holds at cool target."""
+        assert should_cool_with_tolerance(24.0, 24.0, 0.5, True) is True
+
+    def test_releases_below_cool_target(self):
+        """Cooling stops below cool_target – never cool past the setpoint."""
+        assert should_cool_with_tolerance(23.9, 24.0, 0.5, True) is False
+
+    def test_min_band_wider_than_tolerance_lowers_hold_edge(self):
+        """A tolerance below min_band takes the missing width from below the target."""
+        # min_band 0.5, tolerance 0.2 → hold edge at 24.0 - 0.3 = 23.7
+        assert should_cool_with_tolerance(23.8, 24.0, 0.2, True, min_band=0.5) is True
+        assert should_cool_with_tolerance(23.6, 24.0, 0.2, True, min_band=0.5) is False
+
+    def test_min_band_wider_than_tolerance_keeps_switch_on_edge(self):
+        """min_band widens the band downwards only – the start edge stays put."""
+        assert should_cool_with_tolerance(24.1, 24.0, 0.2, False, min_band=0.5) is False
+        assert should_cool_with_tolerance(24.2, 24.0, 0.2, False, min_band=0.5) is True
+
+    def test_min_band_narrower_than_tolerance_ignored(self):
+        """A min_band the tolerance already covers leaves both edges untouched."""
+        assert should_cool_with_tolerance(24.0, 24.0, 0.5, True, min_band=0.2) is True
+        assert should_cool_with_tolerance(23.9, 24.0, 0.5, True, min_band=0.2) is False
+        assert should_cool_with_tolerance(24.5, 24.0, 0.5, False, min_band=0.2) is True
+
+    def test_negative_tolerance_clamped(self):
+        """Negative tolerance is clamped to 0 → both edges sit on cool_target."""
+        assert should_cool_with_tolerance(24.0, 24.0, -1.0, False) is True
+        assert should_cool_with_tolerance(23.9, 24.0, -1.0, False) is False
+
+    def test_negative_tolerance_clamped_before_min_band(self):
+        """A clamped tolerance still leaves min_band its full width to give."""
+        # tolerance clamped to 0, min_band 0.4 → hold edge at 24.0 - 0.4 = 23.6
+        assert should_cool_with_tolerance(23.7, 24.0, -1.0, True, min_band=0.4) is True
+        assert should_cool_with_tolerance(23.5, 24.0, -1.0, True, min_band=0.4) is False
+
+    def test_zero_tolerance_collapses_band(self):
+        """Zero tolerance without a min_band: start and hold edge are both target."""
+        assert should_cool_with_tolerance(24.0, 24.0, 0.0, False) is True
+        assert should_cool_with_tolerance(23.99, 24.0, 0.0, True) is False
 
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Motivation:

### The defect

`control_cooler()` decides the cooler's HVAC mode from a single threshold shifted **down** by the tolerance:

```python
self.cur_temp >= self.bt_target_cooltemp - self.tolerance
```

With a cooling target of 24.0 and a tolerance of 0.5 the air conditioner is commanded `COOL` from **23.5 °C** — while
the room is already half a degree *below* the target the user asked for. The tolerance moves the whole control point
instead of forming a band, so on the cooling side it provides no flap guard at all: the switch-on and switch-off edges
are the same expression.

Everywhere else in the codebase `tolerance` is a band whose *satisfied-side* edge **is** the setpoint:

| source | rule |
|---|---|
| `utils/hvac_action.py::should_heat_with_tolerance` | heating band `[target - tolerance, target)` — "stop at `target`, never heat *above* target" |
| `calibration.py` | "asymmetric band [target - tol, target] so the TRV stops receiving a heating-promoting calibration once the room reaches the set temperature (not target + tolerance)" |
| `utils/hvac_action.py::compute_hvac_action` | reports `HVACAction.COOLING` only above **`cool_target + tolerance`** |
| `docs/Configuration/configuration.md`, `translations/en.json` | a two-edge flap guard, described with a worked heating example |

The third row is the decisive one: the *reported* action already uses the mirrored sign. Today Better Thermostat
commands `COOL` while publishing `IDLE` across a `2 × tolerance` wide interval, and issues `set_temperature 24.0`
together with `set_hvac_mode COOL` in the same cycle at a room temperature of 23.5.

`git blame` traces the expression to the first cooler implementation (`17973329`, 2023-09-22). It carries no rationale,
no linked issue, no test and no documentation, and every later refactor only moved it.

## Changes:

### What this changes

Cooling becomes a genuine two-edge band, with the tolerance moved to the mirrored side of the setpoint:

```
switch ON   when  room_temp >= cool_target + tolerance
hold  COOL  while room_temp >= cool_target
```

The pre-existing `room_temp > bt_target_temp` heating-target floor is kept verbatim, so cooling still never fights the
TRVs. The band lives in one shared predicate, `should_cool_with_tolerance`, placed next to `should_heat_with_tolerance`
in `utils/hvac_action.py`.

With target 24.0 and tolerance 0.5: **ON at 24.5, OFF below 24.0**, achieved room temperature in `[24.0, 24.5]` — at or
above the number the user typed, instead of up to a tolerance below it.

It is the mirrored *sign*, not an exact mirror of the heating band, and it is not meant to be one. Two measured
differences:

- the cooling edges are **inclusive** where heating's are exclusive. `should_heat_with_tolerance(19.5, 20.0, 0.5, None)`
  is `False` at exactly `target − tolerance`, while `should_cool_with_tolerance(24.5, 24.0, 0.5, False)` is `True` at
  exactly `cool_target + tolerance`; on the other edge heating already stops *at* `target`
  (`should_heat_with_tolerance(20.0, 20.0, 0.5, HEATING) is False`) while cooling still holds *at* `cool_target`
  (`should_cool_with_tolerance(24.0, 24.0, 0.5, True) is True`);
- the minimum band below (next section) gives cooling a hold edge underneath `cool_target`. Heating has no counterpart:
  `should_heat_with_tolerance` never returns `True` at or above `target`, whatever the tolerance.

### The minimum band width

A band only as wide as the tolerance puts the switch-off edge exactly on `cool_target` — which is where a working air
conditioner parks the room, because BT writes `bt_target_cooltemp` as the unit's own setpoint. The room then dithers
across that edge and flips the decision on every control cycle.

`COOLER_MODE_HYSTERESIS_K = 0.2` gives the band a minimum width, matching the v2 twin (#2165). The missing width is
taken from **below** `cool_target`, so the switch-on edge never moves for it: the guard buys decision stability, not a
colder room.

Measured on this branch — room dithering one 0.1 K sensor step around the target
(`[24.0, 24.1, 24.0, 23.9] × 5`, `cool_target` 24.0, tolerance 0.1, latch `COOL`):

| `min_band` | `set_hvac_mode` writes / 20 cycles |
|---|---|
| `0.0` (band = tolerance) | **9**, alternating `off → cool → off → cool` |
| `COOLER_MODE_HYSTERESIS_K` | **0** |

The resend throttle does not absorb this: at `min_cooler_resend_interval_s` of 0 / 300 / 3600 the count stays 9 / 9 / 9,
because each write is a genuinely *changed* mode rather than a resend. Every room-sensor update queues a control cycle,
so the real-world rate is the sensor update rate — compressor short-cycling, and a write storm on cloud-backed coolers.
The exposure window is roughly `0 < tolerance < 0.2 K`; on a Fahrenheit system the configured tolerance is multiplied by
5/9, so any Fahrenheit tolerance below about 0.36 °F lands inside it (measured: 0.1 °F → 0.0556 K → 9 writes / 20 cycles
without the minimum band).

### Behaviour change for existing installations

Installations that configured **both** a cooler and a tolerance change the most: for them the cooler starts later and
stops earlier — less run time, and a room at or above the chosen setpoint.

At the default tolerance of `0.0` (`config_flow.py`) the switch-on edge stays on `cool_target`, exactly today's switch
point. The switch-off edge moves to `cool_target - 0.2` while the cooler is running, which is the flap guard described
above and the only default-configuration change.

`docs/Configuration/configuration.md` gains the cooling direction of the Tolerance example, stated in its own terms
rather than as "the same in the other direction" — the two directions are not symmetric at the edges (see above). It
gains a second sentence for the minimum band, because below a tolerance of 0.2 the stop edge moves *underneath* the
cooling target, and a documented stop condition that names the cooling target would be wrong exactly there.

Both documented number sets are pinned by `test_the_documented_example_decides_the_documented_edges`, which drives them
through `control_cooler` (`cool_target` 24.0, heating target 20.0) rather than through the predicate alone:

| tolerance | switches on at | still off at | still cooling at | released at |
|---|---|---|---|---|
| 0.3 | 24.3 | 24.29 | 24.0 | 23.99 |
| 0.1 | 24.1 | 24.09 | 23.9 | 23.89 |

The 0.3 example is wider than the 0.2 minimum band, so the borrow never applies to it. The 0.1 example is the case the
minimum band is written for: its stop edge sits 0.1 K below the cooling target, while its switch-on edge is exactly
where the tolerance alone would put it.

### The latch

A two-edge band has to know whether it is already inside the band, so `develop` gains `last_cooler_mode_decided`. Three
properties are pinned by tests:

- it records the **decision**, not the send — `last_sent_cooler_hvac_mode` is written only after a successful service
  call, so reusing it would leave the hold edge unreachable on a device that rejects every command, and the decision
  would flap;
- a cycle that cannot decide — missing readings (`cur_temp`, either target, the tolerance) or BT in `OFF` — commands
  `OFF` **and clears the latch**. The guard stops the cooler outright, so the run is over and the way back in is the
  switch-on edge. This is the same contract `compute_hvac_action` already applies on its own guards, each of which
  returns `new_last_action` to `IDLE`. Measured cost, `cool_target` 24.0 and tolerance 0.5: a run at 24.5 → *[one blind
  cycle]* → 24.2 does **not** resume at 24.2; it stays off until the room is back at 24.5. One missed reading therefore
  costs one band excursion — deliberately, in exchange for exactly one write instead of an `off → cool` flap;
- while it holds no decision at all — the state a restart or a config-entry reload leaves behind — the hold edge is
  seeded from the cooler's own reported mode, and only a reported `cool` seeds it. `heat_cool`, `auto`, `dry` and
  `fan_only` are all modes other than `off` and none of them is a cooling run, so at 24.1 (inside the band, below the
  24.5 switch-on edge) each of them decides `OFF` while `cool` holds. Once the latch holds a decision it wins, because
  the reported mode lags a command and can be changed externally. The initial value that opens this
  branch is pinned through a real `BetterThermostat`: with `cool_target` 24.0, tolerance 0.3 and the room
  at 24.1 — inside the band, below the 24.3 switch-on edge — a first cycle leaves a cooler reporting
  `cool` running and a cooler reporting `off` stopped, and neither sends a command.

### Out of scope, deliberately

`compute_hvac_action`'s cooling decision is **not** rewired to the same predicate, so a residual command/report
disagreement remains: the cooler is commanded `COOL` while the entity publishes `IDLE`. Measured by sweeping the room
temperature in 0.001 K steps through both paths with the latch holding `COOL`, the interval is

```
[cool_target − max(0, COOLER_MODE_HYSTERESIS_K − tolerance),  cool_target + tolerance]
```

— closed at **both** ends. The upper end is closed because the two sides compare differently at the same number: the
control path uses `>=` (`should_cool_with_tolerance`) and `compute_hvac_action` uses `cur_temp > (cool_target +
tolerance)`, so at exactly `cool_target + tolerance` the cooler is commanded on and the action still reads `IDLE`.
Measured with `cool_target` 24.0:

| tolerance | mismatch interval | width |
|---|---|---|
| 0.0 | `[23.8, 24.0]` | 0.2 |
| 0.1 | `[23.9, 24.1]` | 0.2 |
| 0.3 | `[24.0, 24.3]` | 0.3 |
| 0.5 | `[24.0, 24.5]` | 0.5 |

With the latch unset the interval collapses to the single point `cool_target + tolerance`. So the width goes from
`2 × tolerance` before this PR to `max(tolerance, COOLER_MODE_HYSTERESIS_K)` after it: narrower for every tolerance
above 0.1 K, unchanged at 0.1 K, and wider only below that, where the minimum band is what widens it.

This deferral was re-checked by running the code rather than reading it, because the remaining mismatch now covers the
region a running cooler spends nearly all its time in. Widening `HVACAction.COOLING` downward flips the
`self.hvac_action == HVACAction.IDLE` gates in `calibration.py`, and the direction is wrong: with the room at 24.2
(inside the hold band, above the heating target at 20.0), a TRV reporting 22.0 °C on a `target_temp_step` of 0.5 in
`CalibrationMode.DEFAULT`, `calculate_calibration_setpoint` returns **17.5 when IDLE and 18.0 when COOLING**, because
the direction-aware rounding gate falls through to `rounding.nearest` — the exact case its own comment warns about
("would keep the valve open at the current temp"). Reporting `COOLING` would therefore open the TRV valves further
precisely while the air conditioner is cooling the room.

Those two numbers belong to those parameters, not to the mechanism: both are the same unrounded 17.8 rounded in
different directions, and on a 0.1-step TRV the gap disappears (17.8 either way). Swept over TRV temperatures
21.0–23.0 in 0.5 steps × `target_temp_step` 0.1 / 0.5 / 1.0, IDLE and COOLING differ on 8 of the 15 combinations and are
identical on the other 7 — but where they differ, `COOLING` is *always* the higher setpoint, i.e. the valve kept further
open. Fixing that means making the six calibration gates cooling-aware, which is its own change with its own tests.

### Verification

- Full suite: `2262 passed` (`uv run pytest tests/`), ruff check + format clean.
- Counterfactual on each production hunk. Every number below is the full-suite result on this branch, `uv run pytest
  tests/ -q`, with the branch's own baseline being `2262 passed`:
  - replacing the entire body of `should_cool_with_tolerance` — the `tolerance = max(0.0, tolerance)` clamp, the
    `previously_cooling` hold-edge branch and the switch-on `return` — with the single old shifted threshold
    `return cur_temp >= cool_target - tolerance` → **`23 failed, 2239 passed`**: 17 in
    `tests/unit/controlling/test_control_cooler.py` (among them `test_no_entry_just_below_the_switch_on_edge`,
    `test_releases_below_the_cooling_target` and both rows of `test_the_documented_example_decides_the_documented_edges`)
    and 6 in `tests/unit/test_hvac_action.py::TestShouldCoolWithTolerance`;
  - forcing `min_band=0.0` at the call site → **`4 failed, 2258 passed`**:
    `test_the_documented_example_decides_the_documented_edges[0.1-24.1-23.9]`,
    `test_a_tolerance_under_the_minimum_band_still_holds`,
    `test_a_fahrenheit_tolerance_under_the_minimum_band_still_holds`,
    `test_the_default_tolerance_borrows_the_hold_edge_from_below`;
  - moving the latch write from after the branch chain into the band branch, so the guards preserve the latch →
    **`3 failed, 2259 passed`**: `test_none_value_guard_commands_off_and_clears_the_latch`,
    `test_a_missed_reading_costs_one_band_excursion`, `test_bt_switched_off_clears_the_latch`.
- Mutation checks, same command and baseline:
  - restart seed relaxed from `current_hvac_mode == HVACMode.COOL` to `!= HVACMode.OFF` → **`4 failed, 2258 passed`**,
    `test_only_a_reported_cool_seeds_the_hold_edge[heat_cool|auto|dry|fan_only]`;
  - `COOLER_MODE_HYSTERESIS_K` weakened from `0.2` to `0.1` → **`3 failed, 2259 passed`**, among them the documented
    0.1-tolerance row, whose stop edge would move from 23.9 to 24.0;
  - `min_band` allowed to move the switch-on edge as well
    (`return cur_temp >= cool_target + max(tolerance, min_band)`) → **`5 failed, 2257 passed`**, again including the
    documented 0.1-tolerance row, whose switch-on would move from 24.1 to 24.2;
  - the constructor's initial `last_cooler_mode_decided` changed from `None` to `HVACMode.OFF` →
    **`1 failed, 2261 passed`**, `test_a_running_cooler_keeps_running_through_the_first_cycle`; and to
    `HVACMode.COOL` → **`1 failed, 2261 passed`**,
    `test_a_stopped_cooler_stays_stopped_through_the_first_cycle`. Both of those tests drive
    `control_cooler` with a real `BetterThermostat`, so the latch value under test is the one the
    constructor installs rather than one the test supplies — which is what makes the initial value
    falsifiable at all.

  The tests pin the behaviour, not the implementation.
- The Fahrenheit path is safe and was checked: `tolerance` is converted from Fahrenheit degrees to Kelvin in the
  constructor (`climate.py`: `self.tolerance = self.tolerance * 5.0 / 9.0` when the system unit is Fahrenheit), and both
  new edges add that Kelvin delta to a Celsius target. Worth noting because the fix doubles the tolerance's leverage on
  the switch-on point, from `−tol` to `+tol`.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: n/a - covered by unit tests, no hardware run for this change
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

No new device mapping is added by this PR; the `climate.py` change is a control-path fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cooling hysteresis to reduce rapid switching near temperature thresholds.
  * Cooling activates and stops using the configured tolerance band while respecting the heating target.
  * A minimum hysteresis band helps prevent rapid cycling when tolerance settings are very narrow.
  * Cooling decisions remain stable across restarts, delayed status updates, and rejected commands.

* **Documentation**
  * Expanded tolerance configuration guidance with cooling behavior details.

* **Tests**
  * Added comprehensive coverage for cooling thresholds, hysteresis, latching, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


