### PR TITLE
fix(mpc_v2): tie restored _initialised to the snapshot that seeded it

### DIFF
--- a/custom_components/better_thermostat/utils/calibration/mpc_v2/controller.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc_v2/controller.py
@@ -6,6 +6,7 @@ from collections import deque
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 import logging
+import math
 from typing import Any
 
 import numpy as np
@@ -61,8 +62,11 @@ class ControllerSnapshot:
         This is the single place raw (untyped) persisted data is validated and
         coerced; missing keys fall back to the controller's construction
         defaults, so a partial snapshot degrades gracefully. A snapshot with
-        non-numeric values is dropped entirely — the controller then boots
-        fresh instead of running on half-restored state.
+        non-numeric or non-finite values is dropped entirely — ``float`` accepts
+        ``NaN`` and infinity, and either one spreads through the observer into
+        every later command, so the controller boots fresh instead of running on
+        poisoned state. ``rg_v_C`` is the one nullable field: a stored ``null``
+        means "no governor state" and stays legal.
         """
         try:
             version = int(raw.get("v", 0))
@@ -73,7 +77,7 @@ class ControllerSnapshot:
                     SNAPSHOT_VERSION,
                 )
                 return None
-            return cls(
+            snapshot = cls(
                 v=version,
                 x_hat=[float(x) for x in raw.get("x_hat", [])],
                 kalman_P=[[float(x) for x in row] for row in raw.get("kalman_P", [])],
@@ -88,6 +92,21 @@ class ControllerSnapshot:
         except TypeError, ValueError, OverflowError:
             _LOGGER.warning("MPC v2 snapshot contains non-numeric data; ignoring")
             return None
+        numbers = [
+            *snapshot.x_hat,
+            *(x for row in snapshot.kalman_P for x in row),
+            *snapshot.u_history,
+            snapshot.D_hat_K_per_min,
+            snapshot.last_u,
+            snapshot.e_integral_K_min,
+            snapshot.last_t_s,
+            snapshot.next_mpc_t_s,
+            *([] if snapshot.rg_v_C is None else [snapshot.rg_v_C]),
+        ]
+        if not all(math.isfinite(x) for x in numbers):
+            _LOGGER.warning("MPC v2 snapshot contains non-finite data; ignoring")
+            return None
+        return snapshot
 
 
 class MpcV2Controller:
@@ -234,16 +253,17 @@ class MpcV2Controller:
     def restore_snapshot(self, snap: ControllerSnapshot) -> None:
         """Seed controller state from a snapshot, mutating sub-state in place.
 
-        Empty or wrong-shaped estimate/covariance/history (a partial or
-        corrupted snapshot) leaves the freshly constructed defaults in place —
-        a mis-shaped covariance would otherwise poison every subsequent
-        Kalman update. Version gating lives in
+        An estimate or covariance that is empty, wrong-shaped or non-finite (a
+        partial or corrupted snapshot) leaves the freshly constructed defaults
+        in place — a mis-shaped or ``NaN`` covariance would otherwise poison
+        every subsequent Kalman update. Version gating lives in
         :meth:`ControllerSnapshot.from_mapping`.
         """
         n = self.plant_fine.state_dim
-        seeded = len(snap.x_hat) == n
+        x_hat = np.asarray(snap.x_hat, dtype=float)
+        seeded = x_hat.shape == (n,) and bool(np.all(np.isfinite(x_hat)))
         if seeded:
-            self.kalman.initialise(np.asarray(snap.x_hat, dtype=float))
+            self.kalman.initialise(x_hat)
         if snap.kalman_P:
             P = np.asarray(snap.kalman_P, dtype=float)
             if P.shape == (n, n) and bool(np.all(np.isfinite(P))):

--- a/custom_components/better_thermostat/utils/calibration/mpc_v2/controller.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc_v2/controller.py
@@ -241,7 +241,8 @@ class MpcV2Controller:
         :meth:`ControllerSnapshot.from_mapping`.
         """
         n = self.plant_fine.state_dim
