### PR TITLE
chore(cooler): converge cooler-path wording and step tests across lines

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -3431,13 +3431,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         A report from the cooler is authoritative for the cooling channel only.
         Rather than pulling the heating target down to make room, the reported
-        value is raised to the nearest setpoint that clears the heating target
-        by one step, so a press on the air conditioner's own remote can never
-        move the radiators. The floor is capped at the configured maximum
-        because a bound outside the range is not a setpoint BT can hold; the
-        residual :meth:`_enforce_heat_below_cool` then resolves the degenerate
-        case where the heating target rests on the maximum and no legal cooling
-        setpoint above it exists.
+        value is raised onto a floor one step above the heating target, so a
+        press on the air conditioner's own remote leaves the radiators alone.
+        The floor is capped at the configured maximum because a bound outside
+        the range is not a setpoint BT can hold, and that cap is where the
+        separation gives way: a heating target resting on the maximum or above
+        it puts the floor on that target or below it, so the value returned
+        there no longer clears it. The residual
+        :meth:`_enforce_heat_below_cool` settles that degenerate case, and it
+        does so by moving the heating target.
 
         The bound applies whenever a cooling channel is configured rather than
         only while the live mode is HEAT_COOL, matching
@@ -3460,8 +3462,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         Returns
         -------
         float
