### PR TITLE
fix(cooler): seed an unknown cool target from the cooler's own setpoint

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -156,17 +156,19 @@ from .utils.controlling import (
 )
 from .utils.helpers import (
     COOLER_SETPOINT_KEYS,
+    InboundSetpoint,
     async_normalize_bt_entity_ids,
     attr_to_celsius,
     convert_to_float,
     convert_to_float_celsius,
+    device_setpoint_step,
     find_battery_entity,
     get_device_model,
     get_hvac_bt_mode,
     is_reasonable_temperature,
     normalize_hvac_mode,
     normalize_step,
-    read_setpoint_celsius,
+    resolve_inbound_setpoint,
     state_temperature_unit,
 )
 from .utils.hvac_action import (
@@ -1431,6 +1433,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             # been removed in the meantime; bail out before writing to TRVs.
             if self.is_removed:
                 return
+            # A restored preset carries a cooling target the user chose, so the
+            # cooler's own setpoint only fills a target that is still unknown.
+            # Both the temperature range and the heating target are final at
+            # this point, which is what a value read off the device has to be
+            # clamped into and ordered against.
+            self._seed_cool_target_from_cooler("startup()")
             self._validate_hvac_mode(states)
             await self._initialize_trvs()
             await self._finalize_startup()
@@ -1546,7 +1554,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             self.bt_target_temp_step = max(steps) if steps else None
 
     def _initialize_sensors(self, sensor_state: State | None) -> None:
-        """Set up room temperature, humidity, cooler and window sensors."""
+        """Set up room temperature, humidity, window and door sensors."""
         self.all_entities.append(self.sensor_entity_id)
 
         # Handle room temperature sensor with TRV fallback
@@ -1660,22 +1668,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     or 0.0
                 )
             # else: already logged warning above, _current_humidity stays None
-
-        if self.cooler_entity_id is not None:
-            _cooler_state = self.hass.states.get(self.cooler_entity_id)
-            if _cooler_state is not None and _cooler_state.state not in (
-                STATE_UNAVAILABLE,
-                STATE_UNKNOWN,
-                None,
-            ):
-                # A cooler that only supports TARGET_TEMPERATURE_RANGE reports
-                # ``temperature: None`` and carries its setpoint in
-                # ``target_temp_high``, so the same key precedence the event
-                # handler and control_cooler() use applies here too.
-                self.bt_target_cooltemp = read_setpoint_celsius(
-                    self, _cooler_state, COOLER_SETPOINT_KEYS, "startup()"
-                )
-            # else: already logged warning above
 
         # Seed the window and door regions from the sensors' startup state.
         # A non-active sensor (unavailable/unknown) is treated as closed so
@@ -2477,6 +2469,24 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     self.hass, [self.cooler_entity_id], self._trigger_cooler_change
                 )
             )
