### PR TITLE
fix(cooler): surface an unavailable cooler through degraded mode

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2300,6 +2300,14 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             "better_thermostat %s: finding battery entities...", self.device_name
         )
 
+        # The battery scan below reads all_entities, so every configured
+        # device has to be registered before it runs. The cooler and the
+        # outdoor sensor are the two that no earlier init step registers.
+        if self.cooler_entity_id is not None:
+            self.all_entities.append(self.cooler_entity_id)
+        if self.outdoor_sensor is not None:
+            self.all_entities.append(self.outdoor_sensor)
+
         # try to find battery entities for all related entities
         for entity in self.all_entities:
             if entity is not None:
@@ -2315,7 +2323,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         # Add listener
         if self.outdoor_sensor is not None:
-            self.all_entities.append(self.outdoor_sensor)
             self.async_on_remove(
                 async_track_time_change(self.hass, self._trigger_time, 5, 0, 0)
             )

--- a/custom_components/better_thermostat/utils/watcher.py
+++ b/custom_components/better_thermostat/utils/watcher.py
@@ -166,6 +166,10 @@ def get_optional_sensors(self) -> list:
     other visible symptom and degraded mode is the only thing that
     surfaces it.
 
+    The cooler belongs here too: while it is unavailable the heating
+    side keeps running, so the outage has no other visible symptom and
+    degraded mode is the only thing that surfaces it.
+
     Returns
     -------
     list
@@ -182,6 +186,10 @@ def get_optional_sensors(self) -> list:
         optional.append(self.outdoor_sensor)
     if getattr(self, "weather_entity", None):
         optional.append(self.weather_entity)
+    # An actuator rather than a sensor, watched on the same terms because
+    # its loss leaves the thermostat running.
+    if getattr(self, "cooler_entity_id", None):
+        optional.append(self.cooler_entity_id)
     return optional
 
 

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -43,6 +43,7 @@ COOLER_ID = "climate.cooler"
 WINDOW_ID = "binary_sensor.window"
 DOOR_ID = "binary_sensor.door"
 HUMIDITY_ID = "sensor.humidity"
+OUTDOOR_ID = "sensor.outdoor_temp"
 
 
 # ---------------------------------------------------------------------------
@@ -66,6 +67,7 @@ def bt():
     mock.sensor_entity_id = SENSOR_ID
     mock.real_trvs = {TRV_ID: {"calibration": 1}}
     mock.cooler_entity_id = None
+    mock.outdoor_sensor = None
     mock.humidity_sensor_entity_id = None
     mock.window_id = None
     mock.door_id = None
@@ -1100,7 +1102,6 @@ async def _run_finalize_startup(bt):
     bt.is_removed = False
     bt.all_trvs = None
     bt.entity_ids = [TRV_ID]
-    bt.outdoor_sensor = None
     bt._async_unsub_state_changed = None
     # Background jobs are handed to a mocked task factory that never awaits
     # them, so they hand out plain values instead of orphaned coroutines.
@@ -1114,6 +1115,7 @@ async def _run_finalize_startup(bt):
         patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
         patch(f"{_CLIMATE}.async_track_state_change_event", MagicMock()),
         patch(f"{_CLIMATE}.async_track_time_interval", MagicMock()),
+        patch(f"{_CLIMATE}.async_track_time_change", MagicMock()),
         patch(f"{_CLIMATE}.asyncio.sleep", AsyncMock()),
     ):
         await BetterThermostat._finalize_startup(bt)
@@ -1384,6 +1386,65 @@ class TestCoolerTargetReadAtListenerRegistration:
 
         assert "Could not convert 'n/a' to float in _finalize_startup()" in caplog.text
         assert bt.bt_target_cooltemp is None
