### PR TITLE
fix(events): clamp an inbound setpoint instead of moving the other target

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -165,6 +165,7 @@ from .utils.helpers import (
     get_hvac_bt_mode,
     is_reasonable_temperature,
     normalize_hvac_mode,
+    normalize_step,
     read_setpoint_celsius,
     state_temperature_unit,
 )
@@ -3244,6 +3245,83 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             self.bt_target_cooltemp,
         )
         self.bt_target_temp = adjusted
+
+    def _clamp_inbound_cool_target(self, value: float) -> float:
+        """Raise a cooling setpoint reported by the cooler above the heating target.
+
+        A device only ever speaks for its own channel: a press on the air
+        conditioner's remote must not move the radiators' target. So a reported
+        cooling setpoint that would cross the heating target is raised to the
+        nearest value that clears it, instead of pulling the heating target
+        down. The floor stays inside the configured range, so at a heating
+        target within one step of ``bt_max_temp`` the adopted value stops at the
+        maximum and the ordering is settled by
+        :meth:`_enforce_heat_below_cool` moving the heating target one step.
+
+        The bound keys off the configured cooling channel rather than the live
+        mode: the ordering of the two targets is a property of the
+        configuration, so it has to hold whatever mode the group happens to be
+        in. A crossing learned while the group is off is never revisited
+        otherwise.
+
+        A step that is not a positive real number would turn the floor into a
+        ceiling, so it is replaced by the 0.5 fallback.
+
+        Parameters
+        ----------
+        value : float
+            Cooling setpoint in °C, already resolved into BT's range.
+
+        Returns
+        -------
+        float
+            The value to adopt: unchanged unless it had to be raised.
+        """
+        if self.cooler_entity_id is None or self.bt_target_temp is None:
+            return value
+        step = normalize_step(self.bt_target_temp_step)
+        floor = self.bt_target_temp + step
+        if self.bt_max_temp is not None:
+            floor = min(floor, self.bt_max_temp)
+        return max(value, floor)
+
+    def _clamp_inbound_heat_target(self, value: float) -> float:
+        """Lower a heating setpoint reported by a TRV below the cooling target.
+
+        The counterpart to :meth:`_clamp_inbound_cool_target`, for a knob turn
+        on a radiator valve: it may move the heating target only, so a reported
+        setpoint that would cross the cooling target is lowered to the nearest
+        value that clears it rather than pushing the cooling target up. The
+        ceiling stays inside the configured range, so at a cooling target within
+        one step of ``bt_min_temp`` the adopted value stops at the minimum and
+        :meth:`_enforce_cool_above_heat` settles the ordering with a one-step
+        move of the cooling target.
+
+        Like its counterpart the bound keys off the configured cooling channel
+        rather than the live mode, and here that is what makes it hold at all: a
+        valve with ``no_off_system_mode`` reports its knob turn while
+        ``bt_hvac_mode`` is still OFF, and the same event then resolves the mode.
+
+        A step that is not a positive real number would turn the ceiling into a
+        floor, so it is replaced by the 0.5 fallback.
+
+        Parameters
+        ----------
+        value : float
+            Heating setpoint in °C, already resolved into BT's range.
+
+        Returns
+        -------
+        float
+            The value to adopt: unchanged unless it had to be lowered.
+        """
+        if self.cooler_entity_id is None or self.bt_target_cooltemp is None:
+            return value
+        step = normalize_step(self.bt_target_temp_step)
+        ceiling = self.bt_target_cooltemp - step
+        if self.bt_min_temp is not None:
+            ceiling = max(ceiling, self.bt_min_temp)
+        return min(value, ceiling)
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -110,6 +110,10 @@ async def trigger_cooler_change(self, event):
         # change, a temperature push — must not be read as user intent: a
         # stale report would otherwise revert a BT-side target that has not
         # been written yet.
+        # What the cooler reports also speaks for the cooling channel alone: a
+        # value that would cross the heating target is raised above it, so a
+        # press on the air conditioner's remote cannot move the radiators'
+        # target — potentially below room temperature, stopping the heating.
         _reported_moved = abs(
             _new_cooling_setpoint.raw - _old_cooling_setpoint
         ) >= setpoint_echo_window(_step)
@@ -129,7 +133,31 @@ async def trigger_cooler_change(self, event):
                     self.device_name,
                     entity_id,
                 )
-            self.bt_target_cooltemp = _new_cooling_setpoint.value
+            _adopted_cooling_setpoint = self._clamp_inbound_cool_target(
+                _new_cooling_setpoint.value
+            )
+            if _adopted_cooling_setpoint != _new_cooling_setpoint.value:
+                # A user turning the remote down step by step would collect one
+                # warning per press, so yielding to the heating target is an
+                # INFO: the range clamp above and the ordering fallback below
+                # own the WARNING level.
+                _LOGGER.info(
+                    "better_thermostat %s: Cooler %s reported setpoint %.2f does not "
+                    "clear the heating target %.2f, keeping %.2f",
+                    self.device_name,
+                    entity_id,
+                    _new_cooling_setpoint.value,
+                    self.bt_target_temp,
+                    _adopted_cooling_setpoint,
+                )
+            self.bt_target_cooltemp = _adopted_cooling_setpoint
+            # The clamp leaves the heating target alone, so this only settles
+            # the degenerate case where no cooling value above the heating
+            # target exists inside the range: at a heating target within one
+            # step of bt_max_temp it drops that target by one step, and a range
+            # the children narrowed below a target already in place is what
+            # moves it further — that move is what brings it back inside the
+            # range.
             self._enforce_heat_below_cool()
             _main_change = True
         elif _reported_moved:

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -325,14 +325,40 @@ async def trigger_trv_change(self, event):
                     self.device_name,
                     entity_id,
                 )
