### PR TITLE
fix(climate): bound an inbound setpoint instead of moving the other target

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -144,6 +144,7 @@ from .utils.helpers import (
     get_hvac_bt_mode,
     is_reasonable_temperature,
     normalize_hvac_mode,
+    normalize_step,
     read_setpoint_celsius,
     state_temperature_unit,
 )
@@ -2882,6 +2883,87 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             self.bt_target_cooltemp,
         )
         self.bt_target_temp = adjusted
+
+    def _clamp_inbound_cool_target(self, value: float) -> float:
+        """Clamp a device-reported cooling setpoint above the heating target.
+
+        A report from the cooler is authoritative for the cooling channel only.
+        Rather than pulling the heating target down to make room, the reported
+        value is raised to the nearest setpoint that clears the heating target
+        by one step, so a press on the air conditioner's own remote can never
+        move the radiators. The floor is capped at the configured maximum
+        because a bound outside the range is not a setpoint BT can hold; the
+        residual :meth:`_enforce_heat_below_cool` then resolves the degenerate
+        case where the heating target leaves no legal room below the maximum.
+
+        The bound applies whenever a cooling channel is configured rather than
+        only while the live mode is HEAT_COOL, matching
+        :meth:`_clamp_inbound_heat_target`: the ordering of the two targets is a
+        property of the configuration, so it has to hold whatever mode the group
+        happens to be in.
+
+        The one step of separation comes from :func:`normalize_step`, because
+        ``bt_target_temp_step`` can carry whatever a child entity reports: a
+        negative step would put the floor below the heating target and invert
+        the pair this bound exists to order, and a NaN one would make the
+        comparison against it false and drop the bound altogether.
+
+        Parameters
+        ----------
+        value : float
+                the reported cooling setpoint in °C, already clamped into the
+                configured range
+
+        Returns
+        -------
+        float
+                the setpoint to adopt, raised to clear the heating target
+        """
+        if self.cooler_entity_id is None or self.bt_target_temp is None:
+            return value
+        step = normalize_step(self.bt_target_temp_step)
+        floor = self.bt_target_temp + step
+        if self.bt_max_temp is not None:
+            floor = min(floor, self.bt_max_temp)
+        return max(value, floor)
+
+    def _clamp_inbound_heat_target(self, value: float) -> float:
+        """Clamp a device-reported heating setpoint below the cooling target.
+
+        The counterpart to :meth:`_clamp_inbound_cool_target`: a TRV knob turn
+        is authoritative for the heating channel only, so the reported value is
+        lowered to the nearest setpoint that stays one step below the cooling
+        target instead of raising that target. The ceiling is held at the
+        configured minimum, and the residual
+        :meth:`_enforce_cool_above_heat` resolves the degenerate case where the
+        cooling target leaves no legal room above the minimum. Like its
+        counterpart the bound keys off the configured cooling channel rather
+        than the live mode, and here that is what makes it hold at all: a valve
+        with ``no_off_system_mode`` reports its knob turn while ``bt_hvac_mode``
+        is still OFF, and the same event then resolves the mode to HEAT.
+
+        The one step of separation comes from :func:`normalize_step` for the
+        same reason as in the counterpart: a step a child reports as negative or
+        non-finite would either invert the pair or drop the bound.
+
+        Parameters
+        ----------
+        value : float
+                the reported heating setpoint in °C, already clamped into the
+                configured range
+
+        Returns
+        -------
+        float
+                the setpoint to adopt, lowered to clear the cooling target
+        """
+        if self.cooler_entity_id is None or self.bt_target_cooltemp is None:
+            return value
+        step = normalize_step(self.bt_target_temp_step)
+        ceiling = self.bt_target_cooltemp - step
+        if self.bt_min_temp is not None:
+            ceiling = max(ceiling, self.bt_min_temp)
+        return min(value, ceiling)
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -100,7 +100,10 @@ async def trigger_cooler_change(self, event):
         # that republishes the same setpoint — an attribute refresh, a mode
         # change, a temperature push — must not be read as user intent: a
         # stale report would otherwise revert a BT-side target that has not
-        # been written yet.
+        # been written yet. What the cooler reports is authoritative for the
+        # cooling channel alone, so a setpoint that would cross the heating
+        # target is raised to clear it and the heating target stays where the
+        # user put it.
         _reported_moved = abs(
             _new_cooling_setpoint.raw - _old_cooling_setpoint
         ) >= setpoint_echo_window(_step)
@@ -112,7 +115,31 @@ async def trigger_cooler_change(self, event):
                     self.device_name,
                     entity_id,
                 )
-            self.bt_target_cooltemp = _new_cooling_setpoint.value
+            _adopted_cooling_setpoint = self._clamp_inbound_cool_target(
+                _new_cooling_setpoint.value
+            )
+            if _adopted_cooling_setpoint != _new_cooling_setpoint.value:
+                # A user holding the remote's down button reports every
+                # intermediate setpoint, so this is annunciated at info level:
+                # the target is being honoured as far as the heating channel
+                # allows, which is not the anomaly a warning stands for.
+                _LOGGER.info(
+                    "better_thermostat %s: Cooler %s reported setpoint %.2f does not "
+                    "clear the heating target %.2f, keeping %.2f",
+                    self.device_name,
+                    entity_id,
+                    _new_cooling_setpoint.value,
+                    self.bt_target_temp,
+                    _adopted_cooling_setpoint,
+                )
+            self.bt_target_cooltemp = _adopted_cooling_setpoint
+            # Residual tie-break only: the clamp already cleared the heating
+            # target unless it ran into bt_max_temp, so this moves the heating
+            # target by at most one step as long as that target lies inside the
+            # configured range, and only when no legal cooling setpoint above it
+            # exists. A range the children narrowed below a target already in
+            # place is the exception, and there this is also what pulls the
+            # target back inside.
             self._enforce_heat_below_cool()
             _main_change = True
 

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -302,15 +302,42 @@ async def trigger_trv_change(self, event):
                     self.device_name,
                     entity_id,
                 )