+
+
+class TestFinalizeStartupBatteryScan:
+    """The battery scan covers every configured device.
+
+    It reads ``all_entities``, so a device registered after the scan is
+    never asked for a battery entity at all.
+    """
+
+    @staticmethod
+    async def _scan(bt):
+        """Run _finalize_startup and return the entity IDs the scan visited."""
+        scanned: list[str] = []
+
+        async def spy(_self, entity_id, _visited=None):
+            scanned.append(entity_id)
+            return f"sensor.{entity_id.split('.')[-1]}_battery"
+
+        with patch(f"{_CLIMATE}.find_battery_entity", new=spy):
+            await _run_finalize_startup(bt)
+        return scanned
+
+    @pytest.mark.asyncio
+    async def test_scan_reaches_the_cooler(self, bt):
+        """A configured cooler is asked for its battery entity."""
+        bt.cooler_entity_id = COOLER_ID
+        bt.devices_states = {}
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: 24.0})})
+
+        scanned = await self._scan(bt)
+
+        assert COOLER_ID in scanned
+        assert bt.devices_states[COOLER_ID]["battery_id"] == "sensor.cooler_battery"
+
+    @pytest.mark.asyncio
+    async def test_scan_reaches_the_outdoor_sensor(self, bt):
+        """A configured outdoor sensor is asked for its battery entity."""
+        bt.cooler_entity_id = None
+        bt.outdoor_sensor = OUTDOOR_ID
+        bt.devices_states = {}
+
+        scanned = await self._scan(bt)
+
+        assert OUTDOOR_ID in scanned
+        assert (
+            bt.devices_states[OUTDOOR_ID]["battery_id"] == "sensor.outdoor_temp_battery"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_devices_are_not_scanned(self, bt):
+        """Nothing is registered for a cooler or outdoor sensor that is absent."""
+        bt.cooler_entity_id = None
+        bt.outdoor_sensor = None
+        bt.devices_states = {}
+
+        scanned = await self._scan(bt)
+
+        assert scanned == []
+        assert bt.all_entities == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_climate_trigger_degraded_order.py
+++ b/tests/unit/test_climate_trigger_degraded_order.py
@@ -40,6 +40,7 @@ def bt():
     mock.door_id = None
     mock.outdoor_sensor = None
     mock.weather_entity = None
+    mock.cooler_entity_id = None
     mock.unavailable_sensors = []
     mock._degraded_warning_emitted = False
     mock.in_maintenance = False

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -52,6 +52,8 @@ def mock_bt_instance(mock_hass):
     # MagicMock would auto-create a truthy attribute; the default fixture has
     # no door sensor configured.
     bt.door_id = None
+    # Same reason as door_id: the default fixture has no cooler configured.
+    bt.cooler_entity_id = None
     bt.humidity_sensor_entity_id = "sensor.humidity"
     bt.outdoor_sensor = "sensor.outdoor_temp"
     bt.weather_entity = "weather.home"
@@ -207,6 +209,40 @@ class TestGetOptionalSensors:
 
         assert "binary_sensor.door" in result
         assert len(result) == 5
+
+    def test_includes_the_cooler_when_configured(self, mock_bt_instance):
+        """A configured cooler is watched like the optional sensors.
+
+        The heating side keeps running while the cooler is gone, so
+        degraded mode is the only thing that surfaces the outage.
+        """
+        from custom_components.better_thermostat.utils.watcher import (
+            get_optional_sensors,
+        )
+
+        mock_bt_instance.cooler_entity_id = "climate.ac"
+
+        result = get_optional_sensors(mock_bt_instance)
+
+        assert "climate.ac" in result
+        assert len(result) == 5
+
+    def test_excludes_the_cooler_when_not_configured(self, mock_bt_instance):
+        """Without a cooler the optional list stays unchanged."""
+        from custom_components.better_thermostat.utils.watcher import (
+            get_optional_sensors,
+        )
+
+        mock_bt_instance.cooler_entity_id = None
+
+        result = get_optional_sensors(mock_bt_instance)
+
+        assert result == [
+            "binary_sensor.window",
+            "sensor.humidity",
+            "sensor.outdoor_temp",
+            "weather.home",
+        ]
 
 
 class TestGetCriticalEntities:
@@ -812,6 +848,137 @@ class TestDegradedModeGracePeriod:
                 await check_and_update_degraded_mode(mock_bt_instance)
 
         assert not any("Entering degraded mode" in r.message for r in caplog.records)
+        assert not mock_ir.async_create_issue.called
+
+
+class TestCoolerDegradedMode:
+    """A cooler that goes unavailable is annunciated as degraded mode.
+
+    Losing the cooler leaves the heating side running, so nothing else in
+    the system reacts to the outage.
+    """
+
+    COOLER = "climate.ac"
+
+    @staticmethod
+    def _arm_grace(bt, delta):
+        """Set the degraded-mode grace deadline to ``now + delta``."""
+        bt.kernel_state = replace(
+            bt.kernel_state,
+            lifecycle=LifecycleState(
+                phase=LifecyclePhase.STARTING, grace_until=bt.clock.now() + delta
+            ),
+        )
+
+    @staticmethod
+    def _only_dead(unavailable_id):
+        """Build a states.get side effect where one entity is unavailable."""
+
+        def mock_get(entity_id):
+            state = MagicMock()
+            state.state = "unavailable" if entity_id == unavailable_id else "20.0"
+            return state
+
+        return mock_get
+
+    @pytest.mark.anyio
+    async def test_dead_cooler_enters_degraded_mode(self, mock_bt_instance, caplog):
+        """The outage raises the same WARNING repair as an optional sensor."""
+        from datetime import timedelta
+
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        mock_bt_instance.cooler_entity_id = self.COOLER
+        mock_bt_instance.hass.states.get.side_effect = self._only_dead(self.COOLER)
+        self._arm_grace(mock_bt_instance, timedelta(minutes=-1))
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("WARNING"):
+                result = await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert result is True
+        assert self.COOLER in mock_bt_instance.unavailable_sensors
+        assert any("Entering degraded mode" in r.message for r in caplog.records)
+        kwargs = mock_ir.async_create_issue.call_args.kwargs
+        assert kwargs["issue_id"] == "degraded_mode_Test Thermostat"
+        assert kwargs["severity"] is mock_ir.IssueSeverity.WARNING
+
+    @pytest.mark.anyio
+    async def test_dead_cooler_is_silent_during_the_grace_window(
+        self, mock_bt_instance, caplog
+    ):
+        """The startup grace window defers the annunciation, as for the sensors."""
+        from datetime import timedelta
+
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        mock_bt_instance.cooler_entity_id = self.COOLER
+        mock_bt_instance.hass.states.get.side_effect = self._only_dead(self.COOLER)
+        self._arm_grace(mock_bt_instance, timedelta(minutes=5))
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("WARNING"):
+                result = await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert result is True
+        assert self.COOLER in mock_bt_instance.unavailable_sensors
+        assert not any("Entering degraded mode" in r.message for r in caplog.records)
+        assert not mock_ir.async_create_issue.called
+        assert mock_bt_instance._degraded_warning_emitted is False
+
+    @pytest.mark.anyio
+    async def test_recovered_cooler_clears_the_repair_issue(
+        self, mock_bt_instance, caplog
+    ):
+        """A cooler that comes back leaves degraded mode and deletes the issue."""
+        from custom_components.better_thermostat.utils.watcher import (
+            check_and_update_degraded_mode,
+        )
+
+        mock_bt_instance.cooler_entity_id = self.COOLER
+        available = MagicMock()
+        available.state = "cool"
+        mock_bt_instance.hass.states.get.return_value = available
+        mock_bt_instance._degraded_warning_emitted = True
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("INFO"):
+                result = await check_and_update_degraded_mode(mock_bt_instance)
+
+        assert result is False
+        assert mock_bt_instance.unavailable_sensors == []
+        assert any("Exiting degraded mode" in r.message for r in caplog.records)
+        assert (
+            mock_ir.async_delete_issue.call_args.args[-1]
+            == "degraded_mode_Test Thermostat"
+        )
+        assert mock_bt_instance._degraded_warning_emitted is False
+
+    @pytest.mark.anyio
+    async def test_dead_cooler_is_not_a_critical_entity(self, mock_bt_instance):
+        """The cooler stays out of the repair path that reports lost control.
+
+        ``check_critical_entities`` reads the TRVs only; a dead cooler
+        neither fails that check nor raises a ``missing_entity`` repair.
+        """
+        from custom_components.better_thermostat.utils.watcher import (
+            check_critical_entities,
+            get_critical_entities,
+        )
+
+        mock_bt_instance.cooler_entity_id = self.COOLER
+        mock_bt_instance.hass.states.get.side_effect = self._only_dead(self.COOLER)
+
+        assert self.COOLER not in get_critical_entities(mock_bt_instance)
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            result = await check_critical_entities(mock_bt_instance)
+
+        assert result is True
         assert not mock_ir.async_create_issue.called
 
 

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -881,7 +881,7 @@ class TestCoolerDegradedMode:
 
         return mock_get
 
-    @pytest.mark.anyio
+    @pytest.mark.asyncio
     async def test_dead_cooler_enters_degraded_mode(self, mock_bt_instance, caplog):
         """The outage raises the same WARNING repair as an optional sensor."""
         from datetime import timedelta
@@ -905,7 +905,7 @@ class TestCoolerDegradedMode:
         assert kwargs["issue_id"] == "degraded_mode_Test Thermostat"
         assert kwargs["severity"] is mock_ir.IssueSeverity.WARNING
 
-    @pytest.mark.anyio
+    @pytest.mark.asyncio
     async def test_dead_cooler_is_silent_during_the_grace_window(
         self, mock_bt_instance, caplog
     ):
@@ -930,7 +930,7 @@ class TestCoolerDegradedMode:
         assert not mock_ir.async_create_issue.called
         assert mock_bt_instance._degraded_warning_emitted is False
 
-    @pytest.mark.anyio
+    @pytest.mark.asyncio
     async def test_recovered_cooler_clears_the_repair_issue(
         self, mock_bt_instance, caplog
     ):
@@ -958,7 +958,7 @@ class TestCoolerDegradedMode:
         )
         assert mock_bt_instance._degraded_warning_emitted is False
 
