### PR TITLE
fix(cooler): surface an unavailable cooler through degraded mode

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2018,6 +2018,14 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             "better_thermostat %s: finding battery entities...", self.device_name
         )
 
+        # The battery scan below reads all_entities, so every configured
+        # device has to be registered before it runs. The cooler and the
+        # outdoor sensor are the two that no earlier init step registers.
+        if self.cooler_entity_id is not None:
+            self.all_entities.append(self.cooler_entity_id)
+        if self.outdoor_sensor is not None:
+            self.all_entities.append(self.outdoor_sensor)
+
         # try to find battery entities for all related entities
         for entity in self.all_entities:
             if entity is not None:
@@ -2033,7 +2041,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         # Add listener
         if self.outdoor_sensor is not None:
-            self.all_entities.append(self.outdoor_sensor)
             self.async_on_remove(
                 async_track_time_change(self.hass, self._trigger_time, 5, 0, 0)
             )

--- a/custom_components/better_thermostat/utils/watcher.py
+++ b/custom_components/better_thermostat/utils/watcher.py
@@ -154,6 +154,10 @@ def get_optional_sensors(self) -> list:
     Optional sensors are those that can be unavailable without
     blocking thermostat operation (degraded mode).
 
+    The cooler belongs here too: while it is unavailable the heating
+    side keeps running, so the outage has no other visible symptom and
+    degraded mode is the only thing that surfaces it.
+
     Returns
     -------
     list
@@ -170,6 +174,10 @@ def get_optional_sensors(self) -> list:
         optional.append(self.outdoor_sensor)
     if getattr(self, "weather_entity", None):
         optional.append(self.weather_entity)
+    # An actuator rather than a sensor, watched on the same terms because
+    # its loss leaves the thermostat running.
+    if getattr(self, "cooler_entity_id", None):
+        optional.append(self.cooler_entity_id)
     return optional
 
 

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -43,6 +43,7 @@ COOLER_ID = "climate.cooler"
 WINDOW_ID = "binary_sensor.window"
 DOOR_ID = "binary_sensor.door"
 HUMIDITY_ID = "sensor.humidity"
+OUTDOOR_ID = "sensor.outdoor_temp"
 
 
 # ---------------------------------------------------------------------------
@@ -1062,6 +1063,71 @@ class TestFinalizeStartupCoolerReread:
 
         assert bt.bt_target_cooltemp == 24.0
         assert "Could not convert 'n/a' to float in _finalize_startup()" in caplog.text