+            # What the TRV reports speaks for the heating channel alone: a value
+            # that would cross the cooling target is lowered below it, so a knob
+            # turn on a radiator valve cannot move the cooler's target.
+            _adopted_heating_setpoint = self._clamp_inbound_heat_target(
+                _new_heating_setpoint
+            )
+            if _adopted_heating_setpoint != _new_heating_setpoint:
+                # A user turning the knob up step by step would collect one
+                # warning per press, so yielding to the cooling target is an
+                # INFO: the range clamp above and the ordering fallback below
+                # own the WARNING level.
+                _LOGGER.info(
+                    "better_thermostat %s: TRV %s reported setpoint %.2f does not "
+                    "clear the cooling target %.2f, keeping %.2f",
+                    self.device_name,
+                    entity_id,
+                    _new_heating_setpoint,
+                    self.bt_target_cooltemp,
+                    _adopted_heating_setpoint,
+                )
             _LOGGER.debug(
                 "better_thermostat %s: TRV %s decoded TRV target temp changed from %s to %s",
                 self.device_name,
                 entity_id,
                 self.bt_target_temp,
-                _new_heating_setpoint,
+                _adopted_heating_setpoint,
             )
-            self.bt_target_temp = _new_heating_setpoint
+            self.bt_target_temp = _adopted_heating_setpoint
+            # The clamp leaves the cooling target alone, so this only settles the
+            # degenerate case where no heating value below the cooling target
+            # exists inside the range: at a cooling target within one step of
+            # bt_min_temp it lifts that target by one step, and a range the
+            # children narrowed above a target already in place is what moves it
+            # further — that move is what brings it back inside the range.
             self._enforce_cool_above_heat()
 
             _main_change = True
@@ -382,6 +408,11 @@ async def trigger_trv_change(self, event):
                     self.bt_hvac_mode = HVACMode.OFF
             else:
                 self.bt_hvac_mode = HVACMode.HEAT
+                # Leaving OFF is what puts a group with a cooler into HEAT_COOL,
+                # so this is the first moment the ordering of the two targets is
+                # checked at all: a setpoint adopted while the group was still
+                # off has not passed that check yet.
+                self._enforce_cool_above_heat()
             _main_change = True
 
     if _main_change is True:

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -1357,3 +1357,179 @@ class TestEnforceHeatBelowCool:
         mock_bt.bt_target_cooltemp = 22.0
         self._call(mock_bt)
         assert mock_bt.bt_target_temp is None
+
+
+# ===========================================================================
+# 9. TestClampInboundCoolTarget
+# ===========================================================================
+
+
+class TestClampInboundCoolTarget:
+    """_clamp_inbound_cool_target raises a cooler report above the heat target."""
+
+    def _call(self, bt, value):
+        return BetterThermostat._clamp_inbound_cool_target(bt, value)
+
+    def test_without_a_cooler_is_noop(self, mock_bt):
+        """Without a cooling channel there is no second bound."""
+        mock_bt.cooler_entity_id = None
+        mock_bt.bt_target_temp = 22.0
+        assert self._call(mock_bt, 20.0) == 20.0
+
+    def test_a_group_that_is_off_still_keeps_the_targets_apart(self, mock_bt):
+        """The ordering is a property of the configuration, not of the mode.
+
+        A crossing adopted while the group is off is never revisited, because
+        the ordering fallbacks only run inside HEAT_COOL.
+        """
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_temp = 22.0
+        assert self._call(mock_bt, 20.0) == 22.5
+
+    def test_none_heat_target_is_noop(self, mock_bt):
+        """Without a heating target there is no bound to clamp against."""
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = None
+        assert self._call(mock_bt, 20.0) == 20.0
+
+    def test_value_above_heat_target_is_kept(self, mock_bt):
+        """A value that already clears the heating target is returned unchanged."""
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        assert self._call(mock_bt, 26.0) == 26.0
+
+    def test_value_below_heat_target_is_raised_by_one_step(self, mock_bt):
+        """A value below the heating target is raised just above it."""
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 18.0) == 22.5
+
+    def test_value_equal_to_heat_target_is_raised(self, mock_bt):
+        """A value on the heating target still has to clear it."""
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 22.0) == 22.5
+
+    def test_step_falls_back_to_half_degree(self, mock_bt):
+        """A missing/zero step falls back to 0.5."""
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0
+        assert self._call(mock_bt, 22.0) == 22.5
+
+    def test_negative_step_falls_back_to_half_degree(self, mock_bt):
+        """A negative step would turn the floor into a ceiling."""
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = -0.5
+        assert self._call(mock_bt, 20.0) == 22.5
+
+    def test_floor_stays_inside_the_configured_range(self, mock_bt):
+        """With the heating target at the maximum the floor stops there.
+
+        An unbounded floor would leave the configured range, so the value stops
+        at bt_max_temp and the ordering fallback settles the rest.
+        """
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 30.0
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 22.0) == 30.0
+
+
+# ===========================================================================
+# 10. TestClampInboundHeatTarget
+# ===========================================================================
+
+
+class TestClampInboundHeatTarget:
+    """_clamp_inbound_heat_target lowers a TRV report below the cool target."""
+
+    def _call(self, bt, value):
+        return BetterThermostat._clamp_inbound_heat_target(bt, value)
+
+    def test_without_a_cooler_is_noop(self, mock_bt):
+        """Without a cooling channel there is no second bound."""
+        mock_bt.cooler_entity_id = None
+        mock_bt.bt_target_cooltemp = 22.0
+        assert self._call(mock_bt, 24.0) == 24.0
+
+    def test_a_group_that_is_off_still_keeps_the_targets_apart(self, mock_bt):
+        """A valve reporting while the group is off must not cross the cool target.
+
+        A valve with ``no_off_system_mode`` reports its knob turn while
+        ``bt_hvac_mode`` is still OFF, and the same event then resolves the mode.
+        """
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_cooltemp = 22.0
+        assert self._call(mock_bt, 24.0) == 21.5
+
+    def test_none_cool_target_is_noop(self, mock_bt):
+        """Without a cooling target there is no bound to clamp against."""
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_cooltemp = None
+        assert self._call(mock_bt, 24.0) == 24.0
+
+    def test_value_below_cool_target_is_kept(self, mock_bt):
+        """A value that already clears the cooling target is returned unchanged."""
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_cooltemp = 26.0
+        assert self._call(mock_bt, 22.0) == 22.0
+
+    def test_value_above_cool_target_is_lowered_by_one_step(self, mock_bt):
+        """A value above the cooling target is lowered just below it."""
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_cooltemp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 26.0) == 21.5
+
+    def test_value_equal_to_cool_target_is_lowered(self, mock_bt):
+        """A value on the cooling target still has to clear it."""
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_cooltemp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 22.0) == 21.5
+
+    def test_step_falls_back_to_half_degree(self, mock_bt):
+        """A missing/zero step falls back to 0.5."""
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_cooltemp = 22.0
+        mock_bt.bt_target_temp_step = 0
+        assert self._call(mock_bt, 22.0) == 21.5
+
+    def test_negative_step_falls_back_to_half_degree(self, mock_bt):
+        """A negative step would turn the ceiling into a floor."""
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_cooltemp = 22.0
+        mock_bt.bt_target_temp_step = -0.5
+        assert self._call(mock_bt, 24.0) == 21.5
+
+    def test_ceiling_stays_inside_the_configured_range(self, mock_bt):
+        """With the cooling target at the minimum the ceiling stops there.
+
+        An unbounded ceiling would leave the configured range, so the value stops
+        at bt_min_temp and the ordering fallback settles the rest.
+        """
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_cooltemp = 5.0
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_temp_step = 0.5
+        assert self._call(mock_bt, 22.0) == 5.0

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -1,7 +1,7 @@
 """Tests for events/cooler.py – Cooler event handler.
 
 Covers guard clauses, setpoint adoption, echo suppression, unit handling,
-clamping, heat-target sync, and control-queue triggering.
+range and cross-channel clamping, and control-queue triggering.
 """
 
 import logging
