### PR TITLE
chore(helpers): read a published setpoint step through one shared rule

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -21,7 +21,6 @@ from homeassistant.components.climate.const import (
     ATTR_MIN_TEMP,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
-    ATTR_TARGET_TEMP_STEP,
     PRESET_ACTIVITY,
     PRESET_AWAY,
     PRESET_BOOST,
@@ -147,6 +146,7 @@ from .utils.helpers import (
     is_reasonable_temperature,
     normalize_hvac_mode,
     normalize_step,
+    reported_setpoint_step_celsius,
     resolve_inbound_setpoint,
     state_temperature_unit,
 )
@@ -326,20 +326,15 @@ def _target_temp_step_celsius(
 ) -> float | None:
     """Read a child's own setpoint step and return it as a Celsius delta.
 
-    A child publishes its step in its own unit, so a Fahrenheit child's step is
-    scaled as a temperature difference (5/9) rather than run through the
-    absolute Fahrenheit-to-Celsius conversion.
+    ``None`` stays ``None``: a child that publishes no convertible step
+    contributes nothing, which is what lets the callers tell "no child told us
+    anything" apart from a step that was read off a child. The positive-step
+    fallback that ``device_setpoint_step`` applies on top of the same rule is
+    deliberately not applied here.
     """
-    attributes = state.attributes if state is not None else {}
-    raw_step = attributes.get(ATTR_TARGET_TEMP_STEP)
-    if raw_step is None:
-        return None
-    step = convert_to_float(str(raw_step), device_name, "_target_temp_step_celsius")
-    if step is None:
-        return None
-    if state_temperature_unit(attributes, system_unit) == UnitOfTemperature.FAHRENHEIT:
-        return round(step * 5.0 / 9.0, 4)
-    return step
+    return reported_setpoint_step_celsius(
+        state, device_name, system_unit, "_target_temp_step_celsius"
+    )
 
 
 class BetterThermostat(ClimateEntity, RestoreEntity, ABC):

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -9,7 +9,11 @@ import math
 import re
 from typing import Any, NamedTuple
 
-from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
+from homeassistant.components.climate.const import (
+    ATTR_TARGET_TEMP_STEP,
+    ClimateEntityFeature,
+    HVACMode,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_NAME,
@@ -694,6 +698,56 @@ def normalize_step(value: float | int | str | None, fallback: float = 0.5) -> fl
     return step
 
 
+def reported_setpoint_step_celsius(
+    state: State | None, device_name: str, system_unit: str | None, log_source: str
+) -> float | None:
+    """Return the setpoint step a state publishes, as a Celsius delta.
+
+    This is the unit rule and nothing else. A device publishes its step in its
+    own unit, so a Fahrenheit step is scaled as a temperature difference (5/9)
+    rather than run through the absolute Fahrenheit-to-Celsius conversion. The
+    unit is resolved from the same attributes mapping the step was read from,
+    because that is the device the step belongs to.
+
+    ``None`` means the state publishes no convertible step. A missing attribute
+    and an attribute holding ``None`` are the same case and are not logged; a
+    value that fails conversion is logged by ``convert_to_float``. Sign and
+    magnitude are not judged and no fallback is applied, so a caller that needs
+    a usable positive step supplies its own.
+
+    Parameters
+    ----------
+    state : State | None
+            the device state carrying the reported ``target_temp_step``, or
+            None when the state is missing
+    device_name : str
+            the Better Thermostat instance name, for logging context
+    system_unit : str | None
+            the configured system temperature unit, used when the attributes
+            name no unit of their own
+    log_source : str
+            caller name, forwarded to convert_to_float for logging context
+
+    Returns
+    -------
+    float | None
+            the reported step as a Celsius delta, or None when the state
+            publishes no convertible step
+    """
+    attributes = state.attributes if state is not None else {}
+    raw_step = attributes.get(ATTR_TARGET_TEMP_STEP)
+    if raw_step is None:
+        return None
+    # The raw value is stringified before conversion, which is what makes a
+    # boolean fail: ``float(True)`` is 1.0, while ``float("True")`` raises.
+    step = convert_to_float(str(raw_step), device_name, log_source)
+    if step is None:
+        return None
+    if state_temperature_unit(attributes, system_unit) == UnitOfTemperature.FAHRENHEIT:
+        return round(step * 5.0 / 9.0, 4)
+    return step
+
+
 def device_setpoint_step(self, state: State, log_source: str) -> float:
     """Return a controlled device's setpoint step as a °C delta.
 
@@ -717,20 +771,9 @@ def device_setpoint_step(self, state: State, log_source: str) -> float:
     float
             the device's setpoint step as a positive Celsius delta
     """
-    raw_step = state.attributes.get("target_temp_step")
-    step = (
-        convert_to_float(str(raw_step), self.device_name, log_source)
-        if raw_step is not None
-        else None
+    step = reported_setpoint_step_celsius(
+        state, self.device_name, self.hass.config.units.temperature_unit, log_source
     )
-    if (
-        step is not None
-        and state_temperature_unit(
-            state.attributes, self.hass.config.units.temperature_unit
-        )
-        == UnitOfTemperature.FAHRENHEIT
-    ):
-        step = round(step * 5.0 / 9.0, 4)
     if step is None or step <= 0:
         return normalize_step(self.bt_target_temp_step)
     return step

--- a/tests/unit/test_climate_temp_range.py
+++ b/tests/unit/test_climate_temp_range.py
@@ -5,6 +5,7 @@ restrictive bounds across TRVs, Fahrenheit conversion (with step treated as a
 delta), the non-overlapping-range warning, and the step-already-set guard.
 """
 
+import logging
 from unittest.mock import MagicMock
 
 from homeassistant.components.climate.const import (
@@ -17,6 +18,8 @@ from homeassistant.core import State
 import pytest
 
 from custom_components.better_thermostat.climate import BetterThermostat
+
+HELPERS_LOGGER = "custom_components.better_thermostat.utils.helpers"
 
 
 @pytest.fixture
@@ -104,6 +107,26 @@ def test_existing_step_not_overwritten(bt):
     states = [_trv(step=1.0)]
     BetterThermostat._resolve_temperature_range(bt, states)
     assert bt.bt_target_temp_step == 0.25
+
+
+def test_children_without_a_step_leave_the_aggregate_unset(bt):
+    """A child that publishes no step contributes nothing to the aggregate.
+
+    ``None`` here means "no child told us anything", which the startup path
+    reads differently from a step that was aggregated from the children, so a
+    default step must not be invented at this point.
+    """
+    states = [_trv(min_t=5.0, max_t=30.0, eid="climate.a")]
+    BetterThermostat._resolve_temperature_range(bt, states)
+    assert bt.bt_target_temp_step is None
+
+
+def test_unconvertible_child_step_is_logged_against_the_reader(bt, caplog):
+    """An unreadable step yields no aggregate and names the reading site."""
+    with caplog.at_level(logging.DEBUG, logger=HELPERS_LOGGER):
+        BetterThermostat._resolve_temperature_range(bt, [_trv(step="abc")])
+    assert bt.bt_target_temp_step is None
+    assert "_target_temp_step_celsius" in caplog.text
 
 
 def test_empty_states_yield_none(bt):

--- a/tests/unit/test_helpers_inbound_setpoint.py
+++ b/tests/unit/test_helpers_inbound_setpoint.py
@@ -1,5 +1,7 @@
 """Tests for the shared inbound-setpoint boundary in utils/helpers.py."""
 
+from decimal import Decimal
+import logging
 from unittest.mock import Mock
 
 from homeassistant.const import UnitOfTemperature
@@ -14,12 +16,14 @@ from custom_components.better_thermostat.utils.helpers import (
     device_setpoint_step,
     normalize_step,
     read_setpoint_celsius,
+    reported_setpoint_step_celsius,
     resolve_inbound_setpoint,
     resolve_state_change_event,
     setpoint_echo_window,
 )
 
 ENTITY_ID = "climate.device"
+HELPERS_LOGGER = "custom_components.better_thermostat.utils.helpers"
 
 
 def _fake_self(unit=UnitOfTemperature.CELSIUS):
@@ -109,6 +113,65 @@ class TestNormalizeStep:
         assert normalize_step(float("nan")) == 0.5
         assert normalize_step(float("inf")) == 0.5
         assert normalize_step(float("-inf")) == 0.5
+
+
+class TestReportedSetpointStepCelsius:
+    """The shared unit rule behind both setpoint-step readers."""
+
+    def test_missing_attribute_and_explicit_none_are_the_same_case(self, caplog):
+        """Neither shape publishes a step, and neither is worth logging."""
+        with caplog.at_level(logging.DEBUG, logger=HELPERS_LOGGER):
+            missing = reported_setpoint_step_celsius(_state({}), "bt", "°C", "t")
+            explicit = reported_setpoint_step_celsius(
+                _state({"target_temp_step": None}), "bt", "°C", "t"
+            )
+        assert missing is None
+        assert explicit is None
+        assert caplog.records == []
+
+    def test_non_positive_step_is_returned_unjudged(self):
+        """The rule reads the unit only; sign belongs to the caller."""
+        assert reported_setpoint_step_celsius(
+            _state({"target_temp_step": 0}), "bt", "°C", "t"
+        ) == pytest.approx(0.0)
+        assert reported_setpoint_step_celsius(
+            _state({"target_temp_step": -1}), "bt", "°C", "t"
+        ) == pytest.approx(-1.0)
+
+    def test_fahrenheit_step_is_scaled_as_a_delta(self):
+        """A °F step is a temperature difference, not an absolute reading."""
+        step = reported_setpoint_step_celsius(
+            _state({"target_temp_step": 2.0}), "bt", UnitOfTemperature.FAHRENHEIT, "t"
+        )
+        assert step == round(2.0 * 5.0 / 9.0, 4)
+
+    def test_unit_is_read_from_the_same_attributes_as_the_step(self):
+        """A state that names its own unit is read in that unit."""
+        state = _state({"target_temp_step": 2.0, "temperature_unit": "°F"})
+        step = reported_setpoint_step_celsius(
+            state, "bt", UnitOfTemperature.CELSIUS, "t"
+        )
+        assert step == round(2.0 * 5.0 / 9.0, 4)
+
+    def test_boolean_does_not_convert(self):
+        """A boolean is not a step; stringifying it keeps it out."""
+        for raw in (True, False):
+            state = _state({"target_temp_step": raw})
+            assert reported_setpoint_step_celsius(state, "bt", "°C", "t") is None
+
+    def test_decimal_converts(self):
+        """A Decimal published by an integration is a usable step."""
+        state = _state({"target_temp_step": Decimal("0.5")})
+        assert reported_setpoint_step_celsius(state, "bt", "°C", "t") == 0.5
+
+    def test_log_source_names_the_caller(self, caplog):
+        """An unconvertible step is logged against the site that read it."""
+        with caplog.at_level(logging.DEBUG, logger=HELPERS_LOGGER):
+            result = reported_setpoint_step_celsius(
+                _state({"target_temp_step": "abc"}), "bt", "°C", "my_caller()"
+            )
+        assert result is None
+        assert "my_caller()" in caplog.text
 
 
 class TestDeviceSetpointStep:


### PR DESCRIPTION
## Motivation:

`_target_temp_step_celsius` in `climate.py` and `device_setpoint_step` in `utils/helpers.py`
were two copies of the same unit rule: same attribute, same conversion, same 5/9 Fahrenheit
delta. Two copies of a unit rule drift, and this project has been bitten by exactly that
before (#2029, fixed in #2043: a Fahrenheit conversion applied in one place and not in
another).

## Changes:

## What

`_target_temp_step_celsius` (climate.py) and `device_setpoint_step`
(utils/helpers.py) each carried their own copy of the same rule for reading a
device's published `target_temp_step` and turning it into a Celsius delta.
This extracts that rule into one function, `reported_setpoint_step_celsius`,
and makes both existing names thin wrappers over it.

The shared rule is the unit rule and nothing else: no sign check, no
finiteness check, no fallback.

- `_target_temp_step_celsius` keeps its three-positional signature and its
  hardcoded log source, so both of its call sites and their debug output are
  untouched.
- `device_setpoint_step` keeps its signature, its docstring, and — this is the
  part that must not be shared — its own
  `if step is None or step <= 0: return normalize_step(self.bt_target_temp_step)`.

## Why not simply let one delegate to the other

Because they are not the same function. Over the grid below, the two disagree
on **198 of 324** rows. `device_setpoint_step` needs a usable positive step or
it cannot size an echo window, so it falls back. `_target_temp_step_celsius`
must be able to return `None`, because `_resolve_temperature_range` uses
`None` to mean "no child told us anything" — folding the fallback in would
turn `bt_target_temp_step = None` into `0.5` for every install whose children
publish no step. That is a behaviour change, not a de-duplication.

Two new tests in `tests/unit/test_climate_temp_range.py` pin exactly that, and
they were verified to fail against a version that does delegate naively:

```
2 failed, 55 passed
FAILED test_climate_temp_range.py::test_children_without_a_step_leave_the_aggregate_unset
FAILED test_climate_temp_range.py::test_unconvertible_child_step_is_logged_against_the_reader
```

## Behaviour: proven unchanged

A 324-row grid crosses system unit {°C, °F} x the state's own unit attribute
{absent, °C, °F} x raw published step {missing attribute, `None`, `""`,
`"abc"`, `0`, `-1`, `0.1`, `0.5`, `1.0`, `2.5`, `nan`, `inf`, `-inf`,
`Decimal("0.5")`, `int 1`, `True`, `False`, `"0.5"`} x configured BT step
{`None`, `0.1`, `0.5`}. For each row it records the return value of both
functions **and** every log record emitted at DEBUG. Run against the tree
before and after:

```
crossed grid rows compared: 324   mismatches: 0
```

Return values and log records are identical, row for row.

One input outside that grid does change: `device_setpoint_step(self, None,
...)` previously raised `AttributeError`, and now returns the configured
fallback. Its parameter is annotated `state: State` and neither call site can
reach it — `trigger_cooler_change` gets its state from
`resolve_state_change_event`, which returns `None` unless both states are real
`State` objects, and `_seed_cool_target_from_cooler` returns early on
`cooler_state is None`. Stated for completeness, not claimed as a fix.

Three decisions in the shared rule are load-bearing and are documented in it:

- The attribute key is `ATTR_TARGET_TEMP_STEP`. `device_setpoint_step` used
  the bare string literal `"target_temp_step"` here; the constant has the same
  value, and the grid confirms no row moved.
- A missing attribute and an attribute holding `None` are the same case:
  `None`, no log.
- The raw value is stringified before `convert_to_float`. That is what makes
  `True`/`False` fail conversion (`float(True)` is 1.0, `float("True")`
  raises) while `Decimal("0.5")` still succeeds. Removing the `str()` moves
  12 grid rows.

## Tests

Nine added: seven for the shared rule in
`tests/unit/test_helpers_inbound_setpoint.py`, two for the aggregate in
`tests/unit/test_climate_temp_range.py`. Each was mutation-checked by deleting
or corrupting the single guard it claims to cover; all but one fail as
expected. The exception is reported rather than hidden:
`test_missing_attribute_and_explicit_none_are_the_same_case` stays green when
the `if raw_step is None: return None` early return is deleted, because
`convert_to_float(str(None))` short-circuits on the literal string `"None"`
and returns `None` without logging. The guard is kept as the clearest
statement of the rule, but it is not independently pinned by that test.

Gate: `2369 passed` (2360 before + 9 new), `ruff check` and
`ruff format --check` clean.

## Reported separately, deliberately not fixed here

`_resolve_temperature_range` appends every non-`None` step a child publishes
to the aggregate without a positivity check, so a child publishing
`target_temp_step: 0` or a negative value puts that value into
`bt_target_temp_step` when no other child publishes a positive one (`max()`
masks it otherwise). Executed:

```
child publishes target_temp_step=     0 -> bt_target_temp_step=   0.0  entity target_temperature_step=0.0
child publishes target_temp_step=    -1 -> bt_target_temp_step=  -1.0  entity target_temperature_step=-1.0
mixed (-1 and 0.5)                      -> bt_target_temp_step=   0.5
```

Most consumers re-guard with `normalize_step(...)` or an explicit `> 0.0`
test. Two do not: the `target_temperature_step` property publishes the value
to Home Assistant verbatim, and `number.py`'s cooling-preset writer uses
`bt_target_temp_step or 0.5`, which catches `0.0` but not a negative — driven
through `async_set_native_value`, a `-1.0` aggregate stores a cooling preset
*below* the heating target (`heat=21.0`, requested `cool=20.0`, stored
`cool=20.0` instead of `21.5`). Fixing that needs a decision on where the
bound belongs, so it is left out of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat temperature-step handling across Celsius and Fahrenheit devices.
  * Correctly handles missing, null, invalid, non-positive, and unsupported step values without applying misleading defaults.
  * Improved diagnostics when reported temperature steps cannot be interpreted.

* **Tests**
  * Added coverage for unit conversion, decimal values, boolean rejection, missing data, and invalid child settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

Not tested on hardware. The evidence in this PR is unit-level and executed: the full suite plus the
targeted reproductions quoted above, driven against mocked Home Assistant objects. No real TRV,
cooler or Home Assistant instance was involved, so the fields below are left blank rather than
filled with values that were never observed.

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

No new device mapping is added by this PR.

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

This PR does change `climate.py`, but it adds no device mapping — the checkbox above targets
new-mapping PRs, and the dedicated-PR rule it refers to is about mappings, not about this kind
of change.