+            # A knob turn on the TRV is authoritative for the heating channel
+            # alone, so a setpoint that would cross the cooling target is
+            # lowered to clear it and the cooling target stays where the user
+            # put it.
+            _adopted_heating_setpoint = self._clamp_inbound_heat_target(
+                _new_heating_setpoint
+            )
+            if _adopted_heating_setpoint != _new_heating_setpoint:
+                # A user turning the knob up reports every intermediate
+                # setpoint, so this is annunciated at info level: the target is
+                # being honoured as far as the cooling channel allows, which is
+                # not the anomaly a warning stands for.
+                _LOGGER.info(
+                    "better_thermostat %s: TRV %s reported setpoint %.2f does not "
+                    "clear the cooling target %.2f, keeping %.2f",
+                    self.device_name,
+                    entity_id,
+                    _new_heating_setpoint,
+                    self.bt_target_cooltemp,
+                    _adopted_heating_setpoint,
+                )
             _LOGGER.debug(
                 "better_thermostat %s: TRV %s decoded TRV target temp changed from %s to %s",
                 self.device_name,
                 entity_id,
                 self.bt_target_temp,
-                _new_heating_setpoint,
+                _adopted_heating_setpoint,
             )
-            self.bt_target_temp = _new_heating_setpoint
+            self.bt_target_temp = _adopted_heating_setpoint
             if self.cooler_entity_id is not None:
+                # Residual tie-break only: the clamp already cleared the
+                # cooling target unless it ran into bt_min_temp, so this moves
+                # the cooling target by at most one step as long as that target
+                # lies inside the configured range, and only when no legal
+                # heating setpoint below it exists. A range the children narrowed
+                # above a target already in place is the exception.
                 self._enforce_cool_above_heat()
 
             _main_change = True
@@ -360,6 +387,16 @@ async def trigger_trv_change(self, event):
                     self.bt_hvac_mode = HVACMode.OFF
             else:
                 self.bt_hvac_mode = HVACMode.HEAT
+                # A valve that was switched off at the knob reports its turn
+                # back up while bt_hvac_mode still reads OFF, so the tie-break
+                # in the setpoint block above was gated out for a heating
+                # target the bound had to pin to the cooling target at
+                # bt_min_temp. Resolving the mode is what puts a group with a
+                # cooler into HEAT_COOL, so that pair is separated here. This
+                # branch also runs on reports that leave the mode as it was,
+                # where the call only acts on a pair that is already crossed —
+                # the one case it exists to settle wherever it is called from.
+                self._enforce_cool_above_heat()
             _main_change = True
 
     if _main_change is True:

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -1298,3 +1298,178 @@ class TestEnforceHeatBelowCool:
         mock_bt.bt_target_cooltemp = 22.0
         self._call(mock_bt)
         assert mock_bt.bt_target_temp is None
+
+
+# ===========================================================================
+# 9. TestClampInboundCoolTarget
+# ===========================================================================
+
+
+class TestClampInboundCoolTarget:
+    """_clamp_inbound_cool_target raises a reported cool setpoint above heat."""
+
+    def _call(self, bt, value):
+        return BetterThermostat._clamp_inbound_cool_target(bt, value)
+
+    def test_without_a_cooler_is_noop(self, mock_bt):
+        """Without a cooling channel there is no second bound."""
+        mock_bt.cooler_entity_id = None
+        mock_bt.bt_target_temp = 22.0
+        assert self._call(mock_bt, 18.0) == 18.0
+
+    def test_none_heat_target_is_noop(self, mock_bt):
+        """An unknown heat target is no bound to clear."""
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_temp = None
+        assert self._call(mock_bt, 18.0) == 18.0
+
+    def test_value_already_above_heat_target_is_kept(self, mock_bt):
+        """A reported setpoint that already clears the heat target is adopted."""
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_temp = 20.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 24.0) == 24.0
+
+    def test_value_below_heat_target_is_raised(self, mock_bt):
+        """A reported setpoint below the heat target is raised one step above it."""
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_temp = 20.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 18.0) == 20.5
+
+    def test_value_equal_to_heat_target_is_raised(self, mock_bt):
+        """The two targets must not coincide, so an equal report is raised."""
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_temp = 20.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 20.0) == 20.5
+
+    def test_step_falls_back_to_half_degree(self, mock_bt):
+        """A missing/zero step falls back to 0.5."""
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_temp = 20.0
+        mock_bt.bt_target_temp_step = 0
+        assert self._call(mock_bt, 20.0) == 20.5
+
+    @pytest.mark.parametrize("step", [-1.0, float("nan"), float("inf")])
+    def test_unusable_step_falls_back_to_half_degree(self, mock_bt, step):
+        """A step that is not a positive finite number falls back to 0.5.
+
+        ``bt_target_temp_step`` carries whatever the child entities report. A
+        negative step would put the floor below the heating target, and a NaN
+        one would lose every comparison and leave the value unbounded, so both
+        would hand back a cooling target at or under the heating target.
+        """
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_temp = 20.0
+        mock_bt.bt_target_temp_step = step
+        adopted = self._call(mock_bt, 18.0)
+        assert adopted == 20.5
+        assert adopted > mock_bt.bt_target_temp
+
+    def test_floor_is_capped_at_max_temp(self, mock_bt):
+        """With the heat target at the maximum the floor stops at the maximum."""
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_temp = 30.0
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 22.0) == 30.0
+
+    def test_bound_holds_while_bt_reads_off(self, mock_bt):
+        """A configured cooling channel bounds the report even while BT is off.
+
+        The two targets have to be ordered whenever the mode resolves, so the
+        bound does not wait for the mode to be HEAT_COOL.
+        """
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_temp = 20.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 18.0) == 20.5
+
+
+# ===========================================================================
+# 10. TestClampInboundHeatTarget
+# ===========================================================================
+
+
+class TestClampInboundHeatTarget:
+    """_clamp_inbound_heat_target lowers a reported heat setpoint below cool."""
+
+    def _call(self, bt, value):
+        return BetterThermostat._clamp_inbound_heat_target(bt, value)
+
+    def test_without_a_cooler_is_noop(self, mock_bt):
+        """Without a cooling channel there is no second bound."""
+        mock_bt.cooler_entity_id = None
+        mock_bt.bt_target_cooltemp = 22.0
+        assert self._call(mock_bt, 26.0) == 26.0
+
+    def test_none_cool_target_is_noop(self, mock_bt):
+        """An unknown cool target is no bound to clear."""
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_cooltemp = None
+        assert self._call(mock_bt, 26.0) == 26.0
+
+    def test_value_already_below_cool_target_is_kept(self, mock_bt):
+        """A reported setpoint that already clears the cool target is adopted."""
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_cooltemp = 24.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 20.0) == 20.0
+
+    def test_value_above_cool_target_is_lowered(self, mock_bt):
+        """A reported setpoint above the cool target drops one step below it."""
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_cooltemp = 24.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 26.0) == 23.5
+
+    def test_value_equal_to_cool_target_is_lowered(self, mock_bt):
+        """The two targets must not coincide, so an equal report is lowered."""
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_cooltemp = 24.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 24.0) == 23.5
+
+    def test_step_falls_back_to_half_degree(self, mock_bt):
+        """A missing/zero step falls back to 0.5."""
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_cooltemp = 24.0
+        mock_bt.bt_target_temp_step = 0
+        assert self._call(mock_bt, 24.0) == 23.5
+
+    @pytest.mark.parametrize("step", [-1.0, float("nan"), float("inf")])
+    def test_unusable_step_falls_back_to_half_degree(self, mock_bt, step):
+        """A step that is not a positive finite number falls back to 0.5.
+
+        The mirror of the cooling case: a negative step would lift the ceiling
+        above the cooling target and a NaN one would drop the bound, so both
+        would hand back a heating target at or over the cooling target.
+        """
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_cooltemp = 24.0
+        mock_bt.bt_target_temp_step = step
+        adopted = self._call(mock_bt, 26.0)
+        assert adopted == 23.5
+        assert adopted < mock_bt.bt_target_cooltemp
+
+    def test_ceiling_is_held_at_min_temp(self, mock_bt):
+        """With the cool target at the minimum the ceiling stops at the minimum."""
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_target_cooltemp = 5.0
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 22.0) == 5.0
+
+    def test_bound_holds_while_bt_reads_off(self, mock_bt):
+        """A configured cooling channel bounds the report even while BT is off.
+
+        A valve that cannot be switched off reports its knob turn while the mode
+        is still OFF, and the same event resolves the mode to HEAT afterwards.
+        """
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_cooltemp = 24.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 26.0) == 23.5

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -1,9 +1,10 @@
 """Tests for events/cooler.py – Cooler event handler.
 
 Covers guard clauses, setpoint adoption, echo suppression, unit handling,
-clamping, heat-target sync, and control-queue triggering.
+range and cross-channel clamping, and control-queue triggering.
 """
 
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.climate.const import HVACMode
@@ -36,12 +37,16 @@ def mock_bt():
     bt.bt_target_temp_step = 0.5
     bt.bt_min_temp = 5.0
     bt.bt_max_temp = 30.0