-        if len(snap.x_hat) == n:
+        seeded = len(snap.x_hat) == n
+        if seeded:
             self.kalman.initialise(np.asarray(snap.x_hat, dtype=float))
         if snap.kalman_P:
             P = np.asarray(snap.kalman_P, dtype=float)
@@ -255,7 +256,11 @@ class MpcV2Controller:
         self.governor.restore(snap.rg_v_C)
         self._last_t_s = snap.last_t_s
         self._next_mpc_t_s = snap.next_mpc_t_s
-        self._initialised = True
+        # The controller counts as initialised only when the snapshot carried a
+        # usable estimate. Without one the Kalman filter still holds its
+        # construction default, so the first :meth:`step` has to seed it from
+        # the measurement instead of treating the default as restored state.
+        self._initialised = seeded
 
     def set_applied_u(self, u: float) -> None:
         """Record the valve fraction actually applied to the TRV.

--- a/tests/unit/mpc_v2/test_compute_mpc_v2.py
+++ b/tests/unit/mpc_v2/test_compute_mpc_v2.py
@@ -449,3 +449,56 @@ def test_wrong_shaped_covariance_is_ignored_on_restore() -> None:
     np.testing.assert_array_equal(controller.kalman.P, default_P)
     np.testing.assert_array_equal(controller.kalman.x_hat, default_x)
     assert controller._last_u == 0.4  # scalar fields still restore
+
+
+# Snapshot shapes that carry no state vector of the controller's dimension.
+# ``None`` stands for a stored payload whose ``snapshot`` key is null or not a
+# mapping at all, which ``import_mpc_v2_state`` refuses before it builds a
+# controller.
+_SNAPSHOTS_WITHOUT_ESTIMATE = [
+    {},
+    {"u_prev": 0.5},
+    {"v": SNAPSHOT_VERSION},
+    {"v": SNAPSHOT_VERSION, "x_hat": [18.0]},
+    None,
+]
+
+
+@pytest.mark.parametrize("raw", _SNAPSHOTS_WITHOUT_ESTIMATE[:-1])
+def test_snapshot_without_estimate_leaves_controller_uninitialised(
+    raw: dict[str, object],
+) -> None:
+    """A snapshot with no usable x_hat does not mark the controller initialised."""
+    controller = MpcV2Controller(MpcV2Params())
+    snap = ControllerSnapshot.from_mapping(raw)
+    assert snap is not None
+    controller.restore_snapshot(snap)
+    assert controller._initialised is False
+
+
+@pytest.mark.parametrize("raw", _SNAPSHOTS_WITHOUT_ESTIMATE)
+def test_restore_without_estimate_matches_a_freshly_built_controller(
+    raw: dict[str, object] | None,
+) -> None:
+    """Rehydrating from such a payload behaves like booting without one.
+
+    Every other field these payloads carry already equals the construction
+    default, so the observer estimate after the first cycle is the whole
+    difference: seeded from the measured room and radiator temperatures rather
+    than left on the neutral 20.0 °C guess the filter is built with.
+    """
+    params = MpcV2Params()
+    inp = _baseline_input(current_temp_C=24.0, trv_temp_C=26.5)
+
+    restored = import_mpc_v2_state({"snapshot": raw}, params)
+    out_restored, _ = compute_mpc_v2(inp, params, restored, now=1_700_000_000.0)
+    out_fresh, _ = compute_mpc_v2(inp, params, None, now=1_700_000_000.0)
+
+    assert out_restored is not None and out_fresh is not None
+    assert out_restored.diagnostics.T_rad_hat == pytest.approx(
+        out_fresh.diagnostics.T_rad_hat
+    )
+    assert out_restored.diagnostics.T_room_hat == pytest.approx(
+        out_fresh.diagnostics.T_room_hat
+    )
+    assert out_restored.valve_percent == out_fresh.valve_percent

--- a/tests/unit/mpc_v2/test_compute_mpc_v2.py
+++ b/tests/unit/mpc_v2/test_compute_mpc_v2.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import replace
+import json
 
 import numpy as np
 import pytest
@@ -429,6 +430,50 @@ def test_malformed_snapshot_values_are_rejected(caplog) -> None:
     assert any("non-numeric" in r.getMessage() for r in caplog.records)
 
 
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"v": SNAPSHOT_VERSION, "x_hat": [float("nan"), float("nan")]},
+        {"v": SNAPSHOT_VERSION, "x_hat": [float("inf"), 20.0]},
+        {"v": SNAPSHOT_VERSION, "kalman_P": [[float("nan"), 0.0], [0.0, 1.0]]},
+        {"v": SNAPSHOT_VERSION, "u_history": [0.5, float("nan")]},
+        {"v": SNAPSHOT_VERSION, "D_hat_K_per_min": float("nan")},
+        {"v": SNAPSHOT_VERSION, "last_u": float("nan")},
+        {"v": SNAPSHOT_VERSION, "e_integral_K_min": float("-inf")},
+        {"v": SNAPSHOT_VERSION, "rg_v_C": float("nan")},
+        {"v": SNAPSHOT_VERSION, "last_t_s": float("inf")},
+        {"v": SNAPSHOT_VERSION, "next_mpc_t_s": float("nan")},
+    ],
+)
+def test_non_finite_snapshot_values_are_rejected(
+    raw: dict[str, object], caplog
+) -> None:
+    """A non-finite value in any persisted field drops the whole snapshot.
+
+    The payload is routed through ``json`` because ``NaN`` and ``Infinity``
+    survive a serialise/parse round trip, so a store that once wrote them hands
+    them back to ``from_mapping`` exactly as written here.
+    """
+    with caplog.at_level("WARNING"):
+        snap = ControllerSnapshot.from_mapping(json.loads(json.dumps(raw)))
+    assert snap is None
+    assert any("non-finite" in r.getMessage() for r in caplog.records)
+
+
+def test_null_governor_state_is_accepted() -> None:
+    """A stored null ``rg_v_C`` is a legal value, not a non-finite one."""
+    raw = {"v": SNAPSHOT_VERSION, "x_hat": [21.0, 22.0], "rg_v_C": None}
+    snap = ControllerSnapshot.from_mapping(json.loads(json.dumps(raw)))
+    assert snap is not None
+    assert snap.rg_v_C is None
+    assert snap.x_hat == [21.0, 22.0]
+
+    controller = MpcV2Controller(MpcV2Params())
+    controller.restore_snapshot(snap)
+    assert controller._initialised is True
+    np.testing.assert_array_equal(controller.kalman.x_hat, np.array([21.0, 22.0]))
+
+
 def test_wrong_shaped_covariance_is_ignored_on_restore() -> None:
     """A mis-shaped kalman_P/x_hat must not poison the rebuilt filter."""
     controller = MpcV2Controller(MpcV2Params())
@@ -451,17 +496,42 @@ def test_wrong_shaped_covariance_is_ignored_on_restore() -> None:
     assert controller._last_u == 0.4  # scalar fields still restore
 
 
-# Snapshot shapes that carry no state vector of the controller's dimension.
-# ``None`` stands for a stored payload whose ``snapshot`` key is null or not a
-# mapping at all, which ``import_mpc_v2_state`` refuses before it builds a
-# controller.
+# Snapshot shapes that carry no usable state vector of the controller's
+# dimension: absent, too short, or the right length but non-finite. ``None``
+# stands for a stored payload whose ``snapshot`` key is null or not a mapping
+# at all, which ``import_mpc_v2_state`` refuses before it builds a controller.
 _SNAPSHOTS_WITHOUT_ESTIMATE = [
     {},
     {"u_prev": 0.5},
     {"v": SNAPSHOT_VERSION},
     {"v": SNAPSHOT_VERSION, "x_hat": [18.0]},
+    {"v": SNAPSHOT_VERSION, "x_hat": [float("nan"), float("nan")]},
+    {"v": SNAPSHOT_VERSION, "x_hat": [float("inf"), 20.0]},
     None,
 ]
+
+
+def _snapshot_carrying(raw: dict[str, object]) -> ControllerSnapshot:
+    """Build a snapshot object directly from a raw mapping's ``x_hat``.
+
+    ``from_mapping`` drops non-finite payloads, so it cannot deliver the
+    non-finite vectors to ``restore_snapshot``. Constructing the dataclass here
+    exercises the seed condition on its own; every other field is left at the
+    controller's construction default.
+    """
+    vector = raw.get("x_hat", [])
+    return ControllerSnapshot(
+        v=SNAPSHOT_VERSION,
+        x_hat=[float(x) for x in vector] if isinstance(vector, list) else [],
+        kalman_P=[],
+        D_hat_K_per_min=0.0,
+        last_u=0.0,
+        e_integral_K_min=0.0,
+        u_history=[],
+        rg_v_C=None,
+        last_t_s=0.0,
+        next_mpc_t_s=-1.0,
+    )
 
 
 @pytest.mark.parametrize("raw", _SNAPSHOTS_WITHOUT_ESTIMATE[:-1])
@@ -470,10 +540,10 @@ def test_snapshot_without_estimate_leaves_controller_uninitialised(
 ) -> None:
     """A snapshot with no usable x_hat does not mark the controller initialised."""
     controller = MpcV2Controller(MpcV2Params())
-    snap = ControllerSnapshot.from_mapping(raw)
-    assert snap is not None
-    controller.restore_snapshot(snap)
+    default_x = controller.kalman.x_hat.copy()
+    controller.restore_snapshot(_snapshot_carrying(raw))
     assert controller._initialised is False
+    np.testing.assert_array_equal(controller.kalman.x_hat, default_x)
 
 
 @pytest.mark.parametrize("raw", _SNAPSHOTS_WITHOUT_ESTIMATE)


### PR DESCRIPTION
## Motivation:

`MpcV2Controller.restore_snapshot` set `_initialised = True` regardless of whether the
snapshot actually carried a usable state estimate, so a controller could count as restored
while running on its construction default. Review of that change surfaced a second, sharper
case: a correctly sized but non-finite estimate was accepted too, which seeded the Kalman
observer with `NaN` and pinned the commanded valve fully open — measured at 100 % for 12
consecutive cycles with the room 4 K above target, where a healthy restore commands 0 %.

## Changes:

## What

`MpcV2Controller.restore_snapshot` set `self._initialised = True` unconditionally, four lines below the `if len(snap.x_hat) == n:` test that decides whether the estimate was actually seeded. A snapshot carrying no usable estimate therefore rehydrated into a controller that counted as initialised and ran on the Kalman filter's construction default of `[20.0, 20.0] °C` instead of being seeded from the first measurement.

`_initialised` now follows the seeding that actually happened:

```python
n = self.plant_fine.state_dim
seeded = len(snap.x_hat) == n
if seeded:
    self.kalman.initialise(np.asarray(snap.x_hat, dtype=float))
...
self._initialised = seeded
```

Nothing in `state_manager.py` changes.

## This is a contract fix, not a bug fix

The value of the change is that the flag now means what its name says. It is not being presented as closing a hazard.

## Measured actuator effect — it is not zero

It is tempting to record the measured actuator effect as **zero**, on the reasoning that `T_room` is the direct Kalman measurement so the estimate re-converges and the commanded valve never differs. Measured, **the effect is not zero**:

Method — the real dispatcher `_compute_mpc_v2_balance` is driven directly, with `time` in `mpc_v2/compute.py` replaced by a clock advancing 180 s per cycle (a naive loop is degenerate: every cycle after the first hits `MIN_STEP_DT_S` and returns the cached command). State is rehydrated through the real `import_mpc_v2_state`, exactly as `StateManager.get_mpc_v2_live` does. The A/B forces only `_initialised` after restore, i.e. exactly the one bit this PR changes.

Open loop, both runs fed the identical input trajectory so any difference can only come from the controller's own estimator state — 80 cycles, 5 snapshot shapes × 6 regimes:

| regime | max &#124;Δvalve%&#124; | first differing cycle |
|---|---|---|
| flat room 20.0 | 0 | — |
| flat room 23.0 | 0 | — |
| flat room 17.0 | 0 | — |
| warming room | 0 | — |
| cooling room | **4** | 26 |
| no TRV temperature | **1** | 22 |

Closed loop, commanded valve driving a simulated room so a difference compounds, 30 cycles: max &#124;Δvalve%&#124; = **9**.

Both tables came out identical on this branch and on the `v2` branch.

Why the zero reasoning does not hold: the Kalman state is two-dimensional. `T_room` is the direct measurement and re-converges within one cycle — that half is correct. `T_rad` is reconstructed, not measured, and the seed difference (the TRV's reported temperature versus the 20.0 °C construction default) persists for tens of cycles. Example first-cycle diagnostics from the "cooling room" regime: `T_rad_hat` 20.187 without the fix, 24.0 with it.

The magnitude is small and delayed, which is why this is still framed as a contract fix.

## Degenerate snapshots covered

`{}`, `{"u_prev": 0.5}`, `{"v": 1}` and a wrong-length `x_hat` all now leave `_initialised` False.

A null or non-mapping snapshot is a separate mechanism and this PR does not change it: `import_mpc_v2_state` declines it before a controller is constructed, so `restore_snapshot` is never reached. It is carried in the tests as a control row, not as a covered case.

## Tests

Two new test functions, 9 parametrised cases:

- `test_snapshot_without_estimate_leaves_controller_uninitialised` — the flag directly, over the four mapping shapes.
- `test_restore_without_estimate_matches_a_freshly_built_controller` — the behavioural invariant, driven through `compute_mpc_v2`: every other field these payloads carry already equals the construction default, so rehydrating from one must be indistinguishable from booting without one. Includes the null control row.

Mutation-tested: reverting `self._initialised = seeded` to `self._initialised = True` fails 8 of the 9 cases. The behavioural test fails on real observer state, not on an incidental attribute:

```
>   assert out_restored.diagnostics.T_rad_hat == pytest.approx(out_fresh.diagnostics.T_rad_hat)
E   assert 20.256650880295545 == 26.417352325098598 ± 2.6e-05
```

The ninth case is the null control row, which passes under the mutation by design — that path never reaches the changed line.

The two pre-existing restore tests were not edited and stay green, including `test_snapshot_round_trip_preserves_last_u`, which asserts `_initialised is True` after restoring a real snapshot.

`tests/unit/test_state_manager.py` was checked before changing behaviour: its `{"u_prev": 0.5}` payload only exercises the storage-layer deserializer, which keeps `snapshot` as an opaque blob and never hands it to the controller. Unaffected and unedited.

## Gates

```
uv run pytest tests/ -q     2369 passed in 68.60s
uv run ruff check .         All checks passed!
uv run ruff format --check  234 files already formatted
```

## Pairing

The identical hunk lands on `v2` in the sibling PR. `controller.py` was byte-identical between the two branches before the change and is byte-identical after it; the v2 side was produced by applying this branch's patch, and the two diffs — and the two pushed blobs — were verified byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved controller state restoration when saved state estimates are missing, invalid, or non-finite.
  - Added validation for non-finite values in restored controller data.
  - Controllers now correctly reinitialize from current measurements when necessary, producing consistent first-cycle diagnostics and valve output after restoration.

- **Tests**
  - Added coverage for invalid snapshot values and snapshots without a usable state estimate.
  - Added verification that nullable governor state is handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

Not tested on hardware. The evidence in this PR is unit-level and executed: the full suite plus the
targeted reproductions quoted above, driven against mocked Home Assistant objects. No real TRV,
cooler or Home Assistant instance was involved, so the fields below are left blank rather than
filled with values that were never observed.

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

No new device mapping is added by this PR.

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`