-    @pytest.mark.anyio
+    @pytest.mark.asyncio
     async def test_dead_cooler_is_not_a_critical_entity(self, mock_bt_instance):
         """The cooler stays out of the repair path that reports lost control.
 


### PR DESCRIPTION
## Motivation:

A cooler that goes unavailable is completely silent today: no repair issue, no degraded
mode, only DEBUG lines, while Better Thermostat keeps running its heating side. For a room
whose cooling side has died in summer that outage is as invisible as a lost window sensor
was before degraded mode existed. The battery scan also never reached the cooler or the
outdoor sensor, because both are registered after the scan runs.

## Changes:

## What this changes

Same contract as the develop PR (`fix/cooler-availability-visibility`); the
production hunks are byte-identical. A cooler that goes unavailable was watched
by nothing at all, and the battery scan at startup never reached the cooler or
the outdoor sensor.

## The three premises, verified before writing code

**1. `check_all_entities` has zero call sites; the live repair path reads TRVs only.**

```
$ grep -rn "check_all_entities" . --include="*.py"
custom_components/better_thermostat/utils/watcher.py:129:async def check_all_entities(self) -> bool:
```

Definition only. The live path is `check_critical_entities`, reading
`get_critical_entities(self)` = `list(self.real_trvs.keys())`. Registering the
cooler in `all_entities` raises no `missing_entity` repair. Pinned by
`test_dead_cooler_is_not_a_critical_entity`.

**2. Every consumer of `self.all_entities`, exhaustively.**

```
climate.py:302   write  — window/door
climate.py:905   write  — initialised to []
climate.py:1558  write  — room temperature sensor
climate.py:1657  write  — humidity sensor
climate.py:1996  write  — each TRV
climate.py:2318  write  — outdoor sensor (after the scan; see below)
climate.py:2304  READ   — the battery-detection loop
utils/watcher.py:134 READ — check_all_entities, which has no callers
```

Two readers, one dead. The only live effect of a new entry is that
`find_battery_entity` is called for it and, on success, `devices_states` gains
`{"battery_id": …, "battery": None}` — which feeds `get_battery_status` and the
`batteries` extra state attribute. So each consumer newly sees: the loop, two
more lookups; the `batteries` attribute, entries for cooler and outdoor sensor;
`check_all_entities`, nothing.

**3. The outdoor sensor really is appended after the battery loop.**
Loop at `climate.py:2304`, append at `climate.py:2318`. Confirmed by execution
against a real config entry, spying on `find_battery_entity`:

```
before: battery scan visited: ['climate.fake_trv', 'sensor.room_temperature']
after : battery scan visited: ['climate.fake_cooler', 'climate.fake_trv',
                               'sensor.outdoor_temp', 'sensor.room_temperature']
```

## The change

**`utils/watcher.py`** — `get_optional_sensors` returns `cooler_entity_id`,
putting the cooler on the terms the other optional devices already use: the
`await_optional_sensors` startup wait, the lifecycle region's grace window
(`kernel_state.lifecycle.in_grace(self.clock.now())`), one
`degraded_mode_<device>` repair at `IssueSeverity.WARNING`, and self-clearing on
recovery.

No FSM change was needed. `control_mode.step(state, unavailable_sensors, now)`
already takes the watcher's list verbatim, and `ControlModeState.degraded` is
`bool(self.unavailable_sensors)`. The ladder is untouched: `step_ladder` is
driven by `room_sensor_ok` / `trv_temp_ok`, neither of which the cooler feeds,
so a dead cooler annunciates degradation without moving the rung.

Control is not gated: `degraded_mode` (the property over
`kernel_state.control_mode.degraded`) is read only by the extra-state-attributes
dict.

**`climate.py`** — the cooler and the outdoor sensor are registered in
`all_entities` immediately before the battery scan; the outdoor sensor's append
is removed from the listener block that ran after it.

## Executed end to end, before and after

Real `MockConfigEntry` with a fake TRV, a fake cooler, a room sensor and an
outdoor sensor; startup awaited; `hass.states.async_remove` on the cooler; the
real `_maintenance_tick` driven; the lifecycle grace deadline cleared so the
annunciation path is the one observed.

Before:

```
degraded_mode       : False
unavailable_sensors : []
repair issues       : []
bt entity           : heat_cool
```

After:

```
degraded_mode       : True
unavailable_sensors : ['climate.fake_cooler']
devices_errors      : []
repair issues       : ['degraded_mode_BT Cooler Probe']
bt entity           : heat_cool
  DEBUG   … Optional sensor climate.fake_cooler is unavailable (degraded mode)
  WARNING … Entering degraded mode. Unavailable sensors: climate.fake_cooler
  INFO    … Exiting degraded mode. All sensors available.   (after recovery)

=== after recovery ===
degraded_mode       : False
unavailable_sensors : []
repair issues       : []
```

`bt entity: heat_cool` in both runs: the heating side keeps running. Empty
`devices_errors` in both: annunciated, not treated as lost control. The probe was
a scratch file and is not part of this PR.

## Tests

The same nine tests as the develop PR, with byte-identical assertions. Two
places differ, both for v2 architecture reasons:

- `TestCoolerDegradedMode._arm_grace` writes the deadline into
  `kernel_state.lifecycle.grace_until` rather than `_degraded_grace_until`;
- `TestFinalizeStartupBatteryScan` builds its mock from this file's `bt`
  fixture (develop's file uses a different, pre-existing local builder).

Test-only fixture completions, both following the pattern the files already use
for `door_id` / `outdoor_sensor`:

- `tests/unit/test_watcher.py::mock_bt_instance` gains `cooler_entity_id = None`;
- `tests/unit/test_climate_trigger_degraded_order.py::bt` gains
  `cooler_entity_id = None` — without it the auto-created truthy `MagicMock`
  reached `", ".join(unavailable)` and raised `TypeError`. Caught by the full
  suite, not by reading;
- `_run_finalize_startup` no longer hard-sets `outdoor_sensor = None` (moved to
  the `bt` fixture, same value) and now patches `async_track_time_change`.

Gate: `4311 passed` (baseline 4302), ruff check and format clean,
`pyrefly check` → 0 errors.

## Out of scope, worth a separate decision

`check_all_entities` and `check_entity` have no callers on either maintenance
line. Whether to delete them is not answered here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup handling for configured cooler and outdoor temperature sensors.
  * Cooler outages now contribute to degraded-mode detection.
  * Recovered coolers clear related repair notifications.
  * Unconfigured cooler devices are excluded from monitoring and critical-entity checks.

* **Tests**
  * Added coverage for cooler and outdoor sensor monitoring, battery detection, startup grace periods, degraded mode, and recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

Not tested on hardware. The evidence in this PR is unit-level and executed: the full suite plus the
targeted reproductions quoted above, driven against mocked Home Assistant objects. No real TRV,
cooler or Home Assistant instance was involved, so the fields below are left blank rather than
filled with values that were never observed.

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

No new device mapping is added by this PR.

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`

This PR does change `climate.py`, but it adds no device mapping — the checkbox above targets
new-mapping PRs, and the dedicated-PR rule it refers to is about mappings, not about this kind
of change.