+    bt.cooler_entity_id = ENTITY_ID
     bt.last_sent_cooler_temp = None
     bt.startup_running = False
     bt.control_queue_task = AsyncMock()
     bt.context = MagicMock()  # unique context so != event.context
     bt.async_write_ha_state = MagicMock()
     bt._enforce_heat_below_cool = lambda: BetterThermostat._enforce_heat_below_cool(bt)
+    bt._clamp_inbound_cool_target = lambda v: (
+        BetterThermostat._clamp_inbound_cool_target(bt, v)
+    )
     return bt
 
 
@@ -212,11 +217,35 @@ class TestCoolerSetpointAdoption:
 
 
 class TestCoolerSetpointClamping:
-    """Tests for setpoint range clamping."""
+    """Tests for setpoint range clamping.
+
+    The configured range and the heating target bound the reported value in
+    sequence. The cases that isolate the range clamp therefore leave the heating
+    target unknown, which is the only state in which the range is the single
+    bound while a cooler is configured.
+    """
 
     @pytest.mark.asyncio
     async def test_setpoint_clamped_to_min(self, mock_bt):
-        """Setpoint below min should be clamped to bt_min_temp."""
+        """Setpoint below min should be clamped to bt_min_temp.
+
+        In HEAT_COOL the heating target is the tighter of the two bounds, so
+        the range clamp to 5.0 is followed by the channel clamp to one step
+        above the heating target.
+        """
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 2.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 20.5
+        assert mock_bt.bt_target_temp == 20.0
+
+    @pytest.mark.asyncio
+    async def test_setpoint_clamped_to_min_without_a_heating_target(self, mock_bt):
+        """With no heating target known the range is the only bound."""
+        mock_bt.bt_target_temp = None
         old_state = _make_state(attributes={"temperature": 25.0})
         new_state = _make_state(attributes={"temperature": 2.0})
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
@@ -237,15 +266,24 @@ class TestCoolerSetpointClamping:
         assert mock_bt.bt_target_cooltemp == 30.0  # clamped to max
 
     @pytest.mark.asyncio
-    async def test_setpoint_at_exact_min_not_clamped(self, mock_bt):
-        """Setpoint exactly at min should not trigger clamping."""
+    async def test_setpoint_at_exact_min_not_clamped(self, mock_bt, caplog):
+        """Setpoint exactly at min should not trigger clamping.
+
+        The lower bound is inclusive, so the value passes through untouched once
+        the heating target is out of the way. Neither bound moved it, so neither
+        bound may say it did.
+        """
+        mock_bt.bt_target_temp = None
         old_state = _make_state(attributes={"temperature": 25.0})
         new_state = _make_state(attributes={"temperature": 5.0})
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
 
+        caplog.set_level(logging.INFO)
         await trigger_cooler_change(mock_bt, event)
 
         assert mock_bt.bt_target_cooltemp == 5.0
+        assert "setpoint outside of range" not in caplog.text
+        assert "does not clear the heating target" not in caplog.text
 
     @pytest.mark.asyncio
     async def test_setpoint_at_exact_max_not_clamped(self, mock_bt):
@@ -260,16 +298,21 @@ class TestCoolerSetpointClamping:
 
 
 # ---------------------------------------------------------------------------
