### PR TITLE
fix(cooler): seed an unknown cool target from the cooler's own setpoint

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -135,17 +135,19 @@ from .utils.const import (
 from .utils.controlling import control_queue, control_trv
 from .utils.helpers import (
     COOLER_SETPOINT_KEYS,
+    InboundSetpoint,
     async_normalize_bt_entity_ids,
     attr_to_celsius,
     convert_to_float,
     convert_to_float_celsius,
+    device_setpoint_step,
     find_battery_entity,
     get_device_model,
     get_hvac_bt_mode,
     is_reasonable_temperature,
     normalize_hvac_mode,
     normalize_step,
-    read_setpoint_celsius,
+    resolve_inbound_setpoint,
     state_temperature_unit,
 )
 from .utils.hvac_action import (
@@ -1207,6 +1209,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             # been removed in the meantime; bail out before writing to TRVs.
             if self.is_removed:
                 return
+            # A restored preset carries a cooling target the user chose, so the
+            # cooler's own setpoint only fills a target that is still unknown.
+            # Both the temperature range and the heating target are final at
+            # this point, which is what a value read off the device has to be
+            # clamped into and ordered against.
+            self._seed_cool_target_from_cooler("startup()")
             self._validate_hvac_mode(states)
             await self._initialize_trvs()
             await self._finalize_startup()
@@ -1322,7 +1330,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             self.bt_target_temp_step = max(steps) if steps else None
 
     def _initialize_sensors(self, sensor_state: State | None) -> None:
-        """Set up room temperature, humidity, cooler and window sensors."""
+        """Set up room temperature, humidity, window and door sensors."""
         self.all_entities.append(self.sensor_entity_id)
 
         # Handle room temperature sensor with TRV fallback
@@ -1436,22 +1444,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     or 0.0
                 )
             # else: already logged warning above, _current_humidity stays None
-
-        if self.cooler_entity_id is not None:
-            _cooler_state = self.hass.states.get(self.cooler_entity_id)
-            if _cooler_state is not None and _cooler_state.state not in (
-                STATE_UNAVAILABLE,
-                STATE_UNKNOWN,
-                None,
-            ):
-                # A cooler that only supports TARGET_TEMPERATURE_RANGE reports
-                # ``temperature: None`` and carries its setpoint in
-                # ``target_temp_high``, so the same key precedence the event
-                # handler and control_cooler() use applies here too.
-                self.bt_target_cooltemp = read_setpoint_celsius(
-                    self, _cooler_state, COOLER_SETPOINT_KEYS, "startup()"
-                )
-            # else: already logged warning above
 
         self.window_open = _detect_contact_open_at_startup(
             self, self.window_id, "window"
@@ -2186,6 +2178,22 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     self.hass, [self.cooler_entity_id], self._trigger_cooler_change
                 )
             )
+            # A cool target still unknown here means the earlier read of the
+            # cooler setpoint yielded nothing: the cooler published no state
+            # yet, or the state it published carried no readable setpoint.
+            # An unknown cool target holds control_cooler() at OFF on every
+            # cycle, and the event handler only ever sees a cooler that
+            # changes state again. The subscription above is live from this
+            # point on, so this is the last moment a state that never changes
+            # again can still be read.
+            if (
+                self._seed_cool_target_from_cooler("_finalize_startup()")
+                and self.bt_hvac_mode != HVACMode.OFF
+            ):
+                # A thermostat that is off has nothing to act on: the target is
+                # stored for the first cycle after it is switched on, and that
+                # switch queues its own.
+                await self.control_queue_task.put(self)
         if self.outdoor_sensor is not None:
             self.async_on_remove(
                 async_track_state_change_event(
@@ -2836,28 +2844,174 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         await self.control_queue_task.put(self)
 
-    def _enforce_cool_above_heat(self) -> None:
+    def _seed_cool_target_from_cooler(self, log_source: str) -> bool:
+        """Fill a cooling target that is still unknown from the cooler's state.
+
+        The single place a cooling target is taken off the device, so every
+        such value passes the same resolution: it is read with the key
+        precedence a cooler is driven through — a device that only supports
+        TARGET_TEMPERATURE_RANGE reports ``temperature: None`` and carries its
+        setpoint in ``target_temp_high`` — clamped into the configured range,
+        and ordered above the heating target. A cooler that was unavailable
+        while that range was derived contributed no bounds to it, so the
+        setpoint it reports can sit outside the range and is clamped into it
+        exactly like a reported one. Echo detection has nothing to compare
+        against, because no setpoint is written to a cooler whose target is
+        unknown.
+
+        A target that is already known is left alone: it is either the value a
+        restored preset carries, which is the user's own choice, or one this
+        method took earlier.
+
+        Parameters
+        ----------
+        log_source : str
+            the reading site's own name, forwarded for logging context; the
+            startup sequence reads twice, and the line that reports an
+            attribute the resolution could not read names this value, so each
+            caller passes the name of the site it reads from
+
+        Returns
+        -------
+        bool
+            whether a cooling target was seeded; False when one is already
+            known, when no cooler is configured, and when the cooler has no
+            state, is unavailable or publishes no readable setpoint
+        """
+        if self.cooler_entity_id is None or self.bt_target_cooltemp is not None:
+            return False
+        cooler_state = self.hass.states.get(self.cooler_entity_id)
+        if cooler_state is None or cooler_state.state in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+        ):
+            return False
+        setpoint = resolve_inbound_setpoint(
+            self,
+            cooler_state,
+            keys=COOLER_SETPOINT_KEYS,
+            known_values=(),
+            step=device_setpoint_step(self, cooler_state, log_source),
+            log_source=log_source,
+        )
+        if setpoint is None:
+            return False
+        self._seed_cool_target(setpoint, self.cooler_entity_id)
+        return True
+
+    def _seed_cool_target(self, setpoint: InboundSetpoint, entity_id: str) -> None:
+        """Adopt a cooler's own setpoint as the cooling target.
+
+        A cooling target that is unknown holds the cooler off on every control
+        cycle, and the cooler's own setpoint is the only value available to fill
+        it with. That value is an observation rather than user intent, so the
+        cooling side is the one that yields when the two targets collide, and the
+        heating target the user set stays where it is. The ordering is applied in
+        every HVAC mode, because a target seeded while Better Thermostat is off
+        is the one the first cooling cycle after switching on works with and that
+        transition does not revisit the pair.
+
+        A value the user never chose has to be traceable, because the stored
+        target is written back to the cooler: this annunciates the clamp into the
+        configured range, and :meth:`_enforce_cool_above_heat` annunciates a lift
+        above the heating target.
+
+        Parameters
+        ----------
+        setpoint : InboundSetpoint
+            the setpoint the cooler reports, already resolved into BT's range
+        entity_id : str
+            the cooler whose setpoint is being adopted
+        """
+        if setpoint.clamped:
+            _LOGGER.warning(
+                "better_thermostat %s: Cooler %s reported setpoint %s outside of "
+                "range while the cool target is unknown, taking %s as the cool "
+                "target",
+                self.device_name,
+                entity_id,
+                setpoint.raw,
+                setpoint.value,
+            )
+        else:
+            _LOGGER.info(
+                "better_thermostat %s: Cooler %s reports setpoint %s while the "
+                "cool target is unknown, taking it as the cool target",
+                self.device_name,
+                entity_id,
+                setpoint.value,
+            )
+        self.bt_target_cooltemp = setpoint.value
+        self._enforce_cool_above_heat(regardless_of_hvac_mode=True)
+
+    def _enforce_cool_above_heat(
+        self, *, regardless_of_hvac_mode: bool = False
+    ) -> None:
         """Keep the cooling target strictly above the heating target.
 
         In HEAT_COOL mode the two setpoints must not cross. If the cool target is
-        at or below the heat target, bump it up by one temperature step.
+        at or below the heat target, bump it up by one temperature step. The step
+        is normalised to a positive value first: a configured step of zero or
+        below would move the cooling target the wrong way and leave the pair it
+        is meant to order inverted.
+
+        The cooling target is reported as ``target_temperature_high`` and written
+        to the cooler, so the bump is capped at the configured maximum. Where the
+        heating target leaves the range no room, the two invariants collide and
+        one of them decides:
+
+        - A heating target resting on the maximum leaves no value above it inside
+          the range. The range wins: the cooling target goes to the maximum, the
+          closest to ordered that the range holds, and the overlap that remains
+          is annunciated. Cooling is gated on the room being warmer than the
+          heating target as well, so the two targets meeting does not run the
+          cooler against the TRVs.
+        - A heating target above the maximum is itself outside the range, so a
+          cap would put the cooling target below it. The ordering wins: the bump
+          is left uncapped rather than inverting the pair this method exists to
+          order.
+
+        Parameters
+        ----------
+        regardless_of_hvac_mode : bool
+            Enforce the ordering outside HEAT_COOL as well. Callers that store a
+            cooling target read off the device need this: such a value has to be
+            ordered the moment it is stored, because the mode can change without
+            the pair being looked at again, and the first cooling cycle after
+            that would drive the room down while the TRVs heat it up.
         """
+        if not regardless_of_hvac_mode and self.hvac_mode != HVACMode.HEAT_COOL:
+            return
         if (
-            self.hvac_mode != HVACMode.HEAT_COOL
-            or self.bt_target_cooltemp is None
+            self.bt_target_cooltemp is None
             or self.bt_target_temp is None
             or self.bt_target_cooltemp > self.bt_target_temp
         ):
             return
-        step = self.bt_target_temp_step or 0.5
+        step = normalize_step(self.bt_target_temp_step)
         adjusted = self.bt_target_temp + step
-        _LOGGER.warning(
-            "better_thermostat %s: cooling target %.2f adjusted to %.2f to stay above heating target %.2f",
-            self.device_name,
-            self.bt_target_cooltemp,
-            adjusted,
-            self.bt_target_temp,
-        )
+        maximum = self.bt_max_temp
+        if maximum is not None and maximum >= self.bt_target_temp:
+            adjusted = min(adjusted, maximum)
+        if adjusted == self.bt_target_cooltemp:
+            return
+        if adjusted > self.bt_target_temp:
+            _LOGGER.warning(
+                "better_thermostat %s: cooling target %.2f adjusted to %.2f to stay above heating target %.2f",
+                self.device_name,
+                self.bt_target_cooltemp,
+                adjusted,
+                self.bt_target_temp,
+            )
+        else:
+            _LOGGER.warning(
+                "better_thermostat %s: cooling target %.2f raised to the "
+                "configured maximum %.2f, which the heating target occupies as "
+                "well, because the range holds no value above it",
+                self.device_name,
+                self.bt_target_cooltemp,
+                adjusted,
+            )
         self.bt_target_cooltemp = adjusted
 
     def _enforce_heat_below_cool(self) -> None:
@@ -2866,7 +3020,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         The counterpart to :meth:`_enforce_cool_above_heat`, for the case where
         the cooling target is the value that was just set: the heating target
         yields instead, down to one temperature step below the cooling target
-        and never below the configured minimum.
+        and never below the configured minimum. The step is normalised to a
+        positive value first: a configured step of zero or below would move the
+        heating target the wrong way and leave the pair it is meant to order
+        inverted.
+
+        A minimum that the cooling target does not clear by at least one step
+        pins the heating target on the minimum, at or above the cooling target:
+        the range bounds the value that is stored, and the overlap that remains
+        is annunciated as such rather than reported as an ordered pair.
         """
         if (
             self.hvac_mode != HVACMode.HEAT_COOL
@@ -2875,17 +3037,29 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             or self.bt_target_temp < self.bt_target_cooltemp
         ):
             return
-        step = self.bt_target_temp_step or 0.5
+        step = normalize_step(self.bt_target_temp_step)
         adjusted = self.bt_target_cooltemp - step
         if self.bt_min_temp is not None:
             adjusted = max(adjusted, self.bt_min_temp)
-        _LOGGER.warning(
-            "better_thermostat %s: heating target %.2f adjusted to %.2f to stay below cooling target %.2f",
-            self.device_name,
-            self.bt_target_temp,
-            adjusted,
-            self.bt_target_cooltemp,
-        )
+        if adjusted == self.bt_target_temp:
+            return
+        if adjusted < self.bt_target_cooltemp:
+            _LOGGER.warning(
+                "better_thermostat %s: heating target %.2f adjusted to %.2f to stay below cooling target %.2f",
+                self.device_name,
+                self.bt_target_temp,
+                adjusted,
+                self.bt_target_cooltemp,
+            )
+        else:
+            _LOGGER.warning(
+                "better_thermostat %s: heating target %.2f set to the configured "
+                "minimum %.2f, which is not below the cooling target %.2f",
+                self.device_name,
+                self.bt_target_temp,
+                adjusted,
+                self.bt_target_cooltemp,
+            )
         self.bt_target_temp = adjusted
 
     def _clamp_inbound_cool_target(self, value: float) -> float:

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -9,42 +9,19 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.climate.const import HVACMode
-from homeassistant.const import UnitOfTemperature
-from homeassistant.core import State, callback
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import callback
 
 from custom_components.better_thermostat.utils.helpers import (
     COOLER_SETPOINT_KEYS,
-    convert_to_float,
-    normalize_step,
+    device_setpoint_step,
     read_setpoint_celsius,
     resolve_inbound_setpoint,
     resolve_state_change_event,
     setpoint_echo_window,
-    state_temperature_unit,
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _get_cooler_step(self, state: State) -> float:
-    """Return the cooler's setpoint step as a °C delta."""
-    raw_step = state.attributes.get("target_temp_step")
-    step = (
-        convert_to_float(str(raw_step), self.device_name, "trigger_cooler_change()")
-        if raw_step is not None
-        else None
-    )
-    if (
-        step is not None
-        and state_temperature_unit(
-            state.attributes, self.hass.config.units.temperature_unit
-        )
-        == UnitOfTemperature.FAHRENHEIT
-    ):
-        step = round(step * 5.0 / 9.0, 4)
-    if step is None or step <= 0:
-        return normalize_step(self.bt_target_temp_step)
-    return step
 
 
 @callback
@@ -65,7 +42,7 @@ async def trigger_cooler_change(self, event):
     )
 
     _main_change = False