-                the setpoint to adopt, unchanged unless it had to be raised to
-                clear the heating target
+                the setpoint to adopt, unchanged unless it had to be raised
+                onto the floor the heating target and the configured maximum
+                set
         """
         if self.cooler_entity_id is None or self.bt_target_temp is None:
             return value
@@ -3476,16 +3479,17 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         The counterpart to :meth:`_clamp_inbound_cool_target`: a TRV knob turn
         is authoritative for the heating channel only, so the reported value is
-        lowered to the nearest setpoint that stays one step below the cooling
-        target instead of raising that target. The ceiling is held at the
-        configured minimum, and the residual
-        :meth:`_enforce_cool_above_heat` resolves the degenerate case where the
-        cooling target rests on the minimum and no legal heating setpoint below
-        it exists. Like its counterpart the bound keys off the configured
-        cooling channel rather than the live mode, and here that is what makes
-        it hold at all: a valve with ``no_off_system_mode`` reports its knob
-        turn while ``bt_hvac_mode`` is still OFF, and the same event then
-        resolves the mode to HEAT.
+        lowered onto a ceiling one step below the cooling target instead of
+        raising that target. The ceiling is held at the configured minimum, and
+        that bound is where the separation gives way in the same way: a cooling
+        target resting on the minimum or below it puts the ceiling on that
+        target or above it, so the value returned there no longer clears it.
+        The residual :meth:`_enforce_cool_above_heat` settles that degenerate
+        case, and it does so by moving the cooling target. Like its counterpart
+        the bound keys off the configured cooling channel rather than the live
+        mode, and here that is what makes it hold at all: a valve with
+        ``no_off_system_mode`` reports its knob turn while ``bt_hvac_mode`` is
+        still OFF, and the same event then resolves the mode to HEAT.
 
         The one step of separation comes from :func:`normalize_step` for the
         same reason as in the counterpart: a step a child reports as negative or
@@ -3500,8 +3504,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         Returns
         -------
         float
-                the setpoint to adopt, unchanged unless it had to be lowered to
-                clear the cooling target
+                the setpoint to adopt, unchanged unless it had to be lowered
+                onto the ceiling the cooling target and the configured minimum
+                set
         """
         if self.cooler_entity_id is None or self.bt_target_cooltemp is None:
             return value

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -3207,16 +3207,17 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
     def _seed_cool_target_from_cooler(self, log_source: str) -> bool:
         """Fill a cooling target that is still unknown from the cooler's state.
 
-        The single place a cooling target is taken off the device, so every such
-        value passes the same resolution: it is read with the key precedence a
-        cooler is driven through — a device that only supports
+        The single place a cooling target is taken off the device, so every
+        such value passes the same resolution: it is read with the key
+        precedence a cooler is driven through — a device that only supports
         TARGET_TEMPERATURE_RANGE reports ``temperature: None`` and carries its
-        setpoint in ``target_temp_high`` — clamped into the configured range, and
-        ordered above the heating target. A cooler that was unavailable while
-        that range was derived contributed no bounds to it, so the setpoint it
-        reports can sit outside the range and is clamped into it exactly like a
-        reported one. Echo detection has nothing to compare against, because no
-        setpoint is written to a cooler whose target is unknown.
+        setpoint in ``target_temp_high`` — clamped into the configured range,
+        and ordered above the heating target. A cooler that was unavailable
+        while that range was derived contributed no bounds to it, so the
+        setpoint it reports can sit outside the range and is clamped into it
+        exactly like a reported one. Echo detection has nothing to compare
+        against, because no setpoint is written to a cooler whose target is
+        unknown.
 
         A target that is already known is left alone: it is either the value a
         restored preset carries, which is the user's own choice, or one this
@@ -3225,7 +3226,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         Parameters
         ----------
         log_source : str
-            caller name, forwarded for logging context
+            the reading site's own name, forwarded for logging context; the
+            startup sequence reads twice, and the line that reports an
+            attribute the resolution could not read names this value, so each
+            caller passes the name of the site it reads from
 
         Returns
         -------
@@ -3423,35 +3427,41 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.bt_target_temp = adjusted
 
     def _clamp_inbound_cool_target(self, value: float) -> float:
-        """Raise a cooling setpoint reported by the cooler above the heating target.
+        """Clamp a device-reported cooling setpoint above the heating target.
 
-        A device only ever speaks for its own channel: a press on the air
-        conditioner's remote must not move the radiators' target. So a reported
-        cooling setpoint that would cross the heating target is raised to the
-        nearest value that clears it, instead of pulling the heating target
-        down. The floor stays inside the configured range, so at a heating
-        target within one step of ``bt_max_temp`` the adopted value stops at the
-        maximum and the ordering is settled by
-        :meth:`_enforce_heat_below_cool` moving the heating target one step.
+        A report from the cooler is authoritative for the cooling channel only.
+        Rather than pulling the heating target down to make room, the reported
+        value is raised to the nearest setpoint that clears the heating target
+        by one step, so a press on the air conditioner's own remote can never
+        move the radiators. The floor is capped at the configured maximum
+        because a bound outside the range is not a setpoint BT can hold; the
+        residual :meth:`_enforce_heat_below_cool` then resolves the degenerate
+        case where the heating target rests on the maximum and no legal cooling
+        setpoint above it exists.
 
-        The bound keys off the configured cooling channel rather than the live
-        mode: the ordering of the two targets is a property of the
-        configuration, so it has to hold whatever mode the group happens to be
-        in. A crossing learned while the group is off is never revisited
-        otherwise.
+        The bound applies whenever a cooling channel is configured rather than
+        only while the live mode is HEAT_COOL, matching
+        :meth:`_clamp_inbound_heat_target`: the ordering of the two targets is a
+        property of the configuration, so it has to hold whatever mode the group
+        happens to be in.
 
-        A step that is not a positive real number would turn the floor into a
-        ceiling, so it is replaced by the 0.5 fallback.
+        The one step of separation comes from :func:`normalize_step`, because
+        ``bt_target_temp_step`` can carry whatever a child entity reports: a
+        negative step would put the floor below the heating target and invert
+        the pair this bound exists to order, and a NaN one would make the
+        comparison against it false and drop the bound altogether.
 
         Parameters
         ----------
         value : float
-            Cooling setpoint in °C, already resolved into BT's range.
+                the reported cooling setpoint in °C, already clamped into the
+                configured range
 
         Returns
         -------
         float
-            The value to adopt: unchanged unless it had to be raised.
+                the setpoint to adopt, unchanged unless it had to be raised to
+                clear the heating target
         """
         if self.cooler_entity_id is None or self.bt_target_temp is None:
             return value
@@ -3462,34 +3472,36 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         return max(value, floor)
 
     def _clamp_inbound_heat_target(self, value: float) -> float:
-        """Lower a heating setpoint reported by a TRV below the cooling target.
+        """Clamp a device-reported heating setpoint below the cooling target.
 