-# 4. Heat-target sync (cooltemp pushes heat target down)
+# 4. Heat-target protection (a cooler report may not move the heat target)
 # ---------------------------------------------------------------------------
 
 
 class TestHeatTargetSync:
-    """Tests for the heat-target sync when cooltemp <= heat target."""
+    """A cooler report is bounded by the heat target instead of moving it.
+
+    The cooler owns the cooling channel alone, so a reported setpoint that would
+    cross the heating target is raised to clear it. The heating target is the
+    user's and stays put.
+    """
 
     @pytest.mark.asyncio
-    async def test_heat_target_pushed_down_when_equal(self, mock_bt):
-        """When cooltemp == heat target, heat target is pushed down by step."""
+    async def test_report_equal_to_heat_target_is_raised(self, mock_bt):
+        """A setpoint equal to the heat target is raised one step above it."""
         mock_bt.bt_target_temp = 25.0
         mock_bt.bt_target_cooltemp = 27.0
         old_state = _make_state(attributes={"temperature": 27.0})
@@ -278,12 +321,13 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
-        assert mock_bt.bt_target_cooltemp == 25.0
-        assert mock_bt.bt_target_temp == 24.5  # pushed down by step (0.5)
+        assert mock_bt.bt_target_cooltemp == 25.5
+        assert mock_bt.bt_target_temp == 25.0
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
-    async def test_heat_target_pushed_down_when_above_cooltemp(self, mock_bt):
-        """When heat target > new cooltemp, heat target is pushed down."""
+    async def test_report_below_heat_target_is_raised(self, mock_bt):
+        """A setpoint below the heat target does not drag the heat target down."""
         mock_bt.bt_target_temp = 24.0
         old_state = _make_state(attributes={"temperature": 27.0})
         new_state = _make_state(attributes={"temperature": 23.0})
@@ -291,28 +335,89 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
-        assert mock_bt.bt_target_cooltemp == 23.0
-        assert mock_bt.bt_target_temp == 22.5  # 23.0 - 0.5
+        assert mock_bt.bt_target_cooltemp == 24.5
+        assert mock_bt.bt_target_temp == 24.0
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
-    async def test_heat_target_not_pushed_when_below_cooltemp(self, mock_bt):
-        """When heat target < cooltemp, heat target stays unchanged."""
+    async def test_report_above_heat_target_is_adopted_verbatim(self, mock_bt, caplog):
+        """A setpoint that already clears the heat target is adopted as reported.
+
+        Nothing yielded to anything, so the log stays quiet about the heating
+        target.
+        """
         mock_bt.bt_target_temp = 20.0
         old_state = _make_state(attributes={"temperature": 25.0})
         new_state = _make_state(attributes={"temperature": 27.0})
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
 
+        caplog.set_level(logging.INFO)
         await trigger_cooler_change(mock_bt, event)
 
         assert mock_bt.bt_target_cooltemp == 27.0
         assert mock_bt.bt_target_temp == 20.0  # unchanged
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+        assert "heating target" not in caplog.text
 
     @pytest.mark.asyncio
-    async def test_heat_target_sync_respects_min_temp(self, mock_bt):
-        """Heat-target sync keeps the heat target inside the configured range.
+    async def test_clamp_to_the_heat_target_is_annunciated(self, mock_bt, caplog):
+        """The user has to be able to see why the remote's value was not kept.
 
-        With the cool target clamped to the minimum there is no room for a full
-        step below it, so the heat target stops at bt_min_temp.
+        Every press on the remote produces one of these, so the level stays at
+        INFO and WARNING keeps its meaning of something being out of range.
+        """
+        mock_bt.bt_target_temp = 20.0
+        old_state = _make_state(attributes={"temperature": 24.0})
+        new_state = _make_state(attributes={"temperature": 18.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        caplog.set_level(logging.INFO)
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 20.5
+        assert mock_bt.bt_target_temp == 20.0
+        assert (
+            "reported setpoint 18.00 does not clear the heating target 20.00"
+            in caplog.text
+        )
+        assert "keeping 20.50" in caplog.text
+        levels = {
+            record.levelno
+            for record in caplog.records
+            if "heating target" in record.getMessage()
+        }
+        assert levels == {logging.INFO}
+
+    @pytest.mark.asyncio
+    async def test_annunciation_at_the_maximum_states_what_was_kept(
+        self, mock_bt, caplog
+    ):
+        """At the maximum the kept value equals the heating target it yielded to.
+
+        No cooling setpoint above bt_max_temp exists, so the adopted value lands
+        on the heating target itself. The message names the target that was not
+        cleared and the value kept, both of which are true of that state.
+        """
+        mock_bt.bt_target_temp = 30.0
+        mock_bt.bt_max_temp = 30.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 22.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        caplog.set_level(logging.INFO)
+        await trigger_cooler_change(mock_bt, event)
+
+        assert (
+            "reported setpoint 22.00 does not clear the heating target 30.00, "
+            "keeping 30.00" in caplog.text
+        )
+
+    @pytest.mark.asyncio
+    async def test_report_below_min_temp_is_raised_above_the_heat_target(self, mock_bt):
+        """Both bounds compose: the range first, then the heat target.
+
+        A setpoint the range clamp already lifted to bt_min_temp is lifted
+        further, because the heat target sits above the minimum.
         """
         mock_bt.bt_target_temp = 6.0
         mock_bt.bt_min_temp = 5.0
@@ -322,12 +427,56 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
-        assert mock_bt.bt_target_cooltemp == 5.0
-        assert mock_bt.bt_target_temp >= mock_bt.bt_min_temp
+        assert mock_bt.bt_target_cooltemp == 6.5
+        assert mock_bt.bt_target_temp == 6.0
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
-    async def test_heat_target_sync_with_zero_step(self, mock_bt):
-        """A zero step falls back to 0.5 so heat stays below cool."""
+    async def test_no_legal_setpoint_above_heat_target_moves_it_one_step(self, mock_bt):
+        """With the heat target at the maximum the heat target yields one step.
+
+        No cooling setpoint above bt_max_temp exists, so the cool target stops
+        at the maximum and the heat target gives up exactly one step. It is
+        never pulled all the way down to the reported value.
+        """
+        mock_bt.bt_target_temp = 30.0
+        mock_bt.bt_max_temp = 30.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 22.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 30.0
+        assert mock_bt.bt_target_temp == 29.5
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+
+    @pytest.mark.asyncio
+    async def test_a_range_narrowed_below_the_heat_target_pulls_it_inside(
+        self, mock_bt
+    ):
+        """A heat target above the maximum is the one case that moves further.
+
+        The range is recomputed from the children, so it can end up below a
+        target already in place. The clamp stops the cooling setpoint at the
+        maximum and the tie-break brings the heating target back inside the
+        range, which takes more than one step.
+        """
+        mock_bt.bt_target_temp = 30.0
+        mock_bt.bt_max_temp = 28.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 18.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 28.0
+        assert mock_bt.bt_target_temp == 27.5
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+
+    @pytest.mark.asyncio
+    async def test_zero_step_falls_back_to_half_degree(self, mock_bt):
+        """A zero step falls back to 0.5 so the two targets stay apart."""
         mock_bt.bt_target_temp = 25.0
         mock_bt.bt_target_cooltemp = 27.0
         mock_bt.bt_target_temp_step = 0.0
@@ -337,7 +486,26 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
+        assert mock_bt.bt_target_cooltemp == 25.5
+        assert mock_bt.bt_target_temp == 25.0
         assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+
+    @pytest.mark.asyncio
+    async def test_report_is_not_bounded_without_a_heating_target(self, mock_bt):
+        """An unknown heating target is no bound and stays unknown.
+
+        There is nothing to clear and nothing to yield, so the reported setpoint
+        is adopted as it arrived.
+        """
+        mock_bt.bt_target_temp = None
+        old_state = _make_state(attributes={"temperature": 27.0})
+        new_state = _make_state(attributes={"temperature": 23.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 23.0
+        assert mock_bt.bt_target_temp is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_per_trv_target_temp_step.py
+++ b/tests/unit/test_per_trv_target_temp_step.py
@@ -66,6 +66,9 @@ def bt():
     mock.bt_target_temp = 21.0
     mock.bt_target_cooltemp = 25.0
     mock.bt_hvac_mode = HVACMode.HEAT
+    mock._clamp_inbound_heat_target = lambda v: (
+        BetterThermostat._clamp_inbound_heat_target(mock, v)
+    )
     mock.cur_temp = 20.0
     mock.tolerance = 0.3
     mock.startup_running = False

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -6,7 +6,8 @@ and the convert_inbound_states / convert_outbound_states helpers.
 """
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+import logging
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.core import State
@@ -60,6 +61,9 @@ def mock_bt():
     bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
     bt.async_write_ha_state = MagicMock()
     bt._enforce_cool_above_heat = lambda: BetterThermostat._enforce_cool_above_heat(bt)
