### PR TITLE
fix(calibration): make the cooling report and the idle gates agree

### DIFF
--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -82,6 +82,11 @@ _LOGGER = logging.getLogger(__name__)
 _MPC_V2_REID_INTERVAL_S = 6 * 3600.0
 _MPC_V2_REID_MIN_SAMPLES = 240
 
+# Post-adjustment gates that fire because Better Thermostat is not calling for
+# heat take the same arm while the cooler runs: a TRV valve that opens works
+# against the cooler, so cooling is the strongest form of not calling for heat.
+_IDLE_OR_COOLING = (HVACAction.IDLE, HVACAction.COOLING)
+
 
 def _compute_zero_open_offset(
     self,
@@ -1305,9 +1310,11 @@ def calculate_calibration_local(self, entity_id) -> float | None:
 
     # Respecting tolerance, delaying heat; modes that should start
     # heating faster opt out of the delay via their traits.
+    # The delay is sized by the heating tolerance and carries over unchanged
+    # while the cooler runs, where at least as much delay is wanted.
     if not _skip_post_adjustments:
         if traits.tolerance_delay:
-            if self.hvac_action == HVACAction.IDLE:
+            if self.hvac_action in _IDLE_OR_COOLING:
                 if _new_trv_calibration < 0.0:
                     _new_trv_calibration += self.tolerance * 2.0
 
@@ -1329,9 +1336,9 @@ def calculate_calibration_local(self, entity_id) -> float | None:
     # Calibration offset works inversely to setpoint: a positive offset makes
     # the TRV read a higher temperature (closing the valve), a negative offset
     # makes it read lower (opening the valve).
-    # When IDLE, round offset UP to ensure the valve closes.
+    # Idle and cooling round the offset UP to ensure the valve closes.
     # When HEATING, round offset DOWN to ensure the valve opens.
-    if self.hvac_action == HVACAction.IDLE:
+    if self.hvac_action in _IDLE_OR_COOLING:
         _cal_rounding = rounding.up
     elif self.hvac_action == HVACAction.HEATING:
         _cal_rounding = rounding.down
@@ -1506,9 +1513,11 @@ def calculate_calibration_setpoint(self, entity_id) -> float | None:
 
     # Respecting tolerance, delaying heat; modes that should start
     # heating faster opt out of the delay via their traits.
+    # The delay is sized by the heating tolerance and carries over unchanged
+    # while the cooler runs, where at least as much delay is wanted.
     if not _skip_post_adjustments:
         if traits.tolerance_delay:
-            if self.hvac_action == HVACAction.IDLE:
+            if self.hvac_action in _IDLE_OR_COOLING:
                 if _calibrated_setpoint - _cur_trv_temp > 0.0:
                     _calibrated_setpoint -= self.tolerance * 2.0
 
@@ -1528,12 +1537,12 @@ def calculate_calibration_setpoint(self, entity_id) -> float | None:
                     _cur_external_temp - (_cur_target_temp + self.tolerance)
                 ) * 8.0  # Reduced from 10.0 since we already subtract 2.0
 
-    # Direction-aware rounding: when IDLE, round setpoint DOWN so the TRV
-    # sees a target below its current temperature and closes the valve.
+    # Direction-aware rounding: idle and cooling round the setpoint DOWN so the
+    # TRV sees a target below its current temperature and closes the valve.
     # When HEATING, round UP so the TRV keeps the valve open.
     # This prevents integer-step TRVs (step=1.0) from rounding a value like
     # 19.7 up to 20.0 which would keep the valve open at the current temp.