+
+
+class TestFinalizeStartupBatteryScan:
+    """The battery scan covers every configured device.
+
+    It reads ``all_entities``, so a device registered after the scan is
+    never asked for a battery entity at all.
+    """
+
+    @staticmethod
+    async def _scan(bt):
+        """Run _finalize_startup and return the entity IDs the scan visited."""
+        scanned: list[str] = []
+
+        async def spy(_self, entity_id, _visited=None):
+            scanned.append(entity_id)
+            return f"sensor.{entity_id.split('.')[-1]}_battery"
+
+        with patch(
+            "custom_components.better_thermostat.climate.find_battery_entity", new=spy
+        ):
+            await _run_finalize_startup(bt)
+        return scanned
+
+    @pytest.mark.asyncio
+    async def test_scan_reaches_the_cooler(self):
+        """A configured cooler is asked for its battery entity."""
+        bt = _make_finalize_bt()
+        bt.devices_states = {}
+        bt.hass.states.get.return_value = State(
+            COOLER_ID, "cool", {"temperature": 24.0}
+        )
+
+        scanned = await self._scan(bt)
+
+        assert COOLER_ID in scanned
+        assert bt.devices_states[COOLER_ID]["battery_id"] == "sensor.cooler_battery"
+
+    @pytest.mark.asyncio
+    async def test_scan_reaches_the_outdoor_sensor(self):
+        """A configured outdoor sensor is asked for its battery entity."""
+        bt = _make_finalize_bt()
+        bt.cooler_entity_id = None
+        bt.outdoor_sensor = OUTDOOR_ID
+        bt.devices_states = {}
+
+        scanned = await self._scan(bt)
+
+        assert OUTDOOR_ID in scanned
+        assert (
+            bt.devices_states[OUTDOOR_ID]["battery_id"] == "sensor.outdoor_temp_battery"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_devices_are_not_scanned(self):
+        """Nothing is registered for a cooler or outdoor sensor that is absent."""
+        bt = _make_finalize_bt()
+        bt.cooler_entity_id = None
+        bt.outdoor_sensor = None
+        bt.devices_states = {}
+
+        scanned = await self._scan(bt)
+
+        assert scanned == []
+        assert bt.all_entities == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -43,6 +43,8 @@ def mock_bt_instance(mock_hass):
     # MagicMock would auto-create a truthy attribute; the default fixture has
     # no door sensor configured.
     bt.door_id = None
+    # Same reason as door_id: the default fixture has no cooler configured.
+    bt.cooler_entity_id = None
     bt.humidity_sensor_entity_id = "sensor.humidity"
     bt.outdoor_sensor = "sensor.outdoor_temp"
     bt.weather_entity = "weather.home"
@@ -191,6 +193,40 @@ class TestGetOptionalSensors:
 
         assert "binary_sensor.door" in result
         assert len(result) == 5
+
+    def test_includes_the_cooler_when_configured(self, mock_bt_instance):
+        """A configured cooler is watched like the optional sensors.
+
+        The heating side keeps running while the cooler is gone, so
+        degraded mode is the only thing that surfaces the outage.
+        """
+        from custom_components.better_thermostat.utils.watcher import (
+            get_optional_sensors,
+        )
+
+        mock_bt_instance.cooler_entity_id = "climate.ac"
+
+        result = get_optional_sensors(mock_bt_instance)
+
+        assert "climate.ac" in result
+        assert len(result) == 5
+
+    def test_excludes_the_cooler_when_not_configured(self, mock_bt_instance):
+        """Without a cooler the optional list stays unchanged."""
+        from custom_components.better_thermostat.utils.watcher import (
+            get_optional_sensors,
+        )
+
+        mock_bt_instance.cooler_entity_id = None
+
+        result = get_optional_sensors(mock_bt_instance)
+
+        assert result == [
+            "binary_sensor.window",
+            "sensor.humidity",
+            "sensor.outdoor_temp",
+            "weather.home",
+        ]
 
     def test_excludes_door_sensor_when_not_configured(self, mock_bt_instance):
         """Without a door sensor the optional list stays unchanged."""
@@ -777,6 +813,134 @@ class TestDegradedModeGracePeriod:
                 await check_and_update_degraded_mode(mock_bt_instance)
 
         assert not any("Entering degraded mode" in r.message for r in caplog.records)
+        assert not mock_ir.async_create_issue.called
+
+
+class TestCoolerDegradedMode:
+    """A cooler that goes unavailable is annunciated as degraded mode.
+
+    Losing the cooler leaves the heating side running, so nothing else in
+    the system reacts to the outage.
+    """
+
+    COOLER = "climate.ac"
+
+    @staticmethod
+    def _arm_grace(bt, delta):
+        """Set the degraded-mode grace deadline to ``now + delta``."""
+        from homeassistant.util import dt as dt_util
+
+        bt._degraded_grace_until = dt_util.now() + delta
+
+    @staticmethod
+    def _only_dead(unavailable_id):
+        """Build a states.get side effect where one entity is unavailable."""
+
+        def mock_get(entity_id):
+            state = MagicMock()
+            state.state = "unavailable" if entity_id == unavailable_id else "20.0"
+            return state
+
+        return mock_get
+
+    @pytest.mark.anyio
+    async def test_dead_cooler_enters_degraded_mode(self, mock_bt_instance, caplog):
+        """The outage raises the same WARNING repair as an optional sensor."""
+        from datetime import timedelta
+
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        mock_bt_instance.cooler_entity_id = self.COOLER
+        mock_bt_instance.hass.states.get.side_effect = self._only_dead(self.COOLER)
+        self._arm_grace(mock_bt_instance, timedelta(minutes=-1))
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("WARNING"):
+                result = await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert result is True
+        assert self.COOLER in mock_bt_instance.unavailable_sensors
+        assert any("Entering degraded mode" in r.message for r in caplog.records)
+        kwargs = mock_ir.async_create_issue.call_args.kwargs
+        assert kwargs["issue_id"] == "degraded_mode_Test Thermostat"
+        assert kwargs["severity"] is mock_ir.IssueSeverity.WARNING
+
+    @pytest.mark.anyio
+    async def test_dead_cooler_is_silent_during_the_grace_window(
+        self, mock_bt_instance, caplog
+    ):
+        """The startup grace window defers the annunciation, as for the sensors."""
+        from datetime import timedelta
+
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        mock_bt_instance.cooler_entity_id = self.COOLER
+        mock_bt_instance.hass.states.get.side_effect = self._only_dead(self.COOLER)
+        self._arm_grace(mock_bt_instance, timedelta(minutes=5))
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("WARNING"):
+                result = await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert result is True
+        assert self.COOLER in mock_bt_instance.unavailable_sensors
+        assert not any("Entering degraded mode" in r.message for r in caplog.records)
+        assert not mock_ir.async_create_issue.called
+        assert mock_bt_instance._degraded_warning_emitted is False
+
+    @pytest.mark.anyio
+    async def test_recovered_cooler_clears_the_repair_issue(
+        self, mock_bt_instance, caplog
+    ):
+        """A cooler that comes back leaves degraded mode and deletes the issue."""
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        mock_bt_instance.cooler_entity_id = self.COOLER
+        available = MagicMock()
+        available.state = "cool"
+        mock_bt_instance.hass.states.get.return_value = available
+        mock_bt_instance._degraded_warning_emitted = True
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("INFO"):
+                result = await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert result is False
+        assert mock_bt_instance.unavailable_sensors == []
+        assert any("Exiting degraded mode" in r.message for r in caplog.records)
+        assert (
+            mock_ir.async_delete_issue.call_args.args[-1]
+            == "degraded_mode_Test Thermostat"
+        )
+        assert mock_bt_instance._degraded_warning_emitted is False
+
+    @pytest.mark.anyio
+    async def test_dead_cooler_is_not_a_critical_entity(self, mock_bt_instance):
+        """The cooler stays out of the repair path that reports lost control.
+
+        ``check_critical_entities`` reads the TRVs only; a dead cooler
+        neither fails that check nor raises a ``missing_entity`` repair.
+        """
+        from custom_components.better_thermostat.utils.watcher import (
+            check_critical_entities,
+            get_critical_entities,
+        )
+
+        mock_bt_instance.cooler_entity_id = self.COOLER
+        mock_bt_instance.hass.states.get.side_effect = self._only_dead(self.COOLER)
+
+        assert self.COOLER not in get_critical_entities(mock_bt_instance)
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            result = await check_critical_entities(mock_bt_instance)
+
+        assert result is True
         assert not mock_ir.async_create_issue.called
 
 

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -843,7 +843,7 @@ class TestCoolerDegradedMode:
 
         return mock_get
 
-    @pytest.mark.anyio
+    @pytest.mark.asyncio
     async def test_dead_cooler_enters_degraded_mode(self, mock_bt_instance, caplog):
         """The outage raises the same WARNING repair as an optional sensor."""
         from datetime import timedelta
@@ -867,7 +867,7 @@ class TestCoolerDegradedMode:
         assert kwargs["issue_id"] == "degraded_mode_Test Thermostat"
         assert kwargs["severity"] is mock_ir.IssueSeverity.WARNING
 
-    @pytest.mark.anyio
+    @pytest.mark.asyncio
     async def test_dead_cooler_is_silent_during_the_grace_window(
         self, mock_bt_instance, caplog
     ):
@@ -892,7 +892,7 @@ class TestCoolerDegradedMode:
         assert not mock_ir.async_create_issue.called
         assert mock_bt_instance._degraded_warning_emitted is False
 
-    @pytest.mark.anyio
+    @pytest.mark.asyncio
     async def test_recovered_cooler_clears_the_repair_issue(
         self, mock_bt_instance, caplog
     ):
@@ -920,7 +920,7 @@ class TestCoolerDegradedMode:
         )
         assert mock_bt_instance._degraded_warning_emitted is False
 