+    bt._clamp_inbound_heat_target = lambda v: (
+        BetterThermostat._clamp_inbound_heat_target(bt, v)
+    )
 
     bt.all_trvs = [{"advanced": {CONF_HOMEMATICIP: False}}]
 
@@ -948,14 +952,19 @@ class TestTargetTempAdoption:
         ):
             await trigger_trv_change(mock_bt, event)
 
+        assert mock_bt.bt_target_temp == 22.0
         assert mock_bt.bt_target_cooltemp == 25.0
 
     @pytest.mark.asyncio
-    async def test_cooler_sync_pushes_cooltemp_above_target(self, mock_bt):
-        """Cooltemp is pushed to target + step when equal to target."""
+    async def test_knob_turn_equal_to_cooltemp_is_lowered(self, mock_bt):
+        """A knob turn onto the cool target is capped one step below it.
+
+        The TRV owns the heating channel alone, so the cool target the user set
+        on the air conditioner stays where it is.
+        """
         mock_bt.cooler_entity_id = "climate.cooler"
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
-        mock_bt.bt_target_cooltemp = 22.0  # equal to new target
+        mock_bt.bt_target_cooltemp = 22.0  # equal to the reported setpoint
         mock_bt.bt_target_temp_step = 0.5
 
         old_state = _make_state(
@@ -979,14 +988,71 @@ class TestTargetTempAdoption:
         ):
             await trigger_trv_change(mock_bt, event)
 
-        assert mock_bt.bt_target_cooltemp == 22.0 + 0.5
+        assert mock_bt.bt_target_temp == 21.5
+        assert mock_bt.bt_target_cooltemp == 22.0
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
-    async def test_cooler_sync_always_overwrites(self, mock_bt):
-        """Cooltemp is pushed to target + step even when already below target."""
+    async def test_knob_turn_above_cooltemp_is_lowered(self, mock_bt, caplog):
+        """A knob turn past the cool target is capped, not the cool target raised.
+
+        The knob went somewhere the group cannot follow, so the user gets an
+        INFO naming the target that was not cleared and the value kept. Every
+        detent of a turn produces one, which is why it is not a WARNING.
+        """
         mock_bt.cooler_entity_id = "climate.cooler"
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
-        mock_bt.bt_target_cooltemp = 15.0
+        mock_bt.bt_target_cooltemp = 22.5
+        mock_bt.bt_target_temp_step = 0.5
+
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 24.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 24.0},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].last_temperature = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        caplog.set_level(logging.INFO)
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 22.0
+        assert mock_bt.bt_target_cooltemp == 22.5
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+        assert (
+            "reported setpoint 24.00 does not clear the cooling target 22.50"
+            in caplog.text
+        )
+        assert "keeping 22.00" in caplog.text
+        levels = {
+            record.levelno
+            for record in caplog.records
+            if "cooling target" in record.getMessage()
+        }
+        assert levels == {logging.INFO}
+
+    @pytest.mark.asyncio
+    async def test_no_legal_setpoint_below_cooltemp_moves_it_one_step(self, mock_bt):
+        """With the cool target at the minimum the cool target yields one step.
+
+        No heating setpoint below bt_min_temp exists, so the heat target stops
+        at the minimum and the cool target gives up exactly one step.
+        """
+        mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_cooltemp = 5.0
+        mock_bt.bt_min_temp = 5.0
         mock_bt.bt_target_temp_step = 0.5
 
         old_state = _make_state(
@@ -1010,7 +1076,49 @@ class TestTargetTempAdoption:
         ):
             await trigger_trv_change(mock_bt, event)
 
