### PR TITLE
fix(mpc-v2): bound the restored plant prior on both sides

### DIFF
--- a/custom_components/better_thermostat/utils/calibration/mpc_v2/params.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc_v2/params.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field, replace
 from ..mpc_v2_internals.dob import DobParams
 from ..mpc_v2_internals.governor import GovernorParams
 from ..mpc_v2_internals.kalman import KalmanParams
-from ..mpc_v2_internals.plant import PlantParams
+from ..mpc_v2_internals.plant import TAU_ROOM_BOUNDS_MIN, PlantParams
 from ..mpc_v2_internals.qp_optimiser import QpParams
 
 
@@ -68,7 +68,8 @@ def make_plant_prior(
         return replace(PLANT_PRESETS[preset])
     params = PlantParams()
     if heat_loss_rate is not None and heat_loss_rate > 0.0:
-        params.tau_room_min = max(60.0, min(2000.0, typical_delta_K / heat_loss_rate))
+        low, high = TAU_ROOM_BOUNDS_MIN
+        params.tau_room_min = max(low, min(high, typical_delta_K / heat_loss_rate))
     # heating_power not mapped yet — the gain stays at the prior default.
     _ = heating_power
     return params

--- a/custom_components/better_thermostat/utils/calibration/mpc_v2/reid.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc_v2/reid.py
@@ -27,10 +27,11 @@ from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 import math
 
-from ..mpc_v2_internals.plant import PlantParams
-
-TAU_ROOM_BOUNDS_MIN = (60.0, 2000.0)
-GAIN_HEATER_BOUNDS = (0.5, 5.0)
+from ..mpc_v2_internals.plant import (
+    GAIN_HEATER_BOUNDS,
+    TAU_ROOM_BOUNDS_MIN,
+    PlantParams,
+)
 
 
 @dataclass

--- a/custom_components/better_thermostat/utils/calibration/mpc_v2_internals/plant.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc_v2_internals/plant.py
@@ -18,6 +18,15 @@ import numpy as np
 
 from ._types import FloatArray
 
+# Plausible band for the two identifiable prior components, as
+# ``(lower, upper)`` and inclusive at both ends. ``tau_room_min`` divides the
+# room dynamics below and ``gain_heater`` scales the radiator drive, so a
+# value outside these bands drives the commanded valve to one rail. Every
+# producer and consumer of a prior — the offline fit, the heat-loss
+# derivation, the restore gate — refers to these two tuples.
+TAU_ROOM_BOUNDS_MIN = (60.0, 2000.0)
+GAIN_HEATER_BOUNDS = (0.5, 5.0)
+
 
 @dataclass
 class PlantParams:

--- a/custom_components/better_thermostat/utils/state_manager.py
+++ b/custom_components/better_thermostat/utils/state_manager.py
@@ -48,6 +48,7 @@ from .calibration.mpc_v2 import (
     import_mpc_v2_state,
 )
 from .calibration.mpc_v2.reid import ReidBuffer
+from .calibration.mpc_v2_internals.plant import GAIN_HEATER_BOUNDS, TAU_ROOM_BOUNDS_MIN
 from .calibration.pid import PIDState
 from .calibration.tpi import TpiState
 from .const import (
@@ -277,6 +278,15 @@ def _stored_count(value: Any) -> int:
     return max(count, 0)
 
 
+def _within(value: float, bounds: tuple[float, float]) -> bool:
+    """Return whether *value* lies inside *bounds*, inclusive at both ends.
+
+    A NaN answers ``False`` on both comparisons, so it reads as outside.
+    """
+    low, high = bounds
+    return low <= value <= high
+
+
 def _null_or_poison(attr: str, kind: str, nullable: frozenset[str]) -> None:
     """Let a stored null through, unless the declared type forbids one.
 
@@ -468,10 +478,14 @@ def deserialize_mpc_v2_reid(raw: dict[str, Any]) -> MpcV2ReidData | None:
     Three checks reject an entry. A NaN or infinity in one of the five
     float fields; a stored ``null`` in any of the six, since none of them
     is declared to hold one; and a ``tau_room_min`` or ``gain_heater``
-    that is not positive, since those two are the pair that seeds the
-    prior. None of the three bounds magnitude, so a positive but
-    implausibly small ``tau_room_min`` passes and reaches the plant model,
-    whose room dynamics divide by it.
+    outside :data:`TAU_ROOM_BOUNDS_MIN` / :data:`GAIN_HEATER_BOUNDS`,
+    inclusive at both ends, since those two are the pair that seeds the
+    prior and the plant's room dynamics divide by ``tau_room_min``.
+
+    The magnitude check rejects rather than clamps: this deserialiser's
+    contract is that a corrupt entry is left out so the lookup moves on to
+    the heat-loss-derived prior, whereas clamping would present a nonsense
+    stored value as a learned result sitting at the edge of the band.
 
     A float field that does not parse keeps its default, which leaves the
     entry usable as the schema grows. ``n_segments`` is metadata: a value
@@ -495,8 +509,13 @@ def deserialize_mpc_v2_reid(raw: dict[str, Any]) -> MpcV2ReidData | None:
             return None
         except TypeError, ValueError, OverflowError:
             continue
-    # A result without both fitted components cannot seed a plant prior.
-    if state.tau_room_min <= 0.0 or state.gain_heater <= 0.0:
+    # A result whose fitted components lie outside the plausible band cannot
+    # seed a plant prior. The band is two-sided on both: too small a
+    # ``tau_room_min`` and the room dynamics blow up, too large and they
+    # freeze, and either rail pins the commanded valve.
+    if not _within(state.tau_room_min, TAU_ROOM_BOUNDS_MIN):
+        return None
+    if not _within(state.gain_heater, GAIN_HEATER_BOUNDS):
         return None
     return state
 

--- a/tests/unit/mpc_v2/test_plant.py
+++ b/tests/unit/mpc_v2/test_plant.py
@@ -4,10 +4,37 @@ from __future__ import annotations
 
 import numpy as np
 
+from custom_components.better_thermostat.utils import state_manager as _state_manager
+from custom_components.better_thermostat.utils.calibration.mpc_v2 import (
+    params as _params,
+    reid as _reid,
+)
 from custom_components.better_thermostat.utils.calibration.mpc_v2_internals.plant import (
+    GAIN_HEATER_BOUNDS,
+    TAU_ROOM_BOUNDS_MIN,
     PlantModelRC2,
     PlantParams,
 )
+
+
+class TestPlantPriorBands:
+    """Every producer and consumer of a plant prior reads one band."""
+
+    def test_reid_reads_the_bands_from_plant(self) -> None:
+        """The offline fit clamps its emission against these very tuples."""
+        assert _reid.TAU_ROOM_BOUNDS_MIN is TAU_ROOM_BOUNDS_MIN
+        assert _reid.GAIN_HEATER_BOUNDS is GAIN_HEATER_BOUNDS
+
+    def test_state_manager_reads_the_bands_from_plant(self) -> None:
+        """The restore gate rejects against these very tuples."""
+        assert _state_manager.TAU_ROOM_BOUNDS_MIN is TAU_ROOM_BOUNDS_MIN
+        assert _state_manager.GAIN_HEATER_BOUNDS is GAIN_HEATER_BOUNDS
+
+    def test_heat_loss_derivation_clamps_to_the_band(self) -> None:
+        """The AUTO heuristic lands on the band edges, not on its own numbers."""
+        low, high = TAU_ROOM_BOUNDS_MIN
+        assert _params.make_plant_prior(heat_loss_rate=1.0).tau_room_min == low
+        assert _params.make_plant_prior(heat_loss_rate=0.0001).tau_room_min == high
 
 
 def test_state_dim_is_two() -> None:

--- a/tests/unit/mpc_v2/test_reid_integration.py
+++ b/tests/unit/mpc_v2/test_reid_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -30,6 +31,7 @@ from custom_components.better_thermostat.utils.const import (
 )
 from custom_components.better_thermostat.utils.state_manager import (
     MpcV2ReidData,
+    RuntimeState,
     StateManager,
     _deserialize,
     _serialize,
@@ -191,6 +193,32 @@ def test_auto_prior_uses_adopted_reid_result() -> None:
     assert live.controller.plant_fine.params.gain_heater == _REID.gain_heater
     debug = bt.real_trvs["climate.x"].calibration_balance["debug"]
     assert debug["reid_tau_room"] == _REID.tau_room_min
+
+
+def test_out_of_band_stored_prior_never_reaches_the_controller() -> None:
+    """A store entry outside the band is dropped, so AUTO keeps its heuristic.
+
+    Restored through the real ``_deserialize`` on a JSON round trip and read
+    back by the dispatcher: the controller must run on the heat-loss-derived
+    prior (15.0 K / 0.02 K per min = 750 min) and the valve must not sit on a
+    rail, which is what a ``tau_room_min`` of 5e-324 commands.
+    """
+    mgr = _make_manager()
+    raw = _serialize(RuntimeState())
+    raw["mpc_v2_reid"] = {
+        "bt:reid": {"tau_room_min": 5e-324, "gain_heater": 3.0, "fitted_ts": 1000.0}
+    }
+    mgr._state = _deserialize(json.loads(json.dumps(raw)))
+    assert "bt:reid" not in mgr.state.mpc_v2_reid
+
+    bt = _make_bt()
+    bt.state_mgr = mgr
+    out, _ = _compute_mpc_v2_balance(bt, "climate.x")
+    assert out is not None
+    live = next(iter(mgr._mpc_v2_live.values()))
+    assert live.controller is not None
+    assert live.controller.plant_fine.params.tau_room_min == 750.0
+    assert 0.0 < bt.real_trvs["climate.x"].calibration_balance["valve_percent"] < 100.0
 
 
 def test_explicit_preset_beats_reid_result() -> None:

--- a/tests/unit/test_state_manager.py
+++ b/tests/unit/test_state_manager.py
@@ -26,6 +26,10 @@ from custom_components.better_thermostat.utils.calibration.mpc_v2 import MpcV2Pa
 from custom_components.better_thermostat.utils.calibration.mpc_v2.controller import (
     ControllerSnapshot,
 )
+from custom_components.better_thermostat.utils.calibration.mpc_v2_internals.plant import (
+    GAIN_HEATER_BOUNDS,
+    TAU_ROOM_BOUNDS_MIN,
+)
 from custom_components.better_thermostat.utils.const import (
     MAX_HEAT_LOSS,
     MAX_HEATING_POWER,
@@ -441,12 +445,51 @@ class TestDeserializeMpcV2Reid:
         assert "bad" not in restored.mpc_v2_reid
         assert restored.mpc_v2_reid["good"].tau_room_min == 240.0
 
-    def test_tiny_positive_time_constant_is_not_rejected(self):
-        """The guards cover finiteness and sign; magnitude is unbounded."""
+    def test_tiny_positive_time_constant_is_rejected(self):
+        """A positive time constant this small still divides the room dynamics."""
         raw = {"tau_room_min": 5e-324, "gain_heater": 3.0}
+        assert deserialize_mpc_v2_reid(raw) is None
+
+    def test_time_constant_above_the_band_is_rejected(self):
+        """Too slow an envelope freezes the dynamics as surely as too fast."""
+        raw = {"tau_room_min": 1e300, "gain_heater": 3.0}
+        assert deserialize_mpc_v2_reid(raw) is None
+
+    def test_heater_gain_below_the_band_is_rejected(self):
+        """A gain under the band scales the radiator drive out of the model."""
+        raw = {"tau_room_min": 240.0, "gain_heater": 0.4}
+        assert deserialize_mpc_v2_reid(raw) is None
+
+    def test_heater_gain_above_the_band_is_rejected(self):
+        """A gain over the band is outside what the fit itself can emit."""
+        raw = {"tau_room_min": 240.0, "gain_heater": 5.1}
+        assert deserialize_mpc_v2_reid(raw) is None
+
+    @pytest.mark.parametrize(
+        ("tau_room_min", "gain_heater"),
+        [
+            (TAU_ROOM_BOUNDS_MIN[0], GAIN_HEATER_BOUNDS[0]),
+            (TAU_ROOM_BOUNDS_MIN[1], GAIN_HEATER_BOUNDS[1]),
+        ],
+    )
+    def test_band_edges_are_kept(self, tau_room_min, gain_heater):
+        """The band is inclusive, so a value the fit can emit still restores."""
+        raw = {"tau_room_min": tau_room_min, "gain_heater": gain_heater}
         reid = deserialize_mpc_v2_reid(raw)
         assert reid is not None
-        assert reid.tau_room_min == 5e-324
+        assert reid.tau_room_min == tau_room_min
+        assert reid.gain_heater == gain_heater
+
+    def test_out_of_band_entry_is_absent_after_a_full_load(self):
+        """The rejected entry leaves no key behind and spares its neighbour."""
+        raw = _serialize(RuntimeState())
+        raw["mpc_v2_reid"] = {
+            "good": {"tau_room_min": 240.0, "gain_heater": 3.0},
+            "bad": {"tau_room_min": 5e-324, "gain_heater": 3.0},
+        }
+        restored = _deserialize(raw)
+        assert "bad" not in restored.mpc_v2_reid
+        assert restored.mpc_v2_reid["good"].tau_room_min == 240.0
 
     def test_infinite_segment_count_falls_back_to_zero(self):
         """An unconvertible segment count must not abort the whole load."""


### PR DESCRIPTION
## What

`deserialize_mpc_v2_reid` gated a restored re-identification result only on sign — `tau_room_min <= 0.0 or gain_heater <= 0.0`. Magnitude was unbounded, so a positive but implausible value reached `PlantParams`, and `plant.py` divides the room dynamics by `tau_room_min` unclamped.

The gate is now two-sided on both parameters, and the band each is measured against is the one the repo already encoded — moved to a single place.

## The defect, executed

Driven through the real dispatcher `_compute_mpc_v2_balance`, not through helper calls: the poisoned entry is built as a store payload, put through `json.dumps`/`json.loads`, restored by the production `_deserialize`, and then read back by the dispatcher. 30 cycles, `FakeClock` advancing 300 s per cycle, the room integrated closed-loop by `PlantModelRC2` on the default envelope (outdoor 5 °C, target 21.0 °C, start 20.0 °C):

| stored `tau_room_min` | valve, all 30 cycles | room 20.00 °C → |
|---|---|---|
| `5e-324` | 100 % on every cycle | 23.48 °C, still climbing, past target |
| `1e-9` | 0 % on every cycle | 16.05 °C |
| `1e300` | 0 % on every cycle | 16.05 °C |
| `240.0` (control, in band) | 45 % on every cycle | 21.36 °C |

Two honesty notes on this table, because the numbers are weaker than the contract's:

- The contract's expected figure was ~44.85 °C. My closed-loop room is the default `PlantParams` envelope, whose 100 %-valve equilibrium at 5 °C outdoor is bounded around 29 °C, so 44.85 °C is not reachable in it. The *qualitative* finding reproduces exactly — valve pinned to a rail for every one of the 30 cycles, room driven the wrong side of target, no recovery — the magnitude does not. I did not chase the contract's number; I am reporting mine.
- The mirror cases are `≤5 %` in the sense of `0 %` on every cycle, which is what I measured.

**No self-healing.** Handing `run_reid_fit` 300 samples of exactly the pinned-valve trajectory (u = 1.0 throughout, room integrated by the true envelope) returns `status=insufficient_data`, `n_segments=1`, `tau_room_min=None`. With the valve pinned there are no idle stretches to cut a second segment from, so the fit can never produce a replacement result.

## The fix

`deserialize_mpc_v2_reid` **rejects** — returns `None` — an entry whose `tau_room_min` or `gain_heater` falls outside its band, inclusive at both ends. Rejection, not clamping: this deserialiser's contract is already that a corrupt entry is left out so the prior lookup moves on to the heat-loss-derived prior. Clamping would silently promote a nonsense stored value to the edge of the plausible band and present it as a learned result.

## No number is invented

The band existed in three places: `reid.py` (two module constants), and `params.py`, which restated `60.0`/`2000.0` as literals inside `make_plant_prior`. Both constants now live next to `PlantParams` in `mpc_v2_internals/plant.py`; `reid.py`, `params.py` and `state_manager.py` import them and the literal copy is gone. Three drift-guard tests pin the single source: the two identity assertions fail if a module reintroduces its own copy (equal-but-not-identical), and the `make_plant_prior` test fails if the band moves and `params.py` does not follow — all three verified by mutation.

**Import cycle checked before committing, as required.** `plant.py` imports only `dataclasses`, `numpy` and its sibling `._types` — nothing upward — and each of the five affected modules imports cleanly as the first import in a fresh interpreter. `state_manager.py` already depended on `calibration.mpc_v2.reid`, so no new dependency direction is introduced. The constants stayed in `plant.py`; no fallback location was needed.

## Reachability — stated plainly

The only writer is `adopt_mpc_v2_reid`, fed only by `run_reid_fit`. Its fitted emission goes through `_params_from_x`, which clamps to these very bounds. So reaching the read-side gate normally requires a hand-edited or foreign `.storage` file.

What justifies the gate anyway is the repo's own merged convention of re-applying a magnitude bound at read time even where the writer clamps: `clamped_thermal()` re-clamps `heating_power` / `heat_loss_rate` that `thermal_learning.py` already clamped on write, and `restore.py` and `helpers.py` clamp them a third and fourth time.

One executed qualification I did not expect and am reporting rather than hiding: `run_reid_fit` has **one** unclamped emission path. When the holdout segment is a cool-down (`holdout_max_u <= u_idle_frac`) it substitutes `gain_heater=prior.gain_heater` verbatim, because a cool-down cannot validate a gain. Executed against the existing `_generate_day(_TRUTH)` fixture:

```
prior tau=480.0 gain=2.0  -> status=accepted gain=2.0   gain_in_band=True
prior tau=480.0 gain=99.0 -> status=accepted gain=99.0  gain_in_band=False
```

So an out-of-band *prior* gain is re-emitted and re-persisted with `status=accepted`. Priors come from `PLANT_PRESETS` (gain 2.0), `make_plant_prior` (gain 2.0), or a previously restored re-ID result — and it is that last source the new gate closes. Without the gate, a hand-edited out-of-band gain would keep re-adopting and rewriting itself on every cool-down holdout instead of being replaced. This does not make the entry reachable without a hand-edited store in the first place; it means the gate is what stops one from becoming self-sustaining.

## Contract item 3

`test_tiny_positive_time_constant_is_not_rejected` was the single blocker. It is inverted, docstring included — the old docstring ("The guards cover finiteness and sign; magnitude is unbounded") stated the gap as intended behaviour.

## Tests

Added: four band-rejection tests, a parametrised inclusive-edge test (2 rows), a full-load test showing the rejected entry leaves no key behind while its neighbour survives, a dispatcher-level test that the out-of-band entry never reaches the controller (AUTO falls back to the 750 min heat-loss prior and the valve leaves both rails), and three drift-guard tests.

`uv run pytest tests/ -q` → 4312 passed (baseline 4302). `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyrefly check` → clean, 0 errors.

## No develop counterpart

`git grep -n "deserialize_mpc_v2_reid" origin/develop -- custom_components` returns nothing. The re-identification store and `mpc_v2_internals` exist only on `v2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MPC v2 calibration by enforcing plausible bounds for room time constants and heater gains.
  - Invalid persisted calibration values are now discarded during state restoration, allowing safe fallback behavior.
  - Boundary values remain accepted while out-of-range values are rejected.

- **Tests**
  - Added coverage for calibration bounds, state restoration, prior derivation, and controller behavior with invalid stored data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->