-        The counterpart to :meth:`_clamp_inbound_cool_target`, for a knob turn
-        on a radiator valve: it may move the heating target only, so a reported
-        setpoint that would cross the cooling target is lowered to the nearest
-        value that clears it rather than pushing the cooling target up. The
-        ceiling stays inside the configured range, so at a cooling target within
-        one step of ``bt_min_temp`` the adopted value stops at the minimum and
-        :meth:`_enforce_cool_above_heat` settles the ordering with a one-step
-        move of the cooling target.
+        The counterpart to :meth:`_clamp_inbound_cool_target`: a TRV knob turn
+        is authoritative for the heating channel only, so the reported value is
+        lowered to the nearest setpoint that stays one step below the cooling
+        target instead of raising that target. The ceiling is held at the
+        configured minimum, and the residual
+        :meth:`_enforce_cool_above_heat` resolves the degenerate case where the
+        cooling target rests on the minimum and no legal heating setpoint below
+        it exists. Like its counterpart the bound keys off the configured
+        cooling channel rather than the live mode, and here that is what makes
+        it hold at all: a valve with ``no_off_system_mode`` reports its knob
+        turn while ``bt_hvac_mode`` is still OFF, and the same event then
+        resolves the mode to HEAT.
 
-        Like its counterpart the bound keys off the configured cooling channel
-        rather than the live mode, and here that is what makes it hold at all: a
-        valve with ``no_off_system_mode`` reports its knob turn while
-        ``bt_hvac_mode`` is still OFF, and the same event then resolves the mode.
-
-        A step that is not a positive real number would turn the ceiling into a
-        floor, so it is replaced by the 0.5 fallback.
+        The one step of separation comes from :func:`normalize_step` for the
+        same reason as in the counterpart: a step a child reports as negative or
+        non-finite would either invert the pair or drop the bound.
 
         Parameters
         ----------
         value : float
-            Heating setpoint in °C, already resolved into BT's range.
+                the reported heating setpoint in °C, already clamped into the
+                configured range
 
         Returns
         -------
         float
-            The value to adopt: unchanged unless it had to be lowered.
+                the setpoint to adopt, unchanged unless it had to be lowered to
+                clear the cooling target
         """
         if self.cooler_entity_id is None or self.bt_target_cooltemp is None:
             return value

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -3207,14 +3207,14 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
     def _seed_cool_target_from_cooler(self, log_source: str) -> bool:
         """Fill a cooling target that is still unknown from the cooler's state.
 
-        The single place a cooling target is taken off the device, so every
-        such value passes the same resolution: it is read with the key
-        precedence a cooler is driven through — a device that only supports
-        TARGET_TEMPERATURE_RANGE reports ``temperature: None`` and carries its
-        setpoint in ``target_temp_high`` — clamped into the configured range,
-        and ordered above the heating target. A cooler that was unavailable
-        while that range was derived contributed no bounds to it, so the
-        setpoint it reports can sit outside the range and is clamped into it
+        The startup path for a cooling target read off the device;
+        ``trigger_cooler_change`` is the runtime one. Here the value is read
+        with the key precedence a cooler is driven through — a device that only
+        supports TARGET_TEMPERATURE_RANGE reports ``temperature: None`` and
+        carries its setpoint in ``target_temp_high`` — then clamped into the
+        configured range and ordered above the heating target. A cooler that was
+        unavailable while that range was derived contributed no bounds to it, so
+        the setpoint it reports can sit outside the range and is clamped into it
         exactly like a reported one. Echo detection has nothing to compare
         against, because no setpoint is written to a cooler whose target is
         unknown.

--- a/custom_components/better_thermostat/events/cooler.py
+++ b/custom_components/better_thermostat/events/cooler.py
@@ -120,9 +120,12 @@ async def trigger_cooler_change(self, event):
         # stale report would otherwise revert a BT-side target that has not
         # been written yet.
         # What the cooler reports also speaks for the cooling channel alone: a
-        # value that would cross the heating target is raised above it, so a
-        # press on the air conditioner's remote cannot move the radiators'
-        # target — potentially below room temperature, stopping the heating.
+        # value that would cross the heating target is raised onto the floor
+        # above it, so a press on the air conditioner's remote does not pull
+        # the radiators' target down — potentially below room temperature,
+        # stopping the heating. Where the range holds no value above that
+        # target the floor stops short of it, and the fallback below is what
+        # moves the heating target then.
         _reported_moved = abs(
             _new_cooling_setpoint.raw - _old_cooling_setpoint
         ) >= setpoint_echo_window(_step)