-        assert mock_bt.bt_target_cooltemp == 22.0 + 0.5
+        assert mock_bt.bt_target_temp == 5.0
+        assert mock_bt.bt_target_cooltemp == 5.5
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+
+    @pytest.mark.asyncio
+    async def test_a_range_narrowed_above_the_cooltemp_moves_it_further(self, mock_bt):
+        """A cool target below the minimum is the one case that moves further.
+
+        The range is recomputed from the children, so it can end up above a
+        target already in place. The clamp holds the heating setpoint at the
+        minimum and the tie-break then lifts the cooling target clear of it,
+        which takes more than one step.
+        """
+        mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_cooltemp = 10.0
+        mock_bt.bt_min_temp = 20.0
+        mock_bt.bt_target_temp_step = 0.5
+
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 22.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 22.0},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].last_temperature = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 20.0
+        assert mock_bt.bt_target_cooltemp == 20.5
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
     async def test_cooler_sync_with_unknown_cooltemp_adopts_setpoint(self, mock_bt):
@@ -1101,6 +1209,113 @@ class TestTargetTempAdoption:
             await trigger_trv_change(mock_bt, event)
 
         assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+
+    @pytest.mark.asyncio
+    async def test_no_off_leaving_off_keeps_the_two_targets_apart(self, mock_bt):
+        """A knob turn that also switches BT on stays below the cool target.
+
+        The same event adopts the setpoint and resolves the mode from OFF to
+        HEAT, so the mode is still OFF while the setpoint is bounded. Keying the
+        bound off the configured cooler rather than the live mode is what keeps
+        the two channels from ending up crossed with nothing left to repair them.
+        """
+        mock_bt.real_trvs[ENTITY_ID].advanced["no_off_system_mode"] = True
+        mock_bt.real_trvs[ENTITY_ID].min_temp = 5.0
+        mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.bt_hvac_mode = HVACMode.OFF
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_cooltemp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        old_state = _make_state(
+            attributes={"temperature": 5.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 24.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 24.0},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].last_temperature = 5.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+        assert mock_bt.bt_target_temp == 21.5
+        assert mock_bt.bt_target_cooltemp == 22.0
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+
+    @pytest.mark.asyncio
+    async def test_no_off_leaving_off_separates_targets_stuck_at_the_minimum(
+        self, mock_bt, caplog
+    ):
+        """A knob turn against a cool target at the minimum still ends apart.
+
+        With the cool target sitting on bt_min_temp there is no legal heating
+        setpoint below it, so the clamp pins the heat target to that same value
+        and the tie-break has to resolve the draw. The mode is still OFF while
+        the setpoint is adopted, so only the mode resolution later in the same
+        event puts the group into HEAT_COOL and makes the tie-break effective.
+
+        This is the corner where the kept value equals the target it yielded to,
+        so the annunciation is pinned here as well: it may only claim that the
+        report did not clear the cooling target, never that the kept value ends
+        up on either side of it.
+        """
+        mock_bt.real_trvs[ENTITY_ID].advanced["no_off_system_mode"] = True
+        mock_bt.real_trvs[ENTITY_ID].min_temp = 5.0
+        mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.bt_hvac_mode = HVACMode.OFF
+        # A configured cooler drops HEAT from the mode list and reports the
+        # group as HEAT_COOL instead, so the live mode has to be resolved by
+        # the production property rather than pinned to a fixed value.
+        mock_bt.map_on_hvac_mode = HVACMode.HEAT_COOL
+        mock_bt._hvac_list = [HVACMode.OFF, HVACMode.HEAT_COOL]
+        type(mock_bt).hvac_mode = PropertyMock(
+            side_effect=lambda: BetterThermostat.hvac_mode.fget(mock_bt)
+        )
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_cooltemp = 5.0
+        mock_bt.bt_target_temp_step = 0.5
+        old_state = _make_state(
+            attributes={"temperature": 5.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 24.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 24.0},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].last_temperature = 5.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        caplog.set_level(logging.INFO)
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+        assert mock_bt.hvac_mode == HVACMode.HEAT_COOL
+        assert mock_bt.bt_target_temp == 5.0
+        assert mock_bt.bt_target_cooltemp == 5.5
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+        assert (
+            "reported setpoint 24.00 does not clear the cooling target 5.00, "
+            "keeping 5.00" in caplog.text
+        )
+        assert "to stay below cooling target" not in caplog.text
 
 
 class TestTargetTempBasedSync:
@@ -1575,6 +1790,11 @@ def _make_group_bt(entity_ids, *, no_off=False, bt_hvac_mode=HVACMode.HEAT):
     bt.context = MagicMock()
     bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
     bt.async_write_ha_state = MagicMock()
+    bt.hvac_mode = bt_hvac_mode
+    bt._enforce_cool_above_heat = lambda: BetterThermostat._enforce_cool_above_heat(bt)
+    bt._clamp_inbound_heat_target = lambda v: (
+        BetterThermostat._clamp_inbound_heat_target(bt, v)
+    )
     bt.all_trvs = [{"advanced": {CONF_HOMEMATICIP: False}} for _ in entity_ids]
 
     bt.real_trvs = {
@@ -1726,6 +1946,45 @@ class TestGroupedModeAdoption:
             await trigger_trv_change(bt, event)
 
         assert bt.bt_hvac_mode == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_group_knob_turn_stays_below_the_cool_target(self):
+        """A knob turn on one member of a group with a cooler stays below cool.
+
+        The cool target sits on ``bt_min_temp``, so the bound has no legal value
+        below it and the residual tie-break has to separate the two targets.
+        """
+        trigger, other1, other2 = GRP_IDS
+        bt = _make_group_bt(GRP_IDS, bt_hvac_mode=HVACMode.HEAT_COOL)
+        bt.cooler_entity_id = "climate.ac"
+        bt.bt_target_cooltemp = 5.0
+        bt.bt_min_temp = 5.0
+        bt.bt_target_temp_step = 0.5
+        _install_states(
+            bt,
+            {
+                trigger: _grp_state(trigger, "heat", temperature=22.0),
+                other1: _grp_state(other1, "heat"),
+                other2: _grp_state(other2, "heat"),
+            },
+        )
+        bt.real_trvs[trigger].hvac_mode = "heat"
+
+        event = _make_event(
+            bt,
+            new_state=_grp_state(trigger, "heat", temperature=22.0),
+            old_state=_grp_state(trigger, "heat", temperature=19.0),
+            entity_id=trigger,
+        )
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=None,
+        ):
+            await trigger_trv_change(bt, event)
+
+        assert bt.bt_target_temp == 5.0
+        assert bt.bt_target_cooltemp == 5.5
+        assert bt.bt_target_temp < bt.bt_target_cooltemp
 
 
 class TestGroupedNoOffAdoption:


