### PR TITLE
fix(state-manager): reject persisted numbers the store cannot carry

### DIFF
--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -35,7 +35,7 @@ from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 import logging
 import math
-from typing import Any
+from typing import Any, get_args, get_type_hints
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
@@ -161,18 +161,21 @@ class RuntimeState:
 
 # Serialization helpers
 
-# Fields that should be coerced to int during deserialization.
-_INT_FIELDS = frozenset(
+# Integer fields that tally occurrences, so a stored value is only usable
+# when it is a non-negative integer the store can write back.
+_COUNT_FIELDS = frozenset(
     {
         "dead_zone_hits",
         "loss_learn_count",
         "gain_learn_count",
         "profile_samples",
         "consecutive_insufficient_heat",
-        "last_delta_sign",
-        "last_error_sign",
     }
 )
+
+# Integer fields that record which way a quantity last moved, so a negative
+# value is meaningful and only the storable range applies.
+_SIGN_FIELDS = frozenset({"last_delta_sign", "last_error_sign"})
 
 # Fields that should be coerced to bool during deserialization.
 _BOOL_FIELDS = frozenset(
@@ -186,6 +189,25 @@ _BOOL_FIELDS = frozenset(
 
 # Fields that should be coerced to str during deserialization.
 _STR_FIELDS = frozenset({"trv_profile"})
+
+
+def _nullable_fields(cls: Any) -> frozenset[str]:
+    """Return the names of *cls*'s fields whose declared type admits ``None``.
+
+    Read off the declarations rather than listed by hand, so the set
+    still matches once a field's type changes.
+    """
+    hints = get_type_hints(cls)
+    return frozenset(
+        name for name in cls.__dataclass_fields__ if type(None) in get_args(hints[name])
+    )
+
+
+_MPC_NULLABLE_FIELDS = _nullable_fields(MpcState)
+_MPC_V2_NULLABLE_FIELDS = _nullable_fields(MpcV2StateData)
+_MPC_V2_REID_NULLABLE_FIELDS = _nullable_fields(MpcV2ReidData)
+_PID_NULLABLE_FIELDS = _nullable_fields(PIDState)
+_TPI_NULLABLE_FIELDS = _nullable_fields(TpiState)
 
 
 def _make_json_safe(obj: Any) -> Any:
@@ -218,19 +240,80 @@ class _PoisonedState(ValueError):
     """A stored entry carries a mathematical anomaly (NaN/inf)."""
 
 
+# Home Assistant's JSON encoder writes an integer only inside the 64-bit
+# range orjson supports and raises TypeError on anything wider. The Store's
+# write path turns that TypeError into a SerializationError, which the Store
+# catches and only logs, so a single unstorable integer anywhere in the
+# state leaves the config entry's file unwritten without failing the save.
+_MIN_STORED_INT = -(2**63)
+_MAX_STORED_INT = 2**64 - 1
+
+
+def _stored_int(value: Any) -> int:
+    """Return *value* as an integer the store can write back.
+
+    A JSON number wider than 64 bits is parsed as a float, and ``int()``
+    turns it into an arbitrary-precision integer that the encoder refuses.
+    Those raise ``ValueError`` here, so a caller handles them like any
+    other field ``int()`` cannot make sense of.
+    """
+    number = int(value)
+    if not _MIN_STORED_INT <= number <= _MAX_STORED_INT:
+        raise ValueError("integer outside the storable range")
+    return number
+
+
+def _stored_count(value: Any) -> int:
+    """Return *value* as a storable, non-negative tally.
+
+    A tally cannot be negative, so a negative value is as unusable as one
+    the store could not write back or one that is not an integer at all;
+    all three restore as 0.
+    """
+    try:
+        count = _stored_int(value)
+    except TypeError, ValueError, OverflowError:
+        return 0
+    return max(count, 0)
+
+
+def _null_or_poison(attr: str, kind: str, nullable: frozenset[str]) -> None:
+    """Let a stored null through, unless the declared type forbids one.
+
+    A null where a number is declared is how a non-finite value gets back
+    out of a file this module wrote: the store's encoder writes NaN and
+    infinity as ``null``. Where anything else is declared it is simply a
+    value that cannot be held. Neither leaves anything usable, so the
+    entry gets the disposal :func:`_finite_or_poison` gives corrupt math.
+
+    *nullable* names the fields whose declared type admits a ``None``. An
+    empty set means the caller is parsing a place no ``None`` may reach at
+    all, such as an element of a collection declared to hold numbers.
+    """
+    if attr in nullable:
+        return
+    _LOGGER.warning(
+        "better_thermostat: %s in stored %s state is null, which its declared "
+        "type cannot hold; discarding that entry's stored values",
+        attr,
+        kind,
+    )
+    raise _PoisonedState(attr)
+
+
 def _finite_or_poison(value: Any, attr: str, kind: str) -> float:
-    """Parse one float field; a non-finite number poisons the entry.
+    """Parse one stored float; a non-finite number poisons the entry.
 
     Wrong types merely skip the field (schema evolution), but NaN or
-    infinity means the entry's math is corrupt — the rest of it cannot
-    be trusted either, so the whole entry resets to defaults and the
-    learning restarts.
+    infinity means the entry's math is corrupt — the rest of it cannot be
+    trusted either, so the caller keeps none of the entry's stored values
+    and the learning they carried starts over.
     """
     number = float(value)
     if not math.isfinite(number):
         _LOGGER.warning(
             "better_thermostat: non-finite %s in stored %s state; "
-            "resetting that entry to defaults",
+            "discarding that entry's stored values",
             attr,
             kind,
         )
@@ -238,30 +321,88 @@ def _finite_or_poison(value: Any, attr: str, kind: str) -> float:
     return number
 
 
+def _finite_element(value: Any, attr: str, kind: str) -> float:
+    """Parse one number stored inside a collection field.
+
+    ``recent_errors`` and the bins of ``perf_curve`` are declared to hold
+    plain numbers, and the field guards rule only on the collection
+    itself. A null among its numbers is the same saved NaN a null in a
+    numeric field is — the store's encoder writes both that way — and
+    costs the entry its stored values just as one does.
+    """
+    if value is None:
+        _null_or_poison(attr, kind, frozenset())
+    return _finite_or_poison(value, attr, kind)
+
+
+def _finite_perf_curve(
+    value: Mapping[Any, Any], kind: str
+) -> dict[str, dict[str, float]]:
+    """Copy a stored performance curve, parsing every statistic in it.
+
+    What the offending value is decides what it costs. A bin that is not a
+    mapping of statistics, or a statistic ``float()`` refuses outright such
+    as ``"later"``, raises one of the errors the caller skips a field on:
+    the curve is lost and the rest of the entry survives. A statistic that
+    is null or parses as a non-finite number raises :class:`_PoisonedState`
+    instead — the bins are declared to hold plain numbers, so either one is
+    corrupt math, and the entry keeps none of its stored values.
+    """
+    curve: dict[str, dict[str, float]] = {}
+    for label, stats in value.items():
+        if not isinstance(stats, Mapping):
+            raise TypeError("perf_curve bin is not a mapping of statistics")
+        curve[label] = {
+            name: _finite_element(stat, "perf_curve statistic", kind)
+            for name, stat in stats.items()
+        }
+    return curve
+
+
 def deserialize_mpc(raw: dict[str, Any]) -> MpcState:
     """Deserialize a single MPC state dict into an MpcState dataclass.
 
-    A non-finite numeric field rejects the whole entry: learning
-    restarts from defaults rather than continuing on corrupt math.
+    A non-finite number in a float field rejects the whole entry: learning
+    restarts from defaults rather than continuing on corrupt math. That
+    covers the numbers inside ``perf_curve`` and ``recent_errors`` as well
+    as the float fields themselves. This state's integer fields are all
+    tallies and are read as counts instead, so a value ``int()`` cannot
+    make sense of — ``"NaN"`` and ``"Infinity"`` among them, the spellings
+    a stored file delivers a non-finite number in — restores as 0 and
+    leaves the rest of the entry standing.
+
+    A stored ``null`` rejects the entry wherever the declared type has no
+    ``None``, the tallies included, because that is the shape a saved NaN
+    comes back in.
     """
     state = MpcState()
     for attr in MpcState.__dataclass_fields__:
         if attr not in raw:
             continue
         value = raw[attr]
-        if value is None:
-            setattr(state, attr, None)
-            continue
-        if attr == "perf_curve" and isinstance(value, Mapping):
-            setattr(state, attr, dict(value))
-            continue
-        if attr == "recent_errors" and isinstance(value, (list, tuple)):
-            # MpcState.recent_errors is a deque(maxlen=20).
-            setattr(state, attr, deque(value, maxlen=20))
-            continue
         try:
-            if attr in _INT_FIELDS:
-                setattr(state, attr, int(value))
+            if value is None:
+                _null_or_poison(attr, "mpc", _MPC_NULLABLE_FIELDS)
+                setattr(state, attr, None)
+            elif attr == "perf_curve" and isinstance(value, Mapping):
+                setattr(state, attr, _finite_perf_curve(value, "mpc"))
+            elif attr == "recent_errors" and isinstance(value, (list, tuple)):
+                # MpcState.recent_errors is a deque(maxlen=20).
+                setattr(
+                    state,
+                    attr,
+                    deque(
+                        (
+                            _finite_element(item, "recent_errors element", "mpc")
+                            for item in value
+                        ),
+                        maxlen=20,
+                    ),
+                )
+            elif attr in _COUNT_FIELDS:
+                setattr(state, attr, _stored_count(value))
+            elif attr in _SIGN_FIELDS:
+                setattr(state, attr, _stored_int(value))
             elif attr in _BOOL_FIELDS:
                 setattr(state, attr, bool(value))
             elif attr in _STR_FIELDS:
@@ -275,15 +416,39 @@ def deserialize_mpc(raw: dict[str, Any]) -> MpcState:
     return state
 
 
-def deserialize_mpc_v2(raw: dict[str, Any]) -> MpcV2StateData:
-    """Deserialize a single MPC v2 state dict into MpcV2StateData."""
+def deserialize_mpc_v2(raw: dict[str, Any]) -> MpcV2StateData | None:
+    """Deserialize a single MPC v2 state dict; ``None`` if the entry is corrupt.
+
+    A non-finite float in ``last_percent``, ``last_compute_ts`` or
+    ``created_ts`` rejects the whole entry, ``snapshot`` included: the
+    observer state in it was exported by the same controller whose command
+    or timestamp went corrupt. Returning ``None`` keeps the key out of the
+    restored state, which is what makes the restart a cold one: an entry
+    left in place with an empty ``snapshot`` would still rehydrate into a
+    controller and count as initialised, so its Kalman estimate would stay
+    at the construction default rather than being seeded from the first
+    measurement.
+
+    Those three are the only fields parsed; ``outdoor_fallback_logged`` and
+    ``snapshot`` are read past that loop and reach no guard. A ``snapshot``
+    that is null or not a mapping therefore keeps the entry and leaves the
+    empty default in its place — the very shape described above. Only a
+    store this integration did not write can hold one: what it saves is
+    always a mapping.
+    """
     state = MpcV2StateData()
     for attr in ("last_percent", "last_compute_ts", "created_ts"):
-        value = raw.get(attr)
-        if value is None:
+        if attr not in raw:
             continue
+        value = raw[attr]
         try:
-            setattr(state, attr, float(value))
+            if value is None:
+                _null_or_poison(attr, "mpc_v2", _MPC_V2_NULLABLE_FIELDS)
+                setattr(state, attr, None)
+            else:
+                setattr(state, attr, _finite_or_poison(value, attr, "mpc_v2"))
+        except _PoisonedState:
+            return None
         except TypeError, ValueError, OverflowError:
             continue
     state.outdoor_fallback_logged = bool(raw.get("outdoor_fallback_logged", False))
@@ -294,26 +459,42 @@ def deserialize_mpc_v2(raw: dict[str, Any]) -> MpcV2StateData:
 
 
 def deserialize_mpc_v2_reid(raw: dict[str, Any]) -> MpcV2ReidData | None:
-    """Deserialize a persisted re-identification result; None if malformed."""
+    """Deserialize a persisted re-identification result; None if malformed.
+
+    Returning ``None`` leaves the entry out of the restored state, so the
+    plant-prior lookup moves on: to another stored result sharing this
+    entity's key prefix, and failing that to the heat-loss-derived prior.
+
+    Three checks reject an entry. A NaN or infinity in one of the five
+    float fields; a stored ``null`` in any of the six, since none of them
+    is declared to hold one; and a ``tau_room_min`` or ``gain_heater``
+    that is not positive, since those two are the pair that seeds the
+    prior. None of the three bounds magnitude, so a positive but
+    implausibly small ``tau_room_min`` passes and reaches the plant model,
+    whose room dynamics divide by it.
+
+    A float field that does not parse keeps its default, which leaves the
+    entry usable as the schema grows. ``n_segments`` is metadata: a value
+    that is not a storable count falls back to 0 and the entry survives —
+    except a null, which is refused there as in every other field.
+    """
     state = MpcV2ReidData()
-    for attr in (
-        "tau_room_min",
-        "gain_heater",
-        "fitted_ts",
-        "rmse_prior_K",
-        "rmse_fit_K",
-    ):
-        value = raw.get(attr)
-        if value is None:
+    for attr in MpcV2ReidData.__dataclass_fields__:
+        if attr not in raw:
             continue
+        value = raw[attr]
         try:
-            setattr(state, attr, float(value))
+            if value is None:
+                _null_or_poison(attr, "mpc_v2_reid", _MPC_V2_REID_NULLABLE_FIELDS)
+                setattr(state, attr, None)
+            elif attr == "n_segments":
+                setattr(state, attr, _stored_count(value))
+            else:
+                setattr(state, attr, _finite_or_poison(value, attr, "mpc_v2_reid"))
+        except _PoisonedState:
+            return None
         except TypeError, ValueError, OverflowError:
             continue
-    try:
-        state.n_segments = int(raw.get("n_segments", 0))
-    except TypeError, ValueError:
-        state.n_segments = 0
     # A result without both fitted components cannot seed a plant prior.
     if state.tau_room_min <= 0.0 or state.gain_heater <= 0.0:
         return None
@@ -323,20 +504,31 @@ def deserialize_mpc_v2_reid(raw: dict[str, Any]) -> MpcV2ReidData | None:
 def deserialize_pid(raw: dict[str, Any]) -> PIDState:
     """Deserialize a single PID state dict into a PIDState dataclass.
 
-    A non-finite numeric field rejects the whole entry: learning
-    restarts from defaults rather than continuing on corrupt math.
+    A non-finite number in a float field rejects the whole entry: learning
+    restarts from defaults rather than continuing on corrupt math. This
+    state's two integer fields record a direction and are read as integers
+    instead, so a value ``int()`` cannot make sense of — ``"NaN"`` and
+    ``"Infinity"`` among them, the spellings a stored file delivers a
+    non-finite number in — keeps its default and leaves the rest of the
+    entry standing.
+
+    A stored ``null`` rejects the entry wherever the field's type has no
+    ``None``, because that is the shape a saved NaN comes back in; both
+    direction fields are declared ``int | None`` and keep theirs.
     """
     state = PIDState()
     for attr in PIDState.__dataclass_fields__:
         if attr not in raw:
             continue
         value = raw[attr]
-        if value is None:
-            setattr(state, attr, None)
-            continue
         try:
-            if attr in _INT_FIELDS:
-                setattr(state, attr, int(value))
+            if value is None:
+                _null_or_poison(attr, "pid", _PID_NULLABLE_FIELDS)
+                setattr(state, attr, None)
+            elif attr in _COUNT_FIELDS:
+                setattr(state, attr, _stored_count(value))
+            elif attr in _SIGN_FIELDS:
+                setattr(state, attr, _stored_int(value))
             elif attr in _BOOL_FIELDS:
                 setattr(state, attr, bool(value))
             else:
@@ -352,18 +544,21 @@ def deserialize_tpi(raw: dict[str, Any]) -> TpiState:
     """Deserialize a single TPI state dict into a TpiState dataclass.
 
     A non-finite numeric field rejects the whole entry: learning
-    restarts from defaults rather than continuing on corrupt math.
+    restarts from defaults rather than continuing on corrupt math. A
+    stored ``null`` counts as one wherever the field's type has no
+    ``None``, because that is the shape a saved NaN comes back in.
     """
     state = TpiState()
     for attr in TpiState.__dataclass_fields__:
         if attr not in raw:
             continue
         value = raw[attr]
-        if value is None:
-            setattr(state, attr, None)
-            continue
         try:
-            setattr(state, attr, _finite_or_poison(value, attr, "tpi"))
+            if value is None:
+                _null_or_poison(attr, "tpi", _TPI_NULLABLE_FIELDS)
+                setattr(state, attr, None)
+            else:
+                setattr(state, attr, _finite_or_poison(value, attr, "tpi"))
         except _PoisonedState:
             return TpiState()
         except TypeError, ValueError, OverflowError:
@@ -385,7 +580,9 @@ def _deserialize(raw: dict[str, Any]) -> RuntimeState:
     if isinstance(mpc_v2_raw, Mapping):
         for key, state_dict in mpc_v2_raw.items():
             if isinstance(state_dict, dict):
-                state.mpc_v2[key] = deserialize_mpc_v2(state_dict)
+                mpc_v2 = deserialize_mpc_v2(state_dict)
+                if mpc_v2 is not None:
+                    state.mpc_v2[key] = mpc_v2
 
     mpc_v2_reid_raw = raw.get("mpc_v2_reid", {})
     if isinstance(mpc_v2_reid_raw, Mapping):
@@ -567,12 +764,20 @@ class StateManager:
         """Fold live MPC v2 controllers into the persistable snapshot.
 
         Runs at save time only; the per-cycle path keeps the live controller in
-        memory and never serialises it.
+        memory and never serialises it. An export the deserialiser rejects
+        leaves the key's stored entry as it was, so a corrupt ``last_percent``,
+        ``last_compute_ts`` or ``created_ts`` does not overwrite the entry
+        already stored. That is all the rejection buys: ``snapshot`` is
+        copied verbatim, so a non-finite number in the observer state does
+        reach the file, where the encoder writes it as ``null``.
         """
         for key, live in self._mpc_v2_live.items():
             exported = export_mpc_v2_state(live)
-            if exported is not None:
-                self._state.mpc_v2[key] = deserialize_mpc_v2(exported)
+            if exported is None:
+                continue
+            persistable = deserialize_mpc_v2(exported)
+            if persistable is not None:
+                self._state.mpc_v2[key] = persistable
 
     def get_mpc_v2_reid(self, key: str) -> MpcV2ReidData | None:
         """Return the persisted re-identification result for a key, if any."""
@@ -606,15 +811,18 @@ class StateManager:
         for live_key in list(self._mpc_v2_live):
             live = self._mpc_v2_live.pop(live_key)
             exported = export_mpc_v2_state(live)
-            if exported is not None:
-                self._state.mpc_v2[live_key] = deserialize_mpc_v2(exported)
+            persistable = deserialize_mpc_v2(exported) if exported is not None else None
+            if persistable is not None:
+                self._state.mpc_v2[live_key] = persistable
             else:
-                # No exportable observer state to carry over; the rebuild with
-                # the new prior falls back to the last snapshot (or a cold
-                # start). Rare, but log it so a lost transfer is diagnosable.
+                # No observer state to carry over: the controller had none to
+                # export, or what it exported was rejected. The rebuild with
+                # the new prior falls back to the last stored snapshot (or a
+                # cold start). Rare, but log it so a lost transfer is
+                # diagnosable.
                 _LOGGER.debug(
                     "MPC v2 re-identification adopt for %s: live controller had "
-                    "no exportable state; rebuild will not be bumpless",
+                    "no usable state to carry over; rebuild will not be bumpless",
                     live_key,
                 )
         self._state.mpc_v2_reid[key] = data

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -15,8 +15,11 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import asdict
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.helpers.json import json_bytes, prepare_save_json
+from homeassistant.util.json import json_loads
 import pytest
 
 from custom_components.better_thermostat.utils.calibration.mpc_v2 import MpcV2Params
@@ -30,8 +33,16 @@ from custom_components.better_thermostat.utils.const import (
     MIN_HEATING_POWER,
 )
 from custom_components.better_thermostat.utils.state_manager import (
+    _MAX_STORED_INT,
+    _MIN_STORED_INT,
+    _MPC_NULLABLE_FIELDS,
+    _MPC_V2_NULLABLE_FIELDS,
+    _MPC_V2_REID_NULLABLE_FIELDS,
+    _PID_NULLABLE_FIELDS,
+    _TPI_NULLABLE_FIELDS,
     CURRENT_VERSION,
     MpcState,
+    MpcV2StateData,
     PIDState,
     RuntimeState,
     StateManager,
@@ -41,6 +52,8 @@ from custom_components.better_thermostat.utils.state_manager import (
     _migrate_v0_to_v1,
     _serialize,
     deserialize_mpc,
+    deserialize_mpc_v2,
+    deserialize_mpc_v2_reid,
     deserialize_pid,
     deserialize_tpi,
 )
@@ -331,6 +344,562 @@ class TestDeserializeTpi:
         raw = {"last_percent": "bad"}
         tpi = deserialize_tpi(raw)
         assert tpi.last_percent is None
+
+
+class TestDeserializeMpcV2Reid:
+    """deserialize_mpc_v2_reid should discard entries with corrupt math."""
+
+    def test_happy_path(self):
+        """A plausible payload is restored field by field."""
+        raw = {
+            "tau_room_min": 240.0,
+            "gain_heater": 3.0,
+            "fitted_ts": 1000.0,
+            "rmse_prior_K": 0.4,
+            "rmse_fit_K": 0.1,
+            "n_segments": 4,
+        }
+        reid = deserialize_mpc_v2_reid(raw)
+        assert reid is not None
+        assert reid.tau_room_min == 240.0
+        assert reid.gain_heater == 3.0
+        assert reid.fitted_ts == 1000.0
+        assert reid.rmse_prior_K == 0.4
+        assert reid.rmse_fit_K == 0.1
+        assert reid.n_segments == 4
+
+    def test_nan_tau_room_discards_the_entry(self):
+        """NaN passes every ``<=`` comparison, so the gate cannot catch it."""
+        raw = {"tau_room_min": float("nan"), "gain_heater": 3.0}
+        assert deserialize_mpc_v2_reid(raw) is None
+
+    def test_infinite_gain_discards_the_entry(self):
+        """An infinite heater gain would blow up the plant prior."""
+        raw = {"tau_room_min": 240.0, "gain_heater": float("inf")}
+        assert deserialize_mpc_v2_reid(raw) is None
+
+    def test_non_finite_secondary_field_discards_the_entry(self):
+        """A corrupt validation metric taints the fit it belongs to."""
+        raw = {"tau_room_min": 240.0, "gain_heater": 3.0, "rmse_fit_K": float("-inf")}
+        assert deserialize_mpc_v2_reid(raw) is None
+
+    def test_wrong_type_only_skips_the_field(self):
+        """A wrong type is schema drift, not corrupt math: keep the entry."""
+        raw = {"tau_room_min": 240.0, "gain_heater": 3.0, "rmse_fit_K": "later"}
+        reid = deserialize_mpc_v2_reid(raw)
+        assert reid is not None
+        assert reid.tau_room_min == 240.0
+        assert reid.rmse_fit_K == 0.0
+
+    def test_wrong_type_only_skips_the_segment_count(self):
+        """The count is metadata, so an unreadable one still keeps the entry."""
+        raw = {"tau_room_min": 240.0, "gain_heater": 3.0, "n_segments": "four"}
+        reid = deserialize_mpc_v2_reid(raw)
+        assert reid is not None
+        assert reid.n_segments == 0
+
+    def test_null_fitted_timestamp_discards_the_entry(self):
+        """``fitted_ts`` is typed ``float``, so its null is a saved NaN."""
+        raw = {"tau_room_min": 240.0, "gain_heater": 3.0, "fitted_ts": None}
+        assert deserialize_mpc_v2_reid(raw) is None
+
+    def test_null_validation_metric_discards_the_entry(self):
+        """A null in either RMSE taints the fit those metrics accepted."""
+        base = {"tau_room_min": 240.0, "gain_heater": 3.0}
+        assert deserialize_mpc_v2_reid({**base, "rmse_prior_K": None}) is None
+        assert deserialize_mpc_v2_reid({**base, "rmse_fit_K": None}) is None
+
+    def test_null_segment_count_discards_the_entry(self):
+        """``n_segments`` is typed ``int``; a null is not a tally either."""
+        raw = {"tau_room_min": 240.0, "gain_heater": 3.0, "n_segments": None}
+        assert deserialize_mpc_v2_reid(raw) is None
+
+    def test_null_prior_component_is_refused_as_a_null(self, caplog):
+        """A null is refused on its own terms, not by the positivity gate."""
+        with caplog.at_level(logging.WARNING, logger=_SM):
+            assert deserialize_mpc_v2_reid({"tau_room_min": None}) is None
+        assert "tau_room_min" in caplog.text
+        assert "is null" in caplog.text
+
+    def test_absent_field_is_not_a_null(self):
+        """A field the payload never carried keeps its default, entry intact."""
+        reid = deserialize_mpc_v2_reid({"tau_room_min": 240.0, "gain_heater": 3.0})
+        assert reid is not None
+        assert reid.fitted_ts == 0.0
+        assert reid.rmse_prior_K == 0.0
+        assert reid.rmse_fit_K == 0.0
+        assert reid.n_segments == 0
+
+    def test_null_entry_is_absent_after_a_full_load(self):
+        """A saved NaN comes back as a null and leaves no key behind."""
+        raw = _serialize(RuntimeState())
+        raw["mpc_v2_reid"] = {
+            "good": {"tau_room_min": 240.0, "gain_heater": 3.0},
+            "bad": {"tau_room_min": 240.0, "gain_heater": 3.0, "rmse_fit_K": None},
+        }
+        restored = _deserialize(raw)
+        assert "bad" not in restored.mpc_v2_reid
+        assert restored.mpc_v2_reid["good"].tau_room_min == 240.0
+
+    def test_tiny_positive_time_constant_is_not_rejected(self):
+        """The guards cover finiteness and sign; magnitude is unbounded."""
+        raw = {"tau_room_min": 5e-324, "gain_heater": 3.0}
+        reid = deserialize_mpc_v2_reid(raw)
+        assert reid is not None
+        assert reid.tau_room_min == 5e-324
+
+    def test_infinite_segment_count_falls_back_to_zero(self):
+        """An unconvertible segment count must not abort the whole load."""
+        raw = {"tau_room_min": 240.0, "gain_heater": 3.0, "n_segments": float("inf")}
+        reid = deserialize_mpc_v2_reid(raw)
+        assert reid is not None
+        assert reid.n_segments == 0
+
+    def test_unstorable_segment_count_falls_back_to_zero(self):
+        """A count wider than 64 bits could never be written back."""
+        raw = {"tau_room_min": 240.0, "gain_heater": 3.0, "n_segments": 1e300}
+        reid = deserialize_mpc_v2_reid(raw)
+        assert reid is not None
+        assert reid.n_segments == 0
+
+    def test_negative_segment_count_falls_back_to_zero(self):
+        """Segments are counted, so a negative tally is not a count."""
+        raw = {"tau_room_min": 240.0, "gain_heater": 3.0, "n_segments": -4}
+        reid = deserialize_mpc_v2_reid(raw)
+        assert reid is not None
+        assert reid.n_segments == 0
+
+    def test_largest_storable_segment_count_is_kept(self):
+        """The bound is inclusive: the widest storable count still passes."""
+        raw = {"tau_room_min": 240.0, "gain_heater": 3.0, "n_segments": _MAX_STORED_INT}
+        reid = deserialize_mpc_v2_reid(raw)
+        assert reid is not None
+        assert reid.n_segments == _MAX_STORED_INT
+
+    def test_string_nan_discards_the_entry(self):
+        """A JSON string is the route a real store file can deliver a NaN by."""
+        raw = {"tau_room_min": "NaN", "gain_heater": 3.0}
+        assert deserialize_mpc_v2_reid(raw) is None
+
+    def test_string_infinity_discards_the_entry(self):
+        """``float()`` accepts the spelling ``Infinity``, so the guard must too."""
+        raw = {"tau_room_min": 240.0, "gain_heater": "Infinity"}
+        assert deserialize_mpc_v2_reid(raw) is None
+
+    def test_string_overflowing_exponent_discards_the_entry(self):
+        """``float("1e999")`` is infinity, so the entry is just as corrupt."""
+        raw = {"tau_room_min": 240.0, "gain_heater": 3.0, "rmse_prior_K": "1e999"}
+        assert deserialize_mpc_v2_reid(raw) is None
+
+    def test_non_finite_string_survives_a_real_store_read(self):
+        """The JSON parser keeps ``"NaN"`` a string, so it reaches the guard.
+
+        A bare ``NaN`` literal never gets this far — the parser rejects it
+        and Home Assistant quarantines the file — but a quoted one parses
+        cleanly and only ``float()`` turns it into a non-finite number.
+        """
+        raw = json_loads(
+            '{"version": 1, "mpc_v2_reid": {"bt:reid": '
+            '{"tau_room_min": "NaN", "gain_heater": 3.0}}}'
+        )
+        assert isinstance(raw, dict)
+        assert raw["mpc_v2_reid"]["bt:reid"]["tau_room_min"] == "NaN"
+        assert _deserialize(raw).mpc_v2_reid == {}
+
+    def test_oversized_stored_count_cannot_break_the_next_save(self):
+        """A store file may carry a number that JSON parses as a huge float.
+
+        ``int()`` of it yields an integer the store's encoder refuses, which
+        would abort every later save for this config entry.
+        """
+        raw = json_loads(
+            '{"version": 1, "mpc_v2_reid": {"bt:reid": {"tau_room_min": 240.0, '
+            '"gain_heater": 3.0, "n_segments": ' + "9" * 300 + "}}}"
+        )
+        assert isinstance(raw, dict)
+        assert isinstance(raw["mpc_v2_reid"]["bt:reid"]["n_segments"], float)
+        restored = _deserialize(raw)
+        assert restored.mpc_v2_reid["bt:reid"].n_segments == 0
+        prepare_save_json(_serialize(restored))
+
+    def test_poisoned_entry_is_absent_after_a_full_load(self):
+        """A discarded entry leaves no key behind for the prior lookup."""
+        raw = _serialize(RuntimeState())
+        raw["mpc_v2_reid"] = {
+            "good": {"tau_room_min": 240.0, "gain_heater": 3.0},
+            "bad": {"tau_room_min": float("nan"), "gain_heater": 3.0},
+        }
+        restored = _deserialize(raw)
+        assert "bad" not in restored.mpc_v2_reid
+        assert restored.mpc_v2_reid["good"].tau_room_min == 240.0
+
+
+class TestStorableIntegerBound:
+    """The accepted integer range must be the one the store's encoder writes."""
+
+    def test_bounds_are_exactly_what_the_encoder_accepts(self):
+        """Both bounds are storable and one step past either one is not."""
+        json_bytes({"n": _MIN_STORED_INT})
+        json_bytes({"n": _MAX_STORED_INT})
+        with pytest.raises(TypeError):
+            json_bytes({"n": _MIN_STORED_INT - 1})
+        with pytest.raises(TypeError):
+            json_bytes({"n": _MAX_STORED_INT + 1})
+
+
+class TestStoredIntegerFields:
+    """Restored integer fields must stay writable by the store's encoder."""
+
+    def test_oversized_count_keeps_the_default(self):
+        """An unstorable tally restores as 0, the field's own default."""
+        mpc = deserialize_mpc({"gain_est": 0.5, "dead_zone_hits": float(2**70)})
+        assert mpc.dead_zone_hits == 0
+        assert mpc.gain_est == 0.5
+
+    def test_negative_count_keeps_the_default(self):
+        """Occurrences are tallied upwards, so a negative value is not one."""
+        assert deserialize_mpc({"loss_learn_count": -7}).loss_learn_count == 0
+
+    def test_largest_storable_count_is_kept(self):
+        """The bound is inclusive, so the widest storable tally survives."""
+        raw = {"profile_samples": _MAX_STORED_INT}
+        assert deserialize_mpc(raw).profile_samples == _MAX_STORED_INT
+
+    def test_oversized_sign_keeps_the_default(self):
+        """An unstorable direction is dropped like any other unusable field."""
+        assert (
+            deserialize_pid({"last_error_sign": float(2**70)}).last_error_sign is None
+        )
+
+    def test_negative_sign_is_kept(self):
+        """A direction is signed, so the count rule must not reach it."""
+        assert deserialize_pid({"last_delta_sign": -1}).last_delta_sign == -1
+
+    def test_oversized_count_cannot_break_the_next_save(self):
+        """A store number too wide for JSON must not disable persistence.
+
+        The parser hands it over as a float; ``int()`` of it yields an
+        integer the encoder refuses, and the Store only logs that failure,
+        so the entry's state file would silently stop being written.
+        """
+        raw = json_loads(
+            '{"version": 1, "mpc": {"k": {"dead_zone_hits": '
+            + "9" * 300
+            + '}}, "pid": {"k": {"last_error_sign": '
+            + "9" * 300
+            + "}}}"
+        )
+        assert isinstance(raw, dict)
+        restored = _deserialize(raw)
+        assert restored.mpc["k"].dead_zone_hits == 0
+        assert restored.pid["k"].last_error_sign is None
+        prepare_save_json(_serialize(restored))
+
+
+class TestNonFiniteStringsFromAStore:
+    """``float()`` accepts spellings the JSON parser leaves as strings."""
+
+    def test_mpc_string_nan_resets_the_entry(self):
+        """A quoted NaN reaches the guard and the entry restarts from defaults."""
+        mpc = deserialize_mpc({"gain_est": 0.5, "loss_est": "NaN"})
+        assert mpc == MpcState()
+
+    def test_pid_string_infinity_resets_the_entry(self):
+        """The spelling ``Infinity`` is a float to Python, not a wrong type."""
+        pid = deserialize_pid({"pid_integral": 1.5, "pid_kp": "Infinity"})
+        assert pid == PIDState()
+
+    def test_tpi_string_overflowing_exponent_resets_the_entry(self):
+        """``float("1e999")`` overflows to infinity and poisons the entry."""
+        tpi = deserialize_tpi({"last_percent": "1e999"})
+        assert tpi == TpiState()
+
+    def test_unparsable_string_still_only_skips_the_field(self):
+        """Only strings that parse as non-finite floats reject an entry."""
+        mpc = deserialize_mpc({"gain_est": 0.5, "loss_est": "later"})
+        assert mpc.gain_est == 0.5
+
+
+class TestNullableFieldSets:
+    """Which fields may hold a stored null is read off the dataclasses."""
+
+    def test_fields_declared_with_none_are_nullable(self):
+        """A ``| None`` field keeps its stored null as a value."""
+        assert "gain_est" in _MPC_NULLABLE_FIELDS
+        assert "last_percent" in _MPC_V2_NULLABLE_FIELDS
+        assert "pid_kp" in _PID_NULLABLE_FIELDS
+        assert "last_delta_sign" in _PID_NULLABLE_FIELDS
+        assert "last_percent" in _TPI_NULLABLE_FIELDS
+
+    def test_fields_declared_without_none_are_not_nullable(self):
+        """A field typed ``float``, ``int``, ``str`` or a collection is not."""
+        assert "u_integral" not in _MPC_NULLABLE_FIELDS
+        assert "trv_profile" not in _MPC_NULLABLE_FIELDS
+        assert "perf_curve" not in _MPC_NULLABLE_FIELDS
+        assert "recent_errors" not in _MPC_NULLABLE_FIELDS
+        assert "created_ts" not in _MPC_V2_NULLABLE_FIELDS
+        assert "pid_integral" not in _PID_NULLABLE_FIELDS
+        assert "last_update_ts" not in _TPI_NULLABLE_FIELDS
+
+    def test_the_reid_result_declares_no_nullable_field(self):
+        """Every persisted re-ID field is a plain number, so none takes a null."""
+        assert _MPC_V2_REID_NULLABLE_FIELDS == frozenset()
+
+
+class TestStoredNulls:
+    """A null is a value only where the field's own type allows one.
+
+    The store's encoder writes NaN and infinity as ``null``, so a null in
+    a field typed without ``None`` is a non-finite number coming back and
+    gets the same disposal as one that survived as a string.
+    """
+
+    def test_mpc_null_float_resets_the_entry(self):
+        """``u_integral`` is typed ``float``, so its null is a saved NaN."""
+        mpc = deserialize_mpc({"gain_est": 0.5, "u_integral": None})
+        assert mpc == MpcState()
+
+    def test_mpc_null_profile_resets_the_entry(self):
+        """A null cannot be a profile name either."""
+        assert deserialize_mpc({"gain_est": 0.5, "trv_profile": None}) == MpcState()
+
+    def test_mpc_null_collection_resets_the_entry(self):
+        """The collection fields are not typed to hold a null either."""
+        assert deserialize_mpc({"perf_curve": None}) == MpcState()
+        assert deserialize_mpc({"recent_errors": None}) == MpcState()
+
+    def test_mpc_null_optional_field_is_restored(self):
+        """A ``float | None`` field still restores its stored null."""
+        mpc = deserialize_mpc({"gain_est": None, "u_integral": 3.0})
+        assert mpc.gain_est is None
+        assert mpc.u_integral == 3.0
+
+    def test_pid_null_integral_resets_the_entry(self):
+        """``pid_integral`` is typed ``float``; a null there is corrupt math."""
+        pid = deserialize_pid({"pid_kp": 60.0, "pid_integral": None})
+        assert pid == PIDState()
+
+    def test_pid_null_sign_field_is_restored(self):
+        """``last_delta_sign`` is typed ``int | None``, so its null is a value."""
+        pid = deserialize_pid({"last_delta_sign": None, "pid_integral": 2.0})
+        assert pid.last_delta_sign is None
+        assert pid.pid_integral == 2.0
+
+    def test_tpi_null_timestamp_resets_the_entry(self):
+        """``last_update_ts`` is typed ``float``, so it cannot hold a null."""
+        assert deserialize_tpi({"last_percent": 30.0, "last_update_ts": None}) == (
+            TpiState()
+        )
+
+    def test_tpi_null_percent_is_restored(self):
+        """``last_percent`` is typed ``float | None`` and keeps its null."""
+        tpi = deserialize_tpi({"last_percent": None, "last_update_ts": 5.0})
+        assert tpi.last_percent is None
+        assert tpi.last_update_ts == 5.0
+
+
+class TestStoredCollectionElements:
+    """A collection field's own numbers are guarded like the numeric fields.
+
+    ``perf_curve`` and ``recent_errors`` are restored as collections, so
+    the field guards say nothing about what is inside them. Both are
+    declared to hold numbers, which makes a null among those numbers the
+    same saved NaN a null in a numeric field is.
+    """
+
+    def test_null_error_sample_resets_the_entry(self):
+        """``recent_errors`` is a ``deque[float]``, so a null in it is a NaN."""
+        assert deserialize_mpc({"gain_est": 0.5, "recent_errors": [0.1, None]}) == (
+            MpcState()
+        )
+
+    def test_null_bin_statistic_resets_the_entry(self):
+        """A bin's statistics are declared as numbers, so a null is a NaN."""
+        raw = {"perf_curve": {"p00_05": {"count": 3, "avg_room_rate": None}}}
+        assert deserialize_mpc(raw) == MpcState()
+
+    def test_null_outside_the_deque_window_still_resets_the_entry(self):
+        """Every stored sample is parsed, not only the last twenty kept."""
+        raw = {"recent_errors": [None] + [float(i) for i in range(25)]}
+        assert deserialize_mpc(raw) == MpcState()
+
+    def test_non_finite_error_sample_resets_the_entry(self):
+        """A NaN that reached the file as a string poisons the entry too."""
+        assert deserialize_mpc({"recent_errors": [0.1, "NaN"]}) == MpcState()
+
+    def test_non_finite_bin_statistic_resets_the_entry(self):
+        """An infinite average makes every later average over it useless."""
+        raw = {"perf_curve": {"p00_05": {"avg_percent": float("inf")}}}
+        assert deserialize_mpc(raw) == MpcState()
+
+    def test_unparsable_error_sample_only_skips_the_field(self):
+        """A wrong type is schema drift, so the rest of the entry survives."""
+        mpc = deserialize_mpc({"gain_est": 0.5, "recent_errors": [0.1, "later"]})
+        assert mpc.gain_est == 0.5
+        assert list(mpc.recent_errors) == []
+
+    def test_bin_that_is_not_a_mapping_only_skips_the_field(self):
+        """A curve whose bins are not statistic mappings costs only itself."""
+        mpc = deserialize_mpc({"gain_est": 0.5, "perf_curve": {"p00_05": 3.0}})
+        assert mpc.gain_est == 0.5
+        assert mpc.perf_curve == {}
+
+    def test_finite_collections_are_restored(self):
+        """The element guard must not cost a healthy curve or error series."""
+        raw = {
+            "recent_errors": [0.1, -0.2],
+            "perf_curve": {"p00_05": {"count": 3, "avg_room_rate": 0.05}},
+        }
+        mpc = deserialize_mpc(raw)
+        assert list(mpc.recent_errors) == [0.1, -0.2]
+        assert mpc.perf_curve == {"p00_05": {"count": 3, "avg_room_rate": 0.05}}
+
+    def test_restored_error_series_keeps_its_window(self):
+        """The deque's bound is unchanged by parsing its elements."""
+        mpc = deserialize_mpc({"recent_errors": [float(i) for i in range(30)]})
+        assert mpc.recent_errors.maxlen == 20
+        assert list(mpc.recent_errors) == [float(i) for i in range(10, 30)]
+
+
+class TestLiveNonFiniteRoundTrip:
+    """A non-finite value held at save time must not return as ``None``."""
+
+    async def test_saved_nan_does_not_restore_as_none(self, hass, hass_storage):
+        """Save a live NaN, load it back, and check what the entry holds.
+
+        The encoder writes the NaN as ``null``. Restoring that null into a
+        field typed ``float`` leaves the entry holding ``None`` where the
+        calibrator expects a number, and the first arithmetic on it raises
+        ``TypeError`` — inside ``sanitize_pid_state``, before the guards
+        that would have healed a NaN ever run.
+        """
+        manager = StateManager(hass, "nan_entry")
+        pid = manager.get_pid("k")
+        pid.pid_integral = float("nan")
+        pid.pid_kp = 60.0
+        await manager.save()
+
+        stored = hass_storage["better_thermostat_nan_entry_state"]["data"]
+        assert stored["pid"]["k"]["pid_integral"] is None
+
+        reloaded = StateManager(hass, "nan_entry")
+        await reloaded.load()
+        restored = reloaded.state.pid["k"]
+        assert restored == PIDState()
+        assert restored.pid_integral + 1.0 == 1.0
+
+    async def test_saved_nan_inside_a_collection_does_not_restore_as_none(
+        self, hass, hass_storage
+    ):
+        """The same route reaches the numbers inside an MPC collection.
+
+        The encoder writes them as ``null`` in the stored list and in the
+        stored bin, where no field is null and so no field guard applies.
+        Copied back verbatim they would leave a ``None`` among numbers that
+        ``sanitize_mpc_state`` grades healthy — its finiteness walk has no
+        number to reject — and the first sum over the series raises
+        ``TypeError``.
+        """
+        manager = StateManager(hass, "nan_collection")
+        mpc = manager.get_mpc("k")
+        mpc.gain_est = 0.5
+        mpc.recent_errors = deque([0.1, float("nan")], maxlen=20)
+        mpc.perf_curve = {"p00_05": {"count": 3, "avg_room_rate": float("nan")}}
+        await manager.save()
+
+        stored = hass_storage["better_thermostat_nan_collection_state"]["data"]
+        assert stored["mpc"]["k"]["recent_errors"] == [0.1, None]
+        assert stored["mpc"]["k"]["perf_curve"]["p00_05"]["avg_room_rate"] is None
+
+        reloaded = StateManager(hass, "nan_collection")
+        await reloaded.load()
+        restored = reloaded.state.mpc["k"]
+        assert restored == MpcState()
+        assert sum(restored.recent_errors) == 0.0
+
+
+class TestDeserializeMpcV2:
+    """MPC v2 entries obey the same finiteness contract as their siblings."""
+
+    def test_finite_payload_is_restored(self):
+        """A plausible payload keeps every field, snapshot included."""
+        raw = {
+            "last_percent": 42.0,
+            "last_compute_ts": 100.0,
+            "created_ts": 10.0,
+            "outdoor_fallback_logged": True,
+            "snapshot": {"u_prev": 0.5},
+        }
+        state = deserialize_mpc_v2(raw)
+        assert state.last_percent == 42.0
+        assert state.last_compute_ts == 100.0
+        assert state.created_ts == 10.0
+        assert state.outdoor_fallback_logged is True
+        assert state.snapshot == {"u_prev": 0.5}
+
+    def test_non_finite_strings_from_a_store_discard_the_entry(self):
+        """A stored file delivers non-finite numbers as JSON strings."""
+        raw = json_loads(
+            '{"version":1,"mpc_v2":{"k1":{"last_percent":"NaN",'
+            '"last_compute_ts":"1e999","created_ts":"-1e999"}}}'
+        )
+        assert isinstance(raw, dict)
+        assert "k1" not in _deserialize(raw).mpc_v2
+
+    def test_poisoned_entry_drops_the_snapshot(self):
+        """The snapshot came from the controller whose timestamp went corrupt."""
+        raw = {"last_compute_ts": float("inf"), "snapshot": {"u_prev": 0.5}}
+        assert deserialize_mpc_v2(raw) is None
+
+    def test_null_timestamp_discards_the_entry(self):
+        """``created_ts`` is typed ``float``, so its null is a saved NaN."""
+        raw = {"created_ts": None, "snapshot": {"u_prev": 0.5}}
+        assert deserialize_mpc_v2(raw) is None
+
+    def test_null_percent_is_restored(self):
+        """``last_percent`` is typed ``float | None`` and keeps its null."""
+        state = deserialize_mpc_v2({"last_percent": None, "created_ts": 10.0})
+        assert state is not None
+        assert state.last_percent is None
+        assert state.created_ts == 10.0
+
+    def test_absent_field_keeps_its_default(self):
+        """A field the payload never carried is not a null."""
+        state = deserialize_mpc_v2({"snapshot": {"u_prev": 0.5}})
+        assert state == MpcV2StateData(snapshot={"u_prev": 0.5})
+
+    def test_wrong_type_only_skips_the_field(self):
+        """A wrong type is schema drift, not corrupt math: keep the entry."""
+        state = deserialize_mpc_v2({"created_ts": "later", "last_compute_ts": 100.0})
+        assert state is not None
+        assert state.created_ts == 0.0
+        assert state.last_compute_ts == 100.0
+
+    @pytest.mark.asyncio
+    async def test_a_poisoned_key_comes_back_without_a_controller(self):
+        """Dropping the key is what makes the restart a cold one.
+
+        An entry kept with an empty ``snapshot`` would still be rehydrated
+        into a controller, which then counts as initialised and skips
+        seeding its estimate from the first measurement.
+        """
+        mock_hass = AsyncMock()
+        mock_store = AsyncMock()
+        mock_store.async_load.return_value = {
+            "version": 1,
+            "mpc_v2": {
+                "k1": {
+                    "last_compute_ts": "NaN",
+                    "snapshot": {"v": 1, "x_hat": [18.0, 30.0], "last_u": 0.7},
+                }
+            },
+        }
+        with patch(f"{_SM}.Store", return_value=mock_store):
+            mgr = StateManager(mock_hass, "poisoned_entry")
+        await mgr.load()
+
+        assert mgr.state.mpc_v2 == {}
+        assert mgr.get_mpc_v2_live("k1", MpcV2Params()).controller is None
 
 
 # ---------------------------------------------------------------------------
@@ -676,6 +1245,23 @@ class TestScheduleDelaySave:
         assert data["mpc_v2"]["k1"]["last_percent"] == 55.0
         assert data["mpc_v2"]["k1"]["snapshot"]["last_u"] == 77.0
         assert mgr.dirty is False
+
+    def test_delay_save_keeps_the_last_good_entry_when_the_export_is_corrupt(self):
+        """A live controller gone non-finite must not overwrite what is stored."""
+        mgr, mock_store = self._make_manager_with_store()
+        live = mgr.get_mpc_v2_live("k1", MpcV2Params())
+        live.controller = _StubMpcV2Controller(_make_snapshot(last_u=10.0))
+        live.last_percent = 42.0
+        live.last_compute_ts = 100.0
+        mgr.set_mpc_v2_live("k1", live)
+        mgr.schedule_delay_save()
+        mock_store.async_delay_save.call_args[0][0]()
+
+        live.last_compute_ts = float("nan")
+        mgr.schedule_delay_save()
+        data = mock_store.async_delay_save.call_args[0][0]()
+
+        assert data["mpc_v2"]["k1"]["last_compute_ts"] == 100.0
 
     def test_delay_save_keeps_dirty_when_pre_save_fails(self):
         """A failing pre-save leaves the manager dirty for a retry."""


### PR DESCRIPTION
## Motivation:

### The defect

`deserialize_mpc_v2_reid` and `deserialize_mpc_v2` parsed their float fields with a bare `float()`, so the float-field finiteness contract that the MPC, PID, TPI, thermal and filter restores already share did not reach them.

In the re-ID entry a non-finite value then met the plausibility gate intact. Because every comparison against NaN is `False`, `tau_room_min <= 0.0 or gain_heater <= 0.0` passes a NaN straight through — and those two are exactly the pair that seeds the plant prior (`calibration.py`, `PlantParams(...)`). `fitted_ts` only picks the freshest among stored candidates, and the two RMSE fields record the accepting fit's quality without being read back at all.

### How a store delivers such a value

Home Assistant's encoder writes NaN and infinity as `null`, and its parser rejects a bare `NaN` / `Infinity` / `1e999` literal outright — the file is then renamed to `.corrupt.<isotime>` and the integration starts fresh. So the obvious route does not exist.

Three routes do:

| Route | Reachable from |
|---|---|
| a JSON **string**: `"NaN"`, `"Infinity"`, `"1e999"` — `float()` accepts all three | a restored backup, a hand-edited file, a foreign writer |
| a **live** NaN saved as `null` and read back as `None` | Home Assistant's own write path, no foreign file needed |
| a JSON **number wider than 64 bits**, parsed as a float, turned into an arbitrary-precision `int()` | a restored backup, a hand-edited file, a foreign writer |

### Severity

The second route needs no foreign file. A live NaN in `pid_integral`, `last_percent` or `u_integral` was saved as `null`, read back as `None`, and the `if value is None: setattr(state, attr, None)` branch ran ahead of every guard and installed that `None` into fields declared `float` or `int`. The calibrators do not catch it: `sanitize_pid_state` lets a `None` past its finiteness checks and then raises `TypeError` on `params.i_min <= state.pid_integral`, while `sanitize_mpc_state` grades the state healthy and hands the `None` on.

The same route reached inside `MpcState`'s two collections, which sat above the guarded loop and were copied verbatim. A null *field* poisoned the entry; a null *element* sailed through. `_all_finite` finds no number to reject there, so the state is graded healthy and the first arithmetic that reaches the `None` raises — in `_detect_regime_change` for the error series, in `_update_perf_curve` for a bin.

The third route is quieter and worse. An oversized integer is one the encoder refuses to write, and that refusal never surfaces: `prepare_save_json` converts the `TypeError` into a `SerializationError`, `Store._async_handle_write_data` catches it and only logs `Error writing config for ...`, and the save returns normally with the file untouched. The config entry simply stops being persisted, for every controller it holds, and nothing reports it.

## Changes:

### What is guarded

- Both deserialisers' **float fields** go through `_finite_or_poison`.
- A stored **null** is a value only where the declared type admits one. The nullable sets are derived from the dataclasses via `get_type_hints`, so they cannot drift from the declarations. `MpcV2ReidData` declares no nullable field at all.
- `MpcState`'s two **collections** are parsed element by element inside the guarded loop. A null or non-finite element costs the entry its stored values; an element that is no number at all skips the field and leaves the rest standing.
- The **eight integer fields** are taken only as integers the encoder accepts — the tallies as non-negative ones, the two sign fields across the full storable range so a direction of `-1` survives. The bound is the encoder's measured range and a test pins it. A value meeting neither rule is a lost field rather than corrupt math: a tally restores as `0`, a sign field keeps its default, the entry stands.

### A rejected MPC v2 entry is dropped, not reset

Restoring the dataclass's defaults would *not* leave the key cold. The entry would still be installed, `get_mpc_v2_live` would hand its empty snapshot to `import_mpc_v2_state`, `ControllerSnapshot.from_mapping({})` would pass the version gate with a zero-valued snapshot, and `restore_snapshot` would mark the fresh controller initialised — leaving its Kalman estimate at the construction default of 20 °C instead of seeding it from the first measurement. Measured on a room actually at 15.0 °C: `T_room_hat = 17.377` on the first cycle, against `14.994` for a genuine cold start. Dropping the key is what actually leaves the controller cold.

### What is deliberately not covered

Both are stated where they live, in the docstrings of the functions concerned:

- **MPC v2's `snapshot` and `outdoor_fallback_logged`** are read past that deserialiser's loop and reach no guard, on the restore path or the save one. A null or non-mapping snapshot keeps the entry with the empty default. Only a store this integration did not write can produce one — what it saves is always a mapping.
- **The magnitude of a restored re-ID prior** is unbounded. The gate rejects only a non-positive `tau_room_min` / `gain_heater`, so an implausibly small positive time constant passes and reaches `PlantParams`, whose room dynamics divide by it unclamped. Choosing a plausible range is a domain decision and belongs in its own change.

### Verification

`4177 passed`, `ruff check` and `ruff format --check` clean, `pyrefly check` 0 errors. 586 lines of new tests.

Every claim above was established by executing the real code rather than reading it, including the round trips through a **real** `Store` — built with `async_test_home_assistant` and a config dir on disk, deliberately not the `hass_storage` mock, so `prepare_save_json`, `write_utf8_file` and `json_util.load_json` actually run. The pre-change behaviour was re-run in a throwaway worktree at `origin/v2` rather than assumed.

Counterfactuals were verified in both directions: reverting each production hunk fails the tests that pin it, and a guard that rejects *too much* fails the tests that pin the values which must still restore.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

HA Version: n/a - covered by unit tests, no hardware run for this change
Zigbee2MQTT Version: n/a
TRV Hardware: n/a

## New device mappings

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

No new device mapping is added by this PR, and `climate.py` is not touched — the change is confined to `utils/state_manager.py` and its tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from corrupted or invalid thermostat state data.
  * Rejects invalid null, non-finite, out-of-range, and malformed values during state loading.
  * Preserves the last valid saved state when new live data cannot be accepted.
  * Safely discards corrupted MPC state entries instead of allowing them to affect operation.

* **Tests**
  * Added comprehensive coverage for invalid state values, corruption handling, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->