@@ -162,11 +165,10 @@ async def trigger_cooler_change(self, event):
             self.bt_target_cooltemp = _adopted_cooling_setpoint
             # The clamp leaves the heating target alone, so this only settles
             # the degenerate case where no cooling value above the heating
-            # target exists inside the range: at a heating target within one
-            # step of bt_max_temp it drops that target by one step, and a range
-            # the children narrowed below a target already in place is what
-            # moves it further — that move is what brings it back inside the
-            # range.
+            # target exists inside the range: at a heating target resting on
+            # bt_max_temp it drops that target by one step, and a range the
+            # children narrowed below a target already in place is what moves
+            # it further — that move is what brings it back inside the range.
             self._enforce_heat_below_cool()
             _main_change = True
         elif _reported_moved:

--- a/tests/unit/test_climate_baseline.py
+++ b/tests/unit/test_climate_baseline.py
@@ -133,6 +133,11 @@ def mock_bt():
     return bt
 
 
+# A step that is not a positive real number cannot be the distance a target
+# moves, so every ordering helper replaces it with the 0.5 default.
+UNUSABLE_STEPS = (-1.0, -0.5, float("nan"), float("inf"))
+
+
 # ===========================================================================
 # 1. TestShouldHeatWithTolerance
 # ===========================================================================
@@ -1311,25 +1316,30 @@ class TestEnforceCoolAboveHeat:
         self._call(mock_bt)
         assert mock_bt.bt_target_cooltemp == 22.5
 
-    @pytest.mark.parametrize("step", [-1.0, float("nan"), float("inf")])
-    def test_unusable_step_falls_back_instead_of_moving_the_pair(
-        self, mock_bt, caplog, step
-    ):
-        """A step that is not a positive number falls back like a missing one.
+    @pytest.mark.parametrize("step", UNUSABLE_STEPS)
+    def test_unusable_step_falls_back_to_the_default_step(self, mock_bt, caplog, step):
+        """An unusable step falls back to the default before the cool target moves.
 
-        Only a positive step can lift the cool target above the heat target, so
-        a negative or non-finite one is replaced by the fallback, and the
-        annunciation names the value the cool target actually comes to rest on.
+        ``bt_target_temp_step`` carries whatever the child entities report, and
+        only a positive real step can lift the cool target above the heat
+        target, so a negative or non-finite one is replaced by the 0.5 default.
+        The warning names the value the cool target comes to rest on.
         """
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_max_temp = 30.0
         mock_bt.bt_target_temp = 22.0
         mock_bt.bt_target_temp_step = step
         mock_bt.bt_target_cooltemp = 21.0
-        caplog.set_level(logging.WARNING)
-        self._call(mock_bt)
+
+        with caplog.at_level(logging.WARNING):
+            self._call(mock_bt)
+
         assert mock_bt.bt_target_cooltemp == 22.5
-        assert "adjusted to 22.50 to stay above heating target 22.00" in caplog.text
+        assert mock_bt.bt_target_cooltemp > mock_bt.bt_target_temp
+        assert (
+            "cooling target 21.00 adjusted to 22.50 to stay above heating "
+            "target 22.00" in caplog.text
+        )
 
     def test_none_cool_target_is_noop(self, mock_bt):
         """A None cool target does not raise and stays None."""
@@ -1489,25 +1499,30 @@ class TestEnforceHeatBelowCool:
         self._call(mock_bt)
         assert mock_bt.bt_target_temp == 21.5
 
-    @pytest.mark.parametrize("step", [-0.5, float("nan"), float("inf")])
-    def test_unusable_step_falls_back_instead_of_moving_the_pair(
-        self, mock_bt, caplog, step
-    ):
-        """A step that is not a positive number falls back like a missing one.
+    @pytest.mark.parametrize("step", UNUSABLE_STEPS)
+    def test_unusable_step_falls_back_to_the_default_step(self, mock_bt, caplog, step):
+        """An unusable step falls back to the default before the heat target moves.
 
-        Only a positive step can push the heat target below the cool target, so
-        a negative or non-finite one is replaced by the fallback, and the
-        annunciation names the value the heat target actually comes to rest on.
+        ``bt_target_temp_step`` carries whatever the child entities report, and
+        only a positive real step can push the heat target below the cool
+        target, so a negative or non-finite one is replaced by the 0.5 default.
+        The warning names the value the heat target comes to rest on.
         """
         mock_bt.hvac_mode = HVACMode.HEAT_COOL
         mock_bt.bt_min_temp = 5.0
         mock_bt.bt_target_temp = 22.0
         mock_bt.bt_target_temp_step = step
         mock_bt.bt_target_cooltemp = 22.0