### PR DESCRIPTION
## Motivation:

### The defect

`events/cooler.py::trigger_cooler_change` adopts a cooling setpoint reported **by the cooler** and then calls
`_enforce_heat_below_cool()`, which pushes the user's heating target down to one step below it. Reproduced against the
real method:

| state | remote press | result |
|---|---|---|
| heat 20.0, cool 24.0, `bt_min_temp` 17.0, step 0.5 | AC's own remote to 18.0 | cool 18.0, **heat pulled to 17.5** |

So turning the air conditioner down by hand moves the radiators' target — potentially below room temperature, which
stops the heating. A WARNING appears in the log; nothing in the user interface explains it.

`events/trv.py` has the mirror-image defect: an adopted TRV knob turn calls `_enforce_cool_above_heat()` and raises the
cooling target, so a radiator knob switches the air conditioner off.

### The rule this implements

**An inbound device event clamps the value it is adopting and leaves the other channel's target alone.** A device report
may only ever move its own channel.

That is the rule the integration already applies against the configured range: `resolve_inbound_setpoint` clamps a
reported value into `[bt_min_temp, bt_max_temp]`, reports `clamped`, and the control cycle writes the clamped value back
at the device. `number.py` already applies exactly this clamp to the cooling preset number without touching
`bt_target_temp`. The other channel's target is simply a second bound, applied the same way.

Both handlers change, so the two stay symmetric — a radiator knob must not be authoritative over the air conditioner
while the AC remote is not authoritative over the radiators.

## Changes:

### After the change

| situation | before | after |
|---|---|---|
| heat 20.0, cool 24.0, remote to 18.0 | cool 18.0, heat 17.5 | **cool 20.5, heat 20.0** |
| cool 22.5, TRV knob to 24.0 | heat 24.0, cool 24.5 | **heat 22.0, cool 22.5** |
| heat 30.0 = `bt_max_temp`, remote to 22.0 | cool 22.0, heat 21.5 | **cool 30.0, heat 29.5** (one step) |

The clamped value reaches the device through the control cycle each handler already requests — no new write path. A user
who insists on a lower cooling target lowers the heating target first; that trade is the point of the rule.

The bound on the floor/ceiling is what keeps the degenerate case cheap. An unbounded floor, or a "no legal value, give
up" branch, would hand control straight back to `_enforce_heat_below_cool` and reproduce the reported bug with maximal
damage whenever the heating target sits within one step of the maximum — not only exactly on it.

### What deliberately stays

The two `_enforce_*` calls remain at their call sites as the residual tie-break for the case where the other target sits
within one step of a range bound and no legal value exists. After the clamp they can move a target by at most one step,
and a comment at each call site says so, so the surviving call is not mistaken for the live rule.

### The tie-break also runs where the mode resolves

`_enforce_cool_above_heat()` returns immediately unless the live `hvac_mode` is `HEAT_COOL`, and on a `no_off_system_mode`
valve the setpoint is adopted while `bt_hvac_mode` is still `OFF` — so the call inside the adoption block is a no-op on
exactly the path the clamp was written for. Further down the same handler the `no_off_system_mode` branch sets
`bt_hvac_mode = HVACMode.HEAT`, and with a cooler configured `HEAT` is not in `_hvac_list`, so the `hvac_mode` property
reports `map_on_hvac_mode` — `HEAT_COOL`. That is the first point in the event at which the tie-break can act on
the setpoint adopted a moment earlier, so that branch calls it:

```python
else:
    self.bt_hvac_mode = HVACMode.HEAT
    self._enforce_cool_above_heat()
_main_change = True
```

Observed on the real handler with a `no_off` TRV, a configured cooler and `bt_target_cooltemp == bt_min_temp == 5.0`,
step 0.5, knob turned to 24.0:

| | heating target | cooling target |
|---|---|---|
| without the second call | 5.0 | **5.0** — published equal |
| with it | 5.0 | **5.5** |

The branch is not gated on the mode having changed. It runs on every report from a `no_off` valve above its `min_temp`,
whether `bt_hvac_mode` was `OFF` or already `HEAT`; counting calls on the real handler with the mode already `HEAT`
shows `_enforce_cool_above_heat()` invoked **twice** in one event — once in the adoption block and once here. The
repeat is a no-op unless the two targets are crossed, which is the only condition the helper acts on wherever it is
called from, so nothing moves outside the `OFF` → `HEAT` case the call was added for.

`events/cooler.py` needs no counterpart: it never writes `bt_hvac_mode`, and it gates its whole setpoint block on
`bt_hvac_mode != OFF`, so `_enforce_heat_below_cool()` there always runs with the mode already resolved. The other
`bt_hvac_mode` writes in `events/trv.py` do not reopen the gap either — the mode adoption near the top of the handler
runs before the enforcement call, and the sibling `no_off` branch sets `OFF`, which cannot make the `HEAT_COOL` gate
pass.

That sibling branch — a `no_off` valve reporting its own `min_temp`, read as "heating off" — is the one path that can
still end on a crossed pair. Driven through the real handler with `bt_target_cooltemp == bt_min_temp == 5.0`, step 0.5
and the valve reporting 5.0, it publishes `heat 5.0` / `cool 5.0`. The mode it resolves to is `OFF`, so the `HEAT_COOL`
gate keeps the tie-break out wherever it is called from. That is how the OFF path already behaves; this change neither
causes it nor repairs it, and the comment at the new call site says what that call does rather than claiming to be the
only place a crossed pair can be settled.