@@ -37,6 +37,7 @@ def mock_bt():
     bt.bt_target_temp_step = 0.5
     bt.bt_min_temp = 5.0
     bt.bt_max_temp = 30.0
+    bt.cooler_entity_id = ENTITY_ID
     bt._cooler_last_sent = None
     bt.startup_running = False
     bt.control_queue_task = MagicMock()
@@ -45,6 +46,9 @@ def mock_bt():
     bt.contact_open = False
     bt.async_write_ha_state = MagicMock()
     bt._enforce_heat_below_cool = lambda: BetterThermostat._enforce_heat_below_cool(bt)
+    bt._clamp_inbound_cool_target = lambda v: (
+        BetterThermostat._clamp_inbound_cool_target(bt, v)
+    )
     return bt
 
 
@@ -215,11 +219,35 @@ class TestCoolerSetpointAdoption:
 
 
 class TestCoolerSetpointClamping:
-    """Tests for setpoint range clamping."""
+    """Tests for setpoint range clamping.
+
+    The configured range and the heating target bound the reported value in
+    sequence. A case that isolates the range clamp therefore leaves the heating
+    target unknown, which is the only state in which the range is the single
+    bound while a cooler is configured.
+    """
 
     @pytest.mark.asyncio
     async def test_setpoint_clamped_to_min(self, mock_bt):
-        """Setpoint below min should be clamped to bt_min_temp."""
+        """Setpoint below min is clamped to bt_min_temp and then above heat.
+
+        The two clamps compose: the range clamp lifts the reported 2.0 to
+        bt_min_temp, and the heating target lifts it one step further because a
+        cooler report may not move the heating target.
+        """
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 2.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 20.5  # bt_target_temp 20.0 + step
+        assert mock_bt.bt_target_temp == 20.0
+
+    @pytest.mark.asyncio
+    async def test_setpoint_clamped_to_min_without_a_heating_target(self, mock_bt):
+        """With no heating target known the range is the only bound."""
+        mock_bt.bt_target_temp = None
         old_state = _make_state(attributes={"temperature": 25.0})
         new_state = _make_state(attributes={"temperature": 2.0})
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
@@ -227,6 +255,7 @@ class TestCoolerSetpointClamping:
         await trigger_cooler_change(mock_bt, event)
 
         assert mock_bt.bt_target_cooltemp == 5.0  # clamped to min
+        assert mock_bt.bt_target_temp is None
 
     @pytest.mark.asyncio
     async def test_setpoint_clamped_to_max(self, mock_bt):
@@ -240,15 +269,23 @@ class TestCoolerSetpointClamping:
         assert mock_bt.bt_target_cooltemp == 30.0  # clamped to max
 
     @pytest.mark.asyncio
-    async def test_setpoint_at_exact_min_not_clamped(self, mock_bt):
-        """Setpoint exactly at min should not trigger clamping."""
+    async def test_setpoint_at_exact_min_not_range_clamped(self, mock_bt, caplog):
+        """A setpoint at the range minimum is inside the range but below heat.
+
+        Nothing is out of range, so no warning is due; the heating target still
+        raises the adopted value and that is reported at INFO.
+        """
         old_state = _make_state(attributes={"temperature": 25.0})
         new_state = _make_state(attributes={"temperature": 5.0})
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
 
+        caplog.set_level(logging.INFO)
         await trigger_cooler_change(mock_bt, event)
 
-        assert mock_bt.bt_target_cooltemp == 5.0
+        assert mock_bt.bt_target_cooltemp == 20.5
+        assert mock_bt.bt_target_temp == 20.0
+        assert "setpoint outside of range" not in caplog.text
+        assert "does not clear the heating target" in caplog.text
 
     @pytest.mark.asyncio
     async def test_setpoint_at_exact_max_not_clamped(self, mock_bt):
@@ -295,16 +332,21 @@ class TestCoolerSetpointClamping:
 
 
 # ---------------------------------------------------------------------------
-# 4. Heat-target sync (cooltemp pushes heat target down)
+# 4. Cross-channel clamp (a cooler report yields to the heating target)
 # ---------------------------------------------------------------------------
 
 
-class TestHeatTargetSync:
-    """Tests for the heat-target sync when cooltemp <= heat target."""
+class TestInboundCoolSetpointClamp:
+    """A cooler report may move the cooling target only.
+
+    The reported setpoint is raised above the heating target instead of pulling
+    that target down, so a press on the air conditioner's remote cannot stop the
+    radiators.
+    """
 
     @pytest.mark.asyncio
-    async def test_heat_target_pushed_down_when_equal(self, mock_bt):
-        """When cooltemp == heat target, heat target is pushed down by step."""
+    async def test_reported_setpoint_equal_to_heat_target_is_raised(self, mock_bt):
+        """A report landing on the heating target is raised one step above it."""
         mock_bt.bt_target_temp = 25.0
         mock_bt.bt_target_cooltemp = 27.0
         old_state = _make_state(attributes={"temperature": 27.0})