-    _step = _get_cooler_step(self, new_state)
+    _step = device_setpoint_step(self, new_state, "trigger_cooler_change()")
     # The previous state only answers whether the cooler was publishing a
     # setpoint at all, so it is read without clamping or echo detection.
     _old_cooling_setpoint = read_setpoint_celsius(
@@ -79,7 +56,41 @@ async def trigger_cooler_change(self, event):
         step=_step,
         log_source="trigger_cooler_change()",
     )
-    if (
+    if _new_cooling_setpoint is not None and self.bt_target_cooltemp is None:
+        # An unknown cool target holds the cooler OFF on every control cycle,
+        # and the gate below cannot lift it: that gate needs a setpoint in the
+        # previous state, which a cooler that was away usually no longer
+        # publishes, and a reported move, which a cooler resting on its own
+        # setpoint never reports. The device's own setpoint is the only value
+        # there is; taking it loses no user intent because the field carries
+        # none, and it cannot be an echo either, because no setpoint is written
+        # to the cooler while the target is unknown.
+        if new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            # A cooler that is unavailable or has no mode yet can still carry a
+            # setpoint: an entity reports "unknown" while publishing its full
+            # attributes, and one that writes the state machine directly keeps
+            # the attributes it last set. Such a value is retained rather than
+            # reported and says nothing about the device now, so it must not
+            # become the cool target, which is written straight back to it.
+            # _seed_cool_target_from_cooler() declines the same two states at
+            # startup. This check sits inside the branch rather than in its
+            # condition, so declining ends the event here: the gate below would
+            # otherwise read that same retained setpoint and store it as the
+            # cool target, raised to clear the heating target, which is exactly
+            # what declining refuses.
+            _LOGGER.debug(
+                "better_thermostat %s: Cooler %s is %s, not seeding the cool "
+                "target from its retained setpoint %s",
+                self.device_name,
+                entity_id,
+                new_state.state,
+                _new_cooling_setpoint.raw,
+            )
+        else:
+            self._seed_cool_target(_new_cooling_setpoint, entity_id)
+            if self.bt_hvac_mode != HVACMode.OFF:
+                _main_change = True
+    elif (
         _new_cooling_setpoint is not None
         and _old_cooling_setpoint is not None
         and self.bt_hvac_mode != HVACMode.OFF

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -694,6 +694,48 @@ def normalize_step(value: float | int | str | None, fallback: float = 0.5) -> fl
     return step
 
 
+def device_setpoint_step(self, state: State, log_source: str) -> float:
+    """Return a controlled device's setpoint step as a °C delta.
+
+    The step belongs to the device that reports it and carries that device's
+    unit, so a Fahrenheit reading is converted to a Celsius delta before it can
+    be compared with a Celsius setpoint. A device that publishes no usable step
+    falls back to Better Thermostat's own step.
+
+    Parameters
+    ----------
+    self :
+            the Better Thermostat instance, supplying ``hass``, ``device_name``
+            and the configured step
+    state : State
+            the device state carrying the reported ``target_temp_step``
+    log_source : str
+            caller name, forwarded for logging context
+
+    Returns
+    -------
+    float
+            the device's setpoint step as a positive Celsius delta
+    """
+    raw_step = state.attributes.get("target_temp_step")
+    step = (
+        convert_to_float(str(raw_step), self.device_name, log_source)
+        if raw_step is not None
+        else None
+    )
+    if (
+        step is not None
+        and state_temperature_unit(
+            state.attributes, self.hass.config.units.temperature_unit
+        )
+        == UnitOfTemperature.FAHRENHEIT
+    ):
+        step = round(step * 5.0 / 9.0, 4)
+    if step is None or step <= 0:
+        return normalize_step(self.bt_target_temp_step)
+    return step
+
+
 def setpoint_echo_window(step: float) -> float:
     """Return the distance below which a setpoint difference is grid noise.
 

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -122,6 +122,37 @@ class TestControlCooler:
         assert calls[1].args[2]["hvac_mode"] == HVACMode.COOL
 
     @pytest.mark.asyncio
+    async def test_unknown_cool_target_only_switches_the_cooler_off(self):
+        """An unknown cool target switches a running cooler off and writes no setpoint.
+
+        Without a cooling setpoint there is no value to send, and the mode
+        decision falls through to OFF regardless of how warm the room is, so a
+        cool target that never becomes known keeps a working air conditioner off.
+        """
+        mock_hass = Mock()
+        mock_hass.services = Mock()
+        mock_hass.services.async_call = AsyncMock()
+
+        mock_hass.states.get.return_value = _make_cooler_state(
+            state=HVACMode.COOL, temperature=24.0
+        )
+
+        mock_self = _make_mock_self(
+            mock_hass,
+            bt_target_cooltemp=None,
+            cur_temp=26.0,
+            bt_target_temp=20.0,
+            bt_hvac_mode=HVACMode.HEAT_COOL,
+        )
+
+        await control_cooler(mock_self)
+
+        calls = mock_hass.services.async_call.call_args_list
+        assert len(calls) == 1
+        assert calls[0].args[1] == "set_hvac_mode"
+        assert calls[0].args[2]["hvac_mode"] == HVACMode.OFF
+
+    @pytest.mark.asyncio
     async def test_cooling_not_needed_when_temp_below_bt_target(self):
         """Test cooling doesn't turn on if cur_temp <= bt_target_temp.
 

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -5,6 +5,7 @@ mock_bt fixture (MagicMock with explicit attributes).
 """
 
 from datetime import UTC, datetime, timedelta
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.climate.const import (
@@ -23,6 +24,7 @@ import pytest
 
 from custom_components.better_thermostat.climate import BetterThermostat
 from custom_components.better_thermostat.trv import Trv
+from custom_components.better_thermostat.utils.helpers import InboundSetpoint
 from custom_components.better_thermostat.utils.hvac_action import ToleranceHysteresis
 from custom_components.better_thermostat.utils.thermal_learning import (
     HeatingPowerTracker,
@@ -120,7 +122,12 @@ def mock_bt():
         bt, result
     )
     bt._get_outdoor_temp = lambda: BetterThermostat._get_outdoor_temp(bt)
-    bt._enforce_cool_above_heat = lambda: BetterThermostat._enforce_cool_above_heat(bt)
+    bt._enforce_cool_above_heat = lambda **kwargs: (
+        BetterThermostat._enforce_cool_above_heat(bt, **kwargs)
+    )
+    bt._seed_cool_target = lambda setpoint, entity_id: (
+        BetterThermostat._seed_cool_target(bt, setpoint, entity_id)
+    )
     return bt
 
 
@@ -1226,6 +1233,173 @@ class TestEnforceCoolAboveHeat:
         self._call(mock_bt)
         assert mock_bt.bt_target_cooltemp is None
 
+    def test_regardless_of_hvac_mode_bumps_outside_heat_cool(self, mock_bt):
+        """The mode gate is skipped on request so an off BT is ordered too."""
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 20.0
+        BetterThermostat._enforce_cool_above_heat(mock_bt, regardless_of_hvac_mode=True)
+        assert mock_bt.bt_target_cooltemp == 22.5
+
+    def test_regardless_of_hvac_mode_still_needs_both_targets(self, mock_bt):
+        """Skipping the mode gate does not invent a cool target out of None."""
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_cooltemp = None
+        BetterThermostat._enforce_cool_above_heat(mock_bt, regardless_of_hvac_mode=True)
+        assert mock_bt.bt_target_cooltemp is None
+
+    def test_regardless_of_hvac_mode_still_needs_a_heat_target(self, mock_bt):
+        """Without a heat target there is nothing to order the cool target against."""
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_temp = None
+        mock_bt.bt_target_cooltemp = 20.0
+        BetterThermostat._enforce_cool_above_heat(mock_bt, regardless_of_hvac_mode=True)
+        assert mock_bt.bt_target_cooltemp == 20.0
+
+    def test_regardless_of_hvac_mode_keeps_an_already_ordered_pair(self, mock_bt):
+        """Only the mode gate is skipped, so an ordered pair is still left alone."""
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_cooltemp = 26.0
+        BetterThermostat._enforce_cool_above_heat(mock_bt, regardless_of_hvac_mode=True)
+        assert mock_bt.bt_target_cooltemp == 26.0
+
+    def test_default_is_mode_gated(self, mock_bt):
+        """A caller that omits the flag is gated on HEAT_COOL."""
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 20.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 20.0
+
+    def test_bump_is_capped_at_the_configured_maximum(self, mock_bt):
+        """A step that would overshoot the maximum stops at it.
+
+        The cool target is written to the cooler, so a value the configured
+        range does not contain must never be stored. A maximum above the heat
+        target holds both invariants at once: the capped value is inside the
+        range and still strictly above the heat target.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.bt_target_temp = 29.8
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 29.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 30.0
+        assert mock_bt.bt_target_cooltemp > mock_bt.bt_target_temp
+        assert mock_bt.bt_target_cooltemp <= mock_bt.bt_max_temp
+
+    def test_no_maximum_leaves_the_bump_uncapped(self, mock_bt):
+        """Without a maximum there is no upper bound to stop the bump at."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = None
+        mock_bt.bt_target_temp = 29.8
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 29.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 30.3
+
+    def test_maximum_below_the_heat_target_does_not_cap(self, mock_bt, caplog):
+        """A maximum under the heat target is no bound for the cool target.
+
+        The heat target itself is outside the range there, so capping the cool
+        target to the maximum would leave it below the heat target: the very
+        inversion this method exists to prevent. The ordering decides instead.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = 18.0
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 17.0
+
+        with caplog.at_level(logging.WARNING):
+            self._call(mock_bt)
+
+        assert mock_bt.bt_target_cooltemp == 22.5
+        assert mock_bt.bt_target_cooltemp > mock_bt.bt_target_temp
+        assert "raised to the configured maximum" not in caplog.text
+
+    def test_out_of_range_cool_target_is_raised_not_lowered(self, mock_bt):
+        """A cool target above the maximum but under the heat target moves up.
+
+        Pulling it down to the maximum would put it under the heat target, so
+        it is bumped above the heat target and stays out of range.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.bt_target_temp = 31.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 30.5
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 31.5
+
+    def test_heat_target_at_the_maximum_lifts_cool_to_the_maximum(
+        self, mock_bt, caplog
+    ):
+        """With no room above the heat target the cool target goes to the maximum.
+
+        Leaving it below the heat target would cool a room the TRVs are heating,
+        so it moves as far up as the range allows and the remaining overlap is
+        annunciated.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.bt_target_temp = 30.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 28.0
+
+        with caplog.at_level(logging.WARNING):
+            self._call(mock_bt)
+
+        assert mock_bt.bt_target_cooltemp == 30.0
+        assert (
+            "cooling target 28.00 raised to the configured maximum 30.00, which "
+            "the heating target occupies as well, because the range holds no "
+            "value above it" in caplog.text
+        )
+
+    def test_non_positive_step_falls_back_to_the_default_step(self, mock_bt, caplog):
+        """A step that is not positive cannot be the distance the target moves.
+
+        The configured step reaches this method as the operator entered it, and
+        a value of zero or below would subtract instead of add: the cool target
+        would land at or under the heat target, still inverted, and be
+        annunciated as if it had been lifted.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = -1.0
+        mock_bt.bt_target_cooltemp = 20.0
+
+        with caplog.at_level(logging.WARNING):
+            self._call(mock_bt)
+
+        assert mock_bt.bt_target_cooltemp == 22.5
+        assert mock_bt.bt_target_cooltemp > mock_bt.bt_target_temp
+        assert (
+            "cooling target 20.00 adjusted to 22.50 to stay above heating "
+            "target 22.00" in caplog.text
+        )
+
+    def test_pair_already_at_the_maximum_is_left_alone(self, mock_bt, caplog):
+        """Both targets resting on the maximum leaves nothing to adjust or report."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.bt_target_temp = 30.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 30.0
+
+        with caplog.at_level(logging.WARNING):
+            self._call(mock_bt)
+
+        assert mock_bt.bt_target_cooltemp == 30.0
+        assert "cooling target" not in caplog.text
+
 
 # ===========================================================================
 # 8. TestEnforceHeatBelowCool
@@ -1281,15 +1455,118 @@ class TestEnforceHeatBelowCool:
         self._call(mock_bt)
         assert mock_bt.bt_target_temp == 21.5
 
-    def test_result_is_clamped_to_min_temp(self, mock_bt):
-        """The heat target never drops below the configured minimum."""
+    def test_result_is_clamped_to_min_temp(self, mock_bt, caplog):
+        """The heat target never drops below the configured minimum.
+
+        The clamp lands the heat target on the cool target rather than below
+        it, so the line that reports the move says what it did instead of
+        claiming an ordering the stored pair does not have.
+        """
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_target_temp = 6.0
         mock_bt.bt_target_temp_step = 0.5
         mock_bt.bt_min_temp = 5.0
         mock_bt.bt_target_cooltemp = 5.0
-        self._call(mock_bt)
+
+        with caplog.at_level(logging.WARNING):
+            self._call(mock_bt)
+
         assert mock_bt.bt_target_temp == 5.0
+        assert (
+            "heating target 6.00 set to the configured minimum 5.00, which is "
+            "not below the cooling target 5.00" in caplog.text
+        )
+        assert "to stay below cooling target" not in caplog.text
+
+    def test_minimum_above_the_cool_target_is_reported_as_an_overlap(
+        self, mock_bt, caplog
+    ):
+        """A minimum above the cool target leaves the stored heat target above it.
+
+        The clamp is the only bound applied, so the heat target comes to rest
+        on the minimum even though the cool target sits below it, and the line
+        that reports the move names the minimum rather than an ordering.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_min_temp = 20.0
+        mock_bt.bt_target_cooltemp = 15.0
+
+        with caplog.at_level(logging.WARNING):
+            self._call(mock_bt)
+
+        assert mock_bt.bt_target_temp == 20.0
+        assert (
+            "heating target 22.00 set to the configured minimum 20.00, which is "
+            "not below the cooling target 15.00" in caplog.text
+        )
+
+    def test_ordered_result_is_reported_as_ordered(self, mock_bt, caplog):
+        """A heat target that ends up below the cool target reports the ordering."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 24.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_cooltemp = 22.0
+
+        with caplog.at_level(logging.WARNING):
+            self._call(mock_bt)
+
+        assert mock_bt.bt_target_temp == 21.5
+        assert (
+            "heating target 24.00 adjusted to 21.50 to stay below cooling "
+            "target 22.00" in caplog.text
+        )
+        assert "configured minimum" not in caplog.text
+
+    def test_heat_target_already_at_the_minimum_is_left_alone(self, mock_bt, caplog):
+        """A pair already resting on the minimum leaves nothing to adjust or report."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 5.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_cooltemp = 5.0
+
+        with caplog.at_level(logging.WARNING):
+            self._call(mock_bt)
+
+        assert mock_bt.bt_target_temp == 5.0
+        assert "heating target" not in caplog.text
+
+    def test_negative_step_falls_back_to_the_default_step(self, mock_bt, caplog):
+        """A negative step must not raise the heat target above the cool target.
+
+        A child that publishes ``target_temp_step: -0.5`` reaches
+        ``bt_target_temp_step`` unfiltered, and subtracting a negative step
+        would invert the pair this method exists to order while reporting the
+        move as if it had stayed below.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = -0.5
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_cooltemp = 22.0
+
+        with caplog.at_level(logging.WARNING):
+            self._call(mock_bt)
+
+        assert mock_bt.bt_target_temp == 21.5
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+        assert (
+            "heating target 22.00 adjusted to 21.50 to stay below cooling "
+            "target 22.00" in caplog.text
+        )
+
+    def test_non_finite_step_falls_back_to_the_default_step(self, mock_bt):
+        """A NaN step must not turn the heat target into NaN."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = float("nan")
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_cooltemp = 22.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 21.5
 
     def test_none_heat_target_is_noop(self, mock_bt):
         """A None heat target does not raise and stays None."""
@@ -1473,3 +1750,71 @@ class TestClampInboundHeatTarget:
         mock_bt.bt_target_cooltemp = 24.0
         mock_bt.bt_target_temp_step = 0.5
         assert self._call(mock_bt, 26.0) == 23.5
+
+
+# ===========================================================================
+# 11. TestSeedCoolTarget
+# ===========================================================================
+
+
+class TestSeedCoolTarget:
+    """_seed_cool_target adopts a cooler's own setpoint as the cool target."""
+
+    def _call(self, bt, setpoint, entity_id="climate.cooler"):
+        return BetterThermostat._seed_cool_target(bt, setpoint, entity_id)
+
+    def test_in_range_setpoint_is_stored_and_reported_at_info(self, mock_bt, caplog):
+        """An unremarkable seed is traceable without being flagged as a problem."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 20.0
+        mock_bt.bt_target_cooltemp = None
+        setpoint = InboundSetpoint(raw=24.0, value=24.0, clamped=False, is_echo=False)
+
+        with caplog.at_level(logging.INFO):
+            self._call(mock_bt, setpoint)
+
+        assert mock_bt.bt_target_cooltemp == 24.0
+        assert "reports setpoint 24.0 while the cool target is unknown" in caplog.text
+        assert "outside of range" not in caplog.text
+
+    def test_clamped_setpoint_warns_and_stores_the_clamped_value(self, mock_bt, caplog):
+        """The clamped value is written back to the cooler, so it is annunciated."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 15.0
+        mock_bt.bt_target_cooltemp = None
+        setpoint = InboundSetpoint(raw=16.0, value=18.0, clamped=True, is_echo=False)
+
+        with caplog.at_level(logging.WARNING):
+            self._call(mock_bt, setpoint)
+
+        assert mock_bt.bt_target_cooltemp == 18.0
+        assert (
+            "reported setpoint 16.0 outside of range while the cool target is "
+            "unknown, taking 18.0 as the cool target" in caplog.text
+        )
+
+    def test_seed_colliding_with_the_heat_target_is_lifted(self, mock_bt):
+        """The observation yields, so the heating target the user set survives."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = None
+        setpoint = InboundSetpoint(raw=21.0, value=21.0, clamped=False, is_echo=False)
+
+        self._call(mock_bt, setpoint)
+
+        assert mock_bt.bt_target_cooltemp == 22.5
+        assert mock_bt.bt_target_temp == 22.0
+
+    def test_seed_is_lifted_while_bt_is_off(self, mock_bt):
+        """A seed taken while BT is off is the one the first cooling cycle uses."""
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = None
+        setpoint = InboundSetpoint(raw=20.0, value=20.0, clamped=False, is_echo=False)
+
+        self._call(mock_bt, setpoint)
+
+        assert mock_bt.bt_target_cooltemp == 22.5
+        assert mock_bt.bt_target_temp == 22.0

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -1,15 +1,22 @@
 """Tests for the startup() submethods extracted from BetterThermostat.startup().
 
 Covers: _check_entities_ready, _collect_trv_states, _resolve_temperature_range,
-_initialize_sensors, _restore_state, _validate_hvac_mode.
+_initialize_sensors, _seed_cool_target_from_cooler, _finalize_startup,
+_restore_state, _validate_hvac_mode.
 """
 
 import asyncio
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.climate.const import HVACMode
-from homeassistant.const import ATTR_TEMPERATURE, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    UnitOfTemperature,
+)
 from homeassistant.core import State
 import pytest
 
@@ -23,9 +30,11 @@ from custom_components.better_thermostat.utils.const import (
     ATTR_STATE_HEAT_LOSS,
     ATTR_STATE_HEATING_POWER,
     ATTR_STATE_PRESET_COOL_TEMPERATURES,
+    DEFAULT_TARGET_TEMP,
     MAX_HEAT_LOSS,
     MAX_HEATING_POWER,
 )
+from custom_components.better_thermostat.utils.helpers import device_setpoint_step
 
 SENSOR_ID = "sensor.room_temp"
 TRV_ID = "climate.test_trv"
@@ -463,28 +472,6 @@ class TestInitializeSensors:
         BetterThermostat._initialize_sensors(bt, sensor)
         assert bt.door_open is False
 
-    def test_single_setpoint_cooler_sets_cooltemp(self, bt):
-        """A cooler exposing ``temperature`` seeds the cool target from it."""
-        bt.cooler_entity_id = COOLER_ID
-        sensor = _make_sensor_state("20.0")
-        bt.hass.states.get.return_value = State(
-            COOLER_ID, "cool", {"temperature": 24.0}
-        )
-        BetterThermostat._initialize_sensors(bt, sensor)
-        assert bt.bt_target_cooltemp == 24.0
-
-    def test_range_only_cooler_sets_cooltemp_from_target_temp_high(self, bt):
-        """A range-only cooler seeds the cool target from ``target_temp_high``."""
-        bt.cooler_entity_id = COOLER_ID
-        sensor = _make_sensor_state("20.0")
-        bt.hass.states.get.return_value = State(
-            COOLER_ID,
-            "cool",
-            {"temperature": None, "target_temp_low": 19.0, "target_temp_high": 26.0},
-        )
-        BetterThermostat._initialize_sensors(bt, sensor)
-        assert bt.bt_target_cooltemp == 26.0
-
     def test_humidity_sensor_initialized(self, bt):
         """Test Humidity sensor initialized."""
         bt.humidity_sensor_entity_id = HUMIDITY_ID
@@ -504,7 +491,581 @@ class TestInitializeSensors:
 
 
 # ---------------------------------------------------------------------------
-# 5. _restore_state
+# 5. Cooling target seeded from the cooler
+# ---------------------------------------------------------------------------
+
+
+def _make_startup_bt():
+    """Build a BetterThermostat mock for a startup() run with a cooler."""
+    mock = MagicMock(spec=BetterThermostat)
+    mock.hass = MagicMock()
+    mock.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+    mock.device_name = "Test BT"
+    mock.version = "1.0.0"
+    mock.is_removed = False
+    mock.startup_running = True
+    mock.sensor_entity_id = SENSOR_ID
+    mock.cooler_entity_id = COOLER_ID
+    mock.bt_target_cooltemp = None
+    # The heating target carries its construction default until the restore
+    # step replaces it, which is what makes the ordering of the two steps
+    # observable.
+    mock.bt_target_temp = DEFAULT_TARGET_TEMP
+    mock.bt_target_temp_step = 0.5
+    mock.bt_min_temp = 5.0
+    mock.bt_max_temp = 30.0
+    mock.hvac_mode = HVACMode.HEAT_COOL
+    mock.bt_hvac_mode = HVACMode.HEAT_COOL
+    mock._check_entities_ready.return_value = True
+    mock._enforce_cool_above_heat = lambda **kwargs: (
+        BetterThermostat._enforce_cool_above_heat(mock, **kwargs)
+    )
+    mock._seed_cool_target = lambda setpoint, entity_id: (
+        BetterThermostat._seed_cool_target(mock, setpoint, entity_id)
+    )
+    mock._seed_cool_target_from_cooler = lambda log_source: (
+        BetterThermostat._seed_cool_target_from_cooler(mock, log_source)
+    )
+    return mock
+
+
+async def _run_startup(bt, cooler_state, restored_target, restored_cool_target=None):
+    """Run startup() with a restore step that installs the restored targets."""
+
+    def _states_get(entity_id):
+        if entity_id == SENSOR_ID:
+            return _make_sensor_state("20.0")
+        # Every other lookup answers with the cooler state, including the
+        # ``None`` a run without a configured cooler looks up: the seed then has
+        # a perfectly readable setpoint in front of it, so the missing
+        # configuration is the only thing left that can turn it down.
+        return cooler_state
+
+    bt.hass.states.get.side_effect = _states_get
+
+    async def _restore(_states):
+        bt.bt_target_temp = restored_target
+        if restored_cool_target is not None:
+            bt.bt_target_cooltemp = restored_cool_target
+
+    bt._restore_state.side_effect = _restore
+
+    climate = "custom_components.better_thermostat.climate"
+    with patch(f"{climate}.check_and_update_degraded_mode", AsyncMock()):
+        await asyncio.wait_for(BetterThermostat.startup(bt), timeout=1)
+
+
+class TestStartupCoolTargetSeed:
+    """startup() takes a cooling target off the cooler once restore is done."""
+
+    @pytest.mark.asyncio
+    async def test_single_setpoint_cooler_seeds_the_cool_target(self):
+        """A cooler exposing ``temperature`` fills a cool target nothing else set."""
+        bt = _make_startup_bt()
+
+        await _run_startup(bt, State(COOLER_ID, "cool", {"temperature": 24.0}), 21.0)
+
+        assert bt.bt_target_cooltemp == 24.0
+
+    @pytest.mark.asyncio
+    async def test_range_only_cooler_seeds_from_target_temp_high(self):
+        """A range-only cooler carries its setpoint in ``target_temp_high``."""
+        bt = _make_startup_bt()
+        cooler = State(
+            COOLER_ID,
+            "cool",
+            {"temperature": None, "target_temp_low": 19.0, "target_temp_high": 26.0},
+        )
+
+        await _run_startup(bt, cooler, 21.0)
+
+        assert bt.bt_target_cooltemp == 26.0
+
+    @pytest.mark.asyncio
+    async def test_unavailable_cooler_leaves_the_cool_target_unknown(self):
+        """An unavailable cooler contributes no setpoint to this read.
+
+        An entity that lost contact with its device keeps the attributes it last
+        published, so the setpoint in front of this read is perfectly readable
+        and the state string is the only thing that rejects it. The device may
+        not have reported in yet, or it may have dropped off again; either way
+        there is nothing to take, and the cool target stays unknown for the
+        re-read at the end of startup to pick up.
+        """
+        bt = _make_startup_bt()
+
+        await _run_startup(
+            bt, State(COOLER_ID, STATE_UNAVAILABLE, {"temperature": 24.0}), 21.0
+        )
+
+        assert bt.bt_target_cooltemp is None
+
+    @pytest.mark.asyncio
+    async def test_setpoint_inside_the_configured_range_is_taken_unchanged(
+        self, caplog
+    ):
+        """A setpoint that clears both bounds and the heating target is adopted as is.
+
+        Nothing about such a value has to be corrected, so it reaches the
+        cooling channel exactly as the device reports it and no correction is
+        annunciated.
+        """
+        bt = _make_startup_bt()
+
+        with caplog.at_level(logging.WARNING):
+            await _run_startup(
+                bt, State(COOLER_ID, "cool", {"temperature": 24.0}), 21.0
+            )
+
+        assert bt.bt_target_cooltemp == 24.0
+        assert bt.bt_target_temp == 21.0
+        assert "outside of range" not in caplog.text
+        assert "cooling target" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_setpoint_outside_the_configured_range_is_clamped(self, caplog):
+        """A cooler reporting below the configured minimum is brought into range.
+
+        The heating target is well clear of the value, so the clamp is the only
+        correction, and it is annunciated because the clamped value is written
+        back to the device.
+        """
+        bt = _make_startup_bt()
+        bt.bt_min_temp = 18.0
+
+        with caplog.at_level(logging.WARNING):
+            await _run_startup(
+                bt, State(COOLER_ID, "cool", {"temperature": 16.0}), 15.0
+            )
+
+        assert bt.bt_target_cooltemp == 18.0
+        assert (
+            "reported setpoint 16.0 outside of range while the cool target is "
+            "unknown, taking 18.0 as the cool target" in caplog.text
+        )
+
+    @pytest.mark.asyncio
+    async def test_setpoint_is_ordered_against_the_restored_heating_target(self):
+        """The heating target the restore step installs is the one that bounds the seed.
+
+        Reading the cooler before the restore would order the value against the
+        construction default instead, and the pair Better Thermostat ends up
+        holding would have the cooling target below the heating one.
+        """
+        bt = _make_startup_bt()
+
+        await _run_startup(bt, State(COOLER_ID, "cool", {"temperature": 20.0}), 21.0)
+
+        assert bt.bt_target_cooltemp == 21.5
+        assert bt.bt_target_temp == 21.0
+
+    @pytest.mark.asyncio
+    async def test_restored_preset_cool_target_is_not_overwritten(self):
+        """A preset carries a cooling target the user chose, so the device is not read."""
+        bt = _make_startup_bt()
+
+        await _run_startup(
+            bt,
+            State(COOLER_ID, "cool", {"temperature": 24.0}),
+            21.0,
+            restored_cool_target=26.0,
+        )
+
+        assert bt.bt_target_cooltemp == 26.0
+
+    @pytest.mark.asyncio
+    async def test_no_cooler_configured_leaves_the_cool_target_unknown(self):
+        """Without a cooling channel there is no device to take a target from.
+
+        A readable setpoint answers the lookup all the same, so the missing
+        configuration is what leaves the cool target unknown.
+        """
+        bt = _make_startup_bt()
+        bt.cooler_entity_id = None
+
+        await _run_startup(bt, State(COOLER_ID, "cool", {"temperature": 24.0}), 21.0)
+
+        assert bt.bt_target_cooltemp is None
+
+    @pytest.mark.asyncio
+    async def test_this_read_names_itself_when_an_attribute_cannot_be_read(
+        self, caplog
+    ):
+        """An unreadable setpoint attribute is reported against this read.
+
+        The startup sequence reads the cooler twice through the same helper, so
+        the line that reports the failed conversion names the read it belongs
+        to rather than the sequence both reads run in.
+        """
+        bt = _make_startup_bt()
+
+        with caplog.at_level(logging.DEBUG):
+            await _run_startup(
+                bt, State(COOLER_ID, "cool", {"temperature": "n/a"}), 21.0
+            )
+
+        assert bt.bt_target_cooltemp is None
+        assert "Could not convert 'n/a' to float in startup()" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_this_read_names_itself_when_the_step_cannot_be_read(self, caplog):
+        """An unreadable step attribute is reported against this read as well.
+
+        The cooler's step reaches the resolution through a forwarding of its
+        own, so it names the read it belongs to on the same terms as the
+        setpoint does. The setpoint is readable here, which leaves the step as
+        the only thing the reported conversion can be about.
+        """
+        bt = _make_startup_bt()
+
+        with caplog.at_level(logging.DEBUG):
+            await _run_startup(
+                bt,
+                State(
+                    COOLER_ID, "cool", {"temperature": 24.0, "target_temp_step": "n/a"}
+                ),
+                21.0,
+            )
+
+        assert bt.bt_target_cooltemp == 24.0
+        assert "Could not convert 'n/a' to float in startup()" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# 6. _finalize_startup cooler setpoint re-read
+# ---------------------------------------------------------------------------
+
+
+def _make_finalize_bt():
+    """Build a BetterThermostat mock for a _finalize_startup run with a cooler."""
+    mock = MagicMock(spec=BetterThermostat)
+    mock.hass = MagicMock()
+    mock.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+    mock.device_name = "Test BT"
+    mock.is_removed = False
+    mock.real_trvs = {TRV_ID: Trv(entity_id=TRV_ID)}
+    mock.all_trvs = None
+    mock.all_entities = []
+    mock.entity_ids = [TRV_ID]
+    mock.sensor_entity_id = SENSOR_ID
+    mock.humidity_sensor_entity_id = None
+    mock.window_id = None
+    mock.door_id = None
+    mock.cooler_entity_id = COOLER_ID
+    mock.outdoor_sensor = None
+    mock._async_unsub_state_changed = None
+    mock.bt_target_cooltemp = None
+    mock.bt_target_temp = 21.0
+    mock.bt_target_temp_step = 0.5
+    mock.bt_min_temp = 5.0
+    mock.bt_max_temp = 30.0
+    mock.hvac_mode = HVACMode.HEAT_COOL
+    mock.bt_hvac_mode = HVACMode.HEAT_COOL
+    mock.control_queue_task = AsyncMock()
+    # Plain MagicMocks so the un-awaited coroutines handed to the background
+    # task mock do not raise "coroutine was never awaited" warnings.
+    mock._post_grace_recheck = MagicMock()
+    mock._external_temperature_keepalive = MagicMock()
+    mock._enforce_cool_above_heat = lambda **kwargs: (
+        BetterThermostat._enforce_cool_above_heat(mock, **kwargs)
+    )
+    mock._seed_cool_target = lambda setpoint, entity_id: (
+        BetterThermostat._seed_cool_target(mock, setpoint, entity_id)
+    )
+    mock._seed_cool_target_from_cooler = lambda log_source: (
+        BetterThermostat._seed_cool_target_from_cooler(mock, log_source)
+    )
+    return mock
+
+
+async def _run_finalize_startup(bt):
+    """Run _finalize_startup with its waits, timers and listeners stubbed out."""
+    climate = "custom_components.better_thermostat.climate"
+    with (
+        patch(f"{climate}.await_critical_entities", AsyncMock()),
+        patch(f"{climate}.check_critical_entities", AsyncMock(return_value=True)),
+        patch(f"{climate}.await_optional_sensors", AsyncMock()),
+        patch(f"{climate}.check_and_update_degraded_mode", AsyncMock()),
+        patch(f"{climate}.asyncio.sleep", AsyncMock()),
+        patch(f"{climate}.async_track_time_interval"),
+        patch(f"{climate}.async_track_state_change_event"),
+        patch(f"{climate}.async_track_time_change"),
+    ):
+        await BetterThermostat._finalize_startup(bt)
+
+
+class TestFinalizeStartupCoolerReread:
+    """The cooler setpoint is re-read once the cooler listener is live."""
+
+    @pytest.mark.asyncio
+    async def test_reread_seeds_cooltemp_when_cooler_arrived(self):
+        """A cooler that joined HA after the startup read is picked up."""
+        bt = _make_finalize_bt()
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, "cool", {"temperature": 24.0}
+        )
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 24.0
+        bt.control_queue_task.put.assert_awaited_once_with(bt)
+
+    @pytest.mark.asyncio
+    async def test_reread_seeds_from_a_cooler_resting_at_off(self):
+        """A cooler switched off still carries the setpoint it would cool to.
+
+        This is the resting state of an idle air conditioner, and a device at
+        rest publishes no further state change, so the re-read is the only place
+        its setpoint is ever seen. What the state string names is the mode the
+        device is in, not whether its setpoint can be read, so the value is
+        taken and Better Thermostat runs a cycle on it.
+        """
+        bt = _make_finalize_bt()
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, HVACMode.OFF, {"temperature": 24.0}
+        )
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 24.0
+        bt.control_queue_task.put.assert_awaited_once_with(bt)
+
+    @pytest.mark.asyncio
+    async def test_seed_while_bt_is_off_runs_no_control_cycle(self):
+        """A BT that is OFF learns the cool target from the re-read but stays idle.
+
+        Switching it on queues its own cycle, so a target arriving while it is
+        off is no reason to run one.
+        """
+        bt = _make_finalize_bt()
+        bt.hvac_mode = HVACMode.OFF
+        bt.bt_hvac_mode = HVACMode.OFF
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, "cool", {"temperature": 24.0}
+        )
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 24.0
+        bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reread_raises_a_setpoint_colliding_with_the_heat_target(self):
+        """A read setpoint below the heating target is raised above it.
+
+        The ordering has to hold for a BT that is still off, because switching it
+        on does not revisit the pair.
+        """
+        bt = _make_finalize_bt()
+        bt.hvac_mode = HVACMode.OFF
+        bt.bt_hvac_mode = HVACMode.OFF
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, "cool", {"temperature": 16.0}
+        )
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 21.5
+        assert bt.bt_target_temp == 21.0
+
+    @pytest.mark.asyncio
+    async def test_reread_ignores_an_unavailable_cooler_reporting_a_setpoint(self):
+        """A cooler still absent by then leaves the cool target for the handler.
+
+        An entity that lost contact with its device can keep the attributes it
+        last published, so a readable setpoint alone says nothing about whether
+        the device still stands behind it. The state string is what decides.
+        """
+        bt = _make_finalize_bt()
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, STATE_UNAVAILABLE, {"temperature": 24.0}
+        )
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp is None
+        bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reread_ignores_an_unknown_cooler_reporting_a_setpoint(self):
+        """A cooler that reports no mode yet leaves the cool target unknown.
+
+        An entity Home Assistant has created but whose device has not reported
+        in holds ``unknown`` while its attributes may already carry defaults, so
+        the state string decides here as well.
+        """
+        bt = _make_finalize_bt()
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, STATE_UNKNOWN, {"temperature": 24.0}
+        )
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp is None
+        bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reread_leaves_cooltemp_unknown_when_cooler_has_no_state(self):
+        """An entity that has not been created yet carries no state object.
+
+        A cooler whose integration has not set it up returns nothing at all
+        rather than an unavailable state, so the re-read has no attributes to
+        look at.
+        """
+        bt = _make_finalize_bt()
+        bt.hass.states.get.return_value = None
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp is None
+        bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reread_requests_no_cycle_without_a_usable_setpoint(self):
+        """An available cooler may still publish no setpoint to read.
+
+        None of the setpoint attributes holds a usable value, so there is
+        nothing to seed the cool target with and nothing for a control cycle to
+        act on.
+        """
+        bt = _make_finalize_bt()
+        bt.hass.states.get.return_value = State(
+            COOLER_ID,
+            "cool",
+            {"temperature": None, "target_temp_low": None, "target_temp_high": None},
+        )
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp is None
+        bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reread_skipped_when_cooltemp_already_known(self):
+        """A cool target the startup read resolved is not overwritten."""
+        bt = _make_finalize_bt()
+        bt.bt_target_cooltemp = 26.0
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, "cool", {"temperature": 24.0}
+        )
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 26.0
+        bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reread_raises_a_seed_colliding_with_the_heat_target(self):
+        """The re-read is an observation, so the cooling side yields on a collision."""
+        bt = _make_finalize_bt()
+        bt.bt_target_temp = 21.0
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, "cool", {"temperature": 20.0}
+        )
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 21.5
+        assert bt.bt_target_temp == 21.0
+
+    @pytest.mark.asyncio
+    async def test_reread_reads_a_fahrenheit_cooler_in_its_own_unit(self):
+        """A Fahrenheit cooler's setpoint and step are read as Fahrenheit.
+
+        The re-read shares the unit-aware boundary with the event handler, so
+        the seeded target is the Celsius value of the reported setpoint and the
+        echo window is built from the device's step scaled to a Celsius delta,
+        not from Better Thermostat's own step.
+        """
+        bt = _make_finalize_bt()
+        bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        bt.bt_target_temp = 20.0
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, "cool", {"temperature": 75.0, "target_temp_step": 2.0}
+        )
+        derived_steps = []
+
+        def _record_step(instance, state, log_source):
+            derived_steps.append(device_setpoint_step(instance, state, log_source))
+            return derived_steps[-1]
+
+        with patch(
+            "custom_components.better_thermostat.climate.device_setpoint_step",
+            _record_step,
+        ):
+            await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 23.89
+        assert derived_steps == [round(2.0 * 5.0 / 9.0, 4)]
+
+    @pytest.mark.asyncio
+    async def test_reread_clamps_a_setpoint_outside_the_configured_range(self, caplog):
+        """A cooler absent while the range was derived can report outside it.
+
+        Such a cooler contributed no bounds to the temperature range, so its own
+        setpoint may sit below the configured minimum. The clamped value is
+        written back to the device, so it is annunciated.
+        """
+        bt = _make_finalize_bt()
+        bt.bt_min_temp = 22.0
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, "cool", {"temperature": 20.0}
+        )
+
+        with caplog.at_level(logging.WARNING):
+            await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 22.0
+        assert (
+            "reported setpoint 20.0 outside of range while the cool target is "
+            "unknown, taking 22.0 as the cool target" in caplog.text
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_reread_names_itself_when_an_attribute_cannot_be_read(
+        self, caplog
+    ):
+        """An unreadable setpoint attribute is reported against the re-read.
+
+        This read shares the helper with the one that runs earlier in startup,
+        so it names its own site: a cooler whose setpoint attribute holds
+        something unreadable is otherwise indistinguishable from one the
+        earlier read already stumbled over.
+        """
+        bt = _make_finalize_bt()
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, "cool", {"temperature": "n/a"}
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp is None
+        assert "Could not convert 'n/a' to float in _finalize_startup()" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_the_reread_names_itself_when_the_step_cannot_be_read(self, caplog):
+        """An unreadable step attribute is reported against the re-read as well.
+
+        The cooler's step reaches the resolution through a forwarding of its
+        own, so this read names its own site for a step it cannot convert on
+        the same terms as for a setpoint. The setpoint is readable here, which
+        leaves the step as the only thing the reported conversion can be about.
+        """
+        bt = _make_finalize_bt()
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, "cool", {"temperature": 24.0, "target_temp_step": "n/a"}
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 24.0
+        assert "Could not convert 'n/a' to float in _finalize_startup()" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# 7. _restore_state
 # ---------------------------------------------------------------------------
 
 
@@ -778,7 +1339,7 @@ class TestRestoreState:
 
 
 # ---------------------------------------------------------------------------
-# 6. _validate_hvac_mode
+# 8. _validate_hvac_mode
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -8,7 +8,7 @@ import logging
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.climate.const import HVACMode
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfTemperature
 from homeassistant.core import State
 import pytest
 
@@ -46,6 +46,17 @@ def mock_bt():
     bt._enforce_heat_below_cool = lambda: BetterThermostat._enforce_heat_below_cool(bt)
     bt._clamp_inbound_cool_target = lambda v: (
         BetterThermostat._clamp_inbound_cool_target(bt, v)
+    )
+    bt._enforce_cool_above_heat = lambda **kwargs: (
+        BetterThermostat._enforce_cool_above_heat(bt, **kwargs)
+    )
+    # Wrapped in a spy rather than wired directly, so a test can tell which of
+    # the two branches decided an event both of them would store the same
+    # value for.
+    bt._seed_cool_target = MagicMock(
+        side_effect=lambda setpoint, entity_id: BetterThermostat._seed_cool_target(
+            bt, setpoint, entity_id
+        )
     )
     return bt
 
@@ -475,6 +486,40 @@ class TestHeatTargetSync:
         assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
+    async def test_non_overlapping_child_ranges_leave_the_pair_overlapping(
+        self, mock_bt, caplog
+    ):
+        """Children that share no range put the cool target below the minimum.
+
+        The configured range is the overlap of what the children advertise, so a
+        heater whose maximum is below the cooler's minimum leaves bt_min_temp
+        above bt_max_temp. Both bounds are applied to the report in sequence and
+        the maximum decides, so the cool target lands below the minimum, and the
+        heat target cannot be dropped below that minimum either. The pair keeps
+        the values the range allows and the overlap is annunciated as such.
+        """
+        # The heater advertises 5..25 and the cooler 28..30, so the derived
+        # range is bt_min_temp 28 over bt_max_temp 25.
+        mock_bt.bt_min_temp = 28.0
+        mock_bt.bt_max_temp = 25.0
+        mock_bt.bt_target_temp = 25.0
+        mock_bt.bt_target_cooltemp = 20.0
+        old_state = _make_state(attributes={"temperature": 22.0})
+        new_state = _make_state(attributes={"temperature": 24.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        caplog.set_level(logging.WARNING)
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        assert mock_bt.bt_target_cooltemp < mock_bt.bt_min_temp
+        assert mock_bt.bt_target_temp == 28.0
+        assert (
+            "heating target 25.00 set to the configured minimum 28.00, which is "
+            "not below the cooling target 25.00" in caplog.text
+        )
+
+    @pytest.mark.asyncio
     async def test_zero_step_falls_back_to_half_degree(self, mock_bt):
         """A zero step falls back to 0.5 so the two targets stay apart."""
         mock_bt.bt_target_temp = 25.0
@@ -800,3 +845,248 @@ class TestRangeModeCooler:
 
         assert mock_bt.bt_target_cooltemp == 26.0
         mock_bt.control_queue_task.put.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 9. Seeding an unknown cool target
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownCoolTargetSeed:
+    """An unknown cool target is seeded from the cooler's own setpoint."""
+
+    @pytest.mark.asyncio
+    async def test_seed_from_unavailable_to_available_transition(self, mock_bt):
+        """A cooler returning from an outage publishes no previous setpoint."""
+        mock_bt.bt_target_cooltemp = None
+        old_state = State(ENTITY_ID, "unavailable", attributes={})
+        new_state = _make_state(attributes={"temperature": 24.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 24.0
+        mock_bt.control_queue_task.put.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_seed_from_a_cooler_that_never_moves_its_setpoint(self, mock_bt):
+        """A cooler resting on its own setpoint reports no move to adopt.
+
+        The temperature push is the only event such a cooler produces, and it
+        carries the same setpoint in both states.
+        """
+        mock_bt.bt_target_cooltemp = None
+        old_state = _make_state(
+            attributes={"temperature": 24.0, "current_temperature": 26.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 24.0, "current_temperature": 26.5}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 24.0
+        mock_bt.control_queue_task.put.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_seed_while_bt_is_off_runs_no_control_cycle(self, mock_bt):
+        """A BT that is OFF learns the cool target but stays idle."""
+        mock_bt.bt_hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_cooltemp = None
+        old_state = State(ENTITY_ID, "unavailable", attributes={})
+        new_state = _make_state(attributes={"temperature": 24.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 24.0
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_clamped_seed_warns_and_stores_the_clamped_value(
+        self, mock_bt, caplog
+    ):
+        """A reported setpoint outside BT's range is reported, not taken silently.
+
+        Coolers come back from an outage on a manufacturer default well below a
+        configured minimum, and the clamped value is written straight back to
+        the device, so the user has to be able to see where it came from: the
+        line names the cooler the event arrived from alongside both values.
+        """
+        mock_bt.bt_target_cooltemp = None
+        mock_bt.bt_min_temp = 18.0
+        mock_bt.bt_target_temp = 15.0
+        old_state = State(ENTITY_ID, "unavailable", attributes={})
+        new_state = _make_state(attributes={"temperature": 16.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with caplog.at_level(logging.WARNING):
+            await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 18.0
+        assert (
+            f"Cooler {ENTITY_ID} reported setpoint 16.0 outside of range while "
+            "the cool target is unknown, taking 18.0 as the cool target" in caplog.text
+        )
+
+    @pytest.mark.asyncio
+    async def test_seed_colliding_with_heat_target_raises_the_cool_side(self, mock_bt):
+        """The observed value yields to the heating target the user set."""
+        mock_bt.bt_target_cooltemp = None
+        mock_bt.bt_target_temp = 20.0
+        old_state = State(ENTITY_ID, "unavailable", attributes={})
+        new_state = _make_state(attributes={"temperature": 19.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 20.5
+        assert mock_bt.bt_target_temp == 20.0
+
+    @pytest.mark.asyncio
+    async def test_seed_colliding_with_heat_target_is_raised_while_bt_is_off(
+        self, mock_bt
+    ):
+        """A collision is resolved while BT is off, not left for a later cycle.
+
+        A cooler returning from an outage on a manufacturer default below the
+        heating target would otherwise keep that value until BT is switched on,
+        and the first cooling cycle would then run the air conditioner down to it
+        while the TRVs heat towards the heating target.
+        """
+        mock_bt.bt_hvac_mode = HVACMode.OFF
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_cooltemp = None
+        mock_bt.bt_target_temp = 21.0
+        old_state = State(ENTITY_ID, "unavailable", attributes={})
+        new_state = _make_state(attributes={"temperature": 16.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 21.5
+        assert mock_bt.bt_target_temp == 21.0
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_seed_decides_an_event_the_adoption_gate_would_take_too(
+        self, mock_bt
+    ):
+        """An unknown cool target is seeded even where the gate would fire.
+
+        This event meets the gate's conditions as well: the previous state
+        publishes a setpoint, Better Thermostat is not off and the reported
+        setpoint moved by more than the echo window. Both branches raise the
+        reported setpoint to clear the heating target and leave that target
+        where the user put it, so the pair they store is identical and only
+        the seed's own call tells them apart.
+        """
+        mock_bt.bt_target_cooltemp = None
+        mock_bt.bt_target_temp = 21.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 19.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        mock_bt._seed_cool_target.assert_called_once()
+        assert mock_bt.bt_target_cooltemp == 21.5
+        assert mock_bt.bt_target_temp == 21.0
+        mock_bt.control_queue_task.put.assert_awaited_once()
+
+    @pytest.mark.parametrize("dead_state", [STATE_UNAVAILABLE, STATE_UNKNOWN])
+    @pytest.mark.asyncio
+    async def test_dead_cooler_does_not_seed_from_its_retained_setpoint(
+        self, mock_bt, dead_state
+    ):
+        """A setpoint carried on a dead state is retained, not reported.
+
+        A climate entity without a mode publishes ``unknown`` together with its
+        full attributes, and one that writes the state machine directly keeps
+        the attributes it last set, so a setpoint can reach this handler off a
+        device that is gone. The reading says nothing about the device now, and
+        the target taken from it would be written back to a device that is not
+        there to confirm it. The startup seed rejects both states, so the event
+        path rejects them too.
+        """
+        mock_bt.bt_target_cooltemp = None
+        old_state = _make_state(attributes={"temperature": 24.0})
+        new_state = State(ENTITY_ID, dead_state, attributes={"temperature": 24.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp is None
+        mock_bt._seed_cool_target.assert_not_called()
+        mock_bt.control_queue_task.put.assert_not_awaited()
+        mock_bt.async_write_ha_state.assert_called_once()
+
+    @pytest.mark.parametrize("dead_state", [STATE_UNAVAILABLE, STATE_UNKNOWN])
+    @pytest.mark.asyncio
+    async def test_dead_cooler_seed_is_not_handed_to_the_adoption_gate(
+        self, mock_bt, dead_state
+    ):
+        """Declining the seed must not let the gate read the same dead state.
+
+        A previous state carrying a setpoint the retained one differs from
+        satisfies every condition of the adoption gate, which would store that
+        retained value as the cool target, raised to clear the heating target.
+        An unknown cool target keeps the event with the seeding branch, so
+        nothing is stored at all: the cool target still being None is what
+        carries the proof here, since the heating target is left where it is on
+        either path.
+        """
+        mock_bt.bt_target_cooltemp = None
+        mock_bt.bt_target_temp = 20.0
+        old_state = _make_state(attributes={"temperature": 24.0})
+        new_state = State(ENTITY_ID, dead_state, attributes={"temperature": 19.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp is None
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt._seed_cool_target.assert_not_called()
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_known_cool_target_is_not_re_seeded(self, mock_bt):
+        """With a known cool target the adoption gate keeps deciding alone.
+
+        A transition out of an outage carries no previous setpoint, so the gate
+        does not adopt and the target BT already holds survives.
+        """
+        mock_bt.bt_target_cooltemp = 25.0
+        old_state = State(ENTITY_ID, "unavailable", attributes={})
+        new_state = _make_state(attributes={"temperature": 22.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        mock_bt.control_queue_task.put.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_known_cool_target_still_adopts_a_reported_move(self, mock_bt):
+        """A move reported for a known cool target is decided by the adoption gate.
+
+        The seeding branch takes precedence over that gate, so it has to leave
+        every event it does not own alone: a cool target Better Thermostat
+        already holds still follows what the cooler reports. Both branches
+        would store this reported value, so the stored pair alone does not say
+        which one ran; what separates them is that a target already known is
+        never seeded again.
+        """
+        mock_bt.bt_target_cooltemp = 25.0
+        mock_bt.bt_target_temp = 20.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 23.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 23.0
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt.control_queue_task.put.assert_awaited_once()
+        mock_bt._seed_cool_target.assert_not_called()

--- a/tests/unit/test_helpers_inbound_setpoint.py
+++ b/tests/unit/test_helpers_inbound_setpoint.py
@@ -5,11 +5,13 @@ from unittest.mock import Mock
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import Context, State
 from homeassistant.util.unit_conversion import TemperatureDeltaConverter
+import pytest
 
 from custom_components.better_thermostat.utils.helpers import (
     COOLER_SETPOINT_KEYS,
     SETPOINT_MATCH_TOLERANCE,
     TRV_SETPOINT_KEYS,
+    device_setpoint_step,
     normalize_step,
     read_setpoint_celsius,
     resolve_inbound_setpoint,
@@ -107,6 +109,48 @@ class TestNormalizeStep:
         assert normalize_step(float("nan")) == 0.5
         assert normalize_step(float("inf")) == 0.5
         assert normalize_step(float("-inf")) == 0.5
+
+
+class TestDeviceSetpointStep:
+    """Reading a controlled device's own setpoint step as a Celsius delta."""
+
+    def _self(self, unit=UnitOfTemperature.CELSIUS, bt_step=0.5):
+        """Build a BetterThermostat mock with a known configured step."""
+        mock_self = _fake_self(unit)
+        mock_self.bt_target_temp_step = bt_step
+        return mock_self
+
+    def test_celsius_step_is_taken_as_reported(self):
+        """On a Celsius system the reported step already is a Celsius delta."""
+        state = _state({"target_temp_step": 1.0})
+        assert device_setpoint_step(self._self(), state, "test") == 1.0
+
+    def test_fahrenheit_step_is_scaled_to_a_celsius_delta(self):
+        """A step reported by a Fahrenheit device is a °F delta, not a °C one."""
+        state = _state({"target_temp_step": 2.0})
+        step = device_setpoint_step(
+            self._self(UnitOfTemperature.FAHRENHEIT), state, "test"
+        )
+        assert step == round(2.0 * 5.0 / 9.0, 4)
+
+    def test_explicit_unit_attribute_beats_the_system_unit(self):
+        """A device that names its own unit is read in that unit."""
+        state = _state({"target_temp_step": 2.0, "temperature_unit": "°F"})
+        step = device_setpoint_step(
+            self._self(UnitOfTemperature.CELSIUS), state, "test"
+        )
+        assert step == round(2.0 * 5.0 / 9.0, 4)
+
+    def test_missing_step_falls_back_to_the_configured_step(self):
+        """A device that publishes no step leaves only BT's own."""
+        state = _state({"temperature": 21.0})
+        assert device_setpoint_step(self._self(bt_step=0.1), state, "test") == 0.1
+
+    @pytest.mark.parametrize("raw", [0, -1.0, "unavailable"])
+    def test_unusable_step_falls_back_to_the_configured_step(self, raw):
+        """A non-positive or non-numeric step cannot separate two setpoints."""
+        state = _state({"target_temp_step": raw})
+        assert device_setpoint_step(self._self(bt_step=0.1), state, "test") == 0.1
 
 
 class TestSetpointEchoWindow:

--- a/tests/unit/test_preset_number_restore.py
+++ b/tests/unit/test_preset_number_restore.py
@@ -163,13 +163,14 @@ class TestPresetCoolNumber:
         bt_climate.control_queue_task.put.assert_awaited_once_with(bt_climate)
 
     @pytest.mark.asyncio
-    async def test_active_preset_enforces_cool_above_heat_at_max(self):
-        """With the heat target at ``max_temp`` the applied cool target stays above it.
+    async def test_active_preset_keeps_the_cool_target_in_range_at_max(self):
+        """A heat target at ``max_temp`` leaves the cool target resting on it.
 
-        The pre-clamp bump lifts ``cool_value`` to ``heat + step``, but the
-        ``max_temp`` clamp pulls it back down to ``max_temp`` — equal to the heat
-        target. The setter must run ``_enforce_cool_above_heat`` afterwards so the
-        active cool target and the persisted preset both stay strictly above heat.
+        The applied cool target is reported as ``target_temperature_high`` and
+        written to the cooler, so it stays inside the range the entity
+        advertises even though no value above the heat target exists in it.
+        Cooling is gated on the room being warmer than the heat target, so the
+        two targets meeting does not run the cooler against the TRVs.
         """
         from custom_components.better_thermostat.climate import BetterThermostat
 
@@ -178,6 +179,7 @@ class TestPresetCoolNumber:
         bt_climate.device_name = "Test BT"
         bt_climate.min_temp = 5.0
         bt_climate.max_temp = 30.0
+        bt_climate.bt_max_temp = 30.0
         bt_climate.target_temperature_step = 0.5
         bt_climate.bt_target_temp_step = 0.5
         bt_climate.preset_mode = PRESET_HOME
@@ -187,8 +189,8 @@ class TestPresetCoolNumber:
         bt_climate.bt_hvac_mode = HVACMode.HEAT_COOL
         bt_climate._preset_cool_temperatures = {PRESET_HOME: 30.0}
         bt_climate.control_queue_task.put = AsyncMock()
-        bt_climate._enforce_cool_above_heat.side_effect = lambda: (
-            BetterThermostat._enforce_cool_above_heat(bt_climate)
+        bt_climate._enforce_cool_above_heat.side_effect = lambda **kwargs: (
+            BetterThermostat._enforce_cool_above_heat(bt_climate, **kwargs)
         )
 
         entity = BetterThermostatPresetCoolNumber(bt_climate, PRESET_HOME)
@@ -196,8 +198,8 @@ class TestPresetCoolNumber:
 
         await entity.async_set_native_value(20.0)
 
-        assert bt_climate.bt_target_cooltemp == 30.5
-        assert bt_climate._preset_cool_temperatures[PRESET_HOME] == 30.5
+        assert bt_climate.bt_target_cooltemp == 30.0
+        assert bt_climate._preset_cool_temperatures[PRESET_HOME] == 30.0
         bt_climate.control_queue_task.put.assert_awaited_once_with(bt_climate)
 
     @pytest.mark.asyncio

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -10,6 +10,7 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
 from homeassistant.util import dt as dt_util
 import pytest
@@ -60,7 +61,9 @@ def mock_bt():
     bt.context = MagicMock()  # unique context so != event.context
     bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
     bt.async_write_ha_state = MagicMock()
-    bt._enforce_cool_above_heat = lambda: BetterThermostat._enforce_cool_above_heat(bt)
+    bt._enforce_cool_above_heat = lambda **kwargs: (
+        BetterThermostat._enforce_cool_above_heat(bt, **kwargs)
+    )
     bt._clamp_inbound_heat_target = lambda v: (
         BetterThermostat._clamp_inbound_heat_target(bt, v)
     )
@@ -291,8 +294,6 @@ class TestInternalTemperatureChange:
         system-unit fallback it is mistaken for 64 °C, rejected as implausible
         and dropped.
         """
-        from homeassistant.const import UnitOfTemperature
-
         mock_bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
         trv_state = _make_state(attributes={"current_temperature": 64.0})
         mock_bt.hass.states.get.return_value = trv_state
@@ -1771,6 +1772,9 @@ def _make_group_bt(entity_ids, *, no_off=False, bt_hvac_mode=HVACMode.HEAT):
     """
     bt = MagicMock()
     bt.hass = MagicMock()
+    # Climate entities publish no unit attribute, so every temperature the
+    # handler reads off a group member is interpreted in this system unit.
+    bt.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
     bt.device_name = "Grouped Thermostat"
     bt.bt_hvac_mode = bt_hvac_mode
     bt.bt_target_temp = 19.0
@@ -1791,7 +1795,9 @@ def _make_group_bt(entity_ids, *, no_off=False, bt_hvac_mode=HVACMode.HEAT):
     bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
     bt.async_write_ha_state = MagicMock()
     bt.hvac_mode = bt_hvac_mode
-    bt._enforce_cool_above_heat = lambda: BetterThermostat._enforce_cool_above_heat(bt)
+    bt._enforce_cool_above_heat = lambda **kwargs: (
+        BetterThermostat._enforce_cool_above_heat(bt, **kwargs)
+    )
     bt._clamp_inbound_heat_target = lambda v: (
         BetterThermostat._clamp_inbound_heat_target(bt, v)
     )


### PR DESCRIPTION
## Motivation:

### The defect

The startup read of the cooler setpoint is gated on the cooler being available. With `PRESET_NONE` and a cooler that is
unavailable at that moment, `bt_target_cooltemp` keeps the constructor's `None` — and the event handler cannot heal it:

- its adoption gate requires a setpoint in **both** the old and the new state, and an unavailable → available transition
  has none in the old one;
- it also requires the reported setpoint to have **moved** by at least half a step, which a cooler resting on its own
  setpoint never reports.

`control_cooler()` then takes its None-guard on every cycle, logs *"one or more required values are None … defaulting to
OFF"* at DEBUG, and writes `set_hvac_mode: off` to a running air conditioner. Verified by executing the real handler:
with `bt_target_cooltemp=None`, an old state of `unavailable` and a new state of `cool {temperature: 24.0}`, the field
stays `None` and the single service call is `set_hvac_mode: off`.

It is not literally permanent — dragging the high handle, selecting a non-`NONE` preset, or an external dial move of at
least half a step all heal it. The defect is that an **unattended** Better Thermostat keeps a working air conditioner
switched off, at DEBUG level, with no repair issue and no degraded mode, until a human happens to touch something.

### Note on #2154

`#2154` ("survive an unknown cool target on a range-only cooler") is merged here but does **not** close this hole: it
hardens the write path against a `None` cool target, while this is about the target never being learned in the first
place. Verified by executing the handler against the current `develop` head.

## Changes:

### The fix

Every cooling target that comes off the cooler now passes one
`_seed_cool_target_from_cooler()` helper, reachable only while `bt_target_cooltemp is None`. It resolves the reported
setpoint through `resolve_inbound_setpoint`, clamps it into the configured range, annunciates a clamp, and orders it
above the heating target. Three call sites feed it:

**(A) The first usable report in the event handler.** While the field is `None` there is no BT-side target to
lose and no BT write to echo: `control_cooler()` skips `set_temperature` entirely while the desired temperature is
`None`, so the send cache is empty and both `known_values` are `None`, which makes `is_echo` structurally `False`. This
heals every entry point into the state — unavailable at startup, available but publishing no setpoint, fresh install — on
*any* later cooler event; a `current_temperature` push is enough.

**(B) The startup read, moved behind state restoration.** `_initialize_sensors()` used to store the cooler's setpoint
raw — no range clamp, no ordering — and it ran before the heating target was restored, so there was nothing to order
against: a value read there could stay outside the configured range or at or below the heating target Better Thermostat
ends up holding. It no longer touches the cooling target at all. The read now sits in `startup()` directly after
`_restore_state()`, where both the temperature range and the heating target are final. A cooling target a restored
preset carries is the user's own choice, and a target already set that way keeps the device from being read.

**(C) A one-shot re-read right after the cooler listener is registered.** Between (B) and the listener registration
there is **no subscription at all**, so a cooler that comes online inside that window and then never changes state again
would never produce an event for (A). The moment after the registration is the last point at which such a state can
still be read. A cooler that was unavailable while the temperature range was derived contributed no bounds to it, so the
setpoint it reports can sit outside that range and is clamped into it exactly like a reported one.

All three go through one `_seed_cool_target()` helper below that, so the annunciation and the ordering rule exist once,
and all three derive the device's setpoint step through one `device_setpoint_step()` helper, so a step a cooler reports
in Fahrenheit becomes a Celsius delta at every entry point.

### Design points

**The cooling side yields on a collision.** The seed uses `_enforce_cool_above_heat()`, not `_enforce_heat_below_cool()`,
so a setpoint that would cross the heating target is raised to clear it and the heating target stays where the user put
it. That is the direction the adoption gate already resolves a reported setpoint in, through
`_clamp_inbound_cool_target()`: what the cooler reports is authoritative for the cooling channel alone, on whichever
path it arrives. The in-tree precedent is `number.py`, which pairs its programmatic `bt_target_cooltemp` write with the
same call. Executed with `bt_target_temp=20.0`, a step of `0.5` and a reported setpoint of `19.0`, the seed stores
`cool 20.5 / heat 20.0`.

**The seed branch is placed in front of the adoption gate, which becomes an `elif`.** Some events satisfy both — the
previous state publishes a setpoint, BT is not off, and the reported setpoint moved by more than the echo window — and
for those the precedence is now the seed's. It does not change the numbers: the gate bounds the report with
`_clamp_inbound_cool_target()`, the seed orders it with `_enforce_cool_above_heat()`, and both raise the cooling side
and leave the heating target where it is. Verified by executing the handler under both orderings, with
`bt_target_cooltemp=None`, `bt_target_temp=21.0`, old `temperature: 25.0`, new `temperature: 19.0`:

| ordering | cool target | heat target | control cycle | seeded |
| --- | --- | --- | --- | --- |
| gate first | `21.5` | `21.0` | requested | no |
| seed first (this PR) | `21.5` | `21.0` | requested | yes |

What the precedence decides is the provenance of the value, not its arithmetic. The seed records the take and names
where it came from — *"Cooler … reports setpoint 19.0 while the cool target is unknown, taking it as the cool target"*,
at WARNING when the value had to be clamped into the range — so a target Better Thermostat holds that nobody chose is
traceable to the device it was read off. The gate has no such line. It annunciates the collision it resolved and
nothing else, and for a report that already clears the heating target it says nothing at all: executed with
`bt_target_temp=20.0` and a report of `24.0`, the gate path stores `24.0` and emits no INFO or WARNING record.

The precedence also decides two kinds of event the gate handles differently, one in each direction. An attribute
refresh that republishes the same setpoint satisfies the gate's outer condition but not its inner move check, so behind
the gate that event is taken and then dropped: executed with `24.0 -> 24.0`, this PR seeds `24.0` and requests a cycle,
while the gate leaves the cool target `None` and requests none. A setpoint retained on an `unavailable` or `unknown`
cooler is the other way round — the seed branch declines it and that ends the event, whereas behind the gate the same
retained value is read again and stored: executed, `cool 20.5` against a heating target of `20.0` instead of the field
staying `None`.

The pair the two orderings store diverges in one case only, once the heating target has reached `bt_max_temp`. Executed
with a maximum of `30.0` and a heating target of `30.0`, seed first stores `cool 30.0 / heat 30.0` and gate first
`cool 30.0 / heat 29.5`, the step the gate's residual `_enforce_heat_below_cool()` takes. Below the maximum the two are
identical for every heating target tried (`20.0`, `25.0`, `29.0`, `29.5`, `29.75`).
`test_seed_decides_an_event_the_adoption_gate_would_take_too` pins the seed-first row and spies `_seed_cool_target`,
because the stored pair alone does not say which branch ran.

**The ordering is applied in every HVAC mode**, via a `regardless_of_hvac_mode` flag on `_enforce_cool_above_heat`. A
target seeded while Better Thermostat is off is the one the first cooling cycle after switching on works with, and that
transition does not revisit the pair — an inverted pair would have the air conditioner pull the room down while the TRVs
heat it up. Existing callers keep the default flag, so the mode gate is unchanged for them.

**The range cap on `_enforce_cool_above_heat` is cross-cutting and does change existing callers.** The bump now stops at
`bt_max_temp` for *every* caller, not only for the seed. That is deliberate: the value is published as
`target_temperature_high` and written to the cooler, and the entity range is the tightest limit among the devices under
control, so a cool target above it is not acceptable to at least one of them. The visible consequence is a pre-existing
test that was deliberately re-pinned: `tests/unit/test_preset_number_restore.py` asserted a cool target of `30.5` with a
maximum of `30.0` and now asserts `30.0`.

**Where the cap and the ordering collide, the cap yields.** It applies only while `bt_max_temp >= bt_target_temp`:

| maximum vs. heat target | result |
| --- | --- |
| above | capped — strictly above the heat target *and* at or below the maximum |
| equal | the two targets meet at the maximum; the range wins and the remaining overlap is annunciated at WARNING |
| below | **no cap** — the heat target is itself outside the range, so capping would put the cool target *below* it |
| `None` | no cap at all |

The "below" row is the reason the cap is conditional: an unconditional `min(adjusted, bt_max_temp)` inverts the pair the
method exists to order. Verified by executing the real method with `bt_max_temp=18.0`, `bt_target_temp=22.0`,
`bt_target_cooltemp=17.0`: unconditional gives `18.0` (below the heat target), conditional gives `22.5`. In the "equal"
row, cooling is gated on the room being warmer than the heat target as well, so the two targets meeting does not run the
cooler against the TRVs.

**The cap is an upper bound and nothing else**, so it does not put the stored cool target inside the range on its own:
the lift lands inside the range whenever the heat target itself does, and a heat target outside the range can leave it
outside too. Executed with heat `10.0`, cool `9.0` and a range of `[20.0, 30.0]`: the stored cool target is `10.5`,
below the minimum, even though the range holds plenty of values above the heat target. The same happens above the
maximum when the heat target exceeds it (the "below" row). This is the shape of the method — it orders the pair and
bounds it from above — and the seed inherits it: a seed already clamped into the range can still end up below the
minimum whenever the heat target sits more than one step under it.

**Both ordering helpers take their step distance through `normalize_step()`, which is cross-cutting.** A non-positive
`bt_target_temp_step` reaches them from two directions:

- the operator's own value — `float(target_temp_step)` in the constructor checks only for truthiness and `"0.0"`, so a
  configured negative survives;
- a child's published step — executed: `convert_to_float("-0.5") -> -0.5` (it rejects only NaN and infinity),
  `_target_temp_step_celsius -> -0.5`, and `_resolve_temperature_range` stores `max(steps)` without a sign check, so
  `bt_target_temp_step` ends up `-0.5` for a device publishing `target_temp_step: -0.5`.

The old `self.bt_target_temp_step or 0.5` passed that straight through in both helpers, and the add/subtract then ran
the wrong way. Executed, with the current annunciation and the old expression restored:

| helper | inputs | stored | WARNING emitted |
| --- | --- | --- | --- |
| `_enforce_cool_above_heat` | heat `22.0`, cool `20.0`, max `30.0`, step `-1.0` | `21.0` — still **below** the heat target | *"cooling target 20.00 raised to the configured maximum 21.00 …"* — untrue twice over: the maximum is `30.0` and nothing was lifted |
| `_enforce_heat_below_cool` | heat `22.0`, cool `22.0`, min `5.0`, step `-0.5` | `22.5` — **above** the cool target, i.e. the pair inverted by the helper whose job is to prevent that | *"heating target 22.00 set to the configured minimum 22.50 …"* — untrue: the minimum is `5.0` |

`normalize_step()` rejects zero, negatives and non-finite values, so both land on `0.5` and store `22.5` / `21.5`
respectively. It also stops a NaN step, which `or 0.5` passes through as truthy: executed, the old expression stores
`NaN` as the heating target.

**Each ordering helper annunciates its two outcomes separately.** `_enforce_cool_above_heat` splits its line already;
`_enforce_heat_below_cool` logged one line for both, and that line is false exactly in the case worth reading. A heating
target that comes to rest on `bt_min_temp` is not below the cooling target: executed with heat `6.0`, cool `5.0`, min
`5.0`, it stores `5.0` and logged *"heating target 6.00 adjusted to 5.00 to stay below cooling target 5.00"*. It now
logs *"heating target 6.00 set to the configured minimum 5.00, which is not below the cooling target 5.00"*, and a pair
already resting on the minimum logs nothing instead of reporting an adjustment that did not happen. In that branch the
stored value is provably `bt_min_temp`, because `cool - step` is strictly below the cooling target for every normalised
step.

**The at-maximum WARNING names one number instead of two identical ones.** It reads *"cooling target 28.00 raised to the
configured maximum 30.00, which the heating target occupies as well, because the range holds no value above it"*. That
branch is only reachable while the maximum, the heating target and the stored value are the same number — the cap only
applies while `bt_max_temp >= bt_target_temp`, and `heat + step > heat` for a normalised step — so printing the heating
target as a fourth argument suggested a difference that cannot exist. The wording is identical on the `v2` line.

**The clamp WARNING is load-bearing, not cosmetic.** A cooler returning from an outage on a manufacturer default below
`bt_min_temp` (many report 16–18 °C) gets its clamped value written straight back to it by `control_cooler()` on the next
cycle, so the user has to be able to see where that setpoint came from. Verified: a reported 16.0 with `bt_min_temp` 18.0
and a heating target of 20.0 seeds 20.5 and **is** written back.

**While Better Thermostat is OFF** the field is filled but no control cycle is requested by (A) or (C), so the seed does
not wake a thermostat the user turned off. (B) requests none in any mode, because the startup sequence it sits in runs
its own cycle.

**The ordering needs the restored heating target, which is why (B) sits where it does.** `bt_target_temp` carries
`DEFAULT_TARGET_TEMP` until `_restore_state()` replaces it, so a cooling target stored before that point is ordered
against a number BT does not end up holding. Verified by executing `startup()` with the read moved back in front of
`_restore_state()`: a cooler reporting `20.0` against a restored heating target of `21.0` stores `20.0` instead of
`21.5`.

### Accepted limitations

- The seed takes a device value as BT's target. There is no user intent to overwrite at that point, and the alternative
  — staying `None` — keeps the cooler off.
- No repair issue and no degraded mode. This heals the value; annunciating the condition is a separate concern.
- The re-read runs on every startup with a cooler configured, but performs a state lookup only when the target is `None`,
  so a normal restart pays one extra `hass.states.get` and nothing else.
- A cooling target a restored preset supplies is left exactly as restored. It is user intent on both sides of the pair,
  the device is not consulted for it, and bounding it is a different contract from bounding a device reading.
- **Specific to this line, deliberately not coded around:** `control_cooler()` on `develop` has no window/door
  suppression at all, so after the seed a develop install will run the air conditioner with a window open. That is not a
  new behaviour class — every develop install whose cool target *is* known already does exactly that; the None-guard was
  only preventing it by accident. The fix makes a broken install behave like a normal one. Porting the cooler contact
  suppression to this line is a separate change.

### Verification

- Full suite: `2360 passed` (`uv run pytest tests/`), ruff check + format clean.
- Counterfactuals, each run and reverted:
  - removing the ordering lift fails 8 tests across all three files and both event call paths;
  - moving the startup read back in front of `_restore_state()` fails
    `test_setpoint_is_ordered_against_the_restored_heating_target` (`assert 20.0 == 21.5`), with the cooling target left
    below the heating one BT ends up holding;
  - putting the startup read back on the unclamped `read_setpoint_celsius` — the shape `_initialize_sensors()` had —
    fails 6 tests, among them `test_setpoint_outside_the_configured_range_is_clamped` (`assert 16.0 == 18.0`, the
    out-of-range value stored unannounced) and `test_setpoint_is_ordered_against_the_restored_heating_target`;
  - making the range cap unconditional fails `test_maximum_below_the_heat_target_does_not_cap`
    (`assert 18.0 == 22.5`) and `test_out_of_range_cool_target_is_raised_not_lowered` (`assert 30.0 == 31.5`), both with
    the cool target stored below the heat target;
  - restoring `self.bt_target_temp_step or 0.5` in `_enforce_cool_above_heat` fails
    `test_non_positive_step_falls_back_to_the_default_step` (`assert 21.0 == 22.5`) with the pair left inverted and the
    maximum-branch WARNING emitted;
  - restoring `self.bt_target_temp_step or 0.5` in `_enforce_heat_below_cool` fails
    `test_negative_step_falls_back_to_the_default_step` (heat stored at `22.5`, above the cool target `22.0`) and
    `test_non_finite_step_falls_back_to_the_default_step` (`assert nan == 21.5`);
  - collapsing the two `_enforce_heat_below_cool` WARNINGs back into one fails `test_result_is_clamped_to_min_temp` and
    `test_minimum_above_the_cool_target_is_reported_as_an_overlap`, both on the line claiming an ordering the stored
    pair does not have;
  - removing the `adjusted == self.bt_target_temp` early return fails
    `test_heat_target_already_at_the_minimum_is_left_alone`, which then sees *"heating target 5.00 set to the configured
    minimum 5.00 …"* for a pair nothing moved;
  - restoring the previous at-maximum wording fails `test_heat_target_at_the_maximum_lifts_cool_to_the_maximum`;
  - moving the seed branch behind the adoption gate fails 4 tests. The pair stored for an event both branches accept is
    unchanged, so `test_seed_decides_an_event_the_adoption_gate_would_take_too` fails on the branch it names
    (*"Expected '_seed_cool_target' to have been called once. Called 0 times"*). The other three fail on values:
    `test_seed_from_a_cooler_that_never_moves_its_setpoint` (`assert None == 24.0`, the event taken by the gate's outer
    condition and then dropped by its move check) and both `test_dead_cooler_seed_is_not_handed_to_the_adoption_gate`
    cases (`assert 20.5 is None`, a dead cooler's retained setpoint stored after all);
  - dropping the `cooler_state is not None` guard fails
    `test_reread_leaves_cooltemp_unknown_when_cooler_has_no_state` with `AttributeError: 'NoneType' object has no
    attribute 'state'`, and dropping the `setpoint is not None` guard fails
    `test_reread_requests_no_cycle_without_a_usable_setpoint` with `AttributeError: 'NoneType' object has no attribute
    'clamped'`;
  - disabling the adoption gate (`elif False and …`) fails 25 tests;
  - dropping `and self.bt_target_cooltemp is None` from the event handler's seed branch, so that it swallows an event
    the adoption gate owns, fails `test_known_cool_target_still_adopts_a_reported_move`. That test reports a setpoint
    clear of the heating target, and both branches store the same pair for it and request the same cycle, so it names
    the branch instead: `_seed_cool_target` is spied and asserted uncalled. A colliding setpoint would not separate them
    either — executed with a known cool target of `25.0`, `bt_target_temp=20.0` and a report of `18.0`, both branches
    store `cool 20.5 / heat 20.0`.
- Mutation testing on the state guard in `_seed_cool_target_from_cooler()`,
  `cooler_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN)`. Each mutant was applied and reverted:

  | mutant | tests that fail |
  | --- | --- |
  | state check dropped, leaving `cooler_state is None` | `test_reread_ignores_an_unavailable_cooler_reporting_a_setpoint`, `test_reread_ignores_an_unknown_cooler_reporting_a_setpoint` |
  | tuple reduced to `(STATE_UNAVAILABLE,)` | `test_reread_ignores_an_unknown_cooler_reporting_a_setpoint` |
  | replaced by `cooler_state.state == HVACMode.OFF` | `test_reread_seeds_from_a_cooler_resting_at_off` and both `…_ignores_…` tests |

  The third mutant is the sharp one: it says nothing drives the read with a cooler reporting `off`. That is the
  resting state of an idle air conditioner and precisely the case this PR exists for, because `trigger_cooler_change`
  only fires on a state *change* and a resting cooler is never seen any other way.
- Composition with `#2163`, checked with `git merge-tree` against its head. `tests/unit/test_climate_baseline.py` merges
  clean, and the class this PR inserts there is numbered `11.` rather than `8.` because `#2163` appends `9.` and `10.`
  to the end of the same file: git auto-merges both sides without prompting, so a colliding number would land silently.
  `climate.py`'s `from .utils.helpers import …` block does conflict on one line — this PR removes
  `read_setpoint_celsius`, whose last caller is gone, and `#2163` adds a line next to it — and the resolution is to keep
  both edits.
- A NaN heating target cannot reach `_enforce_cool_above_heat`, so the two annunciation branches are exact complements
  and need no non-finite guard. Every writer of `bt_target_temp` is either a finite constant (`DEFAULT_TARGET_TEMP`), a
  value from `convert_to_float`, or a min/max clamp. `convert_to_float` rejects NaN and infinity by construction — its
  `round_by_step(value, 0.01)` raises `ValueError` on NaN and `OverflowError` on infinity — which was confirmed by
  executing `convert_to_float`, `convert_to_float_celsius`, `restore_target_temperature`, `mean_trv_target` and
  `resolve_inbound_setpoint` on NaN inputs: all five return `None`. `PresetManager.activate()` clamps with
  `min(max_temp, max(min_temp, temp))`, which was executed and returns `min_temp` for a NaN entry. With
  `normalize_step()` in place, `adjusted` is finite for every reachable input.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: n/a - covered by unit tests, no hardware run for this change
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

No new device mapping is added by this PR; the `climate.py` change is a control-path fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cooling target detection when a cooler becomes available or reports its first setpoint.
  * Prevented unknown cooling targets from triggering unnecessary temperature updates when the thermostat is off.
  * Maintained safe separation between heating and cooling targets, including conflict resolution and temperature limits.
  * Added reliable setpoint-step handling across temperature units, with clamping and warnings for unavailable or out-of-range values.

* **Tests**
  * Expanded coverage for startup, cooler events, target seeding, setpoint conflicts, temperature limits, unit conversion, and unavailable devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->