+            # A cool target still unknown here means the earlier read of the
+            # cooler setpoint yielded nothing: the cooler published no state
+            # yet, or the state it published carried no readable setpoint. An
+            # unknown cool target holds control_cooler() at OFF on every cycle,
+            # and the event handler only ever sees a cooler that changes state
+            # again. The subscription above is live from this point on, so this
+            # is the last moment a state that never changes again can still be
+            # read. It names itself rather than the startup it runs under, so a
+            # conversion this read cannot complete is not attributed to the
+            # earlier one.
+            if (
+                self._seed_cool_target_from_cooler("_finalize_startup()")
+                and self.bt_hvac_mode != HVACMode.OFF
+            ):
+                # A thermostat that is off has nothing to act on: the target is
+                # stored for the first cycle after it is switched on, and that
+                # switch requests a cycle of its own.
+                request_control_cycle(self)
         if self.outdoor_sensor is not None:
             self.async_on_remove(
                 async_track_state_change_event(
@@ -3194,28 +3204,172 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         request_control_cycle(self)
 
-    def _enforce_cool_above_heat(self) -> None:
+    def _seed_cool_target_from_cooler(self, log_source: str) -> bool:
+        """Fill a cooling target that is still unknown from the cooler's state.
+
+        The single place a cooling target is taken off the device, so every such
+        value passes the same resolution: it is read with the key precedence a
+        cooler is driven through — a device that only supports
+        TARGET_TEMPERATURE_RANGE reports ``temperature: None`` and carries its
+        setpoint in ``target_temp_high`` — clamped into the configured range, and
+        ordered above the heating target. A cooler that was unavailable while
+        that range was derived contributed no bounds to it, so the setpoint it
+        reports can sit outside the range and is clamped into it exactly like a
+        reported one. Echo detection has nothing to compare against, because no
+        setpoint is written to a cooler whose target is unknown.
+
+        A target that is already known is left alone: it is either the value a
+        restored preset carries, which is the user's own choice, or one this
+        method took earlier.
+
+        Parameters
+        ----------
+        log_source : str
+            caller name, forwarded for logging context
+
+        Returns
+        -------
+        bool
+            whether a cooling target was seeded; False when one is already
+            known, when no cooler is configured, and when the cooler has no
+            state, is unavailable or publishes no readable setpoint
+        """
+        if self.cooler_entity_id is None or self.bt_target_cooltemp is not None:
+            return False
+        cooler_state = self.hass.states.get(self.cooler_entity_id)
+        if cooler_state is None or cooler_state.state in (
+            STATE_UNAVAILABLE,
+            STATE_UNKNOWN,
+        ):
+            return False
+        setpoint = resolve_inbound_setpoint(
+            self,
+            cooler_state,
+            keys=COOLER_SETPOINT_KEYS,
+            known_values=(),
+            step=device_setpoint_step(self, cooler_state, log_source),
+            log_source=log_source,
+        )
+        if setpoint is None:
+            return False
+        self._seed_cool_target(setpoint, self.cooler_entity_id)
+        return True
+
+    def _seed_cool_target(self, setpoint: InboundSetpoint, entity_id: str) -> None:
+        """Adopt a cooler's own setpoint as the cooling target.
+
+        A cooling target that is unknown holds the cooler off on every control
+        cycle, and the cooler's own setpoint is the only value available to fill
+        it with. That value is an observation rather than user intent, so the
+        cooling side is the one that yields when the two targets collide, and the
+        heating target the user set stays where it is. The ordering is applied in
+        every HVAC mode, because a target seeded while Better Thermostat is off
+        is the one the first cooling cycle after switching on works with and that
+        transition does not revisit the pair.
+
+        A value the user never chose has to be traceable, because the stored
+        target is written back to the cooler: this annunciates the clamp into the
+        configured range, and :meth:`_enforce_cool_above_heat` annunciates a lift
+        above the heating target.
+
+        Parameters
+        ----------
+        setpoint : InboundSetpoint
+            the setpoint the cooler reports, already resolved into BT's range
+        entity_id : str
+            the cooler whose setpoint is being adopted
+        """
+        if setpoint.clamped:
+            _LOGGER.warning(
+                "better_thermostat %s: Cooler %s reported setpoint %s outside of "
+                "range while the cool target is unknown, taking %s as the cool "
+                "target",
+                self.device_name,
+                entity_id,
+                setpoint.raw,
+                setpoint.value,
+            )
+        else:
+            _LOGGER.info(
+                "better_thermostat %s: Cooler %s reports setpoint %s while the "
+                "cool target is unknown, taking it as the cool target",
+                self.device_name,
+                entity_id,
+                setpoint.value,
+            )
+        self.bt_target_cooltemp = setpoint.value
+        self._enforce_cool_above_heat(regardless_of_hvac_mode=True)
+
+    def _enforce_cool_above_heat(
+        self, *, regardless_of_hvac_mode: bool = False
+    ) -> None:
         """Keep the cooling target strictly above the heating target.
 
         In HEAT_COOL mode the two setpoints must not cross. If the cool target is
-        at or below the heat target, bump it up by one temperature step.
+        at or below the heat target, bump it up by one temperature step. The step
+        is normalised to a positive value first: a configured step of zero or
+        below would move the cooling target the wrong way and leave the pair it
+        is meant to order inverted.
+
+        The cooling target is reported as ``target_temperature_high`` and written
+        to the cooler, so the bump is capped at the configured maximum. Where the
+        heating target leaves the range no room, the two invariants collide and
+        one of them decides:
+
+        - A heating target resting on the maximum leaves no value above it inside
+          the range. The range wins: the cooling target goes to the maximum, the
+          closest to ordered that the range holds, and the overlap that remains
+          is annunciated. Cooling is gated on the room being warmer than the
+          heating target as well, so the two targets meeting does not run the
+          cooler against the TRVs.
+        - A heating target above the maximum is itself outside the range, so a
+          cap would put the cooling target below it. The ordering wins: the bump
+          is left uncapped rather than inverting the pair this method exists to
+          order.
+
+        Parameters
+        ----------
+        regardless_of_hvac_mode : bool
+            Enforce the ordering outside HEAT_COOL as well. Callers that store a
+            cooling target read off the device need this: such a value has to be
+            ordered the moment it is stored, because the mode can change without
+            the pair being looked at again, and the first cooling cycle after
+            that would drive the room down while the TRVs heat it up.
         """
+        if not regardless_of_hvac_mode and self.hvac_mode != HVACMode.HEAT_COOL:
+            return
         if (
-            self.hvac_mode != HVACMode.HEAT_COOL
-            or self.bt_target_cooltemp is None
+            self.bt_target_cooltemp is None
             or self.bt_target_temp is None
             or self.bt_target_cooltemp > self.bt_target_temp
         ):
             return
-        step = self.bt_target_temp_step or 0.5
+        step = normalize_step(self.bt_target_temp_step)
         adjusted = self.bt_target_temp + step
-        _LOGGER.warning(
-            "better_thermostat %s: cooling target %.2f adjusted to %.2f to stay above heating target %.2f",
-            self.device_name,
-            self.bt_target_cooltemp,
-            adjusted,
-            self.bt_target_temp,
-        )
+        maximum = self.bt_max_temp
+        if maximum is not None and maximum >= self.bt_target_temp:
+            adjusted = min(adjusted, maximum)
+        if adjusted == self.bt_target_cooltemp:
+            # The maximum and the heating target coincide and the cooling target
+            # already rests on them, so the bump has nowhere to land.
+            return
+        if adjusted > self.bt_target_temp:
+            _LOGGER.warning(
+                "better_thermostat %s: cooling target %.2f adjusted to %.2f to stay above heating target %.2f",
+                self.device_name,
+                self.bt_target_cooltemp,
+                adjusted,
+                self.bt_target_temp,
+            )
+        else:
+            _LOGGER.warning(
+                "better_thermostat %s: cooling target %.2f raised to the "
+                "configured maximum %.2f, which the heating target occupies as "
+                "well, because the range holds no value above it",
+                self.device_name,
+                self.bt_target_cooltemp,
+                adjusted,
+            )
         self.bt_target_cooltemp = adjusted
 
     def _enforce_heat_below_cool(self) -> None:
@@ -3224,7 +3378,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         The counterpart to :meth:`_enforce_cool_above_heat`, for the case where
         the cooling target is the value that was just set: the heating target
         yields instead, down to one temperature step below the cooling target
-        and never below the configured minimum.
+        and never below the configured minimum. The step is normalised to a
+        positive value first: a configured step of zero or below would move the
+        heating target the wrong way and leave the pair it is meant to order
+        inverted.
+
+        A minimum that the cooling target does not clear by at least one step
+        pins the heating target on the minimum, at or above the cooling target:
+        the range bounds the value that is stored, and the overlap that remains
+        is annunciated as such rather than reported as an ordered pair.
         """
         if (
             self.hvac_mode != HVACMode.HEAT_COOL
@@ -3233,17 +3395,31 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             or self.bt_target_temp < self.bt_target_cooltemp
         ):
             return
-        step = self.bt_target_temp_step or 0.5
+        step = normalize_step(self.bt_target_temp_step)
         adjusted = self.bt_target_cooltemp - step
         if self.bt_min_temp is not None:
             adjusted = max(adjusted, self.bt_min_temp)
-        _LOGGER.warning(
-            "better_thermostat %s: heating target %.2f adjusted to %.2f to stay below cooling target %.2f",
-            self.device_name,
-            self.bt_target_temp,
-            adjusted,
-            self.bt_target_cooltemp,
-        )
+        if adjusted == self.bt_target_temp:
+            # The minimum pins the drop on the heating target itself, so it has
+            # nowhere to land.
+            return
+        if adjusted < self.bt_target_cooltemp:
+            _LOGGER.warning(
+                "better_thermostat %s: heating target %.2f adjusted to %.2f to stay below cooling target %.2f",
+                self.device_name,
+                self.bt_target_temp,
+                adjusted,
+                self.bt_target_cooltemp,
+            )
+        else:
+            _LOGGER.warning(
+                "better_thermostat %s: heating target %.2f set to the configured "
+                "minimum %.2f, which is not below the cooling target %.2f",
+                self.device_name,
+                self.bt_target_temp,
+                adjusted,
+                self.bt_target_cooltemp,
+            )
         self.bt_target_temp = adjusted
 
     def _clamp_inbound_cool_target(self, value: float) -> float:

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -9,46 +9,22 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.climate.const import HVACMode
-from homeassistant.const import UnitOfTemperature
-from homeassistant.core import State
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
 from custom_components.better_thermostat.utils.controlling import (
     last_sent_cooler_temperature,
 )
 from custom_components.better_thermostat.utils.helpers import (
     COOLER_SETPOINT_KEYS,
-    convert_to_float,
-    normalize_step,
+    device_setpoint_step,
     read_setpoint_celsius,
     resolve_inbound_setpoint,
     resolve_state_change_event,
     setpoint_echo_window,
-    state_temperature_unit,
 )
 from custom_components.better_thermostat.utils.scheduler import request_control_cycle
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _get_cooler_step(self, state: State) -> float:
-    """Return the cooler's setpoint step as a °C delta."""
-    raw_step = state.attributes.get("target_temp_step")
-    step = (
-        convert_to_float(str(raw_step), self.device_name, "trigger_cooler_change()")
-        if raw_step is not None
-        else None
-    )
-    if (
-        step is not None
-        and state_temperature_unit(
-            state.attributes, self.hass.config.units.temperature_unit
-        )
-        == UnitOfTemperature.FAHRENHEIT
-    ):
-        step = round(step * 5.0 / 9.0, 4)
-    if step is None or step <= 0:
-        return normalize_step(self.bt_target_temp_step)
-    return step
 
 
 async def trigger_cooler_change(self, event):
@@ -68,7 +44,7 @@ async def trigger_cooler_change(self, event):
     )
 
     _main_change = False
-    _step = _get_cooler_step(self, new_state)
+    _step = device_setpoint_step(self, new_state, "trigger_cooler_change()")
     # The previous state only answers whether the cooler was publishing a
     # setpoint at all, so it is read without clamping or echo detection.
     _old_cooling_setpoint = read_setpoint_celsius(
@@ -86,7 +62,40 @@ async def trigger_cooler_change(self, event):
         step=_step,
         log_source="trigger_cooler_change()",
     )
-    if (
+    if _new_cooling_setpoint is not None and self.bt_target_cooltemp is None:
+        # An unknown cool target holds the cooler OFF on every control cycle,
+        # and the gate below cannot lift it: that gate needs a setpoint in the
+        # previous state, which a cooler that was away usually no longer
+        # publishes, and a reported move, which a cooler resting on its own
+        # setpoint never reports. The device's own setpoint is the only value
+        # there is; taking it loses no user intent because the field carries
+        # none, and it cannot be an echo either, because no setpoint is written
+        # to the cooler while the target is unknown.
+        if new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            # A cooler that is unavailable or has no mode yet can still carry a
+            # setpoint: an entity reports ``unknown`` while publishing its full
+            # attributes, and one that writes the state machine directly keeps
+            # the attributes it last set. Such a value is retained rather than
+            # reported and says nothing about the device now, so it must not
+            # become the cool target, which is written straight back to it.
+            # :meth:`_seed_cool_target_from_cooler` declines the same two states
+            # at startup. The event stays with this branch even so, because the
+            # gate below would otherwise take that same retained value as the
+            # cool target, raised clear of the heating target it leaves in
+            # place, and an unknown target gives that gate nothing to protect.
+            _LOGGER.debug(
+                "better_thermostat %s: Cooler %s is %s, not seeding the unknown "
+                "cool target from its retained setpoint %s",
+                self.device_name,
+                entity_id,
+                new_state.state,
+                _new_cooling_setpoint.raw,
+            )
+        else:
+            self._seed_cool_target(_new_cooling_setpoint, entity_id)
+            if self.bt_hvac_mode != HVACMode.OFF:
+                _main_change = True
+    elif (
         _new_cooling_setpoint is not None
         and _old_cooling_setpoint is not None
         and self.bt_hvac_mode != HVACMode.OFF

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -9,7 +9,11 @@ import math
 import re
 from typing import Any, NamedTuple
 
-from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
+from homeassistant.components.climate.const import (
+    ATTR_TARGET_TEMP_STEP,
+    ClimateEntityFeature,
+    HVACMode,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_NAME,
@@ -730,6 +734,48 @@ def normalize_step(value: float | int | str | None, fallback: float = 0.5) -> fl
         return fallback
     if not math.isfinite(step) or step <= 0:
         return fallback
+    return step
+
+
+def device_setpoint_step(self, state: State, log_source: str) -> float:
+    """Return a controlled device's setpoint step as a °C delta.
+
+    The step belongs to the device that reports it and carries that device's
+    unit, so a Fahrenheit reading is converted to a Celsius delta before it can
+    be compared with a Celsius setpoint. A device that publishes no usable step
+    falls back to Better Thermostat's own step.
+
+    Parameters
+    ----------
+    self :
+            the Better Thermostat instance, supplying ``hass``, ``device_name``
+            and the configured step
+    state : State
+            the device state carrying the reported ``target_temp_step``
+    log_source : str
+            caller name, forwarded for logging context
+
+    Returns
+    -------
+    float
+            the device's setpoint step as a positive Celsius delta
+    """
+    raw_step = state.attributes.get(ATTR_TARGET_TEMP_STEP)
+    step = (
+        convert_to_float(str(raw_step), self.device_name, log_source)
+        if raw_step is not None
+        else None
+    )
+    if (
+        step is not None
+        and state_temperature_unit(
+            state.attributes, self.hass.config.units.temperature_unit
+        )
+        == UnitOfTemperature.FAHRENHEIT
+    ):
+        step = round(step * 5.0 / 9.0, 4)
+    if step is None or step <= 0:
+        return normalize_step(self.bt_target_temp_step)
     return step
 
 

--- a/tests/unit/controlling/test_control_cooler.py
+++ b/tests/unit/controlling/test_control_cooler.py
@@ -2122,3 +2122,33 @@ class TestControlCoolerTargetRange:
             "target_temp_high": 24.0,
             "target_temp_low": 21.0,
         }
+
+
+class TestControlCoolerUnknownTarget:
+    """A cool target that is not known holds the cooler off."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_cool_target_commands_off_and_writes_no_setpoint(self):
+        """The cycle has nothing to compare the room against.
+
+        Without a cooling target the hysteresis has no switch-on point, so the
+        cooler is commanded off even in a room well above its heating target,
+        and no setpoint is written because there is none to write. A running
+        air conditioner is switched off for as long as the target stays unknown.
+        """
+        mock_self, mock_hass, _ = _make_cooler_setup(
+            cooler_state=HVACMode.COOL, target_cooltemp=None
+        )
+        snapshot = make_snapshot(
+            hvac_mode=CoreHvacMode.HEAT_COOL,
+            target_cooltemp=None,
+            room_temp=26.0,
+            target_temp=20.0,
+            tolerance=0.5,
+        )
+
+        await control_cooler(mock_self, snapshot)
+
+        assert _service_calls(mock_hass, "set_temperature") == []
+        modes = _service_calls(mock_hass, "set_hvac_mode")
+        assert [call.args[2]["hvac_mode"] for call in modes] == [HVACMode.OFF]

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -5,6 +5,7 @@ mock_bt fixture (MagicMock with explicit attributes).
 """
 
 from datetime import UTC, datetime, timedelta
+import logging
 from unittest.mock import MagicMock
 
 from homeassistant.components.climate.const import (
@@ -24,6 +25,7 @@ import pytest
 
 from custom_components.better_thermostat.climate import BetterThermostat
 from custom_components.better_thermostat.trv import Trv
+from custom_components.better_thermostat.utils.helpers import InboundSetpoint
 from custom_components.better_thermostat.utils.hvac_action import ToleranceHysteresis
 from custom_components.better_thermostat.utils.thermal_learning import (
     HeatingPowerTracker,
@@ -125,7 +127,9 @@ def mock_bt():
         bt, result
     )
     bt._get_outdoor_temp = lambda: BetterThermostat._get_outdoor_temp(bt)
-    bt._enforce_cool_above_heat = lambda: BetterThermostat._enforce_cool_above_heat(bt)
+    bt._enforce_cool_above_heat = lambda **kwargs: (
+        BetterThermostat._enforce_cool_above_heat(bt, **kwargs)
+    )
     return bt
 
 
@@ -1231,8 +1235,8 @@ class TestAsyncSetTemperature:
 class TestEnforceCoolAboveHeat:
     """_enforce_cool_above_heat keeps the cool target strictly above the heat target."""
 
-    def _call(self, bt):
-        return BetterThermostat._enforce_cool_above_heat(bt)
+    def _call(self, bt, **kwargs):
+        return BetterThermostat._enforce_cool_above_heat(bt, **kwargs)
 
     def test_not_heat_cool_mode_is_noop(self, mock_bt):
         """Outside HEAT_COOL the cool target is left untouched even if below heat."""
@@ -1241,6 +1245,36 @@ class TestEnforceCoolAboveHeat:
         mock_bt.bt_target_cooltemp = 20.0
         self._call(mock_bt)
         assert mock_bt.bt_target_cooltemp == 20.0
+
+    def test_regardless_of_hvac_mode_skips_the_mode_gate(self, mock_bt):
+        """The flag orders the pair in a mode that does not cool at all."""
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 20.0
+        self._call(mock_bt, regardless_of_hvac_mode=True)
+        assert mock_bt.bt_target_cooltemp == 22.5
+
+    def test_regardless_of_hvac_mode_keeps_the_none_guards(self, mock_bt):
+        """Without both targets there is no pair to order."""
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_cooltemp = None
+        self._call(mock_bt, regardless_of_hvac_mode=True)
+        assert mock_bt.bt_target_cooltemp is None
+
+        mock_bt.bt_target_temp = None
+        mock_bt.bt_target_cooltemp = 20.0
+        self._call(mock_bt, regardless_of_hvac_mode=True)
+        assert mock_bt.bt_target_cooltemp == 20.0
+
+    def test_regardless_of_hvac_mode_keeps_the_ordering_guard(self, mock_bt):
+        """A pair already in order is left alone whatever the mode is."""
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_cooltemp = 26.0
+        self._call(mock_bt, regardless_of_hvac_mode=True)
+        assert mock_bt.bt_target_cooltemp == 26.0
 
     def test_cool_above_heat_is_noop(self, mock_bt):
         """A cool target already above the heat target is unchanged."""
@@ -1277,6 +1311,26 @@ class TestEnforceCoolAboveHeat:
         self._call(mock_bt)
         assert mock_bt.bt_target_cooltemp == 22.5
 
+    @pytest.mark.parametrize("step", [-1.0, float("nan"), float("inf")])
+    def test_unusable_step_falls_back_instead_of_moving_the_pair(
+        self, mock_bt, caplog, step
+    ):
+        """A step that is not a positive number falls back like a missing one.
+
+        Only a positive step can lift the cool target above the heat target, so
+        a negative or non-finite one is replaced by the fallback, and the
+        annunciation names the value the cool target actually comes to rest on.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = step
+        mock_bt.bt_target_cooltemp = 21.0
+        caplog.set_level(logging.WARNING)
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 22.5
+        assert "adjusted to 22.50 to stay above heating target 22.00" in caplog.text
+
     def test_none_cool_target_is_noop(self, mock_bt):
         """A None cool target does not raise and stays None."""
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
@@ -1284,6 +1338,101 @@ class TestEnforceCoolAboveHeat:
         mock_bt.bt_target_cooltemp = None
         self._call(mock_bt)
         assert mock_bt.bt_target_cooltemp is None
+
+    def test_bump_stops_at_the_configured_maximum(self, mock_bt):
+        """A heat target within one step of the maximum shortens the bump.
+
+        The bumped value is written to the cooler and published as the upper end
+        of the range, so it has to stay inside the configured bounds; a step
+        short of the maximum still clears the heat target.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.bt_target_temp = 29.8
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 29.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 30.0
+        assert mock_bt.bt_target_cooltemp > mock_bt.bt_target_temp
+        assert mock_bt.bt_target_cooltemp <= mock_bt.bt_max_temp
+
+    def test_heat_target_at_the_maximum_meets_the_cool_target_there(
+        self, mock_bt, caplog
+    ):
+        """At the maximum the range holds no value above the heat target.
+
+        The pair cannot be ordered without leaving the range, and the maximum is
+        the closest the cool target can come while staying writable, so the two
+        targets come to rest on the same value.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.bt_target_temp = 30.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 28.0
+        caplog.set_level(logging.WARNING)
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 30.0
+        assert (
+            "cooling target 28.00 raised to the configured maximum 30.00, which "
+            "the heating target occupies as well, because the range holds no "
+            "value above it" in caplog.text
+        )
+
+    def test_pair_resting_on_the_maximum_is_left_alone(self, mock_bt, caplog):
+        """Both targets at the maximum have nowhere left to move."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.bt_target_temp = 30.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 30.0
+        caplog.set_level(logging.WARNING)
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 30.0
+        assert caplog.text == ""
+
+    def test_maximum_below_the_heat_target_does_not_cap(self, mock_bt, caplog):
+        """A maximum the heat target already exceeds cannot bound the bump.
+
+        Capping there would put the cool target below the heat target and
+        publish the inverted pair this method exists to prevent, so the ordering
+        keeps precedence and the bump runs its full step.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = 18.0
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 17.0
+        caplog.set_level(logging.WARNING)
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 22.5
+        assert mock_bt.bt_target_cooltemp > mock_bt.bt_target_temp
+        assert "adjusted to 22.50 to stay above heating target 22.00" in caplog.text
+
+    def test_cool_target_above_the_maximum_is_raised_not_lowered(self, mock_bt):
+        """A cool target outside the range is still ordered above the heat one.
+
+        Both targets sit above the maximum, so pulling the cool one down to it
+        would drop it below the heat target instead of bringing the pair back
+        into range.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.bt_target_temp = 32.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 31.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 32.5
+
+    def test_without_a_maximum_the_bump_is_uncapped(self, mock_bt):
+        """No maximum is known until a child entity reports one."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_max_temp = None
+        mock_bt.bt_target_temp = 29.8
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_target_cooltemp = 29.0
+        self._call(mock_bt)
+        assert mock_bt.bt_target_cooltemp == 30.3
 
 
 # ===========================================================================
@@ -1340,15 +1489,84 @@ class TestEnforceHeatBelowCool:
         self._call(mock_bt)
         assert mock_bt.bt_target_temp == 21.5
 
-    def test_result_is_clamped_to_min_temp(self, mock_bt):
-        """The heat target never drops below the configured minimum."""
+    @pytest.mark.parametrize("step", [-0.5, float("nan"), float("inf")])
+    def test_unusable_step_falls_back_instead_of_moving_the_pair(
+        self, mock_bt, caplog, step
+    ):
+        """A step that is not a positive number falls back like a missing one.
+
+        Only a positive step can push the heat target below the cool target, so
+        a negative or non-finite one is replaced by the fallback, and the
+        annunciation names the value the heat target actually comes to rest on.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = step
+        mock_bt.bt_target_cooltemp = 22.0
+        caplog.set_level(logging.WARNING)
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 21.5
+        assert "adjusted to 21.50 to stay below cooling target 22.00" in caplog.text
+
+    def test_result_is_clamped_to_min_temp(self, mock_bt, caplog):
+        """The heat target never drops below the configured minimum.
+
+        A cool target resting on the minimum leaves no value below it inside the
+        range, so the two targets meet there and the annunciation says so rather
+        than claiming an ordering the values do not have.
+        """
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_target_temp = 6.0
         mock_bt.bt_target_temp_step = 0.5
         mock_bt.bt_min_temp = 5.0
         mock_bt.bt_target_cooltemp = 5.0
+        caplog.set_level(logging.WARNING)
         self._call(mock_bt)
         assert mock_bt.bt_target_temp == 5.0
+        assert (
+            "heating target 6.00 set to the configured minimum 5.00, which is "
+            "not below the cooling target 5.00" in caplog.text
+        )
+        assert "to stay below cooling target" not in caplog.text
+
+    def test_minimum_above_the_cool_target_is_reported_as_an_overlap(
+        self, mock_bt, caplog
+    ):
+        """A cool target under the minimum pins the heat target above it.
+
+        The configured range is the overlap of what the child entities
+        advertise, so children whose ranges do not overlap leave the minimum
+        above the maximum. Both bounds are applied to an inbound setpoint in
+        sequence and the maximum decides, which puts the adopted cool target on
+        the maximum, below the minimum. The heat target stops on the minimum and
+        the pair overlaps; the annunciation names the value that was stored
+        rather than reporting an ordering it does not have.
+        """
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_min_temp = 20.0
+        mock_bt.bt_target_cooltemp = 15.0
+        caplog.set_level(logging.WARNING)
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 20.0
+        assert (
+            "heating target 22.00 set to the configured minimum 20.00, which is "
+            "not below the cooling target 15.00" in caplog.text
+        )
+
+    def test_pair_resting_on_the_minimum_is_left_alone(self, mock_bt, caplog):
+        """Both targets at the minimum have nowhere left to move."""
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.bt_target_temp = 5.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_cooltemp = 5.0
+        caplog.set_level(logging.WARNING)
+        self._call(mock_bt)
+        assert mock_bt.bt_target_temp == 5.0
+        assert caplog.text == ""
 
     def test_none_heat_target_is_noop(self, mock_bt):
         """A None heat target does not raise and stays None."""
@@ -1533,3 +1751,59 @@ class TestClampInboundHeatTarget:
         mock_bt.bt_min_temp = 5.0
         mock_bt.bt_target_temp_step = 0.5
         assert self._call(mock_bt, 22.0) == 5.0
+
+
+# ===========================================================================
+# 11. TestSeedCoolTarget
+# ===========================================================================
+
+
+class TestSeedCoolTarget:
+    """_seed_cool_target adopts a cooler's own setpoint as the cool target."""
+
+    COOLER_ID = "climate.test_cooler"
+
+    def _call(self, bt, setpoint):
+        return BetterThermostat._seed_cool_target(bt, setpoint, self.COOLER_ID)
+
+    def test_in_range_setpoint_is_stored_and_reported(self, mock_bt, caplog):
+        """Taking a device value as the target is worth an info entry."""
+        mock_bt.bt_target_temp = 20.0
+        caplog.set_level(logging.INFO)
+        self._call(
+            mock_bt, InboundSetpoint(raw=24.0, value=24.0, clamped=False, is_echo=False)
+        )
+        assert mock_bt.bt_target_cooltemp == 24.0
+        assert "cool target is unknown, taking it as the cool target" in caplog.text
+
+    def test_clamped_setpoint_stores_the_clamped_value_and_warns(self, mock_bt, caplog):
+        """The stored target is written back, so the substitution must be visible."""
+        mock_bt.bt_target_temp = 20.0
+        caplog.set_level(logging.WARNING)
+        self._call(
+            mock_bt, InboundSetpoint(raw=31.0, value=30.0, clamped=True, is_echo=False)
+        )
+        assert mock_bt.bt_target_cooltemp == 30.0
+        assert "reported setpoint 31.0 outside of range" in caplog.text
+
+    def test_setpoint_colliding_with_the_heat_target_is_lifted(self, mock_bt):
+        """The observed value yields, the heating target the user set stays."""
+        mock_bt.hvac_mode = HVACMode.HEAT
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        self._call(
+            mock_bt, InboundSetpoint(raw=21.0, value=21.0, clamped=False, is_echo=False)
+        )
+        assert mock_bt.bt_target_cooltemp == 22.5
+        assert mock_bt.bt_target_temp == 22.0
+
+    def test_setpoint_equal_to_the_heat_target_is_lifted(self, mock_bt):
+        """Equal targets are a collision too: the cooler would never switch on."""
+        mock_bt.hvac_mode = HVACMode.HEAT
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = 0.5
+        self._call(
+            mock_bt, InboundSetpoint(raw=22.0, value=22.0, clamped=False, is_echo=False)
+        )
+        assert mock_bt.bt_target_cooltemp == 22.5
+        assert mock_bt.bt_target_temp == 22.0

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -6,6 +6,7 @@ _initialize_sensors, _restore_state, _validate_hvac_mode.
 
 import asyncio
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.climate.const import HVACMode
@@ -29,9 +30,11 @@ from custom_components.better_thermostat.utils.const import (
     ATTR_STATE_HEAT_LOSS,
     ATTR_STATE_HEATING_POWER,
     ATTR_STATE_PRESET_COOL_TEMPERATURES,
+    DEFAULT_TARGET_TEMP,
     MAX_HEAT_LOSS,
     MAX_HEATING_POWER,
 )
+from custom_components.better_thermostat.utils.helpers import resolve_inbound_setpoint
 
 SENSOR_ID = "sensor.room_temp"
 TRV_ID = "climate.test_trv"
@@ -56,6 +59,9 @@ def bt():
     mock._degraded_grace_until = None
     mock.state_mgr = None
     mock.hass = MagicMock()
+    # climate entities publish no unit attribute, so every temperature read off
+    # a child state resolves through the system unit.
+    mock.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
     mock.device_name = "Test BT"
     mock.sensor_entity_id = SENSOR_ID
     mock.real_trvs = {TRV_ID: {"calibration": 1}}
@@ -99,6 +105,18 @@ def bt():
     mock.preset_modes = ["none", "comfort", "eco"]
     mock.version = "1.0.0"
     mock.startup_running = True
+    # The seed is the one collaborator whose effect on the instance the cooler
+    # assertions read back, so it runs for real while staying observable, and so
+    # do the two rules it delegates to.
+    mock._seed_cool_target_from_cooler.side_effect = lambda log_source: (
+        BetterThermostat._seed_cool_target_from_cooler(mock, log_source)
+    )
+    mock._seed_cool_target.side_effect = lambda setpoint, entity_id: (
+        BetterThermostat._seed_cool_target(mock, setpoint, entity_id)
+    )
+    mock._enforce_cool_above_heat.side_effect = lambda **kwargs: (
+        BetterThermostat._enforce_cool_above_heat(mock, **kwargs)
+    )
     return mock
 
 
@@ -499,22 +517,54 @@ class TestInitializeSensors:
             BetterThermostat._initialize_sensors(bt, sensor)
         assert bt.last_known_external_temp is not None
 
-    def test_single_setpoint_cooler_seeds_cool_target(self, bt):
+
+# ---------------------------------------------------------------------------
+# 5. Cooling target seeded from the cooler
+# ---------------------------------------------------------------------------
+
+
+async def _run_startup(bt, restored_target, restored_cool_target=None):
+    """Run startup() with a restore step that installs the restored targets."""
+    bt.is_removed = False
+    bt._check_entities_ready.return_value = True
+
+    async def _restore(_states):
+        bt.bt_target_temp = restored_target
+        if restored_cool_target is not None:
+            bt.bt_target_cooltemp = restored_cool_target
+
+    bt._restore_state.side_effect = _restore
+    with patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()):
+        await asyncio.wait_for(BetterThermostat.startup(bt), timeout=1)
+
+
+class TestStartupCoolTargetSeed:
+    """startup() takes a cooling target off the cooler once the restore is done.
+
+    The cooler's own setpoint is the only value that can fill a cooling target
+    nothing else supplies, and it is read where both the temperature range and
+    the heating target are final: the range is what the value is clamped into,
+    the heating target what it is ordered against.
+    """
+
+    @pytest.mark.asyncio
+    async def test_single_setpoint_cooler_seeds_the_cool_target(self, bt):
         """A cooler driven through a single setpoint is read from temperature."""
         bt.cooler_entity_id = COOLER_ID
-        bt.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
         _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: 24.0})})