@@ -313,12 +355,13 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
-        assert mock_bt.bt_target_cooltemp == 25.0
-        assert mock_bt.bt_target_temp == 24.5  # pushed down by step (0.5)
+        assert mock_bt.bt_target_cooltemp == 25.5
+        assert mock_bt.bt_target_temp == 25.0  # untouched
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
-    async def test_heat_target_pushed_down_when_above_cooltemp(self, mock_bt):
-        """When heat target > new cooltemp, heat target is pushed down."""
+    async def test_reported_setpoint_below_heat_target_is_raised(self, mock_bt):
+        """A report below the heating target does not drag that target down."""
         mock_bt.bt_target_temp = 24.0
         old_state = _make_state(attributes={"temperature": 27.0})
         new_state = _make_state(attributes={"temperature": 23.0})
@@ -326,28 +369,93 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
-        assert mock_bt.bt_target_cooltemp == 23.0
-        assert mock_bt.bt_target_temp == 22.5  # 23.0 - 0.5
+        assert mock_bt.bt_target_cooltemp == 24.5
+        assert mock_bt.bt_target_temp == 24.0  # untouched
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
-    async def test_heat_target_not_pushed_when_below_cooltemp(self, mock_bt):
-        """When heat target < cooltemp, heat target stays unchanged."""
+    async def test_clamp_to_the_heat_target_is_annunciated(self, mock_bt, caplog):
+        """The user has to be able to see why the remote's value was not kept.
+
+        Every press on the remote produces one of these, so the level stays at
+        INFO and the WARNING level keeps its meaning.
+        """
+        mock_bt.bt_target_temp = 20.0
+        old_state = _make_state(attributes={"temperature": 24.0})
+        new_state = _make_state(attributes={"temperature": 18.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        caplog.set_level(logging.INFO)
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 20.5
+        assert mock_bt.bt_target_temp == 20.0
+        assert (
+            "reported setpoint 18.00 does not clear the heating target 20.00"
+            in caplog.text
+        )
+        assert "keeping 20.50" in caplog.text
+        levels = {
+            record.levelno
+            for record in caplog.records
+            if "heating target" in record.getMessage()
+        }
+        assert levels == {logging.INFO}
+
+    @pytest.mark.asyncio
+    async def test_annunciation_at_the_maximum_states_what_was_kept(
+        self, mock_bt, caplog
+    ):
+        """At the maximum the kept value equals the heating target it yielded to.
+
+        No cooling value above bt_max_temp exists, so the clamp pins the adopted
+        setpoint onto the heating target itself. The message names the target
+        that was not cleared and the value kept, and both remain true of that
+        state — it never claims the kept value ends up above the target.
+        """
+        mock_bt.bt_target_temp = 30.0
+        mock_bt.bt_target_cooltemp = 30.0
+        mock_bt.bt_max_temp = 30.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 22.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        caplog.set_level(logging.INFO)
+        await trigger_cooler_change(mock_bt, event)
+
+        assert (
+            "reported setpoint 22.00 does not clear the heating target 30.00, "
+            "keeping 30.00" in caplog.text
+        )
+        levels = {
+            record.levelno
+            for record in caplog.records
+            if "does not clear the heating target" in record.getMessage()
+        }
+        assert levels == {logging.INFO}
+
+    @pytest.mark.asyncio
+    async def test_reported_setpoint_above_heat_target_is_kept(self, mock_bt, caplog):
+        """A report that already clears the heating target is taken as reported."""
         mock_bt.bt_target_temp = 20.0
         old_state = _make_state(attributes={"temperature": 25.0})
         new_state = _make_state(attributes={"temperature": 27.0})
         event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
 
+        caplog.set_level(logging.INFO)
         await trigger_cooler_change(mock_bt, event)
 
         assert mock_bt.bt_target_cooltemp == 27.0
         assert mock_bt.bt_target_temp == 20.0  # unchanged
+        assert "heating target" not in caplog.text
 
     @pytest.mark.asyncio
-    async def test_heat_target_sync_respects_min_temp(self, mock_bt):
-        """Heat-target sync keeps the heat target inside the configured range.
+    async def test_range_clamped_setpoint_still_clears_the_heat_target(self, mock_bt):
+        """Both clamps compose: into the range first, then above the heat target.
 
-        With the cool target clamped to the minimum there is no room for a full
-        step below it, so the heat target stops at bt_min_temp.
+        A report below bt_min_temp is lifted to the minimum, which is still below
+        the heating target, so the cross-channel clamp lifts it one step above it
+        and the heating target keeps the value the user set.
         """
         mock_bt.bt_target_temp = 6.0
         mock_bt.bt_min_temp = 5.0
@@ -357,12 +465,58 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
-        assert mock_bt.bt_target_cooltemp == 5.0
-        assert mock_bt.bt_target_temp >= mock_bt.bt_min_temp
+        assert mock_bt.bt_target_cooltemp == 6.5
+        assert mock_bt.bt_target_temp == 6.0
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
-    async def test_heat_target_sync_with_zero_step(self, mock_bt):
-        """A zero step falls back to 0.5 so heat stays below cool."""
+    async def test_no_legal_value_above_heat_target_costs_one_step(self, mock_bt):
+        """At the range maximum the heating target yields, but only by one step.
+
+        With the heating target on bt_max_temp no cooling value above it exists,
+        so the clamp stops at the maximum and the ordering fallback moves the
+        heating target one step down — not the full distance to the reported
+        value.
+        """
+        mock_bt.bt_target_temp = 30.0
+        mock_bt.bt_target_cooltemp = 30.0
+        mock_bt.bt_max_temp = 30.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 22.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 30.0
+        assert mock_bt.bt_target_temp == 29.5
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+
+    @pytest.mark.asyncio
+    async def test_a_range_narrowed_below_the_heat_target_pulls_it_inside(
+        self, mock_bt
+    ):
+        """A heating target above the maximum is the one case that moves further.
+
+        The range is recomputed from the children, so it can end up below a
+        target already in place. The clamp stops the cooling setpoint at the
+        maximum and the ordering fallback brings the heating target back inside
+        the range, which takes more than one step.
+        """
+        mock_bt.bt_target_temp = 30.0
+        mock_bt.bt_max_temp = 28.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 18.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 28.0
+        assert mock_bt.bt_target_temp == 27.5
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+
+    @pytest.mark.asyncio
+    async def test_zero_step_falls_back_to_half_a_degree(self, mock_bt):
+        """A zero step falls back to 0.5 so the two targets stay apart."""
         mock_bt.bt_target_temp = 25.0
         mock_bt.bt_target_cooltemp = 27.0
         mock_bt.bt_target_temp_step = 0.0
@@ -372,7 +526,26 @@ class TestHeatTargetSync:
 
         await trigger_cooler_change(mock_bt, event)
 
+        assert mock_bt.bt_target_cooltemp == 25.5
+        assert mock_bt.bt_target_temp == 25.0
         assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+
+    @pytest.mark.asyncio
+    async def test_report_is_not_bounded_without_a_heating_target(self, mock_bt):
+        """An unknown heating target is no bound and stays unknown.
+
+        There is nothing to clear and nothing to yield, so the reported setpoint
+        is adopted as it arrived.
+        """
+        mock_bt.bt_target_temp = None
+        old_state = _make_state(attributes={"temperature": 27.0})
+        new_state = _make_state(attributes={"temperature": 23.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 23.0
+        assert mock_bt.bt_target_temp is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_per_trv_target_temp_step.py
+++ b/tests/unit/test_per_trv_target_temp_step.py
@@ -76,6 +76,9 @@ def bt():
     mock.control_queue_task = MagicMock()
     mock.context = MagicMock()
     mock.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
+    mock._clamp_inbound_heat_target = lambda v: (
+        BetterThermostat._clamp_inbound_heat_target(mock, v)
+    )
     mock.all_trvs = [{"advanced": {CONF_HOMEMATICIP: False}}]
     mock.real_trvs = {
         TRV_ID: Trv(

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -61,6 +61,9 @@ def mock_bt():
     bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
     bt.async_write_ha_state = MagicMock()
     bt._enforce_cool_above_heat = lambda: BetterThermostat._enforce_cool_above_heat(bt)
+    bt._clamp_inbound_heat_target = lambda v: (
+        BetterThermostat._clamp_inbound_heat_target(bt, v)
+    )
 
     bt.all_trvs = [{"advanced": {CONF_HOMEMATICIP: False}}]
 
@@ -122,6 +125,20 @@ def _make_event(bt, new_state=None, old_state=None, entity_id=ENTITY_ID):
     }
     event.context = MagicMock()  # differs from bt.context
     return event
+
+
+def _bind_cooler_hvac_mode(bt):
+    """Let ``bt.hvac_mode`` follow the real property of a cooler setup.
+
+    With a cooler configured the mode list carries HEAT_COOL in place of HEAT,
+    so the property reports HEAT_COOL for a ``bt_hvac_mode`` of HEAT. That
+    mapping decides whether the ordering check between the two targets applies,
+    so a handler that changes ``bt_hvac_mode`` needs the derived value, not a
+    fixed one.
+    """
+    bt._hvac_list = [HVACMode.OFF, HVACMode.HEAT_COOL]
+    bt.map_on_hvac_mode = HVACMode.HEAT_COOL
+    type(bt).hvac_mode = BetterThermostat.hvac_mode
 
 
 # ---------------------------------------------------------------------------
@@ -1064,7 +1081,7 @@ class TestTargetTempAdoption:
 
     @pytest.mark.asyncio
     async def test_cooler_sync_keeps_cooltemp_above_target(self, mock_bt):
-        """A cool target already above the adopted heat target stays untouched."""
+        """A reported target that already clears the cool target is taken as is."""
         mock_bt.cooler_entity_id = "climate.cooler"
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_target_cooltemp = 25.0
@@ -1091,14 +1108,20 @@ class TestTargetTempAdoption:
         ):
             await trigger_trv_change(mock_bt, event)
 
+        assert mock_bt.bt_target_temp == 22.0
         assert mock_bt.bt_target_cooltemp == 25.0
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
-    async def test_cooler_sync_pushes_cooltemp_above_target(self, mock_bt):
-        """Cooltemp is pushed to target + step when equal to target."""
+    async def test_adopted_target_is_capped_below_the_cool_target(self, mock_bt):
+        """A knob turn onto the cool target is capped one step below it.
+
+        The TRV speaks for the heating channel only, so the cool target keeps the
+        value the user set on the cooler.
+        """
         mock_bt.cooler_entity_id = "climate.cooler"
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
-        mock_bt.bt_target_cooltemp = 22.0  # equal to new target
+        mock_bt.bt_target_cooltemp = 22.0  # equal to the reported target
         mock_bt.bt_target_temp_step = 0.5
 
         old_state = _make_state(
@@ -1122,14 +1145,70 @@ class TestTargetTempAdoption:
         ):
             await trigger_trv_change(mock_bt, event)
 
-        assert mock_bt.bt_target_cooltemp == 22.0 + 0.5
+        assert mock_bt.bt_target_temp == 21.5
+        assert mock_bt.bt_target_cooltemp == 22.0  # untouched
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
-    async def test_cooler_sync_always_overwrites(self, mock_bt):
-        """Cooltemp is pushed to target + step even when already below target."""
+    async def test_adopted_target_above_cool_target_is_capped(self, mock_bt, caplog):
+        """A knob turn past the cool target yields to it and says so.
+
+        The knob is turned to 24.0 while the cooler holds 22.5, so the heating
+        target stops one step below the cool target instead of pushing it up.
+        """
         mock_bt.cooler_entity_id = "climate.cooler"
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
-        mock_bt.bt_target_cooltemp = 15.0
+        mock_bt.bt_target_cooltemp = 22.5
+        mock_bt.bt_target_temp_step = 0.5
+
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 24.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 24.0},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].last_temperature = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        caplog.set_level(logging.INFO)
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 22.0
+        assert mock_bt.bt_target_cooltemp == 22.5  # untouched
+        assert (
+            "reported setpoint 24.00 does not clear the cooling target 22.50"
+            in caplog.text
+        )
+        assert "keeping 22.00" in caplog.text
+        levels = {
+            record.levelno
+            for record in caplog.records
+            if "cooling target" in record.getMessage()
+        }
+        assert levels == {logging.INFO}
+
+    @pytest.mark.asyncio
+    async def test_no_legal_value_below_cool_target_costs_one_step(self, mock_bt):
+        """At the range minimum the cool target yields, but only by one step.
+
+        With the cool target on bt_min_temp no heating value below it exists, so
+        the cap stops at the minimum and the ordering fallback lifts the cool
+        target one step — not the full distance to the reported value.
+        """
+        mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_cooltemp = 5.0
+        mock_bt.bt_min_temp = 5.0
         mock_bt.bt_target_temp_step = 0.5
 
         old_state = _make_state(
@@ -1153,7 +1232,51 @@ class TestTargetTempAdoption:
         ):
             await trigger_trv_change(mock_bt, event)
 
-        assert mock_bt.bt_target_cooltemp == 22.0 + 0.5
+        assert mock_bt.bt_target_temp == 5.0
+        assert mock_bt.bt_target_cooltemp == 5.5
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+
+    @pytest.mark.asyncio
+    async def test_a_range_narrowed_above_the_cool_target_moves_it_further(
+        self, mock_bt
+    ):
+        """A cool target below the minimum is the one case that moves further.
+
+        The range is recomputed from the children, so it can end up above a
+        target already in place. The cap holds the heating setpoint at the
+        minimum and the ordering fallback then lifts the cool target clear of
+        it, which takes more than one step.
+        """
+        mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_cooltemp = 10.0
+        mock_bt.bt_min_temp = 20.0
+        mock_bt.bt_target_temp_step = 0.5
+
+        old_state = _make_state(
+            attributes={"temperature": 19.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 22.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 22.0},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].last_temperature = 19.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 20.0
+        assert mock_bt.bt_target_cooltemp == 20.5
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
     async def test_cooler_sync_survives_unset_cooltemp(self, mock_bt):
@@ -1248,6 +1371,111 @@ class TestTargetTempAdoption:
             await trigger_trv_change(mock_bt, event)
 
         assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+
+    @pytest.mark.asyncio
+    async def test_no_off_wakeup_is_capped_without_a_tie_break(self, mock_bt):
+        """A no_off wakeup against a cool target with room below it needs no fallback.
+
+        The mode is still OFF while the setpoint is adopted, so the ordering
+        check is gated out for the whole event. The cap alone has to keep the
+        two targets apart, and it does because it keys off the configured
+        cooler rather than the live mode.
+        """
+        mock_bt.real_trvs[ENTITY_ID].advanced["no_off_system_mode"] = True
+        mock_bt.real_trvs[ENTITY_ID].min_temp = 5.0
+        mock_bt.bt_hvac_mode = HVACMode.OFF
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.bt_target_cooltemp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+
+        old_state = _make_state(
+            attributes={"temperature": 5.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 24.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 24.0},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].last_temperature = 5.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+        assert mock_bt.hvac_mode == HVACMode.OFF
+        assert mock_bt.bt_target_temp == 21.5
+        assert mock_bt.bt_target_cooltemp == 22.0
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+
+    @pytest.mark.asyncio
+    async def test_no_off_wakeup_keeps_targets_separated(self, mock_bt, caplog):
+        """A no_off valve waking the group up still separates the two targets.
+
+        The group is OFF while the setpoint is adopted, so the mode is not
+        HEAT_COOL yet and the ordering check cannot bite. The same event then
+        resolves the mode to HEAT_COOL, and with the cool target sitting on
+        ``bt_min_temp`` the adopted heat target lands on that very value.
+
+        That is the corner where the kept value equals the target it yielded to,
+        so the annunciation is pinned here too: it may only claim that the report
+        did not clear the cooling target, never that the kept value ends up below
+        it.
+        """
+        mock_bt.real_trvs[ENTITY_ID].advanced["no_off_system_mode"] = True
+        mock_bt.real_trvs[ENTITY_ID].min_temp = 5.0
+        mock_bt.bt_hvac_mode = HVACMode.OFF
+        mock_bt.cooler_entity_id = "climate.cooler"
+        mock_bt.bt_target_cooltemp = 5.0
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_temp_step = 0.5
+        _bind_cooler_hvac_mode(mock_bt)
+
+        old_state = _make_state(
+            attributes={"temperature": 5.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 22.0, "current_temperature": 18.0}
+        )
+        trv_state = _make_state(
+            state_str="heat",
+            attributes={"current_temperature": 18.0, "temperature": 22.0},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].last_temperature = 5.0
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        caplog.set_level(logging.INFO)
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+        assert mock_bt.bt_target_temp == 5.0
+        assert mock_bt.bt_target_cooltemp == 5.5
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+        assert (
+            "reported setpoint 22.00 does not clear the cooling target 5.00, "
+            "keeping 5.00" in caplog.text
+        )
+        levels = {
+            record.levelno
+            for record in caplog.records
+            if "does not clear the cooling target" in record.getMessage()
+        }
+        assert levels == {logging.INFO}
+        assert "to stay below cooling target" not in caplog.text
 
 
 class TestTargetTempBasedSync:
@@ -1722,6 +1950,11 @@ def _make_group_bt(entity_ids, *, no_off=False, bt_hvac_mode=HVACMode.HEAT):
     bt.context = MagicMock()
     bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
     bt.async_write_ha_state = MagicMock()
+    bt.hvac_mode = bt_hvac_mode
+    bt._enforce_cool_above_heat = lambda: BetterThermostat._enforce_cool_above_heat(bt)
+    bt._clamp_inbound_heat_target = lambda v: (
+        BetterThermostat._clamp_inbound_heat_target(bt, v)
+    )
     bt.all_trvs = [{"advanced": {CONF_HOMEMATICIP: False}} for _ in entity_ids]
 
     bt.real_trvs = {
@@ -1873,6 +2106,45 @@ class TestGroupedModeAdoption:
             await trigger_trv_change(bt, event)
 
         assert bt.bt_hvac_mode == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_group_knob_turn_stays_below_the_cool_target(self):
+        """A knob turn on one member of a group with a cooler stays below cool.
+
+        The cool target sits on ``bt_min_temp``, so the cap has no legal value
+        below it and the ordering fallback has to separate the two targets.
+        """
+        trigger, other1, other2 = GRP_IDS
+        bt = _make_group_bt(GRP_IDS, bt_hvac_mode=HVACMode.HEAT_COOL)
+        bt.cooler_entity_id = "climate.ac"
+        bt.bt_target_cooltemp = 5.0
+        bt.bt_min_temp = 5.0
+        bt.bt_target_temp_step = 0.5
+        _install_states(
+            bt,
+            {
+                trigger: _grp_state(trigger, "heat", temperature=22.0),
+                other1: _grp_state(other1, "heat"),
+                other2: _grp_state(other2, "heat"),
+            },
+        )
+        bt.real_trvs[trigger].hvac_mode = "heat"
+
+        event = _make_event(
+            bt,
+            new_state=_grp_state(trigger, "heat", temperature=22.0),
+            old_state=_grp_state(trigger, "heat", temperature=19.0),
+            entity_id=trigger,
+        )
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=None,
+        ):
+            await trigger_trv_change(bt, event)
+
+        assert bt.bt_target_temp == 5.0
+        assert bt.bt_target_cooltemp == 5.5
+        assert bt.bt_target_temp < bt.bt_target_cooltemp
 
 
 class TestGroupedNoOffAdoption:


### PR DESCRIPTION
## Motivation:

### The defect

`events/cooler.py::trigger_cooler_change` adopts a cooling setpoint reported **by the cooler** and then calls
`_enforce_heat_below_cool()`, which pushes the user's heating target down to one step below it. Reproduced against the
real method:

| state | remote press | result |
|---|---|---|
| heat 20.0, cool 24.0, `bt_min_temp` 17.0, step 0.5 | AC's own remote to 18.0 | cool 18.0, **heat pulled to 17.5** |

So turning the air conditioner down by hand moves the radiators' target — potentially below room temperature, which
stops the heating. A WARNING appears in the log; nothing in the user interface explains it.

`events/trv.py` has the mirror-image defect: an adopted TRV knob turn calls `_enforce_cool_above_heat()` and raises the
cooling target, so a radiator knob switches the air conditioner off.

### The rule this implements

**An inbound device event clamps the value it is adopting and leaves the other channel's target alone.** A device report
may only ever move its own channel.

That is the rule the integration already applies against the configured range: `resolve_inbound_setpoint` clamps a
reported value into `[bt_min_temp, bt_max_temp]`, reports `clamped`, and the control cycle writes the clamped value back
at the device. `number.py` already applies exactly this clamp to the cooling preset number without touching
`bt_target_temp`. The other channel's target is simply a second bound, applied the same way.

Both handlers change, so the two stay symmetric — a radiator knob must not be authoritative over the air conditioner
while the AC remote is not authoritative over the radiators.

## Changes:

### After the change

| situation | before | after |
|---|---|---|
| heat 20.0, cool 24.0, remote to 18.0 | cool 18.0, heat 17.5 | **cool 20.5, heat 20.0** |
| cool 22.5, TRV knob to 24.0 | heat 24.0, cool 24.5 | **heat 22.0, cool 22.5** |
| heat 30.0 = `bt_max_temp`, remote to 22.0 | cool 22.0, heat 21.5 | **cool 30.0, heat 29.5** (one step) |
| heat 30.0, range narrowed to `bt_max_temp` 28.0, remote to 18.0 | cool 18.0, heat 17.5 | **cool 28.0, heat 27.5** |

The clamped value reaches the device through the control cycle each handler already requests — no new write path. A user
who insists on a lower cooling target lowers the heating target first; that trade is the point of the rule.

The bound on the floor/ceiling is what keeps the degenerate case cheap. An unbounded floor, or a "no legal value, give
up" branch, would hand control straight back to `_enforce_heat_below_cool` and reproduce the reported bug with maximal
damage whenever the heating target sits within one step of the maximum — not only exactly on it.

### What deliberately stays

The two `_enforce_*` calls remain at their call sites as the residual tie-break for the case where the adopting channel
has no legal value left: the other target sits within one step of a range bound. After the clamp they move that other
target by one step there. They move it further in exactly one situation — a range recomputed from the children has
narrowed past a target already in place — and that larger move is what pulls the stale target back inside the range. A
comment at each call site says so, so the surviving call is not mistaken for the live rule.

Those fallbacks only apply inside HEAT_COOL, and with a cooler configured the group reaches HEAT_COOL by way of
`bt_hvac_mode` leaving OFF. So the TRV handler runs `_enforce_cool_above_heat()` a second time, in the
`no_off_system_mode` branch that resolves the mode: the setpoint adopted a moment earlier in the same event was checked
while the mode still read OFF, and with the cooling target on `bt_min_temp` the clamped heating target lands on that
very value. Without the second call the handler publishes two equal targets. The cooler handler needs no counterpart —
it is gated on a group that is not OFF and never assigns `bt_hvac_mode`.

Neither `_enforce_*` method is touched on this branch: their bodies and their signatures are unchanged, so every
caller outside the two event handlers keeps the behaviour it had. Nothing here asks them to grow a range bound of
their own either, because each clamp carries its own and only ever hands the fallback the degenerate case.
`tests/unit/test_preset_number_restore.py` and `tests/unit/controlling/test_control_cooler.py`, which drive the
fallbacks from other call sites, are untouched and stay green.

### Step normalisation

Both clamps take their one step of separation from `normalize_step()` rather than `self.bt_target_temp_step or 0.5`.
That helper exists to reject a value that is not a positive real number, which `or 0.5` lets through — and
`bt_target_temp_step` carries whatever the child entities report. A negative step turns each bound into its opposite,
so the clamp lands the adopted value on the wrong side of the very target it exists to clear:

| step source | `_clamp_inbound_cool_target(20.0)`, heat 22.0 | `_clamp_inbound_heat_target(24.0)`, cool 22.0 |
|---|---|---|
| `normalize_step()` | **22.5** — clears the heating target | **21.5** — clears the cooling target |
| `or 0.5`, step `-0.5` | 21.5 — below the heating target | 22.5 — above the cooling target |

`events/trv.py` already reads its device step through the same helper.

The two `_enforce_*` fallbacks keep `self.bt_target_temp_step or 0.5`, in line with the rest of this branch leaving
them alone.

### Annunciation

A cross-channel clamp is announced at **INFO**, naming the reported value, the target it yielded to and the value kept.
WARNING stays reserved for the out-of-range clamp and for the `_enforce_*` residual: a user stepping a remote reports
every intermediate setpoint and would otherwise collect one WARNING per press.

The message states that the report *does not clear* the other target and which value is kept, so it stays true in the
corner where the clamp pins the adopted value onto that target itself:

```
TRV climate.test_trv reported setpoint 22.00 does not clear the cooling target 5.00, keeping 5.00
Cooler climate.test_cooler reported setpoint 22.00 does not clear the heating target 30.00, keeping 30.00
```

Both lines are pinned verbatim, level included, by
`TestInboundCoolSetpointClamp::test_annunciation_at_the_maximum_states_what_was_kept` and
`TestTargetTempAdoption::test_no_off_wakeup_keeps_targets_separated`.

The TRV adoption debug line now prints the value actually stored, so the log no longer disagrees with `bt_target_temp`
when the clamp lowered it.

### Scope of the bound

Both clamps key off the **configured cooling channel**, not the live HVAC mode. The ordering of the two targets is a
property of the configuration, so it has to hold whatever mode the group is in — and on the TRV side that is what makes
it hold at all: a valve with `no_off_system_mode` reports its knob turn while `bt_hvac_mode` is still OFF, and the same
event then resolves the mode. A crossing adopted while the group is off is never revisited otherwise, because the
`_enforce_*` fallbacks only run inside HEAT_COOL.

Installations without a cooler are unaffected by both clamps, which return the value untouched at their first guard,
`if self.cooler_entity_id is None`. The second `_enforce_cool_above_heat()` call in the wake-up branch is a no-op
there for the same reason its first call always was: its unchanged guard returns while `bt_target_cooltemp` is `None`
or the mode is not HEAT_COOL.

Both clamps are also no-ops while the other channel's target is still `None` — the normal state before a child entity has
reported — so the very first adoption after startup is bounded by the configured range only.

### Test fixtures

Two fixtures in the touched test files passed only by accident and now declare what they mean:

- `tests/unit/test_cooler_events.py::mock_bt` never set `cooler_entity_id`, so the production guard
  `if self.cooler_entity_id is None: return value` was cleared by MagicMock auto-vivification. It is set to the cooler
  under test; putting `None` back in its place turns 10 tests red.
- `tests/unit/test_trv_events.py::_make_group_bt` bound neither `hvac_mode` nor `_enforce_cool_above_heat`. Driving a
  group with a cooler through it produced heat 5.0 / cool 5.0 — the crossing this PR removes, invisible — where the
  single-TRV fixture produces heat 5.0 / cool 5.5. `TestGroupedModeAdoption::test_group_knob_turn_stays_below_the_cool_target`
  now pins that.

The new direct tests of the two clamps set `cooler_entity_id` explicitly for the same reason.

### Verification

- Full suite: `4141 passed` (`uv run pytest tests/`), ruff check + format clean.
- Direct unit tests for both helpers (no-op without a cooler, no-op when the other target is None, no-op when the value
  already clears it, clamp when it does not, zero and negative step falling back to 0.5, bound respected at the range
  edge, and the ordering held while the group is off), plus `TestInboundCoolSetpointClamp` on the cooler side and the
  mirror TRV cases.
- Reverting both clamps to `self.bt_target_temp_step or 0.5` turns exactly the two step-normalisation tests red and
  leaves the rest of the suite green (`2 failed, 4139 passed`), with the pair inverted in each: the cooling clamp
  returns 21.5 below heat 22.0, the heating clamp 22.5 above cool 22.0.
- `TestTargetTempAdoption::test_no_off_wakeup_keeps_targets_separated` drives the whole handler through the wake-up
  path — group OFF, `no_off_system_mode` valve, cooler configured, cooling target on `bt_min_temp` — with `hvac_mode`
  bound to the real property so it follows `bt_hvac_mode`. Without the second `_enforce_cool_above_heat()` call it
  observes heat 5.0 and cool 5.0; with it, heat 5.0 and cool 5.5. It also pins the INFO line quoted above.
- Both annunciation corners — the ones where the kept value lands on the other target itself — are pinned against a
  wording or a level regression, and both pins were checked by mutation. Narrowing the cooler-side condition with
  `and _adopted_cooling_setpoint != self.bt_max_temp`, which silences exactly that corner, leaves the other 42 tests in
  `tests/unit/test_cooler_events.py` green and fails only `test_annunciation_at_the_maximum_states_what_was_kept`; the
  mirror narrowing on the TRV side (`and _adopted_heating_setpoint != self.bt_min_temp`) fails only
  `test_no_off_wakeup_keeps_targets_separated`. Rewording the cooler message to `is below the heating target … raising
  it to` fails the same test.
- `test_no_off_wakeup_is_capped_without_a_tie_break` covers the same wake-up with the cooling target away from
  `bt_min_temp`, where the clamp alone separates the targets and `hvac_mode` never leaves OFF — the case that pins the
  bound to `cooler_entity_id` rather than to the live mode.
- A range narrowed past a target already in place is covered on both sides
  (`test_a_range_narrowed_above_the_cool_target_moves_it_further`,
  `test_a_range_narrowed_below_the_heat_target_pulls_it_inside`), as is an unknown target on the other channel.
- `tests/unit/test_preset_number_restore.py`, `tests/unit/controlling/test_control_cooler.py` and `tests/benchmark/` are
  untouched.
- `docs/internals/design-decisions.md` does not document the inbound-setpoint rules, so no section was invented there.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: n/a - covered by unit tests, no hardware run for this change
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

No new device mapping is added by this PR; the `climate.py` change is a control-path fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat setpoint handling to keep heating and cooling targets safely separated.
  * Prevented incoming heating or cooling values from creating invalid target overlaps.
  * Enforced configured temperature steps and thermostat minimum/maximum boundaries.
  * Added informational logging when reported setpoints are adjusted.

* **Tests**
  * Expanded coverage for dual-mode behavior, boundary conditions, fallback steps, and setpoint ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