-    @pytest.mark.anyio
+    @pytest.mark.asyncio
     async def test_dead_cooler_is_not_a_critical_entity(self, mock_bt_instance):
         """The cooler stays out of the repair path that reports lost control.
 


### PR DESCRIPTION
## What this changes

A cooler that goes unavailable was watched by nothing at all, and the battery
scan at startup never reached the cooler or the outdoor sensor. Both are fixed
by the mechanism that already exists.

## The three premises, verified before writing code

**1. `check_all_entities` has zero call sites; the live repair path reads TRVs only.**

```
$ grep -rn "check_all_entities" . --include="*.py"
custom_components/better_thermostat/utils/watcher.py:122:async def check_all_entities(self) -> bool:
```

The only match is the definition. The live path is `check_critical_entities`,
which reads `get_critical_entities(self)`, and that function returns
`list(self.real_trvs.keys())` and nothing else. Registering the cooler in
`all_entities` therefore raises no `missing_entity` repair — the blocker the
original prompt assumed does not exist. Pinned by the new test
`test_dead_cooler_is_not_a_critical_entity`, which also fails if someone later
adds the cooler to `get_critical_entities`.

**2. Every consumer of `self.all_entities`, exhaustively.**

```
$ grep -rn "all_entities" custom_components/
climate.py:303   write  — window/door, via _detect_contact_open_at_startup
climate.py:699   write  — initialised to [] in __init__
climate.py:1334  write  — room temperature sensor
climate.py:1433  write  — humidity sensor
climate.py:1750  write  — each TRV
climate.py:2036  write  — outdoor sensor (after the scan; see below)
climate.py:2022  READ   — the battery-detection loop
utils/watcher.py:127 READ — check_all_entities, which has no callers
```

Two readers exist; one of them is dead code. So the *only* live effect of
adding an entity to `all_entities` is that `find_battery_entity` is called for
it, and on success `self.devices_states[entity] = {"battery_id": …, "battery":
None}`. `devices_states` is read in exactly two more places: `get_battery_status`
(refreshes the level) and `climate.py:2549`, where it is published as the
`batteries` extra state attribute. What each consumer newly sees, concretely:

- the battery loop: two more entity IDs to look up;
- the `batteries` attribute: a battery entry for the cooler and for the outdoor
  sensor, when their devices have one;
- `check_all_entities`: nothing, because nothing calls it.

**3. The outdoor sensor really is appended after the battery loop.**
Loop at `climate.py:2022`, append at `climate.py:2036` — fourteen lines later,
so the scan has already finished. Confirmed by execution against a real config
entry with a cooler and an outdoor sensor configured, spying on
`find_battery_entity`:

```
before: battery scan visited: ['climate.fake_trv', 'sensor.room_temperature']
after : battery scan visited: ['climate.fake_cooler', 'climate.fake_trv',
                               'sensor.outdoor_temp', 'sensor.room_temperature']
```

## The change

**`utils/watcher.py`** — `get_optional_sensors` returns `cooler_entity_id`.
That single line puts the cooler on exactly the terms the room sensor, the
contact sensors, the humidity sensor, the outdoor sensor and the weather entity
already use, with no new mechanism:

- `await_optional_sensors` waits for it at startup (3/5/10/15/25 s);
- the existing `STARTUP_DEGRADED_GRACE_PERIOD` (5 minutes) defers annunciation;
- one `degraded_mode_<device>` repair per BT device, `IssueSeverity.WARNING`,
  `is_fixable=False`;
- self-clearing: the issue is deleted and an INFO line logged when it returns;
- it does not gate control. `degraded_mode` is read in exactly two places, both
  of them the extra-state-attributes dict.

The existing mechanism expressed "cooler unavailable" without any modification.

**`climate.py`** — the cooler and the outdoor sensor are registered in
`all_entities` immediately before the battery scan; the outdoor sensor's append
is removed from the listener block that ran after the scan.

## Executed end to end, before and after

A real `MockConfigEntry` with a fake TRV, a fake cooler, a room sensor and an
outdoor sensor; startup awaited to completion; then `hass.states.async_remove`
on the cooler and the real `_maintenance_tick` driven (that handler calls
`check_and_update_degraded_mode`). Grace window cleared so the annunciation path
is the one observed.

Before:

```
=== after cooler removed + maintenance tick ===
degraded_mode       : False
unavailable_sensors : []
devices_errors      : []
repair issues       : []
bt entity           : heat_cool
```

After:

```
=== after cooler removed + maintenance tick ===
degraded_mode       : True
unavailable_sensors : ['climate.fake_cooler']
devices_errors      : []
repair issues       : ['degraded_mode_BT Cooler Probe']
bt entity           : heat_cool
  LOG DEBUG: … Optional sensor climate.fake_cooler is unavailable (degraded mode)
  LOG WARNING: … Entering degraded mode. Unavailable sensors: climate.fake_cooler

=== after recovery ===
degraded_mode       : False
unavailable_sensors : []
repair issues       : []
```

`bt entity: heat_cool` in both runs is the non-blocking claim: the heating side
keeps running while the cooler is gone. `devices_errors` stays empty in both,
i.e. no `missing_entity` repair — the cooler is annunciated, not treated as lost
control.

The probe was a scratch file and is not part of this PR.

## Tests

Nine new tests, each mutation-tested (delete the guard it claims to check, the
test must fail):

- `TestGetOptionalSensors::test_includes_the_cooler_when_configured`,
  `…::test_excludes_the_cooler_when_not_configured`
- `TestCoolerDegradedMode` — annunciation with WARNING severity and the correct
  issue id; silence during the startup grace window; self-clearing on recovery;
  and that the cooler never enters `get_critical_entities`
- `TestFinalizeStartupBatteryScan` — the scan reaches the cooler, reaches the
  outdoor sensor, and registers nothing when neither is configured

One test-only fixture change: `mock_bt_instance` in `tests/unit/test_watcher.py`
now sets `cooler_entity_id = None`, for the same reason `door_id` already does —
`MagicMock` would auto-create a truthy attribute.

Gate: `2369 passed` (baseline 2360), ruff check and format clean.

## Out of scope, worth a separate decision

`check_all_entities` and `check_entity` in `utils/watcher.py` have no callers on
either maintenance line. Whether to delete them is a separate question and is not
answered here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup discovery for configured cooler and outdoor temperature sensors.
  * Prevented delayed or duplicate outdoor sensor registration.
  * Improved degraded-mode monitoring for optional cooler sensors.
  * Added clearer handling of cooler warnings, recovery, grace periods, and restored operation.

* **Tests**
  * Added coverage for sensor discovery, cooler configuration, degraded operation, recovery, and excluded critical entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->