### PR TITLE
fix(cooler): decline a setpoint reported on a dead cooler state

### DIFF
--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.climate.const import HVACMode
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import callback
 
 from custom_components.better_thermostat.utils.helpers import (
@@ -19,6 +18,7 @@ from custom_components.better_thermostat.utils.helpers import (
     resolve_inbound_setpoint,
     resolve_state_change_event,
     setpoint_echo_window,
+    state_says_nothing,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,6 +56,31 @@ async def trigger_cooler_change(self, event):
         step=_step,
         log_source="trigger_cooler_change()",
     )
+    if state_says_nothing(new_state):
+        # A cooler that is unavailable or has no mode yet can still carry a
+        # setpoint: an entity reports "unknown" while publishing its full
+        # attributes, and one that writes the state machine directly keeps the
+        # attributes it last set. Such a value is retained rather than reported
+        # and says nothing about the device now, so neither the seed nor the
+        # adoption gate below may take it: whatever either of them stores is
+        # written straight back to that same device.
+        # _seed_cool_target_from_cooler() declines the two states at startup.
+        # The guard sits ahead of both branches so that declining ends the
+        # event: falling through would let the gate read that same retained
+        # setpoint and store it as the cool target, raised to clear the heating
+        # target, which is exactly what declining refuses. The setpoint being
+        # passed over is logged because it is the diagnostic — it is what a
+        # later report has to differ from before anything is adopted.
+        _LOGGER.debug(
+            "better_thermostat %s: Cooler %s is %s, not adopting its retained "
+            "setpoint %s",
+            self.device_name,
+            entity_id,
+            new_state.state,
+            None if _new_cooling_setpoint is None else _new_cooling_setpoint.raw,
+        )
+        self.async_write_ha_state()
+        return
     if _new_cooling_setpoint is not None and self.bt_target_cooltemp is None:
         # An unknown cool target holds the cooler OFF on every control cycle,
         # and the gate below cannot lift it: that gate needs a setpoint in the
@@ -65,31 +90,9 @@ async def trigger_cooler_change(self, event):
         # there is; taking it loses no user intent because the field carries
         # none, and it cannot be an echo either, because no setpoint is written
         # to the cooler while the target is unknown.
-        if new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
-            # A cooler that is unavailable or has no mode yet can still carry a
-            # setpoint: an entity reports "unknown" while publishing its full
-            # attributes, and one that writes the state machine directly keeps
-            # the attributes it last set. Such a value is retained rather than
-            # reported and says nothing about the device now, so it must not
-            # become the cool target, which is written straight back to it.
-            # _seed_cool_target_from_cooler() declines the same two states at
-            # startup. This check sits inside the branch rather than in its
-            # condition, so declining ends the event here: the gate below would
-            # otherwise read that same retained setpoint and store it as the
-            # cool target, raised to clear the heating target, which is exactly
-            # what declining refuses.
-            _LOGGER.debug(
-                "better_thermostat %s: Cooler %s is %s, not seeding the cool "
-                "target from its retained setpoint %s",
-                self.device_name,
-                entity_id,
-                new_state.state,
-                _new_cooling_setpoint.raw,
-            )
-        else:
-            self._seed_cool_target(_new_cooling_setpoint, entity_id)
-            if self.bt_hvac_mode != HVACMode.OFF:
-                _main_change = True
+        self._seed_cool_target(_new_cooling_setpoint, entity_id)
+        if self.bt_hvac_mode != HVACMode.OFF:
+            _main_change = True
     elif (
         _new_cooling_setpoint is not None
         and _old_cooling_setpoint is not None

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -825,6 +825,30 @@ def resolve_inbound_setpoint(
     return InboundSetpoint(raw=raw, value=value, clamped=clamped, is_echo=is_echo)
 
 
+def state_says_nothing(state: State | None) -> bool:
+    """Answer whether a state carries no statement about its own device.
+
+    A missing state, ``unavailable`` and ``unknown`` all leave the device
+    unaccounted for, while attributes can still be present on every one of
+    them: a climate entity publishes its full attribute set while it reports
+    ``unknown``, and one that writes the state machine directly keeps the
+    attributes it last set. A reading taken from such a state is retained
+    rather than reported, so a caller that would act on it as a live value has
+    to decline it.
+
+    Parameters
+    ----------
+    state : State | None
+            the device state to inspect
+
+    Returns
+    -------
+    bool
+            True when the state is missing, ``unavailable`` or ``unknown``
+    """
+    return state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+
+
 def resolve_state_change_event(
     self, event, device_label: str
 ) -> tuple[State, State, str] | None:

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -1050,6 +1050,49 @@ class TestUnknownCoolTargetSeed:
         mock_bt._seed_cool_target.assert_not_called()
         mock_bt.control_queue_task.put.assert_not_awaited()
 
+    @pytest.mark.parametrize("dead_state", [STATE_UNAVAILABLE, STATE_UNKNOWN])
+    @pytest.mark.asyncio
+    async def test_dead_cooler_setpoint_does_not_move_a_known_cool_target(
+        self, mock_bt, dead_state
+    ):
+        """A known cool target puts the adoption gate alone on a dead state.
+
+        With the cool target known the seeding branch is out of reach, so the
+        gate decides on its own and only the reported state can stop it: the
+        previous state publishes a setpoint, Better Thermostat is not off, and
+        the reported value differs from the previous one by more than the echo
+        window. The attribute set is the one a climate entity publishes while
+        it reports ``unknown``.
+        """
+        mock_bt.bt_target_cooltemp = 24.0
+        mock_bt.bt_target_temp = 20.0
+        old_state = _make_state(attributes={"temperature": 24.0})
+        new_state = State(
+            ENTITY_ID,
+            dead_state,
+            attributes={
+                "hvac_modes": [HVACMode.OFF, HVACMode.COOL],
+                "min_temp": 16.0,
+                "max_temp": 30.0,
+                "target_temp_step": 0.5,
+                "fan_modes": ["auto", "low", "high"],
+                "swing_modes": ["off", "vertical"],
+                "current_temperature": 26.0,
+                "temperature": 19.0,
+                "fan_mode": "auto",
+                "swing_mode": "off",
+                "friendly_name": "Test Cooler",
+            },
+        )
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 24.0
+        assert mock_bt.bt_target_temp == 20.0
+        mock_bt.control_queue_task.put.assert_not_awaited()
+        mock_bt.async_write_ha_state.assert_called_once()
+
     @pytest.mark.asyncio
     async def test_known_cool_target_is_not_re_seeded(self, mock_bt):
         """With a known cool target the adoption gate keeps deciding alone.


### PR DESCRIPTION
## Motivation:

`trigger_cooler_change` guarded its seed branch against `unavailable` / `unknown` states but
not the adoption gate beside it, so a retained setpoint from a state that says nothing about
the device could still be stored as the cooling target and written straight back to it.

## Changes:

## What this changes

`trigger_cooler_change` declined `unavailable` and `unknown` only *inside* the seeding branch, and that branch is reachable only while `bt_target_cooltemp is None`. With a cool target already known the event fell through to the adoption gate, which read the very same retained setpoint and stored it.

The check moves into `state_says_nothing()` in `utils/helpers.py` — it answers whether a state says anything about the device it came from and covers `None`, `STATE_UNAVAILABLE` and `STATE_UNKNOWN` — and the guard is hoisted ahead of the seed/adopt `if`/`elif`, so one check covers both branches. Declining still ends the handler with a single `async_write_ha_state()` and no fallthrough. The decline is logged at `debug` with the setpoint being passed over: that value is the diagnostic, since it is what a later report has to differ from before anything is adopted.

## Red baseline, executed through the real `trigger_cooler_change`

`bt_target_cooltemp=24.0`, `bt_target_temp=20.0`, previous state `cool` with `temperature=24.0`, new state `unknown` (and `unavailable`) carrying a full climate attribute set with `temperature=19.0`:

| branch state | `bt_target_cooltemp` | control cycle requested |
|---|---|---|
| before this PR | **20.5** | **yes** |
| after this PR | 24.0 | no |

19.0 does not clear the heating target of 20.0, so `_clamp_inbound_cool_target` raised it to 20.5 — the gate stored a value the device never reported, taken off a state that says nothing about it.

## Severity: LOW

Through a real Home Assistant entity, `unavailable` is effectively unreachable here. `Entity.__async_calculate_state` merges `state_attributes` only inside `if available:`, and `ATTR_TEMPERATURE` is produced by `ClimateEntity.state_attributes`, not by `capability_attributes` (which carries `hvac_modes`, `min_temp`, `max_temp`, `target_temp_step`). An `unavailable` climate entity therefore publishes no `temperature` at all, `resolve_inbound_setpoint` returns `None`, and there is nothing to adopt. Reaching the guard with a setpoint on `unavailable` requires something writing the state machine directly.

The reachable case is `unknown`. `Entity._stringify_state` returns `STATE_UNKNOWN` when the entity *is* available but `self.state is None`, so `unknown` is an available state carrying a live setpoint. That is the case this PR declines.

## The cost of declining, executed

Declining `unknown` is not free, and this is what it costs. Two events, real handler, `bt_target_temp=18.0` so nothing is clamped:

```
start:                                         bt_target_cooltemp=24.0
event 1  cool/24.0 -> unknown/19.0             24.0   (declined)
event 2  unknown/19.0 -> cool/19.0             24.0   (not recovered)
```

On the current code event 1 stores 19.0. After this PR the change is dropped for good: event 2 carries 19.0 in both `old` and `new`, so `_reported_moved` is false and the gate never fires. An air conditioner that reports a real setpoint change in the same state write that loses its mode loses that change. Consistency with the three sibling sites that already decline — the startup seed, the cooler seed branch, and both TRV paths — is what buys it.

## `events/trv.py` — verified, deliberately untouched

`events/trv.py:82` (develop) already performs the equivalent check: `if _org_trv_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):`, and `_org_trv_state` is proven non-`None` by the guard 17 lines above it, so substituting `state_says_nothing(_org_trv_state)` would be behaviour-preserving. It is left alone anyway: being behaviour-preserving means no test can fail without it, which makes it an unverifiable hunk in a bug-fix PR. It belongs in a convergence change, not here.

## Verification

- New test `test_dead_cooler_setpoint_does_not_move_a_known_cool_target`, parametrised over both states. Mutation-tested three ways: deleting the guard fails both params; deleting only its `return` fails both params plus the four pre-existing dead-cooler params; narrowing the predicate to `unavailable` fails the `unknown` param. On the unfixed code the same state object drives the gate to store 20.5, which proves the setpoint really is read rather than silently absent.
- `test_dead_cooler_does_not_seed_from_its_retained_setpoint` and `test_dead_cooler_seed_is_not_handed_to_the_adoption_gate` are unedited and green.
- `uv run pytest tests/ -q` → 2362 passed (baseline 2360; +2 is the new test's two params). `uv run ruff check .` → All checks passed. `uv run ruff format --check .` → 234 files already formatted.

## Not verified here

The evidence is unit-level: the real `trigger_cooler_change` entry point with real `State` objects and a real event shape, but a mocked `BetterThermostat` with the relevant methods bound from the real class — the harness the merged cooler tests already use. No live Home Assistant instance was driven.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable, unknown, or missing cooler states.
  * Prevented unusable states from overwriting an existing cooling target.
  * Ensured Home Assistant state updates continue while unnecessary control cycles are avoided.
* **Tests**
  * Added coverage for cooler behavior when device states are unavailable or unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

Not tested on hardware. The evidence in this PR is unit-level and executed: the full suite plus the
targeted reproductions quoted above, driven against mocked Home Assistant objects. No real TRV,
cooler or Home Assistant instance was involved, so the fields below are left blank rather than
filled with values that were never observed.

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

No new device mapping is added by this PR.

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`
