### PR TITLE
fix(cooler): bound re-injected targets and order the restored pair

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1819,14 +1819,20 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                         self.preset_mgr.mode,
                         preset_temp,
                     )
-                    self.bt_target_temp = preset_temp
+                    self.bt_target_temp = self._bound_target_to_range(preset_temp)
                 if (
                     self.cooler_entity_id is not None
                     and self.preset_mgr.mode in self._preset_cool_temperatures
                 ):
                     cool_temp = self._preset_cool_temperatures[self.preset_mgr.mode]
                     if isinstance(cool_temp, (int, float)):
-                        self.bt_target_cooltemp = cool_temp
+                        self.bt_target_cooltemp = self._bound_target_to_range(cool_temp)
+                # A target that is re-injected rather than chosen is ordered the
+                # moment it is stored: the HVAC mode can change without the pair
+                # being looked at again, and async_set_hvac_mode does not
+                # re-enforce the ordering.
+                if self.cooler_entity_id is not None:
+                    self._enforce_cool_above_heat(regardless_of_hvac_mode=True)
             _LOGGER.debug(
                 "better_thermostat %s: restored preset temperature applied",
                 self.device_name,
@@ -3422,6 +3428,46 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             )
         self.bt_target_temp = adjusted
 
+    def _bound_target_to_range(self, value: float) -> float:
+        """Bound a re-injected target into the configured range.
+
+        Stored targets come back into the entity without passing the range
+        check the value they replace went through: a preset pair written while
+        a cooler was unavailable, or a manual cooling target stashed under a
+        different range, is re-injected verbatim. Both targets are published as
+        ``target_temperature_low`` / ``target_temperature_high`` and written to
+        the devices, so a value the configured range does not contain is not a
+        setpoint BT can hold.
+
+        The lower bound is applied first and the upper bound second, each only
+        when it is known. The order is load-bearing:
+        :meth:`_resolve_temperature_range` permits a non-overlapping range
+        where ``bt_min_temp`` is above ``bt_max_temp``, and applying the two in
+        sequence rather than exclusively lets the upper bound decide there.
+        This is the sequencing :func:`resolve_inbound_setpoint` uses for the
+        same reason.
+
+        The bound is silent. The stored heating target and the active preset's
+        temperature are normally the same number, so a warning here would
+        repeat the one :func:`restore_target_temperature` already emitted for
+        that value.
+
+        Parameters
+        ----------
+        value : float
+                the target being re-injected, in °C
+
+        Returns
+        -------
+        float
+                the target bounded into the configured range
+        """
+        if self.bt_min_temp is not None and value < self.bt_min_temp:
+            value = self.bt_min_temp
+        if self.bt_max_temp is not None and self.bt_max_temp < value:
+            value = self.bt_max_temp
+        return value
+
     def _clamp_inbound_cool_target(self, value: float) -> float:
         """Raise a cooling setpoint reported by the cooler above the heating target.
 
@@ -3827,10 +3873,16 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 and self.cooler_entity_id is not None
                 and self._preset_cool_temperature is not None
             ):
-                self.bt_target_cooltemp = self._preset_cool_temperature
+                self.bt_target_cooltemp = self._bound_target_to_range(
+                    self._preset_cool_temperature
+                )
                 self._preset_cool_temperature = None
 
-            self._enforce_cool_above_heat()
+            # Both targets a preset change writes are re-injected rather than
+            # chosen, so the pair is ordered the moment it is stored: the HVAC
+            # mode can change without it being looked at again, and
+            # async_set_hvac_mode does not re-enforce the ordering.
+            self._enforce_cool_above_heat(regardless_of_hvac_mode=True)
 
             _LOGGER.debug(
                 "better_thermostat %s: After preset change %s -> %s, bt_target_temp=%s, bt_hvac_mode=%s",

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -71,6 +71,9 @@ def mock_bt():
     bt.old_attr_hvac_action = None
     bt.attr_hvac_action = None
     bt.outdoor_sensor = None
+    # Cooling channel: off unless a test configures one
+    bt.cooler_entity_id = None
+    bt._preset_cool_temperature = None
     # Thermal tracker property delegates
     type(bt).heating_power = property(
         lambda self: self._heating_tracker.heating_power,
@@ -129,6 +132,9 @@ def mock_bt():
     bt._get_outdoor_temp = lambda: BetterThermostat._get_outdoor_temp(bt)
     bt._enforce_cool_above_heat = lambda **kwargs: (
         BetterThermostat._enforce_cool_above_heat(bt, **kwargs)
+    )
+    bt._bound_target_to_range = lambda value: BetterThermostat._bound_target_to_range(
+        bt, value
     )
     return bt
 
@@ -969,6 +975,67 @@ class TestAsyncSetPresetMode:
         assert mock_bt.bt_target_cooltemp == 26.0
 
     @pytest.mark.asyncio
+    async def test_restored_manual_cool_target_is_ordered_while_off(self, mock_bt):
+        """Returning to PRESET_NONE while off still orders the pair.
+
+        The manual cooling target is re-injected, not chosen: nothing looks at
+        the pair again before the first cooling cycle, because the mode change
+        that enables cooling does not re-enforce the ordering.
+        """
+        mock_bt.preset_modes = [PRESET_NONE, PRESET_COMFORT, PRESET_ECO, PRESET_AWAY]
+        mock_bt.bt_hvac_mode = HVACMode.OFF
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_min_temp = 16.0
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.min_temp = 16.0
+        mock_bt.max_temp = 30.0
+        mock_bt.bt_target_temp_step = 0.5
+        mock_bt.preset_mgr.mode = PRESET_COMFORT
+        mock_bt.preset_mgr.saved_temperature = None
+        mock_bt._preset_cool_temperatures = {PRESET_NONE: 24.0, PRESET_COMFORT: 26.0}
+        mock_bt._preset_cool_temperature = 22.0
+        mock_bt.bt_target_temp = 24.0
+        mock_bt.bt_target_cooltemp = 26.0
+
+        await self._call(mock_bt, PRESET_NONE)
+
+        assert mock_bt.bt_target_temp == 24.0
+        assert mock_bt.bt_target_cooltemp == 24.5
+        assert mock_bt.bt_min_temp <= mock_bt.bt_target_temp <= mock_bt.bt_max_temp
+        assert mock_bt.bt_min_temp <= mock_bt.bt_target_cooltemp <= mock_bt.bt_max_temp
+        assert mock_bt.bt_target_cooltemp > mock_bt.bt_target_temp
+
+    @pytest.mark.asyncio
+    async def test_restored_manual_cool_target_above_the_maximum_is_bounded(
+        self, mock_bt
+    ):
+        """A stashed cooling target over the maximum comes back bounded.
+
+        The ordering leaves it alone because it already clears the heating
+        target, so the range bound is the only thing that holds it.
+        """
+        mock_bt.preset_modes = [PRESET_NONE, PRESET_COMFORT, PRESET_ECO, PRESET_AWAY]
+        mock_bt.hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.bt_min_temp = 16.0
+        mock_bt.bt_max_temp = 26.0
+        mock_bt.min_temp = 16.0
+        mock_bt.max_temp = 26.0
+        mock_bt.preset_mgr.mode = PRESET_COMFORT
+        mock_bt.preset_mgr.saved_temperature = None
+        mock_bt._preset_cool_temperatures = {PRESET_NONE: 24.0, PRESET_COMFORT: 25.0}
+        mock_bt._preset_cool_temperature = 35.0
+        mock_bt.bt_target_temp = 20.0
+        mock_bt.bt_target_cooltemp = 25.0
+
+        await self._call(mock_bt, PRESET_NONE)
+
+        assert mock_bt.bt_target_cooltemp == 26.0
+        assert mock_bt.bt_min_temp <= mock_bt.bt_target_cooltemp <= mock_bt.bt_max_temp
+        assert mock_bt.bt_target_cooltemp > mock_bt.bt_target_temp
+
+    @pytest.mark.asyncio
     async def test_preset_temp_clamped_to_max(self, mock_bt):
         """Preset temp above max → clamped to max_temp."""
         mock_bt.preset_modes = [PRESET_NONE, PRESET_COMFORT, PRESET_ECO, PRESET_AWAY]
@@ -1578,7 +1645,63 @@ class TestEnforceHeatBelowCool:
 
 
 # ===========================================================================
-# 9. TestClampInboundCoolTarget
+# 9. TestBoundTargetToRange
+# ===========================================================================
+
+
+class TestBoundTargetToRange:
+    """_bound_target_to_range holds a re-injected target inside the range."""
+
+    def _call(self, bt, value):
+        return BetterThermostat._bound_target_to_range(bt, value)
+
+    @pytest.mark.parametrize("value", [16.0, 21.0, 26.0])
+    def test_a_target_the_range_contains_is_returned_unchanged(self, mock_bt, value):
+        """Both bounds are inclusive, so only a target outside the range moves."""
+        mock_bt.bt_min_temp = 16.0
+        mock_bt.bt_max_temp = 26.0
+        assert self._call(mock_bt, value) == value
+
+    def test_value_below_the_minimum_is_raised_to_it(self, mock_bt):
+        """A target under the minimum is not a setpoint BT can hold."""
+        mock_bt.bt_min_temp = 20.0
+        mock_bt.bt_max_temp = 30.0
+        assert self._call(mock_bt, 9.0) == 20.0
+
+    def test_value_above_the_maximum_is_lowered_to_it(self, mock_bt):
+        """A target over the maximum is not a setpoint BT can hold either."""
+        mock_bt.bt_min_temp = 16.0
+        mock_bt.bt_max_temp = 26.0
+        assert self._call(mock_bt, 35.0) == 26.0
+
+    def test_an_unknown_minimum_leaves_the_lower_side_unbounded(self, mock_bt):
+        """A bound stays None until a child entity reports one."""
+        mock_bt.bt_min_temp = None
+        mock_bt.bt_max_temp = 26.0
+        assert self._call(mock_bt, 9.0) == 9.0
+
+    def test_an_unknown_maximum_leaves_the_upper_side_unbounded(self, mock_bt):
+        """The upper side is enforced only once it is known."""
+        mock_bt.bt_min_temp = 16.0
+        mock_bt.bt_max_temp = None
+        assert self._call(mock_bt, 35.0) == 35.0
+
+    def test_a_non_overlapping_range_is_decided_by_the_maximum(self, mock_bt):
+        """A minimum above the maximum leaves the upper bound the last word.
+
+        Heater and cooler ranges that do not overlap put bt_min_temp above
+        bt_max_temp, which _resolve_temperature_range permits. Applying the two
+        bounds in sequence rather than exclusively is what makes the outcome
+        defined there.
+        """
+        mock_bt.bt_min_temp = 25.0
+        mock_bt.bt_max_temp = 20.0
+        assert self._call(mock_bt, 10.0) == 20.0
+        assert self._call(mock_bt, 30.0) == 20.0
+
+
+# ===========================================================================
+# 10. TestClampInboundCoolTarget
 # ===========================================================================
 
 
@@ -1666,7 +1789,7 @@ class TestClampInboundCoolTarget:
 
 
 # ===========================================================================
-# 10. TestClampInboundHeatTarget
+# 11. TestClampInboundHeatTarget
 # ===========================================================================
 
 
@@ -1754,7 +1877,7 @@ class TestClampInboundHeatTarget:
 
 
 # ===========================================================================
-# 11. TestSeedCoolTarget
+# 12. TestSeedCoolTarget
 # ===========================================================================
 
 

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -117,6 +117,9 @@ def bt():
     mock._enforce_cool_above_heat.side_effect = lambda **kwargs: (
         BetterThermostat._enforce_cool_above_heat(mock, **kwargs)
     )
+    mock._bound_target_to_range = lambda value: BetterThermostat._bound_target_to_range(
+        mock, value
+    )
     return mock
 
 
@@ -912,6 +915,104 @@ class TestRestoreState:
 
         assert bt._preset_cool_temperatures["comfort"] == 25.5
         assert bt.bt_target_cooltemp == 25.5
+
+    def _cooling_bt(self, bt, minimum, maximum):
+        """Configure *bt* with a cooling channel and a real ordering method."""
+        bt.cooler_entity_id = COOLER_ID
+        bt.bt_min_temp = minimum
+        bt.bt_max_temp = maximum
+        bt.bt_target_temp_step = 0.5
+        bt.hvac_mode = HVACMode.OFF
+        bt._preset_cool_temperature = None
+        bt._enforce_cool_above_heat = lambda **kwargs: (
+            BetterThermostat._enforce_cool_above_heat(bt, **kwargs)
+        )
+        return bt
+
+    @pytest.mark.asyncio
+    async def test_restored_preset_pair_below_the_minimum_is_bounded_and_ordered(
+        self, bt
+    ):
+        """A stored preset pair under the minimum is bounded, then ordered.
+
+        A preset stored while the cooler was unavailable carries the pair the
+        range in force then allowed. Re-injecting it verbatim publishes two
+        targets the configured range does not contain, and the ordering is not
+        revisited because Better Thermostat comes back OFF.
+        """
+        bt = self._cooling_bt(bt, 20.0, 30.0)
+        bt._preset_cool_temperatures = {"none": 24.0, "comfort": 10.0, "eco": 27.0}
+        bt.preset_mgr.temperatures = {"comfort": 9.0, "eco": 18.0}
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {ATTR_TEMPERATURE: 9.0, "preset_mode": "comfort"}
+        bt.async_get_last_state = AsyncMock(return_value=old)
+
+        await BetterThermostat._restore_state(bt, [_make_trv_state()])
+
+        assert bt.bt_target_temp == 20.0
+        assert bt.bt_target_cooltemp == 20.5
+        assert bt.bt_min_temp <= bt.bt_target_temp <= bt.bt_max_temp
+        assert bt.bt_min_temp <= bt.bt_target_cooltemp <= bt.bt_max_temp
+        assert bt.bt_target_cooltemp > bt.bt_target_temp
+
+    @pytest.mark.asyncio
+    async def test_restored_preset_cool_target_above_the_maximum_is_bounded(self, bt):
+        """A stored preset cooling target over the maximum comes back bounded.
+
+        The ordering leaves it alone because it already clears the heating
+        target, so the range bound is the only thing that holds it.
+        """
+        bt = self._cooling_bt(bt, 16.0, 26.0)
+        bt._preset_cool_temperatures = {"none": 24.0, "comfort": 35.0, "eco": 27.0}
+        bt.preset_mgr.temperatures = {"comfort": 20.0, "eco": 18.0}
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {ATTR_TEMPERATURE: 20.0, "preset_mode": "comfort"}
+        bt.async_get_last_state = AsyncMock(return_value=old)
+
+        await BetterThermostat._restore_state(bt, [_make_trv_state()])
+
+        assert bt.bt_target_temp == 20.0
+        assert bt.bt_target_cooltemp == 26.0
+        assert bt.bt_min_temp <= bt.bt_target_cooltemp <= bt.bt_max_temp
+        assert bt.bt_target_cooltemp > bt.bt_target_temp
+
+    @pytest.mark.asyncio
+    async def test_restored_preset_heating_target_above_the_maximum_is_bounded(
+        self, bt
+    ):
+        """A stored preset heating target over the maximum comes back bounded."""
+        bt = self._cooling_bt(bt, 16.0, 26.0)
+        bt._preset_cool_temperatures = {"none": 24.0, "comfort": 25.0, "eco": 27.0}
+        bt.preset_mgr.temperatures = {"comfort": 31.0, "eco": 18.0}
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {ATTR_TEMPERATURE: 31.0, "preset_mode": "comfort"}
+        bt.async_get_last_state = AsyncMock(return_value=old)
+
+        await BetterThermostat._restore_state(bt, [_make_trv_state()])
+
+        assert bt.bt_target_temp == 26.0
+        assert bt.bt_min_temp <= bt.bt_target_temp <= bt.bt_max_temp
+
+    @pytest.mark.asyncio
+    async def test_restored_preset_pair_is_not_ordered_without_a_cooler(self, bt):
+        """Without a cooling channel there is no pair to order."""
+        bt = self._cooling_bt(bt, 16.0, 26.0)
+        bt.cooler_entity_id = None
+        bt.bt_target_cooltemp = 18.0
+        bt._preset_cool_temperatures = {"none": 24.0, "comfort": 25.0, "eco": 27.0}
+        bt.preset_mgr.temperatures = {"comfort": 22.0, "eco": 18.0}
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {ATTR_TEMPERATURE: 22.0, "preset_mode": "comfort"}
+        bt.async_get_last_state = AsyncMock(return_value=old)
+
+        await BetterThermostat._restore_state(bt, [_make_trv_state()])
+
+        assert bt.bt_target_temp == 22.0
+        assert bt.bt_target_cooltemp == 18.0
 
     @pytest.mark.asyncio
     async def test_restores_heating_power_clamped(self, bt):


### PR DESCRIPTION
## The defect

Same contract as `fix/cooler-target-range` against `develop`; the production
hunks and the tests are byte-identical on both branches.

A stored target that is *re-injected* into the entity skips the range check the
value it replaces went through. Two paths published a pair the configured range
does not hold. Both were reproduced by driving the real entry point against the
current tip of `v2` before anything was changed, and produced the same numbers
as on `develop`.

**Door 1 — `_restore_state`.** `restore_target_temperature` clamps the saved
heating target and warns about it; the restored preset block then overwrites
that clamped value with the preset's stored temperature, and the preset's
cooling target alongside it, neither bounded.

Executed against `BetterThermostat._restore_state()` with `bt_min_temp=20.0`,
`bt_max_temp=30.0` and a preset stored as `heat=9.0 / cool=10.0`:

| | before | after |
|---|---|---|
| `bt_target_temp` (low) | **9.0** | 20.0 |
| `bt_target_cooltemp` (high) | **10.0** | 20.5 |

**Door 2 — `async_set_preset_mode(PRESET_NONE)`.** The stashed manual cooling
target is restored verbatim and the ordering call that follows is gated on
HEAT_COOL, so with BT OFF the inverted pair is published as is.

Executed with `bt_min_temp=16.0`, `bt_max_temp=30.0`, `bt_hvac_mode=OFF`, a
preset holding `heat=24.0 / cool=26.0` and a stashed cooling target of 22.0:

| | before | after |
|---|---|---|
| `bt_target_temp` (low) | 24.0 | 24.0 |
| `bt_target_cooltemp` (high) | **22.0** | 24.5 |

Every value in door 2 is inside `[16, 30]`. The range alone would not have
caught it.

## The change

`_bound_target_to_range(value)` sits next to `_clamp_inbound_cool_target` and
applies the lower bound first and the upper bound second, each only when it is
known. The order is load-bearing and documented as such: `_resolve_temperature_range`
permits a non-overlapping range where `bt_min_temp` is above `bt_max_temp`, and
applying the two bounds in sequence rather than exclusively lets the upper bound
decide there. This is the sequencing `resolve_inbound_setpoint` already uses.

It is applied at the three re-injection sites (restored preset heating target,
restored preset cooling target, stashed manual cooling target on return to
`PRESET_NONE`), and both paths then order the pair with
`regardless_of_hvac_mode=True`. A target that is re-injected rather than chosen
has to be ordered the moment it is stored, because the HVAC mode can change
without the pair being looked at again — v2's `async_set_hvac_mode` contains no
call to `_enforce_cool_above_heat` (checked by extracting the method body and
searching it). `async_set_temperature` and `number.py` stay mode-gated.

Not touched: the default gate inside `_enforce_cool_above_heat`
(`TestEnforceCoolAboveHeat::test_default_is_mode_gated` still passes unedited),
`resolve_inbound_setpoint`, and the `_enforce_cool_above_heat()` call in the
`no_off_system_mode` else arm of `events/trv.py`. No v2 architecture was touched
either: no `@callback`, `request_control_cycle`, cooler send cache or
`kernel_state` code is in the diff.

## Does the bound double-log or contradict `restore_target_temperature`?

No, executed on this branch as well. The bound is silent by design: in a real
restore the stored `ATTR_TEMPERATURE` and the active preset's temperature are
normally the same number, so a warning inside the bound would repeat the one
`restore_target_temperature` has already emitted.

```
[utils.restore] Saved target temperature 9.0 is lower than min_temp 20.0, setting to min_temp
[climate]      cooling target 20.00 adjusted to 20.50 to stay above heating target 20.00
records mentioning the out-of-range value 9.0: 1
```

One warning about 9.0, from `restore_target_temperature`, exactly as before. The
final `bt_target_temp` is 20.0, which is what that warning announced.

## Test invariant

After any of these paths, both targets lie inside `[bt_min_temp, bt_max_temp]`
where the range is wide enough to hold them, and `bt_target_cooltemp >
bt_target_temp`. Deliberately not `cool >= heat` unconditionally: the merged
`_enforce_heat_below_cool` publishes `heat > cool` when the cooling target sits
below `bt_min_temp`.

## Evidence

- 14 new test cases, the same ones as on `develop`.
- Counterfactual per production hunk: 8 reversions, each makes a named test
  fail. No hunk is untested.
- Mutation test per new test: 10 guard deletions, no surviving mutants.
- Full suite: **4316 passed** (baseline 4302). `ruff check`,
  `ruff format --check` clean; `pyrefly check` 0 errors.
- Divergence against the `develop` PR: added and removed lines are byte-identical
  in all three files (283 added, 7 removed on each branch); the diff-of-diffs
  contains only hunk headers, blob hashes and pre-existing context.

## Existing tests

Four pre-existing tests needed fixture plumbing — the same four as on `develop`,
failing for the same reasons — and no assertion was changed. The only removed
lines in the test diff are three section-number comments.

## Scope of the evidence

The reproductions and the new tests drive the real `_restore_state` and
`async_set_preset_mode` unbound on a mock instance, with `PresetManager`,
`restore_target_temperature`, `_enforce_cool_above_heat` and
`_bound_target_to_range` running for real. That is this repo's existing
convention for these two methods, but it is weaker than an end-to-end HA
integration test: the surrounding entity is a mock. The stored out-of-range
preset pair was constructed as a state, not produced by executing a startup with
an unavailable cooler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored heating and cooling preset temperatures are now kept within configured limits.
  * Heating and cooling targets are automatically ordered correctly when both controls are available.
  * Manual cooling targets now remain valid after preset changes, including when the system is turned off.
  * Systems without cooling support continue to handle heating targets appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->