### PR TITLE
fix(cooler): delay the cooling switch-on by the tolerance

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -47,6 +47,9 @@ from custom_components.better_thermostat.utils.helpers import (
     supports_single_target_temperature,
     supports_temperature_range,
 )
+from custom_components.better_thermostat.utils.hvac_action import (
+    should_cool_with_tolerance,
+)
 from custom_components.better_thermostat.utils.scheduler import request_control_cycle
 from custom_components.better_thermostat.utils.snapshot import build_snapshot
 
@@ -106,13 +109,13 @@ COOLER_FAILURE_BACKOFF_MAX_RUN = 1 + math.ceil(
 # or a whole-°F grid). A post-send reading within this distance of the sent
 # value counts as that device-side quantization, not as an unapplied command.
 COOLER_QUANTIZATION_TOLERANCE_K = 0.5
-# Hysteresis band below the cooling switch-on point. Once BT has decided to
-# cool, the room has to fall this far below the switch-on point before OFF is
-# decided, so a room temperature resting on the threshold does not flip the
-# decision — and produce a write — on every control cycle. Two steps of a
-# 0.1 °C room sensor, which is what the flip is made of; and well under the
-# 0.5 °C a cooling setpoint is set in, so the extra run time the band costs
-# is finer than the user can express in the target anyway.
+# Minimum width of the cooling decision band. A tolerance narrower than this
+# leaves the room temperature resting on an edge, where it flips the decision —
+# and produces a write — on every control cycle; the missing width is taken
+# from below the cooling target to keep the switch-on edge where the tolerance
+# puts it. Two steps of a 0.1 °C room sensor, which is what the flip is made
+# of; and well under the 0.5 °C a cooling setpoint is set in, so the extra run
+# time the band costs is finer than the user can express in the target anyway.
 COOLER_MODE_HYSTERESIS_K = 0.2
 # Valve deviations below this are the device's own business.
 RECONCILE_VALVE_TOLERANCE_PCT = 5.0
@@ -768,9 +771,13 @@ def _record_cooler_failure(
 async def control_cooler(self, snapshot=None):
     """Control the cooler entity based on current temperature and cooling setpoint.
 
-    Activates cooling when current temperature exceeds target cooling temperature
-    minus tolerance and is above heating target. Deactivates cooling when
-    temperature drops below cooling target minus tolerance or when BT HVAC mode is OFF.
+    Activates cooling when the current temperature reaches the cooling target
+    plus tolerance and is above the heating target, so a configured tolerance
+    delays the switch-on instead of running the room below the cooling target.
+    Deactivates cooling when the temperature falls back below the cooling
+    target — or below the cooling target minus the width
+    COOLER_MODE_HYSTERESIS_K borrows from underneath it whenever the tolerance
+    is narrower than that minimum band — or when BT HVAC mode is OFF.
 
     The control queue passes the cycle's snapshot in; a standalone
     invocation observes the world itself.
@@ -848,18 +855,40 @@ async def control_cooler(self, snapshot=None):
         # for the kernel to suppress.
         desired_mode = HVACMode.OFF
     else:
-        # Hysteresis around the switch-on point, so a room temperature
-        # resting on it does not flip the decision — and with it the write —
-        # on every cycle. The band widens the COOL state only: entering it
-        # stays at the plain switch-on point the tolerance defines. The
-        # device's own reported mode cannot carry the band — it lags a
-        # command and can be changed externally. The heating target stays a
-        # hard floor; relaxing it would let the cooler run into the band the
-        # heater is working on.
-        _cool_on_at = target_cooltemp - tolerance
-        if last_sent.get("hvac_mode_decided") == HVACMode.COOL:
-            _cool_on_at -= COOLER_MODE_HYSTERESIS_K
-        if room_temp >= _cool_on_at and room_temp > target_temp:
+        # The tolerance delays the switch-on: cooling starts a tolerance above
+        # the cooling target and holds until the room is back at the target, so
+        # the room settles at or above the target rather than below it. A band
+        # narrower than COOLER_MODE_HYSTERESIS_K takes the missing width from
+        # below the target, because a room temperature resting on an edge would
+        # otherwise flip the decision — and with it the write — on every cycle;
+        # the switch-on edge never moves for that guard, which buys decision
+        # stability and not a colder room. The heating target stays a hard
+        # floor; relaxing it would let the cooler run into the band the heater
+        # is working on.
+        #
+        # The latch carries the band, and it is unset only while BT has not
+        # decided a cooler mode of its own — the state a restart or a
+        # config-entry reload leaves behind. Seeding the hold edge from the
+        # cooler's own reported mode there keeps a unit that is already running
+        # inside the band running, instead of stopping it and letting the room
+        # warm all the way back up to the switch-on edge. As soon as the latch
+        # holds a decision it wins, because the reported mode lags a command by
+        # a state update and can be changed externally, either of which would
+        # drop the hold edge mid-band.
+        _decided_mode = last_sent.get("hvac_mode_decided")
+        _previously_cooling = (
+            _decided_mode == HVACMode.COOL
+            if _decided_mode is not None
+            else current_hvac_mode == HVACMode.COOL
+        )
+        _cool_wanted = should_cool_with_tolerance(
+            room_temp,
+            target_cooltemp,
+            tolerance,
+            _previously_cooling,
+            min_band=COOLER_MODE_HYSTERESIS_K,
+        )
+        if _cool_wanted and room_temp > target_temp:
             desired_mode = HVACMode.COOL
         else:
             desired_mode = HVACMode.OFF
@@ -868,7 +897,11 @@ async def control_cooler(self, snapshot=None):
     # decision would keep flipping between the two commands the device is
     # refusing. Recorded for every branch above, so a cycle that fell into a
     # guard leaves the band where that guard put it instead of on a stale
-    # value.
+    # value. Each of those guards stops the cooler outright, so the run ends
+    # there and the way back in is the switch-on edge — the same contract the
+    # heating hysteresis in compute_hvac_action applies to the same three
+    # guards, where a missing reading, an open contact and a mode of OFF each
+    # return the band to IDLE.
     last_sent["hvac_mode_decided"] = desired_mode
 
     # Decide whether a temperature command is needed. When the current

--- a/custom_components/better_thermostat/utils/hvac_action.py
+++ b/custom_components/better_thermostat/utils/hvac_action.py
@@ -76,6 +76,28 @@ def should_heat_with_tolerance(
     return cur_temp < heat_on_threshold
 
 
+def should_cool_with_tolerance(
+    cur_temp: float,
+    cool_target: float,
+    tolerance: float,
+    previously_cooling: bool,
+    min_band: float = 0.0,
+) -> bool:
+    """Determine whether cooling should be active based on hysteresis.
+
+    Band: ``[cool_target, cool_target + tolerance]``
+    * Start cooling when ``cur_temp >= cool_target + tolerance``.
+    * Continue cooling (if already cooling) until ``cur_temp < cool_target``.
+    * A band narrower than ``min_band`` takes the missing width from below
+      ``cool_target``, so a room temperature resting on an edge cannot flip
+      the decision on every cycle. The switch-on edge never moves for it.
+    """
+    tolerance = max(0.0, tolerance)
+    if previously_cooling:
+        return cur_temp >= cool_target - max(0.0, min_band - tolerance)
+    return cur_temp >= cool_target + tolerance
+
+
 _VALVE_THRESH = 0.0
 
 

--- a/docs/Configuration/configuration.md
+++ b/docs/Configuration/configuration.md
@@ -50,7 +50,7 @@ group:
 
 **The outdoor temperature threshold** This is an optional field. If you have an outdoor sensor or a weather entity, you can set a threshold. If the outdoor temperature is higher than the threshold, the thermostat will be turned off. If the outdoor temperature is lower than the threshold, the thermostat will be turned on. If you don't have an outdoor sensor or a weather entity, this field will be ignored.
 
-**Tolerance** This is an optional field. It helps prevent the thermostat from turning on and off too often. Here is an example of how it works: If you set the target temperature to 20.0 and the tolerance to 0.3 for example. Then BT will heat to 20.0 and then go to idle until the temperature drops again to 19.7 and then it will heat again to 20.0.
+**Tolerance** This is an optional field. It helps prevent the thermostat from turning on and off too often. Here is an example of how it works: If you set the target temperature to 20.0 and the tolerance to 0.3 for example. Then BT will heat to 20.0 and then go to idle until the temperature drops again to 19.7 and then it will heat again to 20.0. If you configured a cooler, the tolerance delays the switch-on instead of advancing it: with a cooling target of 24.0 and a tolerance of 0.3, BT starts cooling once the temperature reaches 24.3 and keeps cooling until it is back below 24.0. The cooling band is never narrower than 0.2, so with a tolerance of 0.1 cooling still starts at 24.1, but it keeps running until the temperature is back below 23.9.
 
 ## Second step
 

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -14,6 +14,7 @@ from custom_components.better_thermostat.utils.controlling import (
     COOLER_FAILURE_BACKOFF_BASE_S,
     COOLER_FAILURE_BACKOFF_MAX_RUN,
     COOLER_FAILURE_BACKOFF_MAX_S,
+    COOLER_MODE_HYSTERESIS_K,
     COOLER_RESEND_INTERVAL_S,
     control_cooler,
     last_sent_cooler_temperature,
@@ -118,7 +119,7 @@ class TestControlCooler:
 
     @pytest.mark.asyncio
     async def test_cooling_needed_above_target(self):
-        """Test cooling turns on when temp >= target_cooltemp - tolerance AND > bt_target_temp."""
+        """Test cooling turns on when temp >= target_cooltemp + tolerance AND > bt_target_temp."""
         mock_hass = Mock()
         mock_hass.services = Mock()
         mock_hass.services.async_call = AsyncMock()
@@ -157,10 +158,12 @@ class TestControlCooler:
 
     @pytest.mark.asyncio
     async def test_cooling_not_needed_when_temp_below_bt_target(self):
-        """Test cooling doesn't turn on if cur_temp <= bt_target_temp.
+        """The heating target floors the decision at the switch-on edge.
 
-        The condition requires BOTH cur_temp >= target_cooltemp - tolerance
-        AND cur_temp > bt_target_temp. If cur_temp <= bt_target_temp, goes to else.
+        The room sits exactly on target_cooltemp + tolerance, so the band asks
+        for cooling, but it is below the heating target the TRVs are working
+        towards. Cooling there would pull against the heating side, so the
+        heating target wins and the cooler stays off.
         """
         mock_hass = Mock()
         mock_hass.services = Mock()
@@ -176,9 +179,9 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
-        mock_self.cur_temp = 20.0  # Equal to bt_target_temp
+        mock_self.cur_temp = 24.5  # Exactly on target_cooltemp + tolerance
         mock_self.bt_target_cooltemp = 24.0
-        mock_self.bt_target_temp = 20.0
+        mock_self.bt_target_temp = 25.0  # Above the room, so the floor decides
         mock_self.tolerance = 0.5
 
         await control_cooler(mock_self)
@@ -191,7 +194,7 @@ class TestControlCooler:
 
     @pytest.mark.asyncio
     async def test_stop_cooling_below_threshold(self):
-        """Test cooling stops when temp <= target_cooltemp - tolerance."""
+        """Test cooling stops when temp < target_cooltemp."""
         mock_hass = Mock()
         mock_hass.services = Mock()
         mock_hass.services.async_call = AsyncMock()
@@ -206,12 +209,13 @@ class TestControlCooler:
         mock_self.bt_hvac_mode = HVACMode.COOL
         mock_self.cooler_entity_id = "climate.cooler"
         mock_self.context = None
-        mock_self.cur_temp = 23.0  # Below target_cooltemp - tolerance
+        mock_self.cur_temp = 23.0  # Below bt_target_cooltemp
         mock_self.bt_target_cooltemp = 24.0
         mock_self.bt_target_temp = 20.0
         mock_self.tolerance = 0.5
 
-        # cur_temp (23.0) <= bt_target_cooltemp (24.0) - tolerance (0.5) = 23.5
+        # cur_temp (23.0) < bt_target_cooltemp (24.0), so it is below both
+        # edges of the band and cooling is off regardless of the last decision.
 
         await control_cooler(mock_self)
 
@@ -225,10 +229,10 @@ class TestControlCooler:
     async def test_hysteresis_behavior(self):
         """Test hysteresis behavior between cooling thresholds.
 
-        Temperature in the zone between (target_cooltemp - tolerance) and
-        target_cooltemp, but still above bt_target_temp. The first condition
-        requires cur_temp >= (target_cooltemp - tolerance), so at 23.7 >= 23.5,
-        AND cur_temp > bt_target_temp (23.7 > 20.0), so it should COOL.
+        Temperature inside the band [target_cooltemp, target_cooltemp+tolerance)
+        and above bt_target_temp. The switch-on edge is the upper one, and
+        neither an earlier decision nor the reported mode puts the cooler inside
+        the band, so 24.2 < 24.5 keeps it off.
         """
         mock_hass = Mock()
         mock_hass.services = Mock()
@@ -248,14 +252,13 @@ class TestControlCooler:
         mock_self.bt_target_temp = 20.0
         mock_self.tolerance = 0.5
 
-        # cur_temp (23.7) >= (24.0 - 0.5 = 23.5) AND cur_temp (23.7) > 20.0
-        # -> first branch: COOL
-        mock_self.cur_temp = 23.7
+        # cur_temp (24.2) < (24.0 + 0.5 = 24.5) -> else branch: OFF
+        mock_self.cur_temp = 24.2
 
         await control_cooler(mock_self)
 
-        calls = mock_hass.services.async_call.call_args_list
-        assert calls[-1].args[2]["hvac_mode"] == HVACMode.COOL
+        assert mock_self._cooler_last_sent["hvac_mode_decided"] == HVACMode.OFF
+        assert _service_calls(mock_hass, "set_hvac_mode") == []
 
     @pytest.mark.asyncio
     async def test_context_passed_to_service_calls(self):
@@ -317,8 +320,8 @@ class TestControlCooler:
     async def test_edge_case_exactly_at_threshold(self):
         """Test behavior when temperature is exactly at threshold.
 
-        cur_temp (23.5) >= (24.0 - 0.5 = 23.5) -> True
-        cur_temp (23.5) > bt_target_temp (20.0) -> True
+        cur_temp (24.5) >= (24.0 + 0.5 = 24.5) -> True
+        cur_temp (24.5) > bt_target_temp (20.0) -> True
         -> first branch: COOL
         """
         mock_hass = Mock()
@@ -339,13 +342,13 @@ class TestControlCooler:
         mock_self.bt_target_temp = 20.0
         mock_self.tolerance = 0.5
 
-        # Exactly at target_cooltemp - tolerance AND above bt_target_temp
-        mock_self.cur_temp = 23.5
+        # Exactly at target_cooltemp + tolerance AND above bt_target_temp
+        mock_self.cur_temp = 24.5
 
         await control_cooler(mock_self)
 
         calls = mock_hass.services.async_call.call_args_list
-        # cur_temp (23.5) >= 23.5 AND cur_temp (23.5) > 20.0 -> COOL
+        # cur_temp (24.5) >= 24.5 AND cur_temp (24.5) > 20.0 -> COOL
         assert calls[-1].args[2]["hvac_mode"] == HVACMode.COOL
 
 
@@ -1085,8 +1088,11 @@ class TestControlCoolerContactSuppression:
 class TestControlCoolerModeHysteresis:
     """The COOL/OFF decision spans a band rather than a single threshold."""
 
-    # target_cooltemp - tolerance for the values _make_cooler_setup uses.
-    SWITCH_ON_AT = 23.5
+    # target_cooltemp + tolerance for the values _make_cooler_setup uses.
+    SWITCH_ON_AT = 24.5
+    # The satisfied side of the band is the cooling target itself, because the
+    # tolerance _make_cooler_setup uses is wider than COOLER_MODE_HYSTERESIS_K.
+    HOLD_UNTIL = 24.0
 
     @staticmethod
     def _make_compliant(mock_hass, cooler_state):
@@ -1128,6 +1134,37 @@ class TestControlCoolerModeHysteresis:
         assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
 
     @pytest.mark.asyncio
+    async def test_a_tolerance_under_the_minimum_band_is_widened_to_it(self):
+        """A configured tolerance narrower than the minimum band still holds.
+
+        The room dithers by one step of a 0.1 °C sensor around the cooling
+        target. Without the minimum band the two edges would sit a tenth of a
+        degree apart with the switch-off edge on the target — the value a
+        working air conditioner parks the room at — and every step across it
+        would be a genuinely changed mode, which the resend throttle passes
+        through by design.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        mock_self.tolerance = 0.1
+        assert mock_self.tolerance < COOLER_MODE_HYSTERESIS_K
+        self._make_compliant(mock_hass, cooler_state)
+
+        elapsed = 0.0
+        for _ in range(5):
+            for room_temp in (24.1, 24.0, 23.9, 24.0):
+                mock_self.clock.monotonic_value = elapsed
+                mock_self.cur_temp = room_temp
+                await control_cooler(mock_self)
+                assert mock_self._cooler_last_sent["hvac_mode_decided"] == HVACMode.COOL
+                elapsed += 5.0
+
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 1
+        assert mode_calls[0].args[2]["hvac_mode"] == HVACMode.COOL
+
+    @pytest.mark.asyncio
     async def test_cooling_stops_once_the_room_leaves_the_band(self):
         """The band delays the switch-off, it does not prevent it."""
         mock_self, mock_hass, cooler_state = _make_cooler_setup(
@@ -1141,14 +1178,14 @@ class TestControlCoolerModeHysteresis:
             == HVACMode.COOL
         )
 
-        # Just below the switch-on point but still inside the band.
-        mock_self.cur_temp = self.SWITCH_ON_AT - 0.1
+        # Just above the hold edge, so still inside the band.
+        mock_self.cur_temp = self.HOLD_UNTIL + 0.1
         mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
         await control_cooler(mock_self)
         assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
 
         # Below the band.
-        mock_self.cur_temp = self.SWITCH_ON_AT - 0.25
+        mock_self.cur_temp = self.HOLD_UNTIL - 0.1
         mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
         await control_cooler(mock_self)
 
@@ -1157,20 +1194,20 @@ class TestControlCoolerModeHysteresis:
         assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
 
     @pytest.mark.asyncio
-    async def test_the_band_does_not_delay_the_switch_on(self):
-        """The band widens the COOL state, it does not narrow the way into it.
+    async def test_cooling_starts_a_tolerance_above_the_cooling_target(self):
+        """The switch-on edge sits at target_cooltemp + tolerance.
 
-        A band applied in both directions would hold the cooler off until the
-        room had climbed a further band width past the switch-on point, which
-        is not the deadband the tolerance asks for.
+        The tolerance delays the switch-on so the room settles at or above the
+        cooling target; a band read off the other side of the target would
+        command COOL while the room is already below what the user asked for.
         """
         mock_self, mock_hass, cooler_state = _make_cooler_setup(
             cooler_state=HVACMode.OFF, cooler_temp_attr=24.0, target_cooltemp=24.0
         )
         self._make_compliant(mock_hass, cooler_state)
 
-        # Well below the band, so the decision the band reads is OFF.
-        mock_self.cur_temp = self.SWITCH_ON_AT - 1.0
+        # A hundredth of a degree short of the switch-on edge.
+        mock_self.cur_temp = self.SWITCH_ON_AT - 0.01
         await control_cooler(mock_self)
         assert _service_calls(mock_hass, "set_hvac_mode") == []
 
@@ -1182,6 +1219,199 @@ class TestControlCoolerModeHysteresis:
         mode_calls = _service_calls(mock_hass, "set_hvac_mode")
         assert len(mode_calls) == 1
         assert mode_calls[0].args[2]["hvac_mode"] == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_the_room_is_held_inside_the_band_once_cooling_was_decided(self):
+        """Between the two edges the decided COOL state survives.
+
+        The band is the whole point of the tolerance: the cooler runs the room
+        from the switch-on edge down to the cooling target instead of chasing a
+        single threshold.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        mock_self.cur_temp = self.SWITCH_ON_AT
+        await control_cooler(mock_self)
+        assert (
+            _service_calls(mock_hass, "set_hvac_mode")[-1].args[2]["hvac_mode"]
+            == HVACMode.COOL
+        )
+
+        for offset in (0.4, 0.2, 0.0):
+            mock_self.cur_temp = self.HOLD_UNTIL + offset
+            mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+            await control_cooler(mock_self)
+            assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+        mock_self.cur_temp = self.HOLD_UNTIL - 0.01
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 2
+        assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_the_default_tolerance_switches_on_at_the_cooling_target(self):
+        """Without a configured tolerance the band collapses onto the target.
+
+        The minimum band width still applies below the target, so the decision
+        is stable, but it buys decision stability and not a colder room: the
+        switch-on edge stays on the cooling target.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        mock_self.tolerance = 0.0
+        self._make_compliant(mock_hass, cooler_state)
+
+        mock_self.cur_temp = 23.99
+        await control_cooler(mock_self)
+        assert _service_calls(mock_hass, "set_hvac_mode") == []
+
+        mock_self.cur_temp = 24.0
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        assert (
+            _service_calls(mock_hass, "set_hvac_mode")[-1].args[2]["hvac_mode"]
+            == HVACMode.COOL
+        )
+
+        # Inside the minimum band the guard borrows from below the target.
+        mock_self.cur_temp = 23.9
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+        mock_self.cur_temp = 23.7
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 2
+        assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_the_heating_target_ends_the_hold_inside_the_band(self):
+        """The heating target outranks the hold edge as well as the entry edge.
+
+        The minimum band width reaches below the cooling target, so a heat/cool
+        gap narrower than COOLER_MODE_HYSTERESIS_K puts the hold edge inside the
+        range the TRVs are heating towards. The heating target ends the hold
+        there instead of letting the cooler work against them.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF,
+            cooler_temp_attr=24.0,
+            target_cooltemp=24.0,
+            target_temp=23.9,
+        )
+        mock_self.tolerance = 0.0
+        self._make_compliant(mock_hass, cooler_state)
+
+        # On the switch-on edge and above the heating target, so COOL is
+        # decided and the hold edge at 23.8 is primed.
+        mock_self.cur_temp = 24.0
+        await control_cooler(mock_self)
+        assert (
+            _service_calls(mock_hass, "set_hvac_mode")[-1].args[2]["hvac_mode"]
+            == HVACMode.COOL
+        )
+
+        # Still above the hold edge, but no longer above the heating target.
+        mock_self.cur_temp = 23.85
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 2
+        assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_a_room_resting_on_the_heating_target_ends_the_hold(self):
+        """The floor is strict: the heating target itself is not above it.
+
+        A heating target one step under the cooling target is the closest the
+        ordering guarantee allows, and the hold edge borrowed from below the
+        cooling target reaches past it. The room sitting exactly on the
+        heating target is the only point where the floor's strictness is
+        visible, and there the cooler stops.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF,
+            cooler_temp_attr=24.0,
+            target_cooltemp=24.0,
+            target_temp=23.9,
+        )
+        mock_self.tolerance = 0.0
+        self._make_compliant(mock_hass, cooler_state)
+
+        # On the switch-on edge and above the heating target, so COOL is
+        # decided and the hold edge at 23.8 is primed.
+        mock_self.cur_temp = 24.0
+        await control_cooler(mock_self)
+        assert mock_self._cooler_last_sent["hvac_mode_decided"] == HVACMode.COOL
+
+        # Above the hold edge and exactly on the heating target.
+        mock_self.cur_temp = 23.9
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        assert mock_self._cooler_last_sent["hvac_mode_decided"] == HVACMode.OFF
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 2
+        assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_the_floor_sits_on_the_heating_target_not_a_tolerance_below(self):
+        """The tolerance widens the band above; it never lowers the floor.
+
+        A tolerance narrower than COOLER_MODE_HYSTERESIS_K is the only way the
+        hold edge reaches under the heating target, so it is the only place the
+        floor's height is visible at all. A floor read a tolerance lower would
+        let the air conditioner run that whole tolerance into the range the
+        TRVs are heating towards, and the two would work against each other.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF,
+            cooler_temp_attr=24.0,
+            target_cooltemp=24.0,
+            target_temp=23.9,
+        )
+        mock_self.tolerance = 0.05
+        assert mock_self.tolerance < COOLER_MODE_HYSTERESIS_K
+        self._make_compliant(mock_hass, cooler_state)
+
+        # On the switch-on edge, so COOL is decided and the hold edge at 23.85
+        # — below the heating target — is primed.
+        mock_self.cur_temp = 24.05
+        await control_cooler(mock_self)
+        assert (
+            _service_calls(mock_hass, "set_hvac_mode")[-1].args[2]["hvac_mode"]
+            == HVACMode.COOL
+        )
+
+        # Above both the hold edge and the heating target: the hold stands.
+        mock_self.cur_temp = 23.95
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        assert len(_service_calls(mock_hass, "set_hvac_mode")) == 1
+
+        # Under the heating target and still above the hold edge, and above a
+        # heating target lowered by the tolerance as well. The floor read at
+        # the heating target itself is the only thing that stops the cooler
+        # here.
+        mock_self.cur_temp = 23.87
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        assert mock_self._cooler_last_sent["hvac_mode_decided"] == HVACMode.OFF
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 2
+        assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
 
     @pytest.mark.asyncio
     async def test_an_alternating_decision_is_not_written_every_cycle(self):
@@ -1246,6 +1476,175 @@ class TestControlCoolerModeHysteresis:
         mode_calls = _service_calls(mock_hass, "set_hvac_mode")
         assert len(mode_calls) == 2
         assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_a_running_cooler_seeds_the_hold_edge(self):
+        """A restart must not stop a cooler that is running inside the band.
+
+        The latch holds no decision after a restart or a config-entry reload,
+        and the room sitting between the two edges is below the switch-on
+        point. Reading the reported mode as the band's starting state keeps the
+        unit running down to the cooling target.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.COOL,
+            cooler_temp_attr=24.0,
+            target_cooltemp=24.0,
+            cur_temp=24.1,
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        await control_cooler(mock_self)
+
+        assert _service_calls(mock_hass, "set_hvac_mode") == []
+        assert mock_self._cooler_last_sent["hvac_mode_decided"] == HVACMode.COOL
+
+    @pytest.mark.asyncio
+    async def test_a_running_cooler_is_still_released_below_the_cooling_target(self):
+        """Seeding from the reported mode never cools past the cooling target."""
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.COOL,
+            cooler_temp_attr=24.0,
+            target_cooltemp=24.0,
+            cur_temp=self.HOLD_UNTIL - 0.1,
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        await control_cooler(mock_self)
+
+        mode_calls = _service_calls(mock_hass, "set_hvac_mode")
+        assert len(mode_calls) == 1
+        assert mode_calls[-1].args[2]["hvac_mode"] == HVACMode.OFF
+
+    @pytest.mark.parametrize(
+        ("reported_mode", "decided"),
+        [
+            pytest.param(HVACMode.COOL, HVACMode.COOL, id="cool"),
+            pytest.param(HVACMode.HEAT_COOL, HVACMode.OFF, id="heat_cool"),
+            pytest.param(HVACMode.AUTO, HVACMode.OFF, id="auto"),
+            pytest.param(HVACMode.DRY, HVACMode.OFF, id="dry"),
+            pytest.param(HVACMode.FAN_ONLY, HVACMode.OFF, id="fan_only"),
+            pytest.param(HVACMode.OFF, HVACMode.OFF, id="off"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_only_a_reported_cool_seeds_the_hold_edge(
+        self, reported_mode, decided
+    ):
+        """Any other reported mode leaves the unlatched decision at the entry edge.
+
+        The seed answers one question: is the unit already cooling the room
+        down through the band? ``heat_cool``, ``auto``, ``dry`` and
+        ``fan_only`` are modes the cooler can rest in without cooling towards
+        the target, so a room below the switch-on edge is a room the band has
+        not been entered for.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=reported_mode,
+            cooler_temp_attr=24.0,
+            target_cooltemp=24.0,
+            cur_temp=self.HOLD_UNTIL + 0.1,
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        await control_cooler(mock_self)
+
+        assert mock_self._cooler_last_sent["hvac_mode_decided"] == decided
+        sent = [
+            call.args[2]["hvac_mode"]
+            for call in _service_calls(mock_hass, "set_hvac_mode")
+        ]
+        assert sent == ([] if reported_mode == decided else [decided])
+
+    @pytest.mark.asyncio
+    async def test_the_latch_outranks_a_cooler_reporting_cool(self):
+        """A latched OFF is the band's state even while the device says ``cool``.
+
+        The reported mode lags a command by one state update and can be set
+        from outside Better Thermostat. Reading it once the latch holds a
+        decision would put the room back inside a band the decision has
+        already left.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.COOL,
+            cooler_temp_attr=24.0,
+            target_cooltemp=24.0,
+            cur_temp=self.HOLD_UNTIL - 0.1,
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        await control_cooler(mock_self)
+        assert mock_self._cooler_last_sent["hvac_mode_decided"] == HVACMode.OFF
+
+        # The device reports COOL again: either a state update lagging the
+        # command, or a mode set from outside Better Thermostat.
+        cooler_state.state = HVACMode.COOL
+        mock_self.cur_temp = self.HOLD_UNTIL + 0.1
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+
+        assert mock_self._cooler_last_sent["hvac_mode_decided"] == HVACMode.OFF
+        assert [
+            call.args[2]["hvac_mode"]
+            for call in _service_calls(mock_hass, "set_hvac_mode")
+        ] == [HVACMode.OFF, HVACMode.OFF]
+
+    @pytest.mark.parametrize(
+        "interrupt",
+        [
+            pytest.param({"cur_temp": None}, id="missing_room_temperature"),
+            pytest.param({"contact_open": True}, id="open_contact"),
+            pytest.param({"bt_hvac_mode": HVACMode.OFF}, id="bt_off"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_a_cycle_that_decided_nothing_forfeits_the_band(self, interrupt):
+        """A suspended cycle ends the run; the way back in is the switch-on edge.
+
+        A missing room temperature, a contact the window or door region reports
+        open, and a BT mode of OFF each stop the cooler outright, and each
+        leaves the latch on that stop. The room then has to climb back to the
+        switch-on edge, which is how the heating hysteresis in
+        ``compute_hvac_action`` treats the same three guards: it returns the
+        band to IDLE and heating restarts only below ``target - tolerance``.
+        """
+        mock_self, mock_hass, cooler_state = _make_cooler_setup(
+            cooler_state=HVACMode.OFF, cooler_temp_attr=24.0, target_cooltemp=24.0
+        )
+        self._make_compliant(mock_hass, cooler_state)
+
+        mock_self.cur_temp = self.SWITCH_ON_AT
+        await control_cooler(mock_self)
+        assert mock_self._cooler_last_sent["hvac_mode_decided"] == HVACMode.COOL
+
+        mock_self.cur_temp = self.HOLD_UNTIL + 0.3
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        assert mock_self._cooler_last_sent["hvac_mode_decided"] == HVACMode.COOL
+
+        for attribute, value in interrupt.items():
+            setattr(mock_self, attribute, value)
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        assert mock_self._cooler_last_sent["hvac_mode_decided"] == HVACMode.OFF
+        mock_self.contact_open = False
+        mock_self.bt_hvac_mode = HVACMode.COOL
+
+        # Inside the band the room used to be held in, but no longer latched.
+        mock_self.cur_temp = self.HOLD_UNTIL + 0.2
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        assert mock_self._cooler_last_sent["hvac_mode_decided"] == HVACMode.OFF
+
+        mock_self.cur_temp = self.SWITCH_ON_AT
+        mock_self.clock.monotonic_value += COOLER_RESEND_INTERVAL_S
+        await control_cooler(mock_self)
+        assert mock_self._cooler_last_sent["hvac_mode_decided"] == HVACMode.COOL
+
+        assert [
+            call.args[2]["hvac_mode"]
+            for call in _service_calls(mock_hass, "set_hvac_mode")
+        ] == [HVACMode.COOL, HVACMode.OFF, HVACMode.COOL]
 
 
 class TestControlCoolerTargetRange:

--- a/tests/unit/test_hvac_action.py
+++ b/tests/unit/test_hvac_action.py
@@ -2,6 +2,7 @@
 
 Covers:
   - should_heat_with_tolerance  (hysteresis helper)
+  - should_cool_with_tolerance  (hysteresis helper)
   - to_pct                      (valve normalisation)
   - compute_hvac_action         (main FSM, TRV overrides, idempotency)
   - Hysteresis state transitions
@@ -14,6 +15,7 @@ from custom_components.better_thermostat.utils.hvac_action import (
     ToleranceHysteresis,
     TrvSnapshot,
     compute_hvac_action,
+    should_cool_with_tolerance,
     should_heat_with_tolerance,
     to_pct,
 )
@@ -85,7 +87,67 @@ class TestShouldHeatWithTolerance:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# Group 2: to_pct
+# Group 2: should_cool_with_tolerance
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestShouldCoolWithTolerance:
+    """Tests for should cool with tolerance."""
+
+    def test_starts_at_the_upper_edge(self):
+        """Cooling starts when temp >= cool_target + tolerance."""
+        assert should_cool_with_tolerance(24.5, 24.0, 0.5, False) is True
+
+    def test_no_start_in_band_when_idle(self):
+        """No start in [cool_target, cool_target+tol) when not yet cooling."""
+        assert should_cool_with_tolerance(24.4, 24.0, 0.5, False) is False
+
+    def test_continues_in_band_when_cooling(self):
+        """Continue cooling inside the band when already cooling."""
+        assert should_cool_with_tolerance(24.4, 24.0, 0.5, True) is True
+
+    def test_holds_at_the_cooling_target(self):
+        """The satisfied-side edge is the cooling target itself."""
+        assert should_cool_with_tolerance(24.0, 24.0, 0.5, True) is True
+
+    def test_stops_below_the_cooling_target(self):
+        """Cooling ends once the room is below the cooling target."""
+        assert should_cool_with_tolerance(23.9, 24.0, 0.5, True) is False
+
+    def test_min_band_wider_than_tolerance_lowers_the_hold_edge(self):
+        """A too-narrow band takes the missing width from below the target."""
+        assert should_cool_with_tolerance(23.9, 24.0, 0.1, True, min_band=0.3) is True
+        assert should_cool_with_tolerance(23.7, 24.0, 0.1, True, min_band=0.3) is False
+
+    def test_min_band_leaves_the_switch_on_edge_alone(self):
+        """The guard buys decision stability, not a colder room."""
+        assert should_cool_with_tolerance(24.1, 24.0, 0.1, False, min_band=0.3) is True
+        assert should_cool_with_tolerance(24.0, 24.0, 0.1, False, min_band=0.3) is False
+
+    def test_min_band_narrower_than_tolerance_is_ignored(self):
+        """A band the tolerance already fills keeps the target as hold edge."""
+        assert should_cool_with_tolerance(24.0, 24.0, 0.5, True, min_band=0.2) is True
+        assert should_cool_with_tolerance(23.99, 24.0, 0.5, True, min_band=0.2) is False
+
+    def test_negative_tolerance_clamped(self):
+        """Negative tolerance is clamped to 0 → same as zero tolerance."""
+        assert should_cool_with_tolerance(24.0, 24.0, -1.0, False) is True
+        assert should_cool_with_tolerance(23.99, 24.0, -1.0, False) is False
+
+    def test_zero_tolerance(self):
+        """Zero tolerance: both edges collapse onto the cooling target."""
+        assert should_cool_with_tolerance(24.0, 24.0, 0.0, False) is True
+        assert should_cool_with_tolerance(23.99, 24.0, 0.0, False) is False
+        assert should_cool_with_tolerance(23.99, 24.0, 0.0, True) is False
+
+    def test_zero_tolerance_with_a_min_band(self):
+        """A min_band alone is enough to keep a zero-tolerance decision stable."""
+        assert should_cool_with_tolerance(23.9, 24.0, 0.0, True, min_band=0.2) is True
+        assert should_cool_with_tolerance(23.9, 24.0, 0.0, False, min_band=0.2) is False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Group 3: to_pct
 # ═══════════════════════════════════════════════════════════════════════════
 
 
@@ -119,7 +181,7 @@ class TestToPct:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# Group 3: compute_hvac_action
+# Group 4: compute_hvac_action
 # ═══════════════════════════════════════════════════════════════════════════
 
 
@@ -304,7 +366,7 @@ class TestComputeHvacAction:
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# Group 4: Hysteresis state transitions
+# Group 5: Hysteresis state transitions
 # ═══════════════════════════════════════════════════════════════════════════
 
 


### PR DESCRIPTION
## Motivation:

### The defect

`control_cooler()` decides the cooler's HVAC mode from a single threshold shifted **down** by the tolerance:

```python
self.cur_temp >= self.bt_target_cooltemp - self.tolerance
```

With a cooling target of 24.0 and a tolerance of 0.5 the air conditioner is commanded `COOL` from **23.5 °C** — while
the room is already half a degree *below* the target the user asked for. The tolerance moves the whole control point
instead of forming a band, so on the cooling side it provides no flap guard at all: the switch-on and switch-off edges
are the same expression.

Everywhere else in the codebase `tolerance` is a band whose *satisfied-side* edge **is** the setpoint:

| source | rule |
|---|---|
| `utils/hvac_action.py::should_heat_with_tolerance` | heating band `[target - tolerance, target)` — "stop at `target`, never heat *above* target" |
| `calibration.py` | "asymmetric band [target - tol, target] so the TRV stops receiving a heating-promoting calibration once the room reaches the set temperature (not target + tolerance)" |
| `utils/hvac_action.py::compute_hvac_action` | reports `HVACAction.COOLING` only above **`cool_target + tolerance`** |
| `docs/Configuration/configuration.md`, `translations/en.json` | a two-edge flap guard, described with a worked heating example |

The third row is the decisive one: the *reported* action already uses the mirrored sign. Today Better Thermostat
commands `COOL` while publishing `IDLE` across the closed interval `[cool_target − tolerance, cool_target + tolerance]`,
`2 × tolerance` wide — and `COOLER_MODE_HYSTERESIS_K` wider still at the bottom once the decision is latched, because
this line already borrows that width below the shifted threshold. It issues `set_temperature 24.0` together with
`set_hvac_mode COOL` in the same cycle at a room temperature of 23.5.

`git blame` traces the expression to the first cooler implementation (`17973329`, 2023-09-22). It carries no rationale,
no linked issue, no test and no documentation, and every later refactor only moved it.

## Changes:

### What this changes

Cooling becomes a genuine two-edge band that takes the tolerance on the same side as heating does — the satisfied-side
edge is the setpoint:

```
switch ON   when  room_temp >= cool_target + tolerance
hold  COOL  while room_temp >= cool_target
```

The pre-existing `room_temp > bt_target_temp` heating-target floor is kept verbatim, so cooling still never fights the
TRVs. The band lives in one shared predicate, `should_cool_with_tolerance`, placed next to `should_heat_with_tolerance`
in `utils/hvac_action.py`.

With target 24.0 and tolerance 0.5: **ON at 24.5, OFF below 24.0**, achieved room temperature in `[24.0, 24.5]` — at or
above the number the user typed, instead of up to a tolerance below it.

It is not a bit-exact mirror of `should_heat_with_tolerance`. Evaluating both predicates at reflected offsets
(`target ∓ d` for heating, `target ± d` for cooling, tolerance 0.5) shows where they part:

| offset `d` | heating, idle | cooling, idle | heating, running | cooling, running |
|---|---|---|---|---|
| `0.6` | heat | cool | heat | cool |
| `0.5` (= tolerance) | **idle** | **cool** | heat | cool |
| `0.1` | idle | idle | heat | cool |
| `0.0` (on the target) | idle | idle | **idle** | **cool** |

Both cooling edges are inclusive where the heating edges are exclusive: cooling starts *at* `cool_target + tolerance`
and still holds *at* `cool_target`. The `min_band` borrow below has no heating counterpart at all.

### Out of scope, deliberately

`compute_hvac_action`'s cooling decision is **not** rewired to the same predicate. It keeps its own threshold,
`cur_temp > cool_target + tolerance`, so inside the hold band the cooler is commanded `COOL` while the entity publishes
`IDLE`. Executed walk in `heat_cool` mode, cooling target 24.0, tolerance 0.5, heating target 20.0, descending so the
latch holds `cool` throughout (on the way up the two agree, because the command stays `off` until 24.5):

| room | commanded | reported |
|---|---|---|
| 24.6 | `cool` | `cooling` |
| 24.5 | `cool` | `idle` |
| 24.4 | `cool` | `idle` |
| 24.2 | `cool` | `idle` |
| 24.0 | `cool` | `idle` |
| 23.99 | `off` | `idle` |

Rewiring it is not a report-only change. `self.hvac_action` gates six branches in `calibration.py`. The direction-aware
rounding among them is *not* behind `skip_post_adjustments`, so it applies in every calibration mode; the
overheating-protection adjustment **is** behind that flag, so it only reaches the three modes that do not set it.
Measured by running both calibration channels on an integer-step TRV with the room at 24.2, heating target 20.0 and a
TRV own temperature of 23.7 — identical inputs, only the reported action differs:

| | `IDLE` (today) | `COOLING` (rewired) |
|---|---|---|
| local calibration offset — all eight calibration modes | `+1.0` | `0.0` |
| setpoint, `protect_overheating` on — `fix_calibration`, `heating_power_calibration`, `no_calibration` | `-11.0` | `19.0` |
| setpoint, `protect_overheating` on — the five modes that set `skip_post_adjustments` | `19.0` | `19.0` |

`+1.0` is the valve-closing direction; `rounding.nearest` drops it, which is precisely what the comment at that site
warns about for integer-step TRVs. That row is the one that holds everywhere. The two thermal learners are unaffected:
`HeatLossTracker` and `HeatingPowerTracker` only branch on `HEATING` vs not-`HEATING`.

Closing the mismatch therefore means first teaching those consumers the difference between "not heating" and "actively
cooling". That is its own change with its own tests, and it has to land on both lines together; the develop twin
(#2162) makes the same call.

This PR therefore *narrows* the command/report mismatch rather than closing it. Measured on a 0.01 K grid, target 24.0,
tolerance 0.5, heating target 20.0, with the latch carried along the walk:

| walk | today | with this PR |
|---|---|---|
| descending (latch holds `cool`) | `[23.3, 24.5]`, 1.2 K wide | `[24.0, 24.5]`, 0.5 K wide |
| ascending (latch unset) | `[23.5, 24.5]`, 1.0 K wide | the single point `24.5` |

What remains is the hold band `[cool_target, cool_target + tolerance]`, `1 × tolerance` wide. Its lower end is closed
because the hold edge is `>= cool_target`; its upper end is closed because the report needs a strict `>`. The part
below the cooling target is gone; the part above it remains, and that is worth stating plainly, because it is the
region the cooler now spends essentially all of its run time in, where before it was the region the cooler was leaving.

### Backwards compatibility on this line

`COOLER_MODE_HYSTERESIS_K` (0.2) is passed as the predicate's `min_band`, so a band narrower than 0.2 K takes the missing
width from *below* the target — the switch-on edge never moves for that guard, which buys decision stability and not a
colder room. At the default tolerance of `0.0` that leaves ON at `cool_target` and the hold edge at `cool_target - 0.2`
— **the two edges this line already has today.** A dedicated test pins it.

The constant's comment now describes a minimum band width rather than a band below the switch-on point, which is what it
became.

Unchanged edges are not the same as an unchanged decision, though, because the seed described below picks *which* of the
two edges an unlatched cycle uses. Swept in 0.01 K steps against the pre-PR expression, `cool_target` 24.0, heating
target 20.0, one cycle per sample, the room temperature from which `COOL` is decided:

| tolerance | latch | cooler reports | today | with this PR |
|---|---|---|---|---|
| 0.0 | unset | `off` | 24.0 | 24.0 |
| 0.0 | unset | `cool` | 24.0 | **23.8** |
| 0.0 | `off` | `cool` | 24.0 | 24.0 |
| 0.0 | `cool` | `cool` | 23.8 | 23.8 |

So at the default tolerance the one changed cycle is the first after a restart or a config-entry reload, with the air
conditioner already reporting `cool` inside `[cool_target - 0.2, cool_target)`: today that cycle commands it `off` and
the room warms back to `cool_target`; here it keeps running to the hold edge it was already inside. Every later cycle
runs off the latch and matches today exactly.

Installations that configured a non-zero tolerance change behaviour on every cycle: the cooler starts later and stops
earlier — less run time, and a room at or above the chosen setpoint.

### The latch

The existing `last_sent["hvac_mode_decided"]` latch and its recording site are untouched, so the write-rate and
failure-backoff guards from the preceding cooler changes still hold. One addition: while the latch holds no decision —
the state a restart or a config-entry reload leaves behind — the hold edge is seeded from the cooler's own reported mode,
so a unit already running inside the band keeps running instead of being stopped and letting the room warm back up to
the switch-on edge. Three properties of that seed have a test:

- only a reported `cool` seeds the hold. A cooler resting in `heat_cool`, `auto`, `dry` or `fan_only` is not cooling the
  room down through the band, so an unlatched cycle decides `OFF` there and the way in stays the switch-on edge;
- once the latch holds a decision it wins over the reported mode, which lags a command by one state update and can be
  set from outside Better Thermostat: a latched `OFF` with the device still reporting `cool` decides `OFF` at 24.1;
- the seed never cools past the cooling target.

Recording the decision on **every** branch, guards included, is the contract rather than an oversight: a cycle that
decided nothing forfeits the band, and the room has to climb back to the switch-on edge. That is what the heating
hysteresis already does with the same three guards. Executed, heating target 20.0, tolerance 0.5, heating under way:

```
heating: 19.4 heating → 19.6 heating → [interrupted] idle → 19.7 idle → 19.8 idle → 19.4 heating
         (uninterrupted, the same walk stays "heating" throughout)
cooling: 24.5 cool    → 24.3 cool    → [interrupted] off  → 24.2 off  → 24.5 cool
```

The interruption is a missing room temperature, a contact the window/door region reports open, or a BT mode of `OFF` —
each stops the cooler outright, so ending the run there is what the stop already means. The cost is bounded by one band
width and is the same cost a fresh start pays. A parametrized test pins all three guards, and the comment at the
recording site states the contract instead of only the staleness it avoids.

### Verification

- Full suite: `4140 passed` (`uv run pytest tests/`), ruff check + format clean.
- Counterfactuals, each reverted after checking. Counts are failing **test cases** as pytest reports them:
  - reverting `should_cool_with_tolerance` to the pre-PR expression (`_on_at = cool_target - tolerance`, minus
    `min_band` while cooling) fails **19 cases across 13 test functions** — **14 cases in
    `tests/unit/controlling/test_control_cooler.py`** and **5 in `tests/unit/test_hvac_action.py`**;
  - forcing `min_band=0.0` at the call site fails `test_a_tolerance_under_the_minimum_band_is_widened_to_it` and
    `test_the_default_tolerance_switches_on_at_the_cooling_target` (2 cases);
  - preserving the latch across the guard branches — moving the recording site into the band branch — fails all three
    cases of `test_a_cycle_that_decided_nothing_forfeits_the_band`.
- Mutations applied to the three narrower rules, to check the pins actually hold:
  - seeding on `current_hvac_mode != HVACMode.OFF` instead of `== HVACMode.COOL` fails the `heat_cool`, `auto`, `dry`
    and `fan_only` cases of `test_only_a_reported_cool_seeds_the_hold_edge`;
  - letting the reported mode survive the latch (`current_hvac_mode == COOL or _decided_mode == COOL`) fails
    `test_the_latch_outranks_a_cooler_reporting_cool`;
  - relaxing the heating-target floor to `room_temp >= target_temp` fails
    `test_a_room_resting_on_the_heating_target_ends_the_hold`. That floor is reachable because the hold edge borrowed
    from below the cooling target reaches past a heating target one step underneath it.
  - giving the latch an initial value of `HVACMode.OFF` instead of leaving it unset fails
    `test_a_running_cooler_seeds_the_hold_edge` and the `cool` case of `test_only_a_reported_cool_seeds_the_hold_edge`.
    Applied at both places this line produces the unlatched state — the `last_sent.get("hvac_mode_decided")` default
    and the send-cache initialiser in `cooler_send_cache` — and killed at both. On this line the latch is a key of the
    lazily created send cache rather than an attribute declared in `climate.py`, so it has no declaration a test could
    bypass by pinning a mock attribute: the tests set `_cooler_last_sent = None` and the real initialiser runs.
- Write-rate probe for the `min_band` wiring: a room dithering one 0.1 °C sensor step around the target
  (`[24.0, 24.1, 24.0, 23.9] × 5`, target 24.0, tolerance 0.1, cooler already reporting `cool`) produces **0**
  `set_hvac_mode` writes over 20 cycles on this line. With `min_band` forced to 0 the same walk produces **9**,
  alternating `off → cool`, and stays at 9 for a `COOLER_RESEND_INTERVAL_S` of 0, 240 (its shipped value), 300 and 3600
  — each write is a genuinely changed mode, which the resend throttle passes through by design. The exposed window is
  `0 < tolerance < 0.2 K`, which on a Fahrenheit system is any configured tolerance below about 0.36 °F.
  `test_a_tolerance_under_the_minimum_band_is_widened_to_it` is that probe as an assertion.
- The Fahrenheit path is safe and was checked: `tolerance` is converted to Kelvin in the constructor
  (`climate.py`, "Return the configured tolerance in Kelvin"), and both new edges add a Kelvin delta to a Celsius
  target. Worth noting because the fix doubles the tolerance's leverage on the switch-on point, from `−tol` to `+tol`.
- Six pre-existing tests in `TestControlCooler` and `TestControlCoolerModeHysteresis` encoded the old switch-on point.
  `test_the_band_does_not_delay_the_switch_on` asserted the opposite of the rule above and is renamed to
  `test_cooling_starts_a_tolerance_above_the_cooling_target`; `test_hysteresis_behavior` and
  `test_cooling_not_needed_when_temp_below_bt_target` now assert the opposite verdict at retargeted inputs;
  `test_edge_case_exactly_at_threshold` keeps its verdict at a moved number, and
  `test_cooling_needed_above_target` and `test_stop_cooling_below_threshold` keep both and only had their prose
  corrected.
- `docs/Configuration/configuration.md` gains the cooling direction of the Tolerance example plus the minimum band.
  That line is byte-identical with the develop twin's (`sha256 0c6bbfee…`, verified against the pushed blob), and the
  two branches' hunks for that file are identical as a whole, so the next sync of the two lines has nothing to resolve
  there. The two bases were already byte-identical on it, which is why any divergence in the added half would have
  guaranteed a conflict.
  Both worked numbers were run rather than reasoned, by sweeping the room temperature in **0.01 K** steps through
  `control_cooler` with the latch carried along the walk, `cool_target` 24.0, heating target 20.0:

  | tolerance | switches on at | last sample still `cool` | decides `off` at |
  |---|---|---|---|
  | 0.3 | 24.30 | 24.00 | 23.99 |
  | 0.1 | 24.10 | 23.90 | 23.89 |

  So the release edge is "back below `cool_target`" for tolerance 0.3 and "back below `cool_target - 0.1`" for
  tolerance 0.1 — the minimum band moves the stop edge below the cooling target only where the tolerance is narrower
  than it, and leaves the switch-on edge where the tolerance puts it. The identical sweep run against the develop twin
  returns the same four numbers, so the shared sentence is true of both lines.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: n/a - covered by unit tests, no hardware run for this change
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved cooling hysteresis to prevent rapid switching near the target temperature.
  - Cooling now starts at the configured tolerance threshold and continues within a minimum cooling band.
  - Cooling state is preserved more reliably across control decisions and restarts.

- **Bug Fixes**
  - Prevented invalid negative tolerance and hysteresis values from affecting cooling behavior.

- **Documentation**
  - Updated tolerance documentation to explain cooling hysteresis and the minimum cooling band.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