-    if self.hvac_action == HVACAction.IDLE:
+    if self.hvac_action in _IDLE_OR_COOLING:
         _step_rounding = rounding.down
     elif self.hvac_action == HVACAction.HEATING:
         _step_rounding = rounding.up

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -152,6 +152,7 @@ from .utils.controlling import (
     compute_control_cycle,
     control_queue,
     control_trv,
+    cooler_send_cache,
     reconcile_tick,
 )
 from .utils.helpers import (
@@ -3118,6 +3119,21 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self._commit_hvac_action(result)
         return result.action
 
+    def _cooler_previously_active(self) -> bool:
+        """Whether the cooling hysteresis band currently holds its hold edge.
+
+        Seeded the way ``control_cooler`` seeds it: the latched decision wins,
+        and the cooler's own reported mode stands in while Better Thermostat
+        has not decided a cooler mode of its own.
+        """
+        if self.cooler_entity_id is None:
+            return False
+        decided = cooler_send_cache(self).get("hvac_mode_decided")
+        if decided is not None:
+            return decided == HVACMode.COOL
+        cooler_state = self.hass.states.get(self.cooler_entity_id)
+        return cooler_state is not None and cooler_state.state == HVACMode.COOL
+
     def _compute_hvac_action_pure(self):
         """Compute current HVAC action from the typed containers and regions.
 
@@ -3137,6 +3153,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             tolerance=self.tolerance or 0.0,
             ignore_states=self.ignore_states,
             trv_snapshots=self._build_trv_snapshots(),
+            cool_previously_active=self._cooler_previously_active(),
             device_name=self.device_name,
         )
 

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -48,6 +48,7 @@ from custom_components.better_thermostat.utils.helpers import (
     supports_temperature_range,
 )
 from custom_components.better_thermostat.utils.hvac_action import (
+    COOLER_MODE_HYSTERESIS_K,
     should_cool_with_tolerance,
 )
 from custom_components.better_thermostat.utils.scheduler import request_control_cycle
@@ -109,14 +110,6 @@ COOLER_FAILURE_BACKOFF_MAX_RUN = 1 + math.ceil(
 # or a whole-°F grid). A post-send reading within this distance of the sent
 # value counts as that device-side quantization, not as an unapplied command.
 COOLER_QUANTIZATION_TOLERANCE_K = 0.5
-# Minimum width of the cooling decision band. A tolerance narrower than this
-# leaves the room temperature resting on an edge, where it flips the decision —
-# and produces a write — on every control cycle; the missing width is taken
-# from below the cooling target to keep the switch-on edge where the tolerance
-# puts it. Two steps of a 0.1 °C room sensor, which is what the flip is made
-# of; and well under the 0.5 °C a cooling setpoint is set in, so the extra run
-# time the band costs is finer than the user can express in the target anyway.
-COOLER_MODE_HYSTERESIS_K = 0.2
 # Valve deviations below this are the device's own business.
 RECONCILE_VALVE_TOLERANCE_PCT = 5.0
 # Pause before re-queueing a cycle in which a TRV reported failure, so a

--- a/custom_components/better_thermostat/utils/hvac_action.py
+++ b/custom_components/better_thermostat/utils/hvac_action.py
@@ -76,6 +76,16 @@ def should_heat_with_tolerance(
     return cur_temp < heat_on_threshold
 
 
+# Minimum width of the cooling decision band. A tolerance narrower than this
+# leaves the room temperature resting on an edge, where it flips the decision —
+# and produces a write — on every control cycle; the missing width is taken
+# from below the cooling target to keep the switch-on edge where the tolerance
+# puts it. Two steps of a 0.1 °C room sensor, which is what the flip is made
+# of; and well under the 0.5 °C a cooling setpoint is set in, so the extra run
+# time the band costs is finer than the user can express in the target anyway.
+COOLER_MODE_HYSTERESIS_K = 0.2
+
+
 def should_cool_with_tolerance(
     cur_temp: float,
     cool_target: float,
@@ -112,6 +122,7 @@ def compute_hvac_action(
     tolerance: float,
     ignore_states: bool,
     trv_snapshots: list[TrvSnapshot],
+    cool_previously_active: bool = False,
     device_name: str = "",
 ) -> HvacActionResult:
     """Compute the current HVAC action without mutating *hysteresis*.
@@ -121,7 +132,9 @@ def compute_hvac_action(
     - OFF mode → OFF regardless of temperatures.
     - Open window → IDLE (suppresses active heating/cooling).
     - Heating uses a hysteresis band ``[target - tolerance, target]``.
-    - Cooling when ``heat_cool`` and ``cur_temp > cool_target + tolerance``.
+    - Cooling when ``heat_cool``, the cooling hysteresis calls for it and the
+      room is above the heating target. ``cool_previously_active`` carries the
+      band's hold edge, which the caller seeds the way the cooler command does.
     - Otherwise IDLE, unless a TRV explicitly reports heating.
     """
     prev_action = hysteresis.last_action
@@ -163,11 +176,23 @@ def compute_hvac_action(
 
     tolerance_decision = action
 
-    # Cooling decision
+    # Cooling decision: the same predicate, the same minimum band and the same
+    # heating-target floor the cooler command applies, so the reported action
+    # and the command agree by construction rather than by two implementations
+    # staying in step. COOLING means the cooler is being commanded on, not that
+    # the room is being cooled by something. The report may lag the command by
+    # one cycle, which is correct: it reports what is running.
     if (
         hvac_mode == HVACMode.HEAT_COOL
         and cool_target is not None
-        and cur_temp > (cool_target + tolerance)
+        and should_cool_with_tolerance(
+            cur_temp,
+            cool_target,
+            tolerance,
+            cool_previously_active,
+            min_band=COOLER_MODE_HYSTERESIS_K,
+        )
+        and cur_temp > target_temp
     ):
         action = HVACAction.COOLING
         tolerance_hold = False

--- a/tests/unit/test_calibration_cooling_gates.py
+++ b/tests/unit/test_calibration_cooling_gates.py
@@ -1,0 +1,262 @@
+"""Calibration gates that fire on an idle heating decision also fire while cooling.
+
+A TRV valve that opens while the cooler runs works against it, so every gate
+that exists because Better Thermostat is not calling for heat has to take the
+same arm for ``HVACAction.COOLING`` as for ``HVACAction.IDLE``.
+"""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.climate.const import HVACAction, HVACMode
+import pytest
+
+from custom_components.better_thermostat.calibration import (
+    calculate_calibration_local,
+    calculate_calibration_setpoint,
+)
+from custom_components.better_thermostat.trv import Trv
+from custom_components.better_thermostat.utils.const import CalibrationMode
+from custom_components.better_thermostat.utils.state_manager import StateManager
+
+ENTITY_ID = "climate.trv"
+
+
+def build_bt(
+    calibration_mode,
+    hvac_action,
+    cur_temp,
+    bt_target_temp=21.0,
+    trv_temp=21.0,
+    tolerance=0.0,
+    step=0.5,
+    protect_overheating=False,
+):
+    """Return a BetterThermostat mock carrying a single configured TRV."""
+    bt = MagicMock()
+    bt.name = "better_thermostat"
+    bt.device_name = "Test BT"
+    bt.tolerance = tolerance
+    bt.attr_hvac_action = hvac_action
+    bt.hvac_action = hvac_action
+    bt.cur_temp = cur_temp
+    bt.cur_temp_filtered = None
+    bt.bt_target_temp = bt_target_temp
+    bt.bt_hvac_mode = HVACMode.HEAT_COOL
+    bt.outdoor_sensor = None
+    bt.weather_entity = None
+    bt.window_open = False
+    bt.temp_slope = None
+    bt.heating_power = 0.04
+    bt.heat_loss_rate = 0.02
+    bt.hass = None
+    bt.state_mgr = StateManager(MagicMock(), "cooling_gates")
+
+    quirks = MagicMock()
+    quirks.fix_local_calibration.side_effect = lambda _self, _entity, offset: float(
+        offset
+    )
+    quirks.fix_target_temperature_calibration.side_effect = (
+        lambda _self, _entity, temperature: float(temperature)
+    )
+
+    bt.real_trvs = {
+        ENTITY_ID: Trv.from_legacy_dict(
+            ENTITY_ID,
+            {
+                "advanced": {
+                    "calibration_mode": calibration_mode,
+                    "protect_overheating": protect_overheating,
+                },
+                "current_temperature": trv_temp,
+                "last_calibration": 0.0,
+                "local_calibration_step": step,
+                "local_calibration_min": -5.0,
+                "local_calibration_max": 5.0,
+                "target_temp_step": step,
+                "min_temp": 5.0,
+                "max_temp": 30.0,
+                "model_quirks": quirks,
+            },
+        )
+    }
+    return bt
+
+
+def test_cooling_rounds_setpoint_toward_closed():
+    """A cooling room rounds the setpoint down, as an idle one does.
+
+    Room 21.05 against a TRV reading 20.9 on a 0.5 K grid: rounding to the
+    nearest step writes 21.0, above the TRV's own reading, which calls for
+    heat while the cooler runs.
+    """
+    kwargs = {
+        "calibration_mode": CalibrationMode.DEFAULT,
+        "cur_temp": 21.05,
+        "trv_temp": 20.9,
+    }
+    idle = calculate_calibration_setpoint(
+        build_bt(hvac_action=HVACAction.IDLE, **kwargs), ENTITY_ID
+    )
+    cooling = calculate_calibration_setpoint(
+        build_bt(hvac_action=HVACAction.COOLING, **kwargs), ENTITY_ID
+    )
+    nearest = calculate_calibration_setpoint(
+        build_bt(hvac_action=HVACAction.OFF, **kwargs), ENTITY_ID
+    )
+
+    assert idle == pytest.approx(20.5)
+    assert cooling == pytest.approx(20.5)
+    assert nearest == pytest.approx(21.0)
+    assert cooling < 20.9
+
+
+def test_cooling_rounds_local_offset_toward_closed():
+    """A cooling room rounds the calibration offset up, as an idle one does.
+
+    The offset works inversely to the setpoint, so the closing direction is
+    up; rounding to the nearest step leaves the TRV reading its own room
+    temperature and calling for heat.
+    """
+    kwargs = {
+        "calibration_mode": CalibrationMode.DEFAULT,
+        "cur_temp": 21.05,
+        "trv_temp": 20.9,
+    }
+    idle = calculate_calibration_local(
+        build_bt(hvac_action=HVACAction.IDLE, **kwargs), ENTITY_ID
+    )
+    cooling = calculate_calibration_local(
+        build_bt(hvac_action=HVACAction.COOLING, **kwargs), ENTITY_ID
+    )
+    nearest = calculate_calibration_local(
+        build_bt(hvac_action=HVACAction.OFF, **kwargs), ENTITY_ID
+    )
+
+    assert idle == pytest.approx(0.5)
+    assert cooling == pytest.approx(0.5)
+    assert nearest == pytest.approx(0.0)
+    assert 20.9 + cooling >= 21.0
+
+
+def test_cooling_applies_tolerance_delay_to_local_offset():
+    """The tolerance delay lifts the offset while cooling, as it does when idle."""
+    kwargs = {
+        "calibration_mode": CalibrationMode.NO_CALIBRATION,
+        "cur_temp": 21.4,
+        "trv_temp": 22.0,
+        "tolerance": 0.5,
+        "step": 0.1,
+    }
+    idle = calculate_calibration_local(
+        build_bt(hvac_action=HVACAction.IDLE, **kwargs), ENTITY_ID
+    )
+    cooling = calculate_calibration_local(
+        build_bt(hvac_action=HVACAction.COOLING, **kwargs), ENTITY_ID
+    )
+    undelayed = calculate_calibration_local(
+        build_bt(hvac_action=HVACAction.OFF, **kwargs), ENTITY_ID
+    )
+
+    assert idle == pytest.approx(0.4)
+    assert cooling == pytest.approx(0.4)
+    assert undelayed == pytest.approx(-0.6)
+
+
+def test_cooling_applies_tolerance_delay_to_setpoint():
+    """The tolerance delay lowers the setpoint while cooling, as it does when idle.
+
+    The delay reaches the setpoint only below the heating target, which the
+    heating-target floor in ``compute_hvac_action`` keeps out of the cooling
+    report; the arm is exercised here directly on the calibration function so
+    the two calibration paths carry the same condition.
+    """
+    kwargs = {
+        "calibration_mode": CalibrationMode.NO_CALIBRATION,
+        "cur_temp": 20.5,
+        "trv_temp": 21.0,
+        "tolerance": 0.5,
+        "step": 0.1,
+    }
+    idle = calculate_calibration_setpoint(
+        build_bt(hvac_action=HVACAction.IDLE, **kwargs), ENTITY_ID
+    )
+    cooling = calculate_calibration_setpoint(
+        build_bt(hvac_action=HVACAction.COOLING, **kwargs), ENTITY_ID
+    )
+    undelayed = calculate_calibration_setpoint(
+        build_bt(hvac_action=HVACAction.OFF, **kwargs), ENTITY_ID
+    )
+
+    assert idle == pytest.approx(20.5)
+    assert cooling == pytest.approx(20.5)
+    assert undelayed == pytest.approx(21.5)
+
+
+def test_overheating_protection_applies_to_idle_only():
+    """The overheating term is signed against the heating target and stays idle-only.
+
+    Its magnitude is calibrated against the heating tolerance, and below
+    ``heating target + tolerance`` it turns negative and opens the valve —
+    which is the region a cooling room occupies once the cooling target sits
+    one step above the heating target.
+    """
+    kwargs = {
+        "calibration_mode": CalibrationMode.NO_CALIBRATION,
+        "cur_temp": 23.0,
+        "trv_temp": 21.0,
+        "tolerance": 0.5,
+        "protect_overheating": True,
+    }
+    idle_setpoint = calculate_calibration_setpoint(
+        build_bt(hvac_action=HVACAction.IDLE, **kwargs), ENTITY_ID
+    )
+    cooling_setpoint = calculate_calibration_setpoint(
+        build_bt(hvac_action=HVACAction.COOLING, **kwargs), ENTITY_ID
+    )
+    idle_offset = calculate_calibration_local(
+        build_bt(hvac_action=HVACAction.IDLE, **kwargs), ENTITY_ID
+    )
+    cooling_offset = calculate_calibration_local(
+        build_bt(hvac_action=HVACAction.COOLING, **kwargs), ENTITY_ID
+    )
+
+    assert cooling_setpoint == pytest.approx(19.0)
+    assert idle_setpoint == pytest.approx(7.0)
+    assert cooling_offset == pytest.approx(2.0)
+    assert idle_offset > cooling_offset
+    # Both arms hold the valve shut: the TRV reads 21.0 against a 21.0 target.
+    assert cooling_setpoint < 21.0
+    assert 21.0 + cooling_offset >= 21.0
+
+
+@pytest.mark.parametrize("calibration_mode", list(CalibrationMode))
+@pytest.mark.parametrize("step", [0.1, 0.5, 1.0])
+@pytest.mark.parametrize("tolerance", [0.0, 0.3, 0.5])
+@pytest.mark.parametrize("cur_temp", [21.05, 21.3, 22.0, 23.7, 24.2, 26.4])
+@pytest.mark.parametrize("trv_temp", [20.0, 20.9, 21.0, 22.5])
+def test_cooling_never_opens_further_than_idle(
+    calibration_mode, step, tolerance, cur_temp, trv_temp
+):
+    """Cooling never commands a more open valve than the same idle room does."""
+    kwargs = {
+        "calibration_mode": calibration_mode,
+        "cur_temp": cur_temp,
+        "trv_temp": trv_temp,
+        "tolerance": tolerance,
+        "step": step,
+    }
+    idle_setpoint = calculate_calibration_setpoint(
+        build_bt(hvac_action=HVACAction.IDLE, **kwargs), ENTITY_ID
+    )
+    cooling_setpoint = calculate_calibration_setpoint(
+        build_bt(hvac_action=HVACAction.COOLING, **kwargs), ENTITY_ID
+    )
+    idle_offset = calculate_calibration_local(
+        build_bt(hvac_action=HVACAction.IDLE, **kwargs), ENTITY_ID
+    )
+    cooling_offset = calculate_calibration_local(
+        build_bt(hvac_action=HVACAction.COOLING, **kwargs), ENTITY_ID
+    )
+
+    assert cooling_setpoint <= idle_setpoint
+    assert cooling_offset >= idle_offset

--- a/tests/unit/test_hvac_action_cooling_report.py
+++ b/tests/unit/test_hvac_action_cooling_report.py
@@ -1,0 +1,236 @@
+"""The reported cooling action is derived from the cooler command, not beside it.
+
+``control_cooler`` decides with ``should_cool_with_tolerance``, a minimum band
+of ``COOLER_MODE_HYSTERESIS_K``, a latch carrying the hold edge and the heating
+target as a hard floor. ``compute_hvac_action`` reports ``COOLING`` under
+exactly those conditions, so the two agree by construction.
+"""
+
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.climate.const import HVACAction, HVACMode
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+from custom_components.better_thermostat.core.clock import FakeClock
+from custom_components.better_thermostat.core.snapshot import HvacMode as CoreHvacMode
+from custom_components.better_thermostat.utils.controlling import control_cooler
+from custom_components.better_thermostat.utils.hvac_action import (
+    COOLER_MODE_HYSTERESIS_K,
+    ToleranceHysteresis,
+    compute_hvac_action,
+    should_cool_with_tolerance,
+)
+from tests.factories import make_snapshot
+
+COOLER_ID = "climate.air_conditioner"
+
+
+def build_bt(
+    cur_temp,
+    target_temp=21.0,
+    cool_target=24.0,
+    tolerance=0.5,
+    decided_mode=None,
+    reported_mode=HVACMode.OFF,
+    cooler_entity_id=COOLER_ID,
+):
+    """Return a BT mock with the real hvac-action methods bound to it."""
+    bt = MagicMock()
+    bt.tolerance = tolerance
+    bt.bt_target_temp = target_temp
+    bt.bt_target_cooltemp = cool_target
+    bt.cur_temp = cur_temp
+    bt.hvac_mode = HVACMode.HEAT_COOL
+    bt.bt_hvac_mode = HVACMode.HEAT_COOL
+    bt.contact_open = False
+    bt.ignore_states = False
+    bt.real_trvs = {}
+    bt._hysteresis = ToleranceHysteresis()
+    bt.device_name = "Test"
+    bt.cooler_entity_id = cooler_entity_id
+    bt._cooler_last_sent = (
+        {} if decided_mode is None else {"hvac_mode_decided": decided_mode}
+    )
+
+    cooler_state = MagicMock()
+    cooler_state.state = reported_mode
+    bt.hass.states.get.return_value = cooler_state
+
+    bt._build_trv_snapshots = types.MethodType(
+        BetterThermostat._build_trv_snapshots, bt
+    )
+    bt._cooler_previously_active = types.MethodType(
+        BetterThermostat._cooler_previously_active, bt
+    )
+    bt._compute_hvac_action_pure = types.MethodType(
+        BetterThermostat._compute_hvac_action_pure, bt
+    )
+    return bt
+
+
+def test_report_holds_cooling_inside_the_hold_band():
+    """A running cooler keeps reporting COOLING below the switch-on edge."""
+    bt = build_bt(cur_temp=24.2, decided_mode=HVACMode.COOL)
+    assert bt._compute_hvac_action_pure().action == HVACAction.COOLING
+
+
+def test_report_does_not_start_cooling_inside_the_hold_band():
+    """A stopped cooler does not report COOLING below the switch-on edge."""
+    bt = build_bt(cur_temp=24.2, decided_mode=HVACMode.OFF)
+    assert bt._compute_hvac_action_pure().action == HVACAction.IDLE
+
+
+def test_report_starts_cooling_at_the_switch_on_edge():
+    """At cooling target plus tolerance the report turns to COOLING."""
+    bt = build_bt(cur_temp=24.5, decided_mode=HVACMode.OFF)
+    assert bt._compute_hvac_action_pure().action == HVACAction.COOLING
+
+
+def test_report_drops_cooling_below_the_hold_edge():
+    """Below the cooling target a running cooler stops being reported."""
+    bt = build_bt(cur_temp=23.9, decided_mode=HVACMode.COOL)
+    assert bt._compute_hvac_action_pure().action == HVACAction.IDLE
+
+
+def test_heating_target_floors_the_cooling_report():
+    """At or below the heating target nothing is reported as cooling.
+
+    A cooling target close to the heating target lets the minimum band reach
+    under the heating target; the cooler command refuses to run there and the
+    report follows it.
+    """
+    kwargs = {
+        "target_temp": 21.0,
+        "cool_target": 21.2,
+        "tolerance": 0.0,
+        "decided_mode": HVACMode.COOL,
+    }
+    on_the_floor = build_bt(cur_temp=21.0, **kwargs)
+    above_the_floor = build_bt(cur_temp=21.05, **kwargs)
+
+    assert on_the_floor._compute_hvac_action_pure().action == HVACAction.IDLE
+    assert above_the_floor._compute_hvac_action_pure().action == HVACAction.COOLING
+
+
+def test_cooling_report_does_not_hold_the_heating_tolerance():
+    """A reported cooling action clears the tolerance hold."""
+    bt = build_bt(cur_temp=24.2, decided_mode=HVACMode.COOL)
+    result = bt._compute_hvac_action_pure()
+    assert result.action == HVACAction.COOLING
+    assert result.new_hold_active is False
+    assert result.new_last_action == HVACAction.IDLE
+
+
+def test_seed_follows_the_latched_cooler_decision():
+    """The latched decision decides the hold edge whenever it holds one."""
+    latched_on = build_bt(
+        cur_temp=24.2, decided_mode=HVACMode.COOL, reported_mode=HVACMode.OFF
+    )
+    latched_off = build_bt(
+        cur_temp=24.2, decided_mode=HVACMode.OFF, reported_mode=HVACMode.COOL
+    )
+
+    assert latched_on._cooler_previously_active() is True
+    assert latched_off._cooler_previously_active() is False
+
+
+def test_seed_falls_back_to_the_reported_cooler_mode():
+    """Without a latched decision the cooler's own mode seeds the hold edge."""
+    running = build_bt(cur_temp=24.2, decided_mode=None, reported_mode=HVACMode.COOL)
+    stopped = build_bt(cur_temp=24.2, decided_mode=None, reported_mode=HVACMode.OFF)
+
+    assert running._cooler_previously_active() is True
+    assert stopped._cooler_previously_active() is False
+    assert running._compute_hvac_action_pure().action == HVACAction.COOLING
+    assert stopped._compute_hvac_action_pure().action == HVACAction.IDLE
+
+
+def test_seed_is_off_without_a_cooler():
+    """An installation without a cooler never holds the cooling band open."""
+    bt = build_bt(cur_temp=24.2, decided_mode=HVACMode.COOL, cooler_entity_id=None)
+    assert bt._cooler_previously_active() is False
+
+
+@pytest.mark.parametrize("target_temp, cool_target", [(21.0, 24.0), (21.0, 21.5)])
+@pytest.mark.parametrize("tolerance", [0.0, 0.2, 0.5, 1.0])
+@pytest.mark.parametrize("cool_previously_active", [False, True])
+@pytest.mark.parametrize("offset", [-0.5, -0.2, -0.1, 0.0, 0.1, 0.2, 0.5, 1.0, 2.0])
+def test_report_agrees_with_the_command(
+    target_temp, cool_target, tolerance, cool_previously_active, offset
+):
+    """The reported cooling action matches what control_cooler would command."""
+    cur_temp = round(cool_target + offset, 2)
+    reported = compute_hvac_action(
+        hysteresis=ToleranceHysteresis(),
+        cur_temp=cur_temp,
+        target_temp=target_temp,
+        cool_target=cool_target,
+        hvac_mode=HVACMode.HEAT_COOL,
+        bt_hvac_mode=HVACMode.HEAT_COOL,
+        window_open=False,
+        tolerance=tolerance,
+        ignore_states=False,
+        trv_snapshots=[],
+        cool_previously_active=cool_previously_active,
+    ).action
+    commanded = (
+        should_cool_with_tolerance(
+            cur_temp,
+            cool_target,
+            tolerance,
+            cool_previously_active,
+            min_band=COOLER_MODE_HYSTERESIS_K,
+        )
+        and cur_temp > target_temp
+    )
+
+    assert (reported == HVACAction.COOLING) is commanded
+
+
+@pytest.mark.asyncio
+async def test_command_and_report_agree_across_a_temperature_sweep():
+    """Both real entry points agree at every step of a rise and a fall.
+
+    The sweep crosses the switch-on edge, walks through the hold band and
+    leaves it underneath, which is where two independent decisions drift
+    apart.
+    """
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.states.get.return_value = State(
+        "climate.cooler", HVACMode.OFF, {"temperature": 24.0}
+    )
+
+    bt = build_bt(cur_temp=21.5, cool_target=24.0, target_temp=21.0, tolerance=0.5)
+    bt.hass = hass
+    bt.context = None
+    bt.cooler_entity_id = "climate.cooler"
+    bt.clock = FakeClock()
+    bt._cooler_last_sent = {}
+
+    rise = [21.5, 23.0, 24.0, 24.2, 24.4, 24.5, 24.6, 25.0]
+    sweep = rise + list(reversed(rise))
+    seen = {}
+    for temp in sweep:
+        bt.cur_temp = temp
+        snapshot = make_snapshot(
+            hvac_mode=CoreHvacMode.HEAT_COOL,
+            room_temp=temp,
+            target_temp=21.0,
+            target_cooltemp=24.0,
+            tolerance=0.5,
+            trvs={},
+        )
+        await control_cooler(bt, snapshot)
+        commanded = bt._cooler_last_sent.get("hvac_mode_decided")
+        reported = bt._compute_hvac_action_pure().action
+        assert (reported == HVACAction.COOLING) is (commanded == HVACMode.COOL), temp
+        seen[temp] = commanded
+
+    # The sweep has to reach the hold band, or agreement is trivial.
+    assert seen[25.0] == HVACMode.COOL
+    assert seen[24.2] == HVACMode.COOL
+    assert seen[23.0] == HVACMode.OFF


### PR DESCRIPTION
## What

Same pair as on the maintenance line, adapted to the v2 architecture. Two commits, both of which
change behaviour for cooler installations.

**1. `fix: apply the idle calibration gates while cooling as well`**

The tolerance delay and the direction-aware rounding in `calculate_calibration_local` and
`calculate_calibration_setpoint` exist because Better Thermostat is not calling for heat. Cooling is
the strongest form of that: a TRV valve that opens while the cooler runs works against it. Both
gates now take the same arm for `COOLING` as for `IDLE`, via one shared `_IDLE_OR_COOLING` tuple.
The tolerance delay keeps its `traits.tolerance_delay` opt-out untouched.

The overheating-protection term stays `IDLE`-only. Its magnitude is calibrated against the heating
tolerance and it is signed: below `heating target + tolerance` it turns negative and *opens* the
valve — which is exactly the region a cooling room occupies once the cooling target sits a step
above the heating target.

**2. `fix: derive the cooling report from the cooler command`**

`compute_hvac_action` reported `COOLING` from its own predicate — bare
`cur_temp > cool_target + tolerance`, with no hold band, no latch and no heating-target floor.
`control_cooler` decides with `should_cool_with_tolerance`, a minimum band of
`COOLER_MODE_HYSTERESIS_K`, a latch carrying the hold edge, and the heating target as a hard floor.

The report now calls that same predicate with those same arguments. The hold edge arrives as a
parameter so `compute_hvac_action` stays pure; on this line the caller reads it from the cooler send
cache (`_cooler_last_sent["hvac_mode_decided"]`), which is where `control_cooler` latches its own
decision, and falls back to the cooler's reported mode while no decision has been made yet.
`COOLING` means *the cooler is being commanded on*.

`COOLER_MODE_HYSTERESIS_K` moves next to the predicate it belongs to, so both readers share one
definition instead of the report reaching across into the control module.

`utils/hvac_action.py` is byte-identical to the maintenance line's version, as it was before.
`_cooler_previously_active()` in `climate.py` is the one place the two lines legitimately differ,
because the latch lives in different places.

## Why the order matters

Shipping the report fix alone reproduces the regression that caused the earlier revert: with
`COOLING` reachable in the hold band and the gates untouched, `COOLING` falls through the
direction-aware rounding to `rounding.nearest`, which on part of the grid rounds *toward open*.

## Measured

Calibration grid: 8 calibration modes x 2 protect_overheating x 3 device steps x 10 room temps x
5 TRV readings x 3 tolerances x 4 HVAC actions = 28 800 results, controllers live.

* 2 668 rows move, every one a `COOLING` row. **0 rows move toward a more open valve.**
* States in which a cooling room commands a more open valve than an idle room at the same
  temperatures: 3 003 -> 1 044.
* Of those, states in which the cooling arm actually **calls for heat**: **213 -> 0.** Worked
  example: room 21.05, TRV reading 20.9, 0.5 K grid — idle wrote 20.5 (shut), cooling wrote 21.0,
  above the TRV's own reading, so the valve opened while the AC ran.

Report grid: 288 288 reported actions (identical output to the maintenance line, as the module is
byte-identical).

* With a cooling target above the heating target: 5 544 states change from `IDLE` to `COOLING`, all
  inside the hold band a running cooler holds open.
* The span in which report and command disagreed, summed over 24 target/tolerance combinations:
  **5.94 K -> 0.00 K** (widest single scenario 1.01 K -> 0.00 K).
* The heating decision itself does not move: `tolerance_decision` and `new_last_action` unchanged on
  every row.

## Known residual, deliberately not fixed here

With `protect_overheating` enabled, 1 044 of 7 200 cooling/idle pairs still show a *nominally* more
open cooling command, because the overheating term stays idle-only. All of them command a fully shut
valve on both arms — **zero call for heat** — and they are a strict subset of what the branch already
had (3 003 before).

## Not changed

* The heating path, and no gate switched to reading `tolerance_decision` instead of `hvac_action`.
* `should_cool_with_tolerance` itself — shared with the command.
* Reporting `COOLING` in pure `HVACMode.COOL`: unreachable, `HVACMode.COOL` is never offered.

## Tests

`tests/unit/test_calibration_cooling_gates.py` (1 733 cases, byte-identical to the maintenance line)
and `tests/unit/test_hvac_action_cooling_report.py` (154 cases), including one test that drives the
real `control_cooler` with a cycle snapshot and the real `hvac_action` computation across a rise and
a fall through the hold band and asserts they agree at every step.

Suite: 4 302 -> 6 189 passed. `ruff check`, `ruff format --check` and `pyrefly check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cooling control around temperature tolerances and hysteresis.
  * Cooling now applies appropriate delays and rounds calibration adjustments toward safer, less-open settings.
  * Preserved heating behavior while preventing unnecessary valve opening during cooling.
  * Improved cooling-state detection for more consistent HVAC action reporting.

* **Tests**
  * Added comprehensive coverage for cooling calibration, hysteresis boundaries, overheating protection, and reported HVAC actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->