`_enforce_cool_above_heat` did **not** gain a `bt_max_temp` bound.
`tests/unit/test_preset_number_restore.py::test_active_preset_enforces_cool_above_heat_at_max` documents in its docstring
that exceeding `bt_max_temp` at the ceiling is intentional — strict ordering is ranked above the max bound — and asserts
`bt_target_cooltemp == 30.5` with `bt_max_temp == 30.0`. That file is untouched.

### Annunciation

A cross-channel clamp is announced at **INFO**, naming the reported value, the target it did not clear and the value
kept:

```
TRV climate.trv reported setpoint 24.00 does not clear the cooling target 22.50, keeping 22.00
Cooler climate.ac reported setpoint 18.00 does not clear the heating target 20.00, keeping 20.50
```

The message says what the report failed to do; it does not say where the kept value ended up relative to the other
target. That matters in the corner where the bound stops on a range limit: with `bt_target_cooltemp == bt_min_temp ==
5.0` the kept value *is* 5.0, so a phrasing such as "keeping 5.00 to stay below cooling target 5.00" would print a false
statement.

WARNING stays reserved for the out-of-range clamp and for the `_enforce_*` residual: a user stepping a remote reports
every intermediate setpoint and would otherwise collect one WARNING per press. Both the text and the level are asserted
on both handlers, including in that pinned-at-the-limit corner, and the cases where no bound bit assert that nothing is
logged about the other channel.

The TRV adoption debug line now prints the value actually stored, so the log no longer disagrees with `bt_target_temp`
when the clamp lowered it.

### The one step of separation

Both clamps take their step from `normalize_step(self.bt_target_temp_step)`. `bt_target_temp_step` falls back to
`max(steps)` collected from the child entities, so it carries whatever they report. Run against the two helpers with
`heat 20.0` / `cool 24.0`:

| step | heat clamp of 26.0 | cool clamp of 18.0 | resulting pair |
|---|---|---|---|
| `-1.0` | 25.0 | 19.0 | **crossed in both directions** |
| `nan` | 26.0 | 18.0 | **crossed — every comparison fails, the bound is dropped** |
| `inf` | 5.0 | 30.0 | pinned to the range bound |

`normalize_step` returns 0.5 for anything that is not a positive finite number and is what `events/trv.py` and
`events/cooler.py` already apply to the same value. The `_enforce_*` helpers are outside this change and keep their own
step handling.

### Scope of the bound

Both clamps key off the **configured cooling channel**, not the live HVAC mode. The ordering of the two targets is a
property of the configuration, so it has to hold whatever mode the group is in — and on the TRV side that is what makes
it hold at all: a valve with `no_off_system_mode` reports its knob turn while `bt_hvac_mode` is still OFF, and the same
event then resolves the mode. The `_enforce_*` fallbacks only run inside HEAT_COOL, so the clamp is what holds the
ordering while the group is off, and the tie-break call at the mode resolution is what closes the one case the clamp
cannot separate on its own.

Installations without a cooler are provably unaffected: both helpers return the value untouched.

Both clamps are also no-ops while the other channel's target is still `None` — the normal state before a child entity has
reported — so the very first adoption after startup is bounded by the configured range only.

### Verification

- Full suite: `2255 passed` (`uv run pytest tests/`), ruff check + format clean.
- Direct unit tests for both helpers (no-op without a cooler, no-op when the other target is None, no-op when the value
  already clears it, clamp when it does not, bound respected at the range edge, the ordering held while the group is
  off, and a step of `-1.0` / `nan` / `inf` falling back to 0.5), plus rewritten `TestHeatTargetSync` and the mirror TRV
  cases.
- Counterfactual on the step: restoring `self.bt_target_temp_step or 0.5` fails all six new step cases, e.g.
  `assert 5.0 == 23.5` for an infinite step and `assert 26.0 == 23.5` for a NaN one.
- Counterfactual on the annunciation: restoring the earlier phrasing fails four tests, and the captured log shows the
  false line it produced — `reported setpoint 22.00, keeping 30.00 to stay above heating target 30.00`. Downgrading the
  call from `_LOGGER.info` to `_LOGGER.warning` fails the two level assertions.
- `tests/unit/test_trv_events.py::TestTargetTempAdoption::test_no_off_leaving_off_separates_targets_stuck_at_the_minimum`
  drives the real handler through the OFF → HEAT resolution with the cool target on `bt_min_temp` and resolves
  `hvac_mode` through the production property, so the `HEAT_COOL` gate is evaluated rather than pinned. Reverting the
  added `_enforce_cool_above_heat()` call makes it fail with `assert 5.0 == 5.5` — the two targets published equal.
- `tests/unit/test_trv_events.py::TestGroupedModeAdoption::test_group_knob_turn_stays_below_the_cool_target` runs the
  same pinned-at-the-minimum corner through a three-TRV group with a cooler configured, so the bound and the tie-break
  are exercised on the multi-member path as well. Bypassing the bound (`self.bt_target_temp = _new_heating_setpoint`)
  fails it with `assert 22.0 == 5.0`, and dropping the group fixture's `hvac_mode` / `_enforce_cool_above_heat` /
  `_clamp_inbound_heat_target` wiring fails this test and no other — that wiring had no exercising test before.
- `tests/unit/test_preset_number_restore.py`, `tests/unit/controlling/test_control_cooler.py` and `tests/benchmark/` are
  untouched.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: n/a - covered by unit tests, no hardware run for this change
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

No new device mapping is added by this PR; the `climate.py` change is a control-path fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat setpoint handling when heating and cooling targets conflict.
  * Cooling targets are adjusted above heating targets, while heating targets remain below cooling targets.
  * Adjustments respect configured temperature limits and work when HVAC mode is off.
  * Heating targets are preserved when cooling reports require correction.
  * Informational messages indicate when reported targets are adjusted.

* **Tests**
  * Expanded coverage for temperature bounds, missing targets, zero-step settings, and grouped thermostat behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


