### PR TITLE
fix(setpoint): match an inbound setpoint against the report and the clamp

### DIFF
--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -674,7 +674,7 @@ class InboundSetpoint(NamedTuple):
     clamped : bool
             whether clamping changed the value
     is_echo : bool
-            whether the value is BT's own write coming back
+            whether the report is BT's own write coming back
     """
 
     raw: float
@@ -820,6 +820,14 @@ def resolve_inbound_setpoint(
     step. Answering rather than logging keeps the caller free to decide
     whether a clamp is worth reporting.
 
+    A write of BT's own comes back in one of two shapes, and both are the same
+    question. The device republishes the written value verbatim, which the
+    reported value answers; or the write was itself the product of a clamp, and
+    the device's out-of-range report maps back onto that written value, which
+    the clamped value answers. Either match means the device is carrying BT's
+    own write, so a report is an echo when either comparison lands inside the
+    window.
+
     Parameters
     ----------
     self :
@@ -862,7 +870,8 @@ def resolve_inbound_setpoint(
 
     echo_window = setpoint_echo_window(step)
     is_echo = any(
-        isinstance(known, (int, float)) and abs(value - known) < echo_window
+        isinstance(known, (int, float))
+        and (abs(raw - known) < echo_window or abs(value - known) < echo_window)
         for known in known_values
     )
     return InboundSetpoint(raw=raw, value=value, clamped=clamped, is_echo=is_echo)

--- a/tests/unit/test_helpers_inbound_setpoint.py
+++ b/tests/unit/test_helpers_inbound_setpoint.py
@@ -354,6 +354,22 @@ class TestResolveInboundSetpoint:
         )
         assert (result.value, result.clamped) == (20.0, True)
 
+    def test_report_outside_the_range_matching_a_known_value_is_an_echo(self):
+        """A device parked outside BT's range republishes what BT wrote to it.
+
+        The clamp lifts the report onto the configured minimum and away from
+        the known value, so only the reported value still identifies the write.
+        """
+        result = resolve_inbound_setpoint(
+            _fake_self(),
+            _state({"temperature": 2.0}),
+            keys=TRV_SETPOINT_KEYS,
+            known_values=(21.0, 2.0),
+            step=0.5,
+            log_source="t",
+        )
+        assert (result.raw, result.value, result.is_echo) == (2.0, 5.0, True)
+
     def test_echo_is_judged_after_clamping(self):
         """A value the clamp pulls onto a known value is an echo, not input."""
         result = resolve_inbound_setpoint(

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -962,6 +962,46 @@ class TestTargetTempAdoption:
         assert "setpoint outside of range" not in caplog.text
 
     @pytest.mark.asyncio
+    async def test_parked_no_off_valve_keeps_the_heating_target(self, mock_bt):
+        """A valve resting on its own minimum republishes BT's own write.
+
+        BT parks a no_off valve on the device minimum while it is OFF and
+        records that write in ``last_temperature``. The report sits below
+        ``bt_min_temp``, so the clamp lifts it onto the configured minimum and
+        only the reported value still identifies the write. The ordered pair
+        the user configured has to survive the report unchanged.
+        """
+        mock_bt.bt_hvac_mode = HVACMode.OFF
+        mock_bt.hvac_mode = HVACMode.OFF
+        mock_bt.bt_min_temp = 20.0
+        mock_bt.bt_target_temp = 21.0
+        mock_bt.bt_target_cooltemp = 24.0
+        mock_bt.cooler_entity_id = "climate.test_cooler"
+        trv = mock_bt.real_trvs[ENTITY_ID]
+        trv.advanced["no_off_system_mode"] = True
+        trv.temperature = 5.0
+        trv.last_temperature = 5.0
+        old_state = _make_state(
+            attributes={"temperature": 5.0, "current_temperature": 18.0}
+        )
+        new_state = _make_state(
+            attributes={"temperature": 5.0, "current_temperature": 18.4}
+        )
+        mock_bt.hass.states.get.return_value = new_state
+
+        event = _make_event(mock_bt, new_state=new_state, old_state=old_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.bt_target_temp == 21.0
+        assert mock_bt.bt_target_cooltemp == 24.0
+        assert mock_bt.bt_hvac_mode == HVACMode.OFF
+
+    @pytest.mark.asyncio
     async def test_setpoint_blocked_when_off(self, mock_bt):
         """No setpoint adoption when bt_hvac_mode is OFF."""
         mock_bt.bt_hvac_mode = HVACMode.OFF


### PR DESCRIPTION
## Motivation:

`resolve_inbound_setpoint` judged the echo test on the value *after* the range clamp, so a
device parked outside Better Thermostat's configured range never matched the write Better
Thermostat had made to it. The reported setpoint was then adopted as user input on every
state update.

## Changes:

## The defect

`resolve_inbound_setpoint` decided whether a reported setpoint is BT's own write
coming back by comparing only `value` — the result *after* the range clamp. A
device parked outside BT's configured range therefore never matched the write BT
had made to it.

Executed through the real entry point `events/trv.py::trigger_trv_change`:
a cooler configured, a `no_off_system_mode` TRV with `min_temp` 5.0 parked at
5.0, BT OFF, `trv.last_temperature = 5.0`, an ordered in-range pair
`heat=21.0 / cool=24.0` (range `[20.0, 30.0]`), and an event in which **only
`current_temperature` moved** (18.0 -> 18.4, the setpoint identical in `old` and
`new`):

```
before: bt_target_temp=21.0 bt_target_cooltemp=24.0 bt_hvac_mode=off
after : bt_target_temp=20.0 bt_target_cooltemp=24.0 bt_hvac_mode=off
WARNING better_thermostat Test Thermostat: New TRV climate.test_trv setpoint
        outside of range, overwriting it
```

The valve's resting report of its own minimum is read as user input, the clamp
lifts it to `bt_min_temp`, and the user's heating target is silently replaced.
Nothing in the event carries new information. `develop` reproduces this row
identically; the fix is the same on both lines.

## The rule

A report is BT's own write coming back when **either** the value the device
reported **or** the value BT would store after clamping it matches a known write:

```python
is_echo = any(
    isinstance(known, (int, float))
    and (abs(raw - known) < echo_window or abs(value - known) < echo_window)
    for known in known_values
)
```

Both comparisons ask the same question. BT's write comes back in one of two
shapes: the device republishes the written value verbatim, which the reported
value answers; or BT's write was itself the product of a clamp, in which case
the device's out-of-range report maps back onto that written value, which the
clamped value answers. This is not a hedge — dropping either half loses a real
class of echo, and the tests below pin both halves.

`InboundSetpoint.value` and `.clamped` keep their meaning.

## Measured effect

Executed grids driven through the real handlers, before and after, one canonical
line per row and diffed row by row:

| grid | rows | rows changed | suppressed -> adopted | adopted -> suppressed |
|---|---|---|---|---|
| TRV (`trigger_trv_change`) | 2304 | 24 | **0** | 24 |
| cooler (`trigger_cooler_change`) | 350 | 6 | **0** | 6 |

All 24 and all 6 changed rows move a stored target. Every changed row has
`raw == 5.0`, i.e. exactly the parked-valve class. The flip sets are equal as
sets between this branch and `develop`.

Set comparison against the rejected raw-only rule (executed on the same grids):
the adopted -> suppressed sets are **identical** (symmetric difference empty,
24 and 6 rows). The raw-only rule additionally flipped 420 TRV rows and 116
cooler rows from suppressed to adopted; the disjunction flips none. So this
change fixes exactly the intended class and nothing else.

Exhaustive matrix over 3549 (report, known-value pair) combinations executed
through `resolve_inbound_setpoint` on the pristine and on the patched tree:

```
in-range rows      : 1183   echo False -> False: 880   echo True -> True: 303
out-of-range rows  : 2366   echo False -> False: 1298  echo False -> True: 76
                            echo True  -> True: 992
echo -> NOT echo (a suppressed report becoming adoptable): 0
```

The verdict is unchanged on every in-range report (there `raw == value`, so the
new disjunct is redundant) and only ever moves from "not an echo" to "echo" on
an out-of-range one. No report that is suppressed today becomes adopted.

## The verification rows, re-executed

| row | `last_temperature` | before | after |
|---|---|---|---|
| A1 valve parked at min, BT OFF | 5.0 | heat 9.0 -> **20.0**, pair inverted | heat stays **9.0** |
| A3 fresh restart | `None` | heat 9.0 -> 20.0 | heat 9.0 -> **20.0** (unchanged) |
| B1 ordered in-range pair | 5.0 | heat 21.0 -> **20.0** | heat stays **21.0** |

A3 is **not** fixed by this PR and this PR does not claim to fix it: with no
recorded write there is nothing for the echo test to match, so the report is
correctly still adopted. That case is closed by the cooler-target-range pair.

## Tests

- `test_report_outside_the_range_matching_a_known_value_is_an_echo` —
  a report of 2.0 with a known write of 2.0 and the range starting at 5.0.
- `test_parked_no_off_valve_keeps_the_heating_target` — pins the control row
  above through `trigger_trv_change`.

Mutation-tested: deleting the reported-value disjunct fails both new tests;
deleting the clamped-value disjunct fails all three merged tests that assert the
current behaviour — `test_echo_is_judged_after_clamping` and both
`test_clamped_setpoint_that_is_discarded_is_silent` (TRV and cooler). Neither
half of the disjunction is dead.

Those three merged tests stay green **unedited** — this change adds a way to be
an echo, it never removes one.

## Gate

`uv run pytest tests/ -q` 4304 passed (4302 at the branch point + 2 new) ·
`uv run ruff check .` clean · `uv run ruff format --check .` clean ·
`uv run pyrefly check` 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of thermostat setpoint echoes, including reported values outside the configured range.
  * Prevented device-minimum echoes from incorrectly changing heating or cooling targets while the thermostat is off.
  * Improved handling of valve parking behavior when the thermostat is disabled.

* **Tests**
  * Added regression coverage for out-of-range setpoints and off-state valve parking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

Not tested on hardware. The evidence in this PR is unit-level and executed: the full suite plus the
targeted reproductions quoted above, driven against mocked Home Assistant objects. No real TRV,
cooler or Home Assistant instance was involved, so the fields below are left blank rather than
filled with values that were never observed.

HA Version:
Zigbee2MQTT Version:
TRV Hardware:

## New device mappings

No new device mapping is added by this PR.

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`