-        BetterThermostat._initialize_sensors(bt, _make_sensor_state("21.5"))
+
+        await _run_startup(bt, restored_target=21.0)
+
         assert bt.bt_target_cooltemp == 24.0
 
-    def test_range_only_cooler_seeds_cool_target_from_range_high(self, bt):
+    @pytest.mark.asyncio
+    async def test_range_only_cooler_seeds_from_target_temp_high(self, bt):
         """A range-only cooler publishes an empty temperature and a range.
 
         Its setpoint sits in target_temp_high, so reading only temperature
         would leave the cool target unset for the whole session.
         """
         bt.cooler_entity_id = COOLER_ID
-        bt.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
         _install_states(
             bt,
             {
@@ -527,12 +577,175 @@ class TestInitializeSensors:
                 )
             },
         )
-        BetterThermostat._initialize_sensors(bt, _make_sensor_state("21.5"))
+
+        await _run_startup(bt, restored_target=21.0)
+
         assert bt.bt_target_cooltemp == 25.5
+
+    @pytest.mark.asyncio
+    async def test_unavailable_cooler_leaves_the_cool_target_unknown(self, bt):
+        """An unavailable cooler contributes no setpoint to this read.
+
+        The device may not have reported in yet, or it may have dropped off
+        again; either way there is nothing to take, and the cool target stays
+        unknown for the re-read at the end of startup to pick up.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        _install_states(
+            bt,
+            {
+                COOLER_ID: _make_cooler_state(
+                    {ATTR_TEMPERATURE: 24.0}, state=STATE_UNAVAILABLE
+                )
+            },
+        )
+
+        await _run_startup(bt, restored_target=21.0)
+
+        assert bt.bt_target_cooltemp is None
+
+    @pytest.mark.asyncio
+    async def test_setpoint_inside_the_configured_range_is_taken_unchanged(
+        self, bt, caplog
+    ):
+        """A setpoint clearing both bounds and the heating target is adopted as is.
+
+        Nothing about such a value has to be corrected, so it reaches the
+        cooling channel exactly as the device reports it and no correction is
+        annunciated.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_target_temp_step = 0.5
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: 24.0})})
+
+        caplog.set_level(logging.WARNING)
+        await _run_startup(bt, restored_target=21.0)
+
+        assert bt.bt_target_cooltemp == 24.0
+        assert bt.bt_target_temp == 21.0
+        assert caplog.text == ""
+
+    @pytest.mark.asyncio
+    async def test_setpoint_outside_the_configured_range_is_clamped(self, bt, caplog):
+        """A cooler reporting below the configured minimum is brought into range.
+
+        Better Thermostat advertises the overlap of the ranges its devices
+        advertise, and a cooler that was unreachable while that overlap was
+        derived contributed no bounds to it. The heating target is well clear of
+        the value, so the clamp is the only correction, and it is annunciated
+        because the clamped value is written back to the device.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_min_temp = 18.0
+        bt.bt_target_temp_step = 0.5
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: 16.0})})
+
+        caplog.set_level(logging.WARNING)
+        await _run_startup(bt, restored_target=15.0)
+
+        assert bt.bt_target_cooltemp == 18.0
+        assert (
+            "reported setpoint 16.0 outside of range while the cool target is "
+            "unknown, taking 18.0 as the cool target" in caplog.text
+        )
+
+    @pytest.mark.asyncio
+    async def test_setpoint_is_ordered_against_the_restored_heating_target(self, bt):
+        """The heating target the restore installs is the one that bounds the seed.
+
+        Reading the cooler before the restore would order the value against the
+        construction default instead, and the pair Better Thermostat ends up
+        holding would have the cooling target below the heating one.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_target_temp = DEFAULT_TARGET_TEMP
+        bt.bt_target_temp_step = 0.5
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: 20.0})})
+
+        await _run_startup(bt, restored_target=21.0)
+
+        assert bt.bt_target_cooltemp == 21.5
+        assert bt.bt_target_temp == 21.0
+
+    @pytest.mark.asyncio
+    async def test_restored_preset_cool_target_is_not_overwritten(self, bt):
+        """A preset carries a cooling target the user chose, so it is kept.
+
+        The device is only asked for a target nothing else supplies, and a
+        restored preset supplies one.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_target_temp_step = 0.5
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: 24.0})})
+
+        await _run_startup(bt, restored_target=21.0, restored_cool_target=26.0)
+
+        assert bt.bt_target_cooltemp == 26.0
+
+    @pytest.mark.asyncio
+    async def test_no_cooler_configured_leaves_the_cool_target_unknown(self, bt):
+        """Without a cooling channel there is no device to take a target from.
+
+        Every state lookup answers with a readable setpoint here, so the absent
+        cooling channel is the only thing that can leave the target unknown: a
+        read that went ahead without one would find a value and store it.
+        """
+        bt.cooler_entity_id = None
+        bt.hass.states.get.return_value = _make_cooler_state({ATTR_TEMPERATURE: 24.0})
+
+        await _run_startup(bt, restored_target=21.0)
+
+        assert bt.bt_target_cooltemp is None
+        bt._seed_cool_target.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unreadable_step_is_logged_against_this_read(self, bt, caplog):
+        """The read names itself when the cooler's step cannot be converted.
+
+        The second startup read, at the cooler's listener registration, resolves
+        the step through the same helper. Naming this one after the method it
+        runs in is what keeps an entry the two could both have produced
+        attributable to one of them.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_target_temp_step = 0.5
+        _install_states(
+            bt,
+            {
+                COOLER_ID: _make_cooler_state(
+                    {ATTR_TEMPERATURE: 24.0, "target_temp_step": "unavailable"}
+                )
+            },
+        )
+
+        caplog.set_level(logging.DEBUG)
+        await _run_startup(bt, restored_target=21.0)
+
+        assert "Could not convert 'unavailable' to float in startup()" in caplog.text
+        assert bt.bt_target_cooltemp == 24.0
+
+    @pytest.mark.asyncio
+    async def test_unreadable_setpoint_is_logged_against_this_read(self, bt, caplog):
+        """The read names itself when the cooler's setpoint cannot be converted.
+
+        The step and the setpoint are resolved through two separate helpers,
+        and this read hands its own name to both of them, so whichever of the
+        two attributes a cooler publishes unreadably is reported against the
+        read that asked for it.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_target_temp_step = 0.5
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: "n/a"})})
+
+        caplog.set_level(logging.DEBUG)
+        await _run_startup(bt, restored_target=21.0)
+
+        assert "Could not convert 'n/a' to float in startup()" in caplog.text
+        assert bt.bt_target_cooltemp is None
 
 
 # ---------------------------------------------------------------------------
-# 5. _restore_state
+# 6. TRV attribute initialization (_initialize_trvs)
 # ---------------------------------------------------------------------------
 
 
@@ -584,6 +797,11 @@ class TestInitializeTrvCurrentTemperature:
         bt = self._trv_only_bt(bt, {"current_temperature": marker_temp})
         await self._run(bt)
         assert bt.real_trvs[TRV_ID].current_temperature is None
+
+
+# ---------------------------------------------------------------------------
+# 7. _restore_state
+# ---------------------------------------------------------------------------
 
 
 class TestRestoreState:
@@ -804,12 +1022,7 @@ class TestRestoreState:
 
 
 # ---------------------------------------------------------------------------
-# 6. TRV attribute initialization (_initialize_trvs)
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# 7. Initial TRV sync (_finalize_startup / _startup_control_trvs)
+# 8. Initial TRV sync (_finalize_startup / _startup_control_trvs)
 # ---------------------------------------------------------------------------
 
 
@@ -882,8 +1095,299 @@ class TestStartupControlSync:
         assert ctl.call_count == 2
 
 
+async def _run_finalize_startup(bt):
+    """Run _finalize_startup with its external hooks patched out."""
+    bt.is_removed = False
+    bt.all_trvs = None
+    bt.entity_ids = [TRV_ID]
+    bt.outdoor_sensor = None
+    bt._async_unsub_state_changed = None
+    # Background jobs are handed to a mocked task factory that never awaits
+    # them, so they hand out plain values instead of orphaned coroutines.
+    bt._post_grace_recheck = MagicMock()
+    bt._external_temperature_keepalive = MagicMock()
+    bt.control_queue_task = asyncio.Queue(maxsize=1)
+    with (
+        patch(f"{_CLIMATE}.await_critical_entities", AsyncMock()),
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock()),
+        patch(f"{_CLIMATE}.await_optional_sensors", AsyncMock()),
+        patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
+        patch(f"{_CLIMATE}.async_track_state_change_event", MagicMock()),
+        patch(f"{_CLIMATE}.async_track_time_interval", MagicMock()),
+        patch(f"{_CLIMATE}.asyncio.sleep", AsyncMock()),
+    ):
+        await BetterThermostat._finalize_startup(bt)
+
+
+class TestCoolerTargetReadAtListenerRegistration:
+    """The cool target is re-read once the cooler subscription is live.
+
+    A cooler that joins Home Assistant after the startup seed and then never
+    changes state again produces no event, so the registration of its listener
+    is the last point at which its setpoint can still be read.
+    An unknown cool target holds the cooler off on every control cycle.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cooler_online_by_now_seeds_the_cool_target(self, bt):
+        """The state the startup seed could not see is read here."""
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_hvac_mode = HVACMode.HEAT_COOL
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: 24.0})})
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 24.0
+        bt._seed_cool_target.assert_called_once()
+        assert bt.control_queue_task.qsize() == 1
+
+    @pytest.mark.asyncio
+    async def test_seed_while_off_requests_no_control_cycle(self, bt):
+        """An off thermostat still needs the field, but no cycle to use it.
+
+        A cycle would command the cooler off whatever the target says, and
+        switching the thermostat back on requests a cycle of its own.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_hvac_mode = HVACMode.OFF
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: 24.0})})
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 24.0
+        assert bt.control_queue_task.empty()
+
+    @pytest.mark.asyncio
+    async def test_setpoint_outside_the_range_is_clamped_and_reported(self, bt, caplog):
+        """A cooler absent from the range derivation can report outside it.
+
+        The temperature range comes from the devices that were reachable, and an
+        offline cooler contributed no bounds of its own, so the setpoint it
+        reports once it joins can sit above the advertised maximum. Storing it
+        unclamped would put the published target outside the range and write a
+        value the cooler may reject.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_max_temp = 30.0
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: 31.0})})
+
+        caplog.set_level(logging.WARNING)
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 30.0
+        assert "reported setpoint 31.0 outside of range" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_setpoint_colliding_with_the_heat_target_is_lifted(self, bt):
+        """The observed value yields, the restored heating target stays.
+
+        A setpoint read off the device carries no user intent, so a collision
+        between the two targets of the published range is resolved on the
+        cooling side.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_target_temp = 21.0
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: 19.0})})
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 21.5
+        assert bt.bt_target_temp == 21.0
+
+    @pytest.mark.asyncio
+    async def test_cooler_reporting_off_seeds_the_cool_target(self, bt):
+        """An air conditioner at rest reports off and still carries a setpoint.
+
+        Off is where an idle cooler sits and the only state a cooler that never
+        switches on will ever publish, so it is the state this read exists for.
+        The read asks whether a setpoint can be obtained, not whether the device
+        is currently cooling.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_hvac_mode = HVACMode.HEAT_COOL
+        _install_states(
+            bt,
+            {
+                COOLER_ID: _make_cooler_state(
+                    {ATTR_TEMPERATURE: 24.0}, state=HVACMode.OFF
+                )
+            },
+        )
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 24.0
+        bt._seed_cool_target.assert_called_once()
+        assert bt.control_queue_task.qsize() == 1
+
+    @pytest.mark.asyncio
+    async def test_unavailable_cooler_leaves_the_cool_target_unknown(self, bt):
+        """Attributes an unavailable cooler carries are not a reading.
+
+        The state tells whether the device can be reached, and attributes can
+        survive alongside an unavailable one. Seeding from them would store a
+        value no reachable device stands behind, while the listener registered
+        just above delivers the real one as soon as the cooler returns.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        _install_states(
+            bt,
+            {
+                COOLER_ID: _make_cooler_state(
+                    {ATTR_TEMPERATURE: 24.0}, state=STATE_UNAVAILABLE
+                )
+            },
+        )
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp is None
+        bt._seed_cool_target.assert_not_called()
+        assert bt.control_queue_task.empty()
+
+    @pytest.mark.asyncio
+    async def test_unknown_cooler_leaves_the_cool_target_unknown(self, bt):
+        """A cooler that has joined without reporting yet has nothing to offer.
+
+        An entity registered but not yet updated holds the unknown state, and
+        an attribute standing next to it is no value the device has confirmed.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        _install_states(
+            bt,
+            {
+                COOLER_ID: _make_cooler_state(
+                    {ATTR_TEMPERATURE: 24.0}, state=STATE_UNKNOWN
+                )
+            },
+        )
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp is None
+        bt._seed_cool_target.assert_not_called()
+        assert bt.control_queue_task.empty()
+
+    @pytest.mark.asyncio
+    async def test_cooler_without_a_state_leaves_the_cool_target_unknown(self, bt):
+        """An entity that does not exist yet returns no state at all."""
+        bt.cooler_entity_id = COOLER_ID
+        _install_states(bt, {})
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp is None
+        bt._seed_cool_target.assert_not_called()
+        assert bt.control_queue_task.empty()
+
+    @pytest.mark.asyncio
+    async def test_cooler_publishing_no_setpoint_requests_no_cycle(self, bt):
+        """An available cooler may still carry no setpoint in its attributes."""
+        bt.cooler_entity_id = COOLER_ID
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: None})})
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp is None
+        bt._seed_cool_target.assert_not_called()
+        assert bt.control_queue_task.empty()
+
+    @pytest.mark.asyncio
+    async def test_known_cool_target_is_not_re_read(self, bt):
+        """A target the startup seed or a restore already filled is not re-read.
+
+        The device is asked again only for a target that is still unknown, so a
+        cooler that has moved on since the startup seed cannot overwrite a value
+        Better Thermostat already holds.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_target_cooltemp = 26.0
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: 24.0})})
+
+        await _run_finalize_startup(bt)
+
+        assert bt.bt_target_cooltemp == 26.0
+        bt._seed_cool_target.assert_not_called()
+        assert bt.control_queue_task.empty()
+
+    @pytest.mark.asyncio
+    async def test_fahrenheit_cooler_is_read_with_its_own_converted_step(self, bt):
+        """The device's step reaches the adoption gate as a Celsius delta.
+
+        A Fahrenheit cooler publishes its step as a °F delta, so the 2 °F grid
+        it advertises is 1.11 °C wide, and the setpoint it reports is converted
+        along with it.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_target_temp_step = 0.5
+        bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        _install_states(
+            bt,
+            {
+                COOLER_ID: _make_cooler_state(
+                    {ATTR_TEMPERATURE: 75.0, "target_temp_step": 2.0}
+                )
+            },
+        )
+        spy = MagicMock(side_effect=resolve_inbound_setpoint)
+
+        with patch(f"{_CLIMATE}.resolve_inbound_setpoint", spy):
+            await _run_finalize_startup(bt)
+
+        assert spy.call_args.kwargs["step"] == 1.1111
+        assert bt.bt_target_cooltemp == 23.89
+
+    @pytest.mark.asyncio
+    async def test_unreadable_step_is_logged_against_this_read(self, bt, caplog):
+        """The read names itself when the cooler's step cannot be converted.
+
+        Three reads resolve a cooler's step through the same helper: the seed
+        under startup(), this one, and the event handler. The caller each names
+        is what tells a reader which of them produced the entry, so this one
+        names the method it runs in rather than the startup around it.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_target_temp_step = 0.5
+        _install_states(
+            bt,
+            {
+                COOLER_ID: _make_cooler_state(
+                    {ATTR_TEMPERATURE: 24.0, "target_temp_step": "unavailable"}
+                )
+            },
+        )
+
+        caplog.set_level(logging.DEBUG)
+        await _run_finalize_startup(bt)
+
+        assert (
+            "Could not convert 'unavailable' to float in _finalize_startup()"
+            in caplog.text
+        )
+        assert bt.bt_target_cooltemp == 24.0
+
+    @pytest.mark.asyncio
+    async def test_unreadable_setpoint_is_logged_against_this_read(self, bt, caplog):
+        """The read names itself when the cooler's setpoint cannot be converted.
+
+        The step and the setpoint are resolved through two separate helpers,
+        and this read hands its own name to both of them, so a setpoint this
+        read cannot convert is not reported against the read under startup()
+        that stumbles over the same attribute.
+        """
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_target_temp_step = 0.5
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: "n/a"})})
+
+        caplog.set_level(logging.DEBUG)
+        await _run_finalize_startup(bt)
+
+        assert "Could not convert 'n/a' to float in _finalize_startup()" in caplog.text
+        assert bt.bt_target_cooltemp is None
+
+
 # ---------------------------------------------------------------------------
-# 7. _validate_hvac_mode
+# 9. _validate_hvac_mode
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -8,7 +8,7 @@ import logging
 from unittest.mock import MagicMock
 
 from homeassistant.components.climate.const import HVACMode
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfTemperature
 from homeassistant.core import State
 import pytest
 
@@ -48,6 +48,17 @@ def mock_bt():
     bt._enforce_heat_below_cool = lambda: BetterThermostat._enforce_heat_below_cool(bt)
     bt._clamp_inbound_cool_target = lambda v: (
         BetterThermostat._clamp_inbound_cool_target(bt, v)
+    )
+    bt._enforce_cool_above_heat = lambda **kwargs: (
+        BetterThermostat._enforce_cool_above_heat(bt, **kwargs)
+    )
+    # Wrapped in a spy rather than wired directly, so a test can tell which of
+    # the two branches decided an event both of them would store the same
+    # value for.
+    bt._seed_cool_target = MagicMock(
+        side_effect=lambda setpoint, entity_id: BetterThermostat._seed_cool_target(
+            bt, setpoint, entity_id
+        )
     )
     return bt
 
@@ -515,6 +526,40 @@ class TestInboundCoolSetpointClamp:
         assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
+    async def test_non_overlapping_child_ranges_leave_the_pair_overlapping(
+        self, mock_bt, caplog
+    ):
+        """Children that share no range put the cool target below the minimum.
+
+        The configured range is the overlap of what the children advertise, so
+        a heater whose maximum is below the cooler's minimum leaves the minimum
+        above the maximum. Both bounds are applied to the report in sequence and
+        the maximum decides, so the cool target lands below the minimum, and the
+        heating target cannot be dropped below it. The pair keeps the values the
+        range allows and the overlap is annunciated as such.
+        """
+        # heater advertises 5..25 and cooler 28..30, so the derived range is
+        # bt_min_temp 28 over bt_max_temp 25.
+        mock_bt.bt_min_temp = 28.0
+        mock_bt.bt_max_temp = 25.0
+        mock_bt.bt_target_temp = 25.0
+        mock_bt.bt_target_cooltemp = 20.0
+        old_state = _make_state(attributes={"temperature": 22.0})
+        new_state = _make_state(attributes={"temperature": 24.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        caplog.set_level(logging.WARNING)
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        assert mock_bt.bt_target_cooltemp < mock_bt.bt_min_temp
+        assert mock_bt.bt_target_temp == 28.0
+        assert (
+            "heating target 25.00 set to the configured minimum 28.00, which is "
+            "not below the cooling target 25.00" in caplog.text
+        )
+
+    @pytest.mark.asyncio
     async def test_zero_step_falls_back_to_half_a_degree(self, mock_bt):
         """A zero step falls back to 0.5 so the two targets stay apart."""
         mock_bt.bt_target_temp = 25.0
@@ -860,3 +905,315 @@ class TestRangeModeCooler:
 
         assert mock_bt.bt_target_cooltemp == 26.0
         mock_bt.control_queue_task.put_nowait.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 9. Seeding an unknown cool target
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownCoolTargetSeed:
+    """An unknown cool target is seeded from the first usable cooler report.
+
+    While the cool target is None the control cycle has nothing to compare the
+    room against and commands the cooler OFF, so the field has to be filled
+    from the only value available: the setpoint the device itself reports.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cooler_returning_from_unavailable_seeds_the_target(self, mock_bt):
+        """An unavailable previous state publishes no setpoint of its own.
+
+        A restart while the cooler was offline leaves the target unknown, and
+        the first event after the cooler joins carries the old state of an
+        unavailable entity, which the adoption gate cannot work with.
+        """
+        mock_bt.bt_target_cooltemp = None
+        old_state = State(ENTITY_ID, STATE_UNAVAILABLE)
+        new_state = _make_state(attributes={"temperature": 24.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 24.0
+        mock_bt.control_queue_task.put_nowait.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_resting_cooler_seeds_from_a_current_temperature_push(self, mock_bt):
+        """A cooler on its own setpoint never reports a move.
+
+        The adoption gate needs the reported setpoint to have moved by half a
+        step, so a device that only pushes its room reading would keep the
+        target unknown forever.
+        """
+        mock_bt.bt_target_cooltemp = None
+        old_state = _make_state(
+            attributes={"temperature": 24.0, "current_temperature": 26.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 24.0, "current_temperature": 26.2}
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 24.0
+        mock_bt.control_queue_task.put_nowait.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_seed_reports_the_adopted_value(self, mock_bt, caplog):
+        """Taking a device value as the target is worth an info entry.
+
+        The entry names the cooler the value came off, because that entity is
+        what has to be looked at to find out where a target nobody chose came
+        from.
+        """
+        mock_bt.bt_target_cooltemp = None
+        new_state = _make_state(attributes={"temperature": 24.0})
+        event = _make_event(mock_bt, new_state=new_state)
+
+        caplog.set_level(logging.INFO)
+        await trigger_cooler_change(mock_bt, event)
+
+        assert (
+            f"Cooler {ENTITY_ID} reports setpoint 24.0 while the cool target is "
+            "unknown, taking it as the cool target" in caplog.text
+        )
+
+    @pytest.mark.asyncio
+    async def test_seed_while_off_stores_without_a_control_cycle(self, mock_bt):
+        """An OFF thermostat still needs the field, but no cycle to use it."""
+        mock_bt.bt_hvac_mode = HVACMode.OFF
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_cooltemp = None
+        new_state = _make_state(attributes={"temperature": 24.0})
+        event = _make_event(mock_bt, new_state=new_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 24.0
+        mock_bt.control_queue_task.put_nowait.assert_not_called()
+        mock_bt.async_write_ha_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_clamped_seed_is_reported(self, mock_bt, caplog):
+        """A cooler back from an outage may report a manufacturer default.
+
+        Such a default can sit below BT's range, and the clamped value is
+        written back to the device, so the substitution must be visible, and
+        the entry names the cooler it is written to.
+        """
+        mock_bt.bt_target_cooltemp = None
+        mock_bt.bt_min_temp = 18.0
+        mock_bt.bt_target_temp = 15.0
+        new_state = _make_state(attributes={"temperature": 16.0})
+        event = _make_event(mock_bt, new_state=new_state)
+
+        caplog.set_level(logging.WARNING)
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 18.0
+        assert (
+            f"Cooler {ENTITY_ID} reported setpoint 16.0 outside of range" in caplog.text
+        )
+
+    @pytest.mark.asyncio
+    async def test_seed_colliding_with_the_heat_target_yields(self, mock_bt):
+        """The observed value gives way, the heating target the user set stays.
+
+        A seed carries no user intent, so a collision between the two targets
+        is resolved by lifting the cooling side above the heating one. The
+        adoption gate raises a colliding report to the same value and leaves
+        the heating target alone as well, so the pair that ends up stored does
+        not say which branch decided this event and the spy is what does.
+        """
+        mock_bt.bt_target_cooltemp = None
+        mock_bt.bt_target_temp = 20.0
+        new_state = _make_state(attributes={"temperature": 19.0})
+        event = _make_event(mock_bt, new_state=new_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 20.5
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt._seed_cool_target.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_seed_colliding_with_the_heat_target_yields_while_off(self, mock_bt):
+        """An OFF thermostat still publishes both targets as a range.
+
+        The range is advertised for as long as a cooler is configured, so an
+        inverted pair would reach the thermostat card and, once the thermostat
+        is switched back on, cap the cooler at the heating target that acts as
+        its hard floor.
+        """
+        mock_bt.bt_hvac_mode = HVACMode.OFF
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_target_cooltemp = None
+        mock_bt.bt_target_temp = 25.0
+        new_state = _make_state(attributes={"temperature": 20.0})
+        event = _make_event(mock_bt, new_state=new_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.5
+        assert mock_bt.bt_target_temp == 25.0
+        mock_bt.control_queue_task.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_known_cool_target_is_not_re_seeded(self, mock_bt, caplog):
+        """A target BT already holds is only moved by the adoption gate.
+
+        With the previous state carrying no setpoint the gate declines, and a
+        known target must stay put rather than fall back to the device value.
+        """
+        mock_bt.bt_target_cooltemp = 25.0
+        old_state = State(ENTITY_ID, "cool", attributes={"current_temperature": 26.0})
+        new_state = _make_state(attributes={"temperature": 27.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        caplog.set_level(logging.INFO)
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 25.0
+        assert "cool target is unknown" not in caplog.text
+        mock_bt.control_queue_task.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_known_cool_target_still_adopts_a_reported_move(self, mock_bt):
+        """A move reported for a known cool target is decided by the adoption gate.
+
+        The seeding branch takes precedence over that gate, so it has to leave
+        every event it does not own alone: a cool target Better Thermostat
+        already holds still follows what the cooler reports. Both branches
+        would store this reported value, so the stored pair alone does not say
+        which one ran; what separates them is that a target already known is
+        never seeded again.
+        """
+        mock_bt.bt_target_cooltemp = 25.0
+        mock_bt.bt_target_temp = 20.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 23.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 23.0
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt.control_queue_task.put_nowait.assert_called_once()
+        mock_bt._seed_cool_target.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unknown_target_seeds_a_report_the_gate_would_adopt(self, mock_bt):
+        """A report the gate would take as well is seeded, not adopted.
+
+        A cooler that comes back publishing a setpoint different from the one
+        its previous state carried satisfies the adoption gate too: the
+        previous state holds a setpoint, Better Thermostat is not off, and the
+        reported value moved by more than the echo window. That gate resolves a
+        collision on the cooling side as well, so it would store this very pair
+        and only the spy tells the two branches apart. Which of them runs still
+        matters, because the gate protects a cooling target Better Thermostat
+        already holds and there is none while the target is unknown.
+        """
+        mock_bt.bt_target_cooltemp = None
+        mock_bt.bt_target_temp = 20.0
+        old_state = _make_state(attributes={"temperature": 24.0})
+        new_state = _make_state(attributes={"temperature": 19.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 20.5
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt.control_queue_task.put_nowait.assert_called_once()
+        mock_bt._seed_cool_target.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_open_contact_does_not_suppress_the_seed(self, mock_bt):
+        """An airing must not leave the cooler off for the rest of the session.
+
+        The gate declines a report that arrives while a contact is open,
+        because BT holds the cooler off and writes it no setpoint then, so
+        nothing BT wrote explains what the device reports. An unknown target
+        has no user intent to protect and holds the cooler off on every cycle,
+        so the reading is taken and the airing keeps the cooler off by itself.
+        """
+        mock_bt.bt_target_cooltemp = None
+        mock_bt.contact_open = True
+        old_state = _make_state(attributes={"temperature": 24.0})
+        new_state = _make_state(attributes={"temperature": 22.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 22.0
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt.control_queue_task.put_nowait.assert_called_once()
+
+    @pytest.mark.parametrize("dead_state", [STATE_UNAVAILABLE, STATE_UNKNOWN])
+    @pytest.mark.asyncio
+    async def test_dead_cooler_does_not_seed_from_a_retained_setpoint(
+        self, mock_bt, dead_state
+    ):
+        """A setpoint on a dead state is retained, not reported.
+
+        A climate entity without a mode publishes ``unknown`` together with its
+        full attributes, and one that writes the state machine directly keeps
+        the attributes it last set, so a setpoint can reach this handler off a
+        device that is gone. Startup declines the same two states, and a target
+        taken here would be written straight back to the device.
+        """
+        mock_bt.bt_target_cooltemp = None
+        old_state = State(ENTITY_ID, "cool", attributes={"current_temperature": 26.0})
+        new_state = _make_state(state_str=dead_state, attributes={"temperature": 24.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp is None
+        mock_bt._seed_cool_target.assert_not_called()
+        mock_bt.control_queue_task.put_nowait.assert_not_called()
+
+    @pytest.mark.parametrize("dead_state", [STATE_UNAVAILABLE, STATE_UNKNOWN])
+    @pytest.mark.asyncio
+    async def test_dead_cooler_seed_is_not_handed_to_the_adoption_gate(
+        self, mock_bt, dead_state
+    ):
+        """Declining the seed must not let the gate read the same dead state.
+
+        A previous state that carries a setpoint the retained one differs from
+        satisfies every condition of the adoption gate, which would store that
+        retained value as the cool target, raised clear of the heating target
+        it leaves where the user set it. The cool target staying unknown is
+        therefore what proves the gate never ran, together with the control
+        cycle it does not request; the heating target holds either way.
+        """
+        mock_bt.bt_target_cooltemp = None
+        mock_bt.bt_target_temp = 20.0
+        old_state = _make_state(attributes={"temperature": 24.0})
+        new_state = _make_state(state_str=dead_state, attributes={"temperature": 19.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp is None
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt.control_queue_task.put_nowait.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_live_cooler_with_a_mode_still_seeds(self, mock_bt):
+        """The guard turns on the reported state, not on the setpoint.
+
+        A cooler that publishes a mode is live, so the same retained-looking
+        report is the device's own setpoint and fills the unknown target.
+        """
+        mock_bt.bt_target_cooltemp = None
+        old_state = State(ENTITY_ID, "cool", attributes={"current_temperature": 26.0})
+        new_state = _make_state(state_str="cool", attributes={"temperature": 24.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 24.0
+        mock_bt._seed_cool_target.assert_called_once()

--- a/tests/unit/test_helpers_inbound_setpoint.py
+++ b/tests/unit/test_helpers_inbound_setpoint.py
@@ -5,11 +5,13 @@ from unittest.mock import Mock
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import Context, State
 from homeassistant.util.unit_conversion import TemperatureDeltaConverter
+import pytest
 
 from custom_components.better_thermostat.utils.helpers import (
     COOLER_SETPOINT_KEYS,
     SETPOINT_MATCH_TOLERANCE,
     TRV_SETPOINT_KEYS,
+    device_setpoint_step,
     normalize_step,
     read_setpoint_celsius,
     resolve_inbound_setpoint,
@@ -107,6 +109,48 @@ class TestNormalizeStep:
         assert normalize_step(float("nan")) == 0.5
         assert normalize_step(float("inf")) == 0.5
         assert normalize_step(float("-inf")) == 0.5
+
+
+class TestDeviceSetpointStep:
+    """Reading a controlled device's own setpoint step as a Celsius delta."""
+
+    def _self(self, unit=UnitOfTemperature.CELSIUS, bt_step=0.5):
+        """Build a BetterThermostat mock with a known configured step."""
+        mock_self = _fake_self(unit)
+        mock_self.bt_target_temp_step = bt_step
+        return mock_self
+
+    def test_celsius_step_is_taken_as_reported(self):
+        """On a Celsius system the reported step already is a Celsius delta."""
+        state = _state({"target_temp_step": 1.0})
+        assert device_setpoint_step(self._self(), state, "test") == 1.0
+
+    def test_fahrenheit_step_is_scaled_to_a_celsius_delta(self):
+        """A step reported by a Fahrenheit device is a °F delta, not a °C one."""
+        state = _state({"target_temp_step": 2.0})
+        step = device_setpoint_step(
+            self._self(UnitOfTemperature.FAHRENHEIT), state, "test"
+        )
+        assert step == round(2.0 * 5.0 / 9.0, 4)
+
+    def test_explicit_unit_attribute_beats_the_system_unit(self):
+        """A device that names its own unit is read in that unit."""
+        state = _state({"target_temp_step": 2.0, "temperature_unit": "°F"})
+        step = device_setpoint_step(
+            self._self(UnitOfTemperature.CELSIUS), state, "test"
+        )
+        assert step == round(2.0 * 5.0 / 9.0, 4)
+
+    def test_missing_step_falls_back_to_the_configured_step(self):
+        """A device that publishes no step leaves only BT's own."""
+        state = _state({"temperature": 21.0})
+        assert device_setpoint_step(self._self(bt_step=0.1), state, "test") == 0.1
+
+    @pytest.mark.parametrize("raw", [0, -1.0, "unavailable"])
+    def test_unusable_step_falls_back_to_the_configured_step(self, raw):
+        """A non-positive or non-numeric step cannot separate two setpoints."""
+        state = _state({"target_temp_step": raw})
+        assert device_setpoint_step(self._self(bt_step=0.1), state, "test") == 0.1
 
 
 class TestSetpointEchoWindow:

--- a/tests/unit/test_preset_number_restore.py
+++ b/tests/unit/test_preset_number_restore.py
@@ -163,13 +163,13 @@ class TestPresetCoolNumber:
         bt_climate.control_queue_task.put.assert_awaited_once_with(bt_climate)
 
     @pytest.mark.asyncio
-    async def test_active_preset_enforces_cool_above_heat_at_max(self):
-        """With the heat target at ``max_temp`` the applied cool target stays above it.
+    async def test_active_preset_keeps_the_cool_target_inside_the_range(self):
+        """With the heat target at ``max_temp`` the cool target stops there.
 
-        The pre-clamp bump lifts ``cool_value`` to ``heat + step``, but the
-        ``max_temp`` clamp pulls it back down to ``max_temp`` — equal to the heat
-        target. The setter must run ``_enforce_cool_above_heat`` afterwards so the
-        active cool target and the persisted preset both stay strictly above heat.
+        The pre-clamp bump lifts ``cool_value`` to ``heat + step`` and the
+        ``max_temp`` clamp pulls it back down to ``max_temp``. The range holds no
+        value above that, and both the active target and the persisted preset are
+        written to the cooler, so the two targets meet at the maximum instead.
         """
         from custom_components.better_thermostat.climate import BetterThermostat
 
@@ -178,6 +178,7 @@ class TestPresetCoolNumber:
         bt_climate.device_name = "Test BT"
         bt_climate.min_temp = 5.0
         bt_climate.max_temp = 30.0
+        bt_climate.bt_max_temp = 30.0
         bt_climate.target_temperature_step = 0.5
         bt_climate.bt_target_temp_step = 0.5
         bt_climate.preset_mode = PRESET_HOME
@@ -187,8 +188,8 @@ class TestPresetCoolNumber:
         bt_climate.bt_hvac_mode = HVACMode.HEAT_COOL
         bt_climate._preset_cool_temperatures = {PRESET_HOME: 30.0}
         bt_climate.control_queue_task.put = AsyncMock()
-        bt_climate._enforce_cool_above_heat.side_effect = lambda: (
-            BetterThermostat._enforce_cool_above_heat(bt_climate)
+        bt_climate._enforce_cool_above_heat.side_effect = lambda **kwargs: (
+            BetterThermostat._enforce_cool_above_heat(bt_climate, **kwargs)
         )
 
         entity = BetterThermostatPresetCoolNumber(bt_climate, PRESET_HOME)
@@ -196,8 +197,8 @@ class TestPresetCoolNumber:
 
         await entity.async_set_native_value(20.0)
 
-        assert bt_climate.bt_target_cooltemp == 30.5
-        assert bt_climate._preset_cool_temperatures[PRESET_HOME] == 30.5
+        assert bt_climate.bt_target_cooltemp == 30.0
+        assert bt_climate._preset_cool_temperatures[PRESET_HOME] == 30.0
         bt_climate.control_queue_task.put.assert_awaited_once_with(bt_climate)
 
     @pytest.mark.asyncio

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -10,6 +10,7 @@ import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import State
 from homeassistant.util import dt as dt_util
 import pytest
@@ -40,6 +41,9 @@ def mock_bt():
     """Create a mock BetterThermostat instance with sensible defaults."""
     bt = MagicMock()
     bt.hass = MagicMock()
+    # climate entities publish no unit attribute, so every temperature read off
+    # a TRV state resolves through the system unit.
+    bt.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
     bt.device_name = "Test Thermostat"
     bt.bt_hvac_mode = HVACMode.HEAT
     bt.hvac_mode = HVACMode.HEAT
@@ -60,7 +64,9 @@ def mock_bt():
     bt.context = MagicMock()  # unique context so != event.context
     bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
     bt.async_write_ha_state = MagicMock()
-    bt._enforce_cool_above_heat = lambda: BetterThermostat._enforce_cool_above_heat(bt)
+    bt._enforce_cool_above_heat = lambda **kwargs: (
+        BetterThermostat._enforce_cool_above_heat(bt, **kwargs)
+    )
     bt._clamp_inbound_heat_target = lambda v: (
         BetterThermostat._clamp_inbound_heat_target(bt, v)
     )
@@ -304,8 +310,6 @@ class TestInternalTemperatureChange:
         system-unit fallback it is mistaken for 64 °C, rejected as implausible
         and dropped.
         """
-        from homeassistant.const import UnitOfTemperature
-
         mock_bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
         trv_state = _make_state(attributes={"current_temperature": 64.0})
         mock_bt.hass.states.get.return_value = trv_state
@@ -1931,6 +1935,9 @@ def _make_group_bt(entity_ids, *, no_off=False, bt_hvac_mode=HVACMode.HEAT):
     """
     bt = MagicMock()
     bt.hass = MagicMock()
+    # climate entities publish no unit attribute, so every temperature read off
+    # a TRV state resolves through the system unit.
+    bt.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
     bt.device_name = "Grouped Thermostat"
     bt.bt_hvac_mode = bt_hvac_mode
     bt.bt_target_temp = 19.0
@@ -1951,7 +1958,9 @@ def _make_group_bt(entity_ids, *, no_off=False, bt_hvac_mode=HVACMode.HEAT):
     bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
     bt.async_write_ha_state = MagicMock()
     bt.hvac_mode = bt_hvac_mode
-    bt._enforce_cool_above_heat = lambda: BetterThermostat._enforce_cool_above_heat(bt)
+    bt._enforce_cool_above_heat = lambda **kwargs: (
+        BetterThermostat._enforce_cool_above_heat(bt, **kwargs)
+    )
     bt._clamp_inbound_heat_target = lambda v: (
         BetterThermostat._clamp_inbound_heat_target(bt, v)
     )


### PR DESCRIPTION
## Motivation:

### The defect

The startup read of the cooler setpoint is gated on the cooler being available. With `PRESET_NONE` and a cooler that is
unavailable at that moment, `bt_target_cooltemp` keeps the constructor's `None` — and the event handler cannot heal it:

- its adoption gate requires a setpoint in **both** the old and the new state, and an unavailable → available transition
  has none in the old one;
- it also requires the reported setpoint to have **moved** by at least half a step, which a cooler resting on its own
  setpoint never reports.

`control_cooler()` then takes its None-guard on every cycle, logs *"one or more required values are None … defaulting to
OFF"* at DEBUG, and writes `set_hvac_mode: off` to a running air conditioner. Verified by executing the real handler:
with `bt_target_cooltemp=None`, an old state of `unavailable` and a new state of `cool {temperature: 24.0}`, the field
stays `None` and the single service call is `set_hvac_mode: off`.

It is not literally permanent — dragging the high handle, selecting a non-`NONE` preset, or an external dial move of at
least half a step all heal it. The defect is that an **unattended** Better Thermostat keeps a working air conditioner
switched off, at DEBUG level, with no repair issue and no degraded mode, until a human happens to touch something.

## Changes:

### The fix

Two additions, both reachable only while `bt_target_cooltemp is None`:

**(A) Seed from the first usable report in the event handler.** While the field is `None` there is no BT-side target to
lose and no BT write to echo: `control_cooler()` skips `set_temperature` entirely while the desired temperature is
`None`, so the send cache is empty and both `known_values` are `None`, which makes `is_echo` structurally `False`. This
heals every entry point into the state — unavailable at startup, available but publishing no setpoint, fresh install — on
*any* later cooler event; a `current_temperature` push is enough.

**(B) Two startup seeds through one helper.** `_seed_cool_target_from_cooler()` is the single place a cooling target is
taken off the cooler's state. It declines when no cooler is configured or a target is already known, reads with the
`COOLER_SETPOINT_KEYS` precedence, resolves through `resolve_inbound_setpoint` — a cooler that was unavailable while the
temperature range was derived contributed no bounds to it, so the setpoint it reports can sit outside that range and is
clamped into it exactly like a reported one — and hands the result to `_seed_cool_target()`. It runs at two points:

- **once the restored state is in place**, replacing the raw read that used to sit in `_initialize_sensors()`. Both the
  temperature range and the heating target are final there, which is what the value has to be clamped into and ordered
  against; a restored preset has supplied its own cooling target by then and keeps it.
- **right after the cooler listener is registered**, for the window between the two in which a cooler can reach a
  readable state and then never change state again. There is **no subscription at all** across that window, so such a
  state would never produce an event for (A), and the moment after the registration is the last point at which it can
  still be read. The same three situations leave the target unknown up to there: the cooler is not in the state machine
  yet, it is `unavailable`/`unknown`, or it is readable but publishes no usable setpoint under any of
  `COOLER_SETPOINT_KEYS`.

All three entry points go through one `_seed_cool_target()` helper, so the annunciation and the ordering rule exist once,
and all three resolve the reading with the cooler's own published step: the step derivation moves out of
`events/cooler.py` and next to the rest of the inbound-setpoint boundary as `utils/helpers.py::device_setpoint_step()`,
with the caller passing its own logging context. A Fahrenheit cooler's `target_temp_step` is therefore scaled into a
Celsius delta on the startup path too rather than being replaced by BT's own step, and a step the startup read cannot
convert is logged against `startup()` instead of against the event handler.

### Design points

**The seed decides ahead of the adoption gate.** Some events satisfy both branches — a cooler that comes back publishing
a setpoint different from the one its previous state carried, one whose report arrives while a contact is open, one that
carries a setpoint on a dead state. Three things change for those, all deliberately:

- The seed records the value as one read off the device; the gate does not. The stored pair is the same either way, so
  the difference is the record rather than the arithmetic: executed on this branch with `bt_target_cooltemp=None`,
  `bt_target_temp=20.0` and a report of 19.0 after 24.0, the seed stores `cool 20.5 / heat 20.0` and so does the gate.
  The seed annunciates the take and names where the value came from — *"Cooler … reports setpoint 19.0 while the cool
  target is unknown, taking it as the cool target"* at INFO, or its clamp variant at WARNING. The gate annunciates an
  adjustment it made, not a take, and where it has none to report it stores the value silently: executed with the same
  setup and a report of 22.0, it stores `cool 22.0` with no INFO and no WARNING at all. A target nobody chose is written
  straight back to the cooler, so the entity it was read off has to be findable in the log.
- The gate declines a report that arrives while a contact is open, because BT holds the cooler off and writes it no
  setpoint then. Executed with the same setup and `contact_open=True`, that left the target `None` — the cooler stays off
  for the rest of the session. While the target is unknown BT has written the cooler nothing at all, so an airing has no
  BT-side value to distort, and the airing keeps the cooler off by itself.
- The gate would take a setpoint retained on a dead state. An `unavailable` or `unknown` cooler can still carry the
  attributes it last set, and such a value says nothing about the device now, so the seed branch declines it — the same
  two states `_seed_cool_target_from_cooler()` declines at startup — and keeps the event rather than handing it on.
  Executed with a report of 19.0 on an `unavailable` state, the gate stores `cool 20.5` where the seed leaves the target
  `None`.

All three outcomes are pinned by tests.

**The cooler is read after the state restore, not before it.** `_initialize_sensors()` used to store the cooler's
setpoint raw and early — before any clamp, and before `_restore_state()` installs the heating target the pair has to be
ordered against. Executed on the base shape, a cooler reporting 16.0 with `bt_min_temp` 18.0 stored **16.0**, outside the
range and unannounced, where the resolved read stores 18.0 at WARNING. And a cooler reporting 20.0 ordered against the
construction default of 5.0 comes out as `cool 20.0 / heat 5.0`, which the restore then turns into `cool 20.0 / heat
21.0` — inverted; ordered against the restored 21.0 it comes out `cool 21.5 / heat 21.0`. Moving the read behind the
restore is what makes both halves of the resolution apply to it.

**The cooling side yields on a collision.** The seed orders the pair with `_enforce_cool_above_heat()`, not
`_enforce_heat_below_cool()`: a value that arrives from the cooler speaks for the cooling channel alone and must not move
the heating target the user set. That is the direction the whole inbound boundary resolves in — the adoption gate raises
a colliding report through `_clamp_inbound_cool_target()` — so the rule holds whichever branch takes the report. The
in-tree precedent for pairing a programmatic `bt_target_cooltemp` write with the same call is `number.py`.

**The ordering is applied in every HVAC mode**, via a `regardless_of_hvac_mode` flag on `_enforce_cool_above_heat`. A
target seeded while Better Thermostat is off is the one the first cooling cycle after switching on works with, and that
transition does not revisit the pair — an inverted pair would have the air conditioner pull the room down while the TRVs
heat it up. Every existing caller keeps the flag's default and stays gated on HEAT_COOL.

**The step is normalised, not just defaulted — in both ordering rules.** `_enforce_cool_above_heat` and
`_enforce_heat_below_cool` resolve their step through `normalize_step()`, the same rejection of non-positive and
non-finite values the device steps already pass. The `or 0.5` idiom it replaces only caught `0` and `None`, and each rule
was executed with a bad step to see what it does:

- `_enforce_cool_above_heat` with `bt_target_temp_step` at `-1.0`, a heat target of 22.0 and a cool target of 21.0 left
  the pair inverted and silent; with `nan` the cool target became `nan`.
- `_enforce_heat_below_cool` with a step of `-0.5` and both targets at 22.0 **raised** the heating target to 22.5, i.e.
  above the cooling target it exists to clear, while annunciating *"heating target 22.00 adjusted to 22.50 to stay below
  cooling target 22.00"*; with `nan` the heating target became `nan`.

Both step values are reachable: `_target_temp_step_celsius()` passes a child's negative `target_temp_step` straight
through into the `max(steps)` that fills `bt_target_temp_step`, and the constructor's `float(target_temp_step)` has no
finiteness check.

**The bump is now bounded by `bt_max_temp`, and that part is cross-cutting.** It applies to every caller of
`_enforce_cool_above_heat`, not only to the seed: the value it stores is published as `target_temperature_high` and
written to the cooler, and the entity range is the tightest limit across the controlled devices, so a value above it is
not acceptable to at least one of them. The visible consequence is a pre-existing test in
`tests/unit/test_preset_number_restore.py`, which asserted that a preset write with the heat target at `max_temp` left an
out-of-range cool target of 30.5; it is deliberately re-pinned to 30.0, where the two targets meet at the maximum.

**The cap yields to the ordering where the two invariants conflict.** It is applied only while `bt_max_temp >=
bt_target_temp`:

| maximum vs. heat target | result |
| --- | --- |
| above | capped; still strictly above the heat target and inside the range |
| equal | the pair meets at the maximum — the range holds no value above it; annunciated at WARNING |
| below | no cap; the heat target is itself already out of range, and capping would put the cool target **below** it |
| `None` | no cap; no child entity has reported a maximum yet |

**Each rule annunciates the bound it lands on instead of claiming an ordering the values do not have.**
`_enforce_heat_below_cool` stops at `bt_min_temp`, and a minimum the cooling target does not clear by a full step pins
the heating target on that minimum, at or above the cooling target — the mirror of the `equal` row above. Executed with a
heat target of 6.0, a cool target of 5.0 and `bt_min_temp` 5.0, the single WARNING it used to emit read *"heating target
6.00 adjusted to 5.00 to stay below cooling target 5.00"*, and 5.00 is not below 5.00. The branch is split like
`_enforce_cool_above_heat`'s, into *"…adjusted to 5.00 to stay below cooling target 5.00"* for a result that is really
ordered and *"…set to the configured minimum 5.00, which is not below the cooling target 5.00"* for one that is not. Also
like it, a move with nowhere to land — the bound pinning the target on the value it already has — returns without writing
or logging instead of re-announcing a value that does not change.

Both shapes are pinned directly on `_enforce_heat_below_cool`, by tests that set the pair and the minimum: one where
the drop lands strictly below the cooling target, one where the minimum pins it at or above. The cooler is no longer a
source for the second shape — every value read off the device now passes `resolve_inbound_setpoint` and reaches the
field inside the range.

**The clamp WARNING is load-bearing, not cosmetic.** A cooler returning from an outage on a manufacturer default below
`bt_min_temp` (many report 16–18 °C) gets its clamped value written straight back to it by `control_cooler()` on the next
cycle, so the user has to be able to see where that setpoint came from. Verified: a reported 16.0 with `bt_min_temp` 18.0
and a heating target of 20.0 seeds 20.5 and **is** written back.

**While Better Thermostat is OFF** the field is filled but no control cycle is requested, so the seed does not wake a
thermostat the user turned off.

### Accepted limitations

- The seed takes a device value as BT's target. There is no user intent to overwrite at that point, and the alternative
  — staying `None` — keeps the cooler off.
- The seed resolves a heat/cool collision on the cooling side: a value read off the cooler must not move the heating
  target the user set. `test_seed_colliding_with_the_heat_target_yields` and its OFF-mode twin pin that half.
- A cool target that is already above the maximum while the pair is ordered is left alone; this method only moves the
  cool target when the pair would otherwise cross.
- No repair issue and no degraded mode. This heals the value; annunciating the condition is a separate concern.
- Both startup seeds run on every startup with a cooler configured, but each performs a state lookup only when the
  target is still `None`, so a normal restart pays one extra `hass.states.get` and nothing else.
- The existing adoption gate keeps its contact-open guard, its echo suppression and its not-adopted debug log unchanged,
  and it is still the only branch that runs once `bt_target_cooltemp` is known. It no longer runs while the target is
  unknown; that shift is the design point above.

### Verification

- Full suite: `4302 passed` (`uv run pytest tests/`), ruff check + format clean. The base carries
  `_clamp_inbound_cool_target()`, so that is the rule the adoption gate applies in every figure below.
- Counterfactuals, all run and reverted: removing the ordering lift fails 5 tests; dropping only the
  `regardless_of_hvac_mode` flag fails exactly the three tests that run outside HEAT_COOL and leaves the HEAT_COOL one
  green, which is the expected split; putting the re-read back on the unclamped read stores an out-of-range 31.0 instead
  of clamping to 30.0, unannounced; making the maximum cap unconditional inverts the pair — with `bt_max_temp=18.0`,
  `bt_target_temp=22.0` and a reported 17.0 the cool target comes out as 18.0, below the heat target, and both degenerate
  cases fail.
- Counterfactual for the branch precedence: with the adoption gate back in front of the seed, eight
  `TestUnknownCoolTargetSeed` cases fail, in four pairs. Two lose the seed altogether, because the gate's own guards
  decline the report the seed exists to take: no reported move leaves
  `test_resting_cooler_seeds_from_a_current_temperature_push` at `cool None` instead of `24.0`, an open contact leaves
  `test_open_contact_does_not_suppress_the_seed` at `cool None` instead of `22.0`. Two lose the record of where the value
  came from — `test_seed_reports_the_adopted_value` sees an empty log, and `test_clamped_seed_is_reported` sees the
  gate's generic *"New Cooler … setpoint outside of range, overwriting it"* instead of an entry naming the reported 16.0.
  Two hand a dead cooler's retained setpoint to the gate, which stores `cool 20.5` where the seed leaves `None`. The last
  two — `test_seed_colliding_with_the_heat_target_yields` and `test_unknown_target_seeds_a_report_the_gate_would_adopt` —
  fail on the spy alone: the gate stores the very pair the seed does, and only the call tells the two branches apart.
- The availability guard now lives in `_seed_cool_target_from_cooler()` and is pinned per state, every case carrying a usable setpoint so that the
  guard is what decides rather than the absence of a value: a cooler reporting `off` — where an idle air conditioner
  rests, and the only state a cooler that never switches on ever publishes — seeds, while `unknown`, `unavailable` and
  no state at all do not. Four mutations of that guard were applied, and each failed exactly the case that owns it:
  replacing it with `state != HVACMode.OFF` fails all three of the off/unknown/unavailable cases; dropping
  `STATE_UNKNOWN` fails `test_unknown_cooler_leaves_the_cool_target_unknown`; dropping `STATE_UNAVAILABLE` fails
  `test_unavailable_cooler_leaves_the_cool_target_unknown` in both seed classes; dropping the `is not None` check fails
  `test_cooler_without_a_state_leaves_the_cool_target_unknown` with an `AttributeError`.
- Counterfactuals for the step normalisation, one per rule: restoring `self.bt_target_temp_step or 0.5` in
  `_enforce_cool_above_heat` leaves the cool target at 21.0 under a `-1.0` step, i.e. below the heat target of 22.0 and
  without an annunciation; restoring it in `_enforce_heat_below_cool` fails
  `test_unusable_step_falls_back_instead_of_moving_the_pair` with `assert 22.5 == 21.5` — the heat target ends up above
  the cool target of 22.0.
- Counterfactual for the at-minimum annunciation: collapsing the two branches of `_enforce_heat_below_cool` back into one
  WARNING fails `test_result_is_clamped_to_min_temp` *and* `test_minimum_above_the_cool_target_is_reported_as_an_overlap`,
  which observe the old text *"heating target 6.00 adjusted to 5.00 to stay below cooling target 5.00"* and its
  strictly-inverted counterpart. Deleting only the nowhere-to-land early return fails
  `test_pair_resting_on_the_minimum_is_left_alone`, which observes a WARNING for a write that changes nothing.
- Counterfactuals for the read position, all run and reverted: deleting the post-restore seed fails five
  `TestStartupCoolTargetSeed` cases; moving it ahead of `_restore_state()` fails exactly the two that observe the
  restored heating target and the range —
  `test_setpoint_is_ordered_against_the_restored_heating_target` and `test_setpoint_outside_the_configured_range_is_clamped`
  — while moving it one statement later, still behind the restore, changes nothing; dropping the
  `bt_target_cooltemp is not None` guard fails `test_restored_preset_cool_target_is_not_overwritten` and
  `test_known_cool_target_is_not_re_read`.
- Counterfactual for the logging context: hard-coding `"trigger_cooler_change()"` inside `device_setpoint_step` makes the
  startup read log `Could not convert 'unavailable' to float in trigger_cooler_change()`, which the new startup test
  rejects.
- Reachability check for a non-finite heating target, run rather than read: `convert_to_float` rejects NaN and infinity,
  so `restore_target_temperature`, `mean_trv_target`, `async_set_temperature` and the inbound-setpoint boundary cannot
  deliver one, and `PresetManager.activate` clamps a NaN preset temperature to `min_temp`. The two annunciation branches
  of `_enforce_cool_above_heat` are therefore exact complements for every reachable input, and they are spelled as one
  positive condition with the common case first.
- The event handler's seed branch is pinned against the adoption gate by a mutation of its own: dropping
  `self.bt_target_cooltemp is None` from the branch condition fails
  `test_known_cool_target_still_adopts_a_reported_move`, which observes that a known target never reaches
  `_seed_cool_target`. Both branches store the same value for that report, so the call is what separates them rather
  than the stored pair.
- Test-fixture hygiene: the `bt` fixture in `tests/unit/test_climate_startup.py` and the `mock_bt` fixture in
  `tests/unit/test_trv_events.py` left `hass.config.units.temperature_unit` a bare `MagicMock`, so every climate-entity
  read in those files resolved through an unknown unit instead of Celsius. Both are pinned to Celsius now; no assertion
  in either file changed as a result, since only an explicit Fahrenheit unit triggers a conversion.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: n/a - covered by unit tests, no hardware run for this change
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

No new device mapping is added by this PR; the `climate.py` change is a control-path fix.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically initializes unknown cooling targets from the connected cooler.
  - Supports device-specific temperature increments, including Fahrenheit-to-Celsius conversion.
  - Keeps heating and cooling targets within configured limits and maintains correct ordering.

- **Bug Fixes**
  - Prevents invalid cooling commands when no target is available.
  - Improves handling of unavailable readings, temperature ranges, HVAC mode changes, and startup restoration.
  - Avoids unnecessary target updates while preserving existing settings.

- **Tests**
  - Expanded coverage for target initialization, conversions, bounds, ordering, and unavailable devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
