### PR TITLE
chore(cooler): converge cooler-path wording and step tests across lines

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -3071,13 +3071,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         A report from the cooler is authoritative for the cooling channel only.
         Rather than pulling the heating target down to make room, the reported
-        value is raised to the nearest setpoint that clears the heating target
-        by one step, so a press on the air conditioner's own remote can never
-        move the radiators. The floor is capped at the configured maximum
-        because a bound outside the range is not a setpoint BT can hold; the
-        residual :meth:`_enforce_heat_below_cool` then resolves the degenerate
-        case where the heating target rests on the maximum and no legal cooling
-        setpoint above it exists.
+        value is raised onto a floor one step above the heating target, so a
+        press on the air conditioner's own remote leaves the radiators alone.
+        The floor is capped at the configured maximum because a bound outside
+        the range is not a setpoint BT can hold, and that cap is where the
+        separation gives way: a heating target resting on the maximum or above
+        it puts the floor on that target or below it, so the value returned
+        there no longer clears it. The residual
+        :meth:`_enforce_heat_below_cool` settles that degenerate case, and it
+        does so by moving the heating target.
 
         The bound applies whenever a cooling channel is configured rather than
         only while the live mode is HEAT_COOL, matching
@@ -3100,8 +3102,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         Returns
         -------
         float
-                the setpoint to adopt, unchanged unless it had to be raised to
-                clear the heating target
+                the setpoint to adopt, unchanged unless it had to be raised
+                onto the floor the heating target and the configured maximum
+                set
         """
         if self.cooler_entity_id is None or self.bt_target_temp is None:
             return value
@@ -3116,16 +3119,17 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         The counterpart to :meth:`_clamp_inbound_cool_target`: a TRV knob turn
         is authoritative for the heating channel only, so the reported value is
-        lowered to the nearest setpoint that stays one step below the cooling
-        target instead of raising that target. The ceiling is held at the
-        configured minimum, and the residual
-        :meth:`_enforce_cool_above_heat` resolves the degenerate case where the
-        cooling target rests on the minimum and no legal heating setpoint below
-        it exists. Like its counterpart the bound keys off the configured
-        cooling channel rather than the live mode, and here that is what makes
-        it hold at all: a valve with ``no_off_system_mode`` reports its knob
-        turn while ``bt_hvac_mode`` is still OFF, and the same event then
-        resolves the mode to HEAT.
+        lowered onto a ceiling one step below the cooling target instead of
+        raising that target. The ceiling is held at the configured minimum, and
+        that bound is where the separation gives way in the same way: a cooling
+        target resting on the minimum or below it puts the ceiling on that
+        target or above it, so the value returned there no longer clears it.
+        The residual :meth:`_enforce_cool_above_heat` settles that degenerate
+        case, and it does so by moving the cooling target. Like its counterpart
+        the bound keys off the configured cooling channel rather than the live
+        mode, and here that is what makes it hold at all: a valve with
+        ``no_off_system_mode`` reports its knob turn while ``bt_hvac_mode`` is
+        still OFF, and the same event then resolves the mode to HEAT.
 
         The one step of separation comes from :func:`normalize_step` for the
         same reason as in the counterpart: a step a child reports as negative or
@@ -3140,8 +3144,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         Returns
         -------
         float
-                the setpoint to adopt, unchanged unless it had to be lowered to
-                clear the cooling target
+                the setpoint to adopt, unchanged unless it had to be lowered
+                onto the ceiling the cooling target and the configured minimum
+                set
         """
         if self.cooler_entity_id is None or self.bt_target_cooltemp is None:
             return value

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2994,6 +2994,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if maximum is not None and maximum >= self.bt_target_temp:
             adjusted = min(adjusted, maximum)
         if adjusted == self.bt_target_cooltemp:
+            # The maximum and the heating target coincide and the cooling target
+            # already rests on them, so the bump has nowhere to land.
             return
         if adjusted > self.bt_target_temp:
             _LOGGER.warning(
@@ -3042,6 +3044,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if self.bt_min_temp is not None:
             adjusted = max(adjusted, self.bt_min_temp)
         if adjusted == self.bt_target_temp:
+            # The minimum pins the drop on the heating target itself, so it has
+            # nowhere to land.
             return
         if adjusted < self.bt_target_cooltemp:
             _LOGGER.warning(
@@ -3072,7 +3076,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         move the radiators. The floor is capped at the configured maximum
         because a bound outside the range is not a setpoint BT can hold; the
         residual :meth:`_enforce_heat_below_cool` then resolves the degenerate
-        case where the heating target leaves no legal room below the maximum.
+        case where the heating target rests on the maximum and no legal cooling
+        setpoint above it exists.
 
         The bound applies whenever a cooling channel is configured rather than
         only while the live mode is HEAT_COOL, matching
@@ -3095,7 +3100,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         Returns
         -------
         float
-                the setpoint to adopt, raised to clear the heating target
+                the setpoint to adopt, unchanged unless it had to be raised to
+                clear the heating target
         """
         if self.cooler_entity_id is None or self.bt_target_temp is None:
             return value
@@ -3114,11 +3120,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         target instead of raising that target. The ceiling is held at the
         configured minimum, and the residual
         :meth:`_enforce_cool_above_heat` resolves the degenerate case where the
-        cooling target leaves no legal room above the minimum. Like its
-        counterpart the bound keys off the configured cooling channel rather
-        than the live mode, and here that is what makes it hold at all: a valve
-        with ``no_off_system_mode`` reports its knob turn while ``bt_hvac_mode``
-        is still OFF, and the same event then resolves the mode to HEAT.
+        cooling target rests on the minimum and no legal heating setpoint below
+        it exists. Like its counterpart the bound keys off the configured
+        cooling channel rather than the live mode, and here that is what makes
+        it hold at all: a valve with ``no_off_system_mode`` reports its knob
+        turn while ``bt_hvac_mode`` is still OFF, and the same event then
+        resolves the mode to HEAT.
 
         The one step of separation comes from :func:`normalize_step` for the
         same reason as in the counterpart: a step a child reports as negative or
@@ -3133,7 +3140,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         Returns
         -------
         float
-                the setpoint to adopt, lowered to clear the cooling target
+                the setpoint to adopt, unchanged unless it had to be lowered to
+                clear the cooling target
         """
         if self.cooler_entity_id is None or self.bt_target_cooltemp is None:
             return value

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2847,14 +2847,14 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
     def _seed_cool_target_from_cooler(self, log_source: str) -> bool:
         """Fill a cooling target that is still unknown from the cooler's state.
 
-        The single place a cooling target is taken off the device, so every
-        such value passes the same resolution: it is read with the key
-        precedence a cooler is driven through — a device that only supports
-        TARGET_TEMPERATURE_RANGE reports ``temperature: None`` and carries its
-        setpoint in ``target_temp_high`` — clamped into the configured range,
-        and ordered above the heating target. A cooler that was unavailable
-        while that range was derived contributed no bounds to it, so the
-        setpoint it reports can sit outside the range and is clamped into it
+        The startup path for a cooling target read off the device;
+        ``trigger_cooler_change`` is the runtime one. Here the value is read
+        with the key precedence a cooler is driven through — a device that only
+        supports TARGET_TEMPERATURE_RANGE reports ``temperature: None`` and
+        carries its setpoint in ``target_temp_high`` — then clamped into the
+        configured range and ordered above the heating target. A cooler that was
+        unavailable while that range was derived contributed no bounds to it, so
+        the setpoint it reports can sit outside the range and is clamped into it
         exactly like a reported one. Echo detection has nothing to compare
         against, because no setpoint is written to a cooler whose target is
         unknown.

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -111,10 +111,11 @@ async def trigger_cooler_change(self, event):
         # that republishes the same setpoint — an attribute refresh, a mode
         # change, a temperature push — must not be read as user intent: a
         # stale report would otherwise revert a BT-side target that has not
-        # been written yet. What the cooler reports is authoritative for the
-        # cooling channel alone, so a setpoint that would cross the heating
-        # target is raised to clear it and the heating target stays where the
-        # user put it.
+        # been written yet.
+        # What the cooler reports also speaks for the cooling channel alone: a
+        # value that would cross the heating target is raised above it, so a
+        # press on the air conditioner's remote cannot move the radiators'
+        # target — potentially below room temperature, stopping the heating.
         _reported_moved = abs(
             _new_cooling_setpoint.raw - _old_cooling_setpoint
         ) >= setpoint_echo_window(_step)
@@ -130,10 +131,10 @@ async def trigger_cooler_change(self, event):
                 _new_cooling_setpoint.value
             )
             if _adopted_cooling_setpoint != _new_cooling_setpoint.value:
-                # A user holding the remote's down button reports every
-                # intermediate setpoint, so this is annunciated at info level:
-                # the target is being honoured as far as the heating channel
-                # allows, which is not the anomaly a warning stands for.
+                # A user turning the remote down step by step would collect one
+                # warning per press, so yielding to the heating target is an
+                # INFO: the range clamp above and the ordering fallback below
+                # own the WARNING level.
                 _LOGGER.info(
                     "better_thermostat %s: Cooler %s reported setpoint %.2f does not "
                     "clear the heating target %.2f, keeping %.2f",
@@ -144,13 +145,13 @@ async def trigger_cooler_change(self, event):
                     _adopted_cooling_setpoint,
                 )
             self.bt_target_cooltemp = _adopted_cooling_setpoint
-            # Residual tie-break only: the clamp already cleared the heating
-            # target unless it ran into bt_max_temp, so this moves the heating
-            # target by at most one step as long as that target lies inside the
-            # configured range, and only when no legal cooling setpoint above it
-            # exists. A range the children narrowed below a target already in
-            # place is the exception, and there this is also what pulls the
-            # target back inside.
+            # The clamp leaves the heating target alone, so this only settles
+            # the degenerate case where no cooling value above the heating
+            # target exists inside the range: at a heating target within one
+            # step of bt_max_temp it drops that target by one step, and a range
+            # the children narrowed below a target already in place is what
+            # moves it further — that move is what brings it back inside the
+            # range.
             self._enforce_heat_below_cool()
             _main_change = True
 

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -113,9 +113,12 @@ async def trigger_cooler_change(self, event):
         # stale report would otherwise revert a BT-side target that has not
         # been written yet.
         # What the cooler reports also speaks for the cooling channel alone: a
-        # value that would cross the heating target is raised above it, so a
-        # press on the air conditioner's remote cannot move the radiators'
-        # target — potentially below room temperature, stopping the heating.
+        # value that would cross the heating target is raised onto the floor
+        # above it, so a press on the air conditioner's remote does not pull
+        # the radiators' target down — potentially below room temperature,
+        # stopping the heating. Where the range holds no value above that
+        # target the floor stops short of it, and the fallback below is what
+        # moves the heating target then.
         _reported_moved = abs(
             _new_cooling_setpoint.raw - _old_cooling_setpoint
         ) >= setpoint_echo_window(_step)
@@ -147,11 +150,10 @@ async def trigger_cooler_change(self, event):
             self.bt_target_cooltemp = _adopted_cooling_setpoint
             # The clamp leaves the heating target alone, so this only settles
             # the degenerate case where no cooling value above the heating
-            # target exists inside the range: at a heating target within one
-            # step of bt_max_temp it drops that target by one step, and a range
-            # the children narrowed below a target already in place is what
-            # moves it further — that move is what brings it back inside the
-            # range.
+            # target exists inside the range: at a heating target resting on
+            # bt_max_temp it drops that target by one step, and a range the
+            # children narrowed below a target already in place is what moves
+            # it further — that move is what brings it back inside the range.
             self._enforce_heat_below_cool()
             _main_change = True
 

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -131,6 +131,11 @@ def mock_bt():
     return bt
 
 
+# A step that is not a positive real number cannot be the distance a target
+# moves, so every ordering helper replaces it with the 0.5 default.
+UNUSABLE_STEPS = (-1.0, -0.5, float("nan"), float("inf"))
+
+
 # ===========================================================================
 # 1. TestShouldHeatWithTolerance
 # ===========================================================================
@@ -1362,19 +1367,20 @@ class TestEnforceCoolAboveHeat:
             "value above it" in caplog.text
         )
 
-    def test_non_positive_step_falls_back_to_the_default_step(self, mock_bt, caplog):
-        """A step that is not positive cannot be the distance the target moves.
+    @pytest.mark.parametrize("step", UNUSABLE_STEPS)
+    def test_unusable_step_falls_back_to_the_default_step(self, mock_bt, caplog, step):
+        """An unusable step falls back to the default before the cool target moves.
 
-        The configured step reaches this method as the operator entered it, and
-        a value of zero or below would subtract instead of add: the cool target
-        would land at or under the heat target, still inverted, and be
-        annunciated as if it had been lifted.
+        ``bt_target_temp_step`` carries whatever the child entities report, and
+        only a positive real step can lift the cool target above the heat
+        target, so a negative or non-finite one is replaced by the 0.5 default.
+        The warning names the value the cool target comes to rest on.
         """
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_max_temp = 30.0
         mock_bt.bt_target_temp = 22.0
-        mock_bt.bt_target_temp_step = -1.0
-        mock_bt.bt_target_cooltemp = 20.0
+        mock_bt.bt_target_temp_step = step
+        mock_bt.bt_target_cooltemp = 21.0
 
         with caplog.at_level(logging.WARNING):
             self._call(mock_bt)
@@ -1382,7 +1388,7 @@ class TestEnforceCoolAboveHeat:
         assert mock_bt.bt_target_cooltemp == 22.5
         assert mock_bt.bt_target_cooltemp > mock_bt.bt_target_temp
         assert (
-            "cooling target 20.00 adjusted to 22.50 to stay above heating "
+            "cooling target 21.00 adjusted to 22.50 to stay above heating "
             "target 22.00" in caplog.text
         )
 
@@ -1534,18 +1540,19 @@ class TestEnforceHeatBelowCool:
         assert mock_bt.bt_target_temp == 5.0
         assert "heating target" not in caplog.text
 
-    def test_negative_step_falls_back_to_the_default_step(self, mock_bt, caplog):
-        """A negative step must not raise the heat target above the cool target.
+    @pytest.mark.parametrize("step", UNUSABLE_STEPS)
+    def test_unusable_step_falls_back_to_the_default_step(self, mock_bt, caplog, step):
+        """An unusable step falls back to the default before the heat target moves.
 
-        A child that publishes ``target_temp_step: -0.5`` reaches
-        ``bt_target_temp_step`` unfiltered, and subtracting a negative step
-        would invert the pair this method exists to order while reporting the
-        move as if it had stayed below.
+        ``bt_target_temp_step`` carries whatever the child entities report, and
+        only a positive real step can push the heat target below the cool
+        target, so a negative or non-finite one is replaced by the 0.5 default.
+        The warning names the value the heat target comes to rest on.
         """
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
-        mock_bt.bt_target_temp = 22.0
-        mock_bt.bt_target_temp_step = -0.5
         mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_temp = 22.0
+        mock_bt.bt_target_temp_step = step
         mock_bt.bt_target_cooltemp = 22.0
 
         with caplog.at_level(logging.WARNING):
@@ -1557,16 +1564,6 @@ class TestEnforceHeatBelowCool:
             "heating target 22.00 adjusted to 21.50 to stay below cooling "
             "target 22.00" in caplog.text
         )
-
-    def test_non_finite_step_falls_back_to_the_default_step(self, mock_bt):
-        """A NaN step must not turn the heat target into NaN."""
-        mock_bt.hvac_mode = HVACMode.HEAT_COOL
-        mock_bt.bt_target_temp = 22.0
-        mock_bt.bt_target_temp_step = float("nan")
-        mock_bt.bt_min_temp = 5.0
-        mock_bt.bt_target_cooltemp = 22.0
-        self._call(mock_bt)
-        assert mock_bt.bt_target_temp == 21.5
 
     def test_none_heat_target_is_noop(self, mock_bt):
         """A None heat target does not raise and stays None."""
@@ -1628,16 +1625,16 @@ class TestClampInboundCoolTarget:
         mock_bt.bt_target_temp_step = 0
         assert self._call(mock_bt, 20.0) == 20.5
 
-    @pytest.mark.parametrize("step", [-1.0, float("nan"), float("inf")])
-    def test_unusable_step_falls_back_to_half_degree(self, mock_bt, step):
-        """A step that is not a positive finite number falls back to 0.5.
+    @pytest.mark.parametrize("step", UNUSABLE_STEPS)
+    def test_unusable_step_falls_back_to_the_default_step(self, mock_bt, step):
+        """An unusable step falls back to the default before the floor is built.
 
-        ``bt_target_temp_step`` carries whatever the child entities report. A
-        negative step would put the floor below the heating target, and a NaN
-        one would lose every comparison and leave the value unbounded, so both
-        would hand back a cooling target at or under the heating target.
+        ``bt_target_temp_step`` carries whatever the child entities report, and
+        only a positive real step puts the floor above the heating target, so a
+        negative or non-finite one is replaced by the 0.5 default.
         """
-        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.bt_max_temp = 30.0
         mock_bt.bt_target_temp = 20.0
         mock_bt.bt_target_temp_step = step
         adopted = self._call(mock_bt, 18.0)
@@ -1716,15 +1713,16 @@ class TestClampInboundHeatTarget:
         mock_bt.bt_target_temp_step = 0
         assert self._call(mock_bt, 24.0) == 23.5
 
-    @pytest.mark.parametrize("step", [-1.0, float("nan"), float("inf")])
-    def test_unusable_step_falls_back_to_half_degree(self, mock_bt, step):
-        """A step that is not a positive finite number falls back to 0.5.
+    @pytest.mark.parametrize("step", UNUSABLE_STEPS)
+    def test_unusable_step_falls_back_to_the_default_step(self, mock_bt, step):
+        """An unusable step falls back to the default before the ceiling is built.
 
-        The mirror of the cooling case: a negative step would lift the ceiling
-        above the cooling target and a NaN one would drop the bound, so both
-        would hand back a heating target at or over the cooling target.
+        ``bt_target_temp_step`` carries whatever the child entities report, and
+        only a positive real step puts the ceiling below the cooling target, so
+        a negative or non-finite one is replaced by the 0.5 default.
         """
-        mock_bt.cooler_entity_id = "switch.ac"
+        mock_bt.cooler_entity_id = "climate.ac"
+        mock_bt.bt_min_temp = 5.0
         mock_bt.bt_target_cooltemp = 24.0
         mock_bt.bt_target_temp_step = step
         adopted = self._call(mock_bt, 26.0)

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -463,6 +463,27 @@ class TestHeatTargetSync:
         assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
+    async def test_heat_target_under_the_maximum_costs_no_step(self, mock_bt):
+        """Only a heating target on bt_max_temp gives up a step, none below it.
+
+        A heating target closer to the maximum than one step still leaves the
+        capped floor above itself, so the clamp separates the pair on its own,
+        the adopted value stays inside the range and the tie-break finds
+        nothing to move.
+        """
+        mock_bt.bt_target_temp = 29.75
+        mock_bt.bt_target_cooltemp = 30.0
+        mock_bt.bt_max_temp = 30.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 22.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 30.0
+        assert mock_bt.bt_target_temp == 29.75
+
+    @pytest.mark.asyncio
     async def test_a_range_narrowed_below_the_heat_target_pulls_it_inside(
         self, mock_bt
     ):


### PR DESCRIPTION
## What

Convergence only. `develop` and `v2` had drifted apart in the cooler path in two ways that carry no
behaviour but cost a conflict at every sync: the wording of comments and docstrings, and the shape of
the "unusable step falls back to the default step" tests.

Zero production behaviour change. Every hunk is a comment, a docstring, or a test rename/parametrise.

## Wording

The direction is **develop adopts `v2`'s text** wherever `v2`'s said something develop's did not, so
the surviving sentence is the more informative one:

- `events/cooler.py`, the "no device-side gate of its own" rationale — `v2`'s version splits it in
  two, mirroring the two independent guards (echo suppression, then channel authority), and names the
  user-visible consequence: a cooler setpoint that crossed the heating target would pull the
  radiators' target *potentially below room temperature, stopping the heating*. develop's version
  asserted only that the heating target stays put.
- `events/cooler.py`, why the "does not clear the heating target" line is INFO — `v2`'s version names
  which sites own the WARNING level (the range clamp above, the ordering fallback below). That is
  checkable against the surrounding code; develop's version only asserted a level.
- `events/cooler.py`, the residual tie-break above `_enforce_heat_below_cool()` — both were correct;
  `v2`'s is the more concrete one (it names `bt_max_temp` and the one-step drop), so it is the one
  that survives.
- `climate.py`, the `_clamp_inbound_cool_target` / `_clamp_inbound_heat_target` docstrings and the
  two early returns in `_enforce_cool_above_heat` / `_enforce_heat_below_cool` — same rule.

The seed-branch comment and its log line in `events/cooler.py` also differ between the lines, and are
deliberately **not** touched here: the sibling PR `fix(cooler): decline a setpoint reported on a dead
cooler state` deletes that whole block on both lines and replaces it with one shared text, so
converging it here would only create a conflict between the two PRs.

## Tests

One canonical parametrised test per method instead of a different set of singletons on each line:

- name: `test_unusable_step_falls_back_to_the_default_step`
- parameters: the **union** of every value either line already tested — `-1.0`, `-0.5`, `nan`, `inf`
- applied in all four classes: `TestEnforceCoolAboveHeat`, `TestEnforceHeatBelowCool`,
  `TestClampInboundCoolTarget`, `TestClampInboundHeatTarget`

Strictly coverage-preserving: no value either line tested is dropped, and no new value is added.
`-inf` and `"unavailable"` also fall back to 0.5 on both lines, but adding them would be new coverage
rather than convergence and is left out on purpose.

After this PR and its `v2` sibling, `pytest tests/unit/test_climate_baseline.py --collect-only -q`
yields the same test ids on both lines for these four classes.

## What is deliberately left alone

The hunks that are real `v2` architecture, not wording: the missing `@callback`, the cooler send
cache (`last_sent_cooler_temperature`), the `contact_open` gate and its diagnostic `elif` branch, and
`request_control_cycle`. Those are the whole point of the `v2` branch and converging them would be a
port, not a cleanup.

## Verification

- Comments and docstrings were classified by stripping them via AST and diffing the stripped forms;
  what the stripped diff does not show is by construction wording-only.
- Composition was checked against the other six PRs of this round, in both merge orders. Both orders
  produce an identical tree, and the suite is green on it.

## Gates

```
uv run pytest tests/ -q     2367 passed in 57.08s
uv run ruff check .         All checks passed!
uv run ruff format --check  234 files already formatted
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified thermostat target ordering at temperature limits and during heating transitions.
  * Added explanations for cooler setpoint echoes, heating-target protection, warnings, and residual adjustments.

* **Tests**
  * Expanded coverage for invalid temperature-step settings, including negative, NaN, and infinite values.
  * Verified fallback handling and preservation of heating and cooling target ordering.
  * Added regression coverage confirming cooler targets remain capped when heating targets are just below the maximum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->