-        caplog.set_level(logging.WARNING)
-        self._call(mock_bt)
+
+        with caplog.at_level(logging.WARNING):
+            self._call(mock_bt)
+
         assert mock_bt.bt_target_temp == 21.5
-        assert "adjusted to 21.50 to stay below cooling target 22.00" in caplog.text
+        assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
+        assert (
+            "heating target 22.00 adjusted to 21.50 to stay below cooling "
+            "target 22.00" in caplog.text
+        )
 
     def test_result_is_clamped_to_min_temp(self, mock_bt, caplog):
         """The heat target never drops below the configured minimum.
@@ -1643,13 +1658,21 @@ class TestClampInboundCoolTarget:
         mock_bt.bt_target_temp_step = 0
         assert self._call(mock_bt, 22.0) == 22.5
 
-    def test_negative_step_falls_back_to_half_degree(self, mock_bt):
-        """A negative step would turn the floor into a ceiling."""
+    @pytest.mark.parametrize("step", UNUSABLE_STEPS)
+    def test_unusable_step_falls_back_to_the_default_step(self, mock_bt, step):
+        """An unusable step falls back to the default before the floor is built.
+
+        ``bt_target_temp_step`` carries whatever the child entities report, and
+        only a positive real step puts the floor above the heating target, so a
+        negative or non-finite one is replaced by the 0.5 default.
+        """
         mock_bt.cooler_entity_id = "climate.ac"
-        mock_bt.hvac_mode = HVACMode.HEAT_COOL
-        mock_bt.bt_target_temp = 22.0
-        mock_bt.bt_target_temp_step = -0.5
-        assert self._call(mock_bt, 20.0) == 22.5
+        mock_bt.bt_max_temp = 30.0
+        mock_bt.bt_target_temp = 20.0
+        mock_bt.bt_target_temp_step = step
+        adopted = self._call(mock_bt, 18.0)
+        assert adopted == 20.5
+        assert adopted > mock_bt.bt_target_temp
 
     def test_floor_stays_inside_the_configured_range(self, mock_bt):
         """With the heating target at the maximum the floor stops there.
@@ -1731,13 +1754,21 @@ class TestClampInboundHeatTarget:
         mock_bt.bt_target_temp_step = 0
         assert self._call(mock_bt, 22.0) == 21.5
 
-    def test_negative_step_falls_back_to_half_degree(self, mock_bt):
-        """A negative step would turn the ceiling into a floor."""
+    @pytest.mark.parametrize("step", UNUSABLE_STEPS)
+    def test_unusable_step_falls_back_to_the_default_step(self, mock_bt, step):
+        """An unusable step falls back to the default before the ceiling is built.
+
+        ``bt_target_temp_step`` carries whatever the child entities report, and
+        only a positive real step puts the ceiling below the cooling target, so
+        a negative or non-finite one is replaced by the 0.5 default.
+        """
         mock_bt.cooler_entity_id = "climate.ac"
-        mock_bt.hvac_mode = HVACMode.HEAT_COOL
-        mock_bt.bt_target_cooltemp = 22.0
-        mock_bt.bt_target_temp_step = -0.5
-        assert self._call(mock_bt, 24.0) == 21.5
+        mock_bt.bt_min_temp = 5.0
+        mock_bt.bt_target_cooltemp = 24.0
+        mock_bt.bt_target_temp_step = step
+        adopted = self._call(mock_bt, 26.0)
+        assert adopted == 23.5
+        assert adopted < mock_bt.bt_target_cooltemp
 
     def test_ceiling_stays_inside_the_configured_range(self, mock_bt):
         """With the cooling target at the minimum the ceiling stops there.

--- a/tests/unit/test_cooler_events.py
+++ b/tests/unit/test_cooler_events.py
@@ -503,6 +503,27 @@ class TestInboundCoolSetpointClamp:
         assert mock_bt.bt_target_temp < mock_bt.bt_target_cooltemp
 
     @pytest.mark.asyncio
+    async def test_heat_target_under_the_maximum_costs_no_step(self, mock_bt):
+        """Only a heating target on bt_max_temp gives up a step, none below it.
+
+        A heating target closer to the maximum than one step still leaves the
+        capped floor above itself, so the clamp separates the pair on its own,
+        the adopted value stays inside the range and the tie-break finds
+        nothing to move.
+        """
+        mock_bt.bt_target_temp = 29.75
+        mock_bt.bt_target_cooltemp = 30.0
+        mock_bt.bt_max_temp = 30.0
+        old_state = _make_state(attributes={"temperature": 25.0})
+        new_state = _make_state(attributes={"temperature": 22.0})
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        await trigger_cooler_change(mock_bt, event)
+
+        assert mock_bt.bt_target_cooltemp == 30.0
+        assert mock_bt.bt_target_temp == 29.75
+
+    @pytest.mark.asyncio
     async def test_a_range_narrowed_below_the_heat_target_pulls_it_inside(
         self, mock_bt
     ):


### PR DESCRIPTION
## What

Convergence only, the `v2` half of a pair. `develop` and `v2` had drifted apart in the cooler path in
two ways that carry no behaviour but cost a conflict at every sync: the wording of comments and
docstrings, and the shape of the "unusable step falls back to the default step" tests.

Zero production behaviour change. Every hunk is a comment, a docstring, or a test rename/parametrise.

## Wording

For the cooler path the direction is **`develop` adopts this branch's text**, because `v2`'s wording
was the more informative one at every drifted site — it names the user-visible consequence of a
cooler setpoint crossing the heating target, it names which sites own the WARNING level, and its
residual tie-break comment is the concrete one. So `events/cooler.py` is **not touched on this
branch**; the sibling PR moves develop onto this text.

What this branch does change is `climate.py`, where the drift runs the other way in places: the
`_clamp_inbound_cool_target` / `_clamp_inbound_heat_target` docstrings and the two early returns in
`_enforce_cool_above_heat` / `_enforce_heat_below_cool` converge onto one text with develop.

## Tests

One canonical parametrised test per method instead of a different set of singletons on each line:

- name: `test_unusable_step_falls_back_to_the_default_step`
- parameters: the **union** of every value either line already tested — `-1.0`, `-0.5`, `nan`, `inf`
- applied in all four classes: `TestEnforceCoolAboveHeat`, `TestEnforceHeatBelowCool`,
  `TestClampInboundCoolTarget`, `TestClampInboundHeatTarget`

Strictly coverage-preserving: no value either line tested is dropped, and no new value is added.
`-inf` and `"unavailable"` also fall back to 0.5 on both lines, but adding them would be new coverage
rather than convergence and is left out on purpose.

After this PR and its `develop` sibling, `pytest tests/unit/test_climate_baseline.py --collect-only -q`
yields the same test ids on both lines for these four classes.

## What is deliberately left alone

The hunks that are real `v2` architecture, not wording: the missing `@callback`, the cooler send
cache (`last_sent_cooler_temperature`), the `contact_open` gate and its diagnostic `elif` branch, and
`request_control_cycle`.

## Verification

- Comments and docstrings were classified by stripping them via AST and diffing the stripped forms.
- Composition was checked against the other six `v2` PRs of this round. An earlier revision of this
  branch also rewrote the seed-branch comment in `events/cooler.py` and conflicted, in both merge
  orders, with `fix(cooler): decline a setpoint reported on a dead cooler state`, which deletes that
  whole block. Leaving `events/cooler.py` untouched here removes the conflict; the composed tip is
  green.

## Gates

```
uv run pytest tests/ -q     4310 passed, 21 warnings in 55.87s
uv run ruff check .         All checks passed!
uv run ruff format --check  291 files already formatted
uv run pyrefly check        0 errors
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how thermostat target values are seeded, prioritized, logged, ordered, and constrained across heating and cooling modes.
  * Documented heating-target floor behavior when valid cooling values are unavailable.

* **Tests**
  * Expanded coverage for invalid temperature-step values, including negative, zero, NaN, and infinite values.
  * Verified fallback to the standard 0.5° step and correct heating/cooling target ordering.
  * Added checks for relevant warnings and preserved heating targets when cooler readings are within one step of the maximum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->