### PR TITLE
fix: resolve a device-less thermostat model in the options flow

### DIFF
--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -951,6 +951,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         # Dynamic config structures use Any as they store heterogeneous data
         self.trv_bundle: list[dict[str, Any]] = []
         self.device_name = ""
+        self.model: str | None = None
         self._last_step = False
         self.updated_config: dict[str, Any] = {}
         self._active_trv_config: dict[str, Any] | None = None

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -1626,6 +1626,20 @@ async def get_device_model(self, entity_id: str) -> str:
     """Determine the device model from the Device Registry entry.
 
     Priority: model_id > model (before parens) > model > config > "generic"
+
+    Parameters
+    ----------
+    self :
+            any object exposing ``hass`` and ``device_name``. A ``model``
+            attribute is optional and only consulted as a fallback; callers
+            without one fall through to ``"generic"``.
+    entity_id :
+            entity id of the TRV to look up
+
+    Returns
+    -------
+    str
+            the detected model, or ``"generic"`` when nothing is known
     """
     selected: str | None = None
     source: str = "none"
@@ -1680,8 +1694,13 @@ async def get_device_model(self, entity_id: str) -> str:
         pass
 
     # Final fallback: configured model, then generic
-    if not selected and isinstance(self.model, str) and len(self.model.strip()) >= 2:
-        selected = self.model.strip()
+    configured_model = getattr(self, "model", None)
+    if (
+        not selected
+        and isinstance(configured_model, str)
+        and len(configured_model.strip()) >= 2
+    ):
+        selected = configured_model.strip()
         source = "config.model"
     if not selected:
         selected = "generic"

--- a/tests/unit/test_config_flow_options_model.py
+++ b/tests/unit/test_config_flow_options_model.py
@@ -1,0 +1,174 @@
+"""Tests for model resolution in the options flow.
+
+Swapping the configured thermostat of an existing entry to an entity without a
+device-registry device (a ``generic_thermostat``, for example) sends the
+options flow down the "new TRV" branch, where the model has to be resolved from
+scratch. Model resolution falls back to the flow's own ``model`` attribute, so
+the options flow must carry one and ``get_device_model`` must tolerate callers
+that do not.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.const import CONF_NAME
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.config_flow import (
+    ConfigFlow,
+    OptionsFlowHandler,
+)
+from custom_components.better_thermostat.utils.const import CONF_HEATER, CONF_SENSOR
+from custom_components.better_thermostat.utils.helpers import get_device_model
+
+GENERIC_TRV = "climate.generic_thermostat"
+STORED_TRV = "climate.stored_trv"
+
+
+class _CallerWithoutModel:
+    """Duck-typed ``get_device_model`` caller that carries no model attribute."""
+
+    def __init__(self, hass):
+        self.hass = hass
+        self.device_name = "Living Room"
+
+
+class _CallerWithModel(_CallerWithoutModel):
+    """Duck-typed ``get_device_model`` caller that carries a configured model."""
+
+    def __init__(self, hass, model):
+        super().__init__(hass)
+        self.model = model
+
+
+def _make_config_entry():
+    entry = MagicMock()
+    entry.data = {
+        CONF_NAME: "Living Room",
+        CONF_HEATER: [
+            {"trv": STORED_TRV, "integration": "mqtt", "model": "TRVZB", "advanced": {}}
+        ],
+        CONF_SENSOR: "sensor.living_room_temperature",
+    }
+    return entry
+
+
+def _make_hass():
+    hass = MagicMock()
+    hass.states.get.return_value = State(
+        GENERIC_TRV, "heat", {"hvac_modes": ["heat", "off"]}
+    )
+    return hass
+
+
+def _make_adapter():
+    adapter = MagicMock()
+    adapter.get_info = AsyncMock(
+        return_value={"support_offset": False, "support_valve": False}
+    )
+    return adapter
+
+
+def _patch_empty_registries():
+    """Patch both registries so the entity resolves to no device."""
+    entity_registry = MagicMock()
+    entity_registry.async_get.return_value = None
+    return (
+        patch(
+            "custom_components.better_thermostat.utils.helpers.er.async_get",
+            return_value=entity_registry,
+        ),
+        patch(
+            "custom_components.better_thermostat.utils.helpers.dr.async_get",
+            return_value=MagicMock(),
+        ),
+    )
+
+
+def _submission():
+    return {
+        CONF_NAME: "Living Room",
+        CONF_HEATER: [GENERIC_TRV],
+        CONF_SENSOR: "sensor.living_room_temperature",
+    }
+
+
+@pytest.mark.asyncio
+async def test_options_flow_swap_to_generic_thermostat_resolves_generic_model():
+    """Swapping to a device-less thermostat advances the flow with model 'generic'."""
+    flow = OptionsFlowHandler(_make_config_entry())
+    flow.hass = _make_hass()
+    patch_er, patch_dr = _patch_empty_registries()
+
+    with (
+        patch_er,
+        patch_dr,
+        patch(
+            "custom_components.better_thermostat.config_flow.load_adapter",
+            AsyncMock(return_value=_make_adapter()),
+        ),
+    ):
+        result = await flow.async_step_user(_submission())
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "advanced"
+    assert [trv["trv"] for trv in flow.trv_bundle] == [GENERIC_TRV]
+    assert flow.trv_bundle[0]["model"] == "generic"
+
+
+@pytest.mark.asyncio
+async def test_config_flow_swap_to_generic_thermostat_resolves_generic_model():
+    """The create flow resolves the same model for a device-less thermostat."""
+    flow = ConfigFlow()
+    flow.hass = _make_hass()
+    patch_er, patch_dr = _patch_empty_registries()
+
+    with (
+        patch_er,
+        patch_dr,
+        patch(
+            "custom_components.better_thermostat.config_flow.load_adapter",
+            AsyncMock(return_value=_make_adapter()),
+        ),
+    ):
+        result = await flow.async_step_user(_submission())
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "advanced"
+    assert flow.trv_bundle[0]["model"] == "generic"
+
+
+def test_options_flow_handler_starts_without_a_model():
+    """The options flow exposes the same initial model attribute as the config flow."""
+    assert OptionsFlowHandler(_make_config_entry()).model is None
+    assert ConfigFlow().model is None
+
+
+@pytest.mark.asyncio
+async def test_get_device_model_without_model_attribute_returns_generic():
+    """A caller that carries no model attribute falls through to 'generic'."""
+    caller = _CallerWithoutModel(MagicMock())
+    patch_er, patch_dr = _patch_empty_registries()
+
+    with patch_er, patch_dr:
+        assert await get_device_model(caller, GENERIC_TRV) == "generic"
+
+
+@pytest.mark.asyncio
+async def test_get_device_model_prefers_configured_model_over_generic():
+    """A caller with a configured model keeps it when the registry knows nothing."""
+    caller = _CallerWithModel(MagicMock(), "TRVZB")
+    patch_er, patch_dr = _patch_empty_registries()
+
+    with patch_er, patch_dr:
+        assert await get_device_model(caller, STORED_TRV) == "TRVZB"
+
+
+@pytest.mark.asyncio
+async def test_get_device_model_ignores_non_string_configured_model():
+    """A configured model of the wrong type is not used as a fallback."""
+    caller = _CallerWithModel(MagicMock(), 42)
+    patch_er, patch_dr = _patch_empty_registries()
+
+    with patch_er, patch_dr:
+        assert await get_device_model(caller, STORED_TRV) == "generic"


### PR DESCRIPTION
Fixes #2172.

## Symptom

Changing an existing entry's underlying thermostat to a Home Assistant
`generic_thermostat` aborts the options flow with an unknown error, and the log
shows:

```
File "custom_components/better_thermostat/config_flow.py", in async_step_user
    "model": await get_device_model(self, trv_id),
File "custom_components/better_thermostat/utils/helpers.py", in get_device_model
    if not selected and isinstance(self.model, str) and len(self.model.strip()) >= 2:
AttributeError: 'OptionsFlowHandler' object has no attribute 'model'
```

## Mechanism

Reproduced by execution, both end-to-end through `async_step_user` and directly
through the helper:

* `ConfigFlow.__init__` sets `self.model = None`; `OptionsFlowHandler.__init__`
  does not.
* Swapping the configured entity makes the submitted TRV absent from the stored
  entry data, so `OptionsFlowHandler.async_step_user` takes its "new TRV"
  branch and calls `get_device_model(self, trv_id)`.
* The tail of `get_device_model` reads `self.model` after the
  `except Exception: pass` that wraps the device-registry lookup, so that read
  is unguarded. A `generic_thermostat` has no device-registry device, `selected`
  stays empty, and the unguarded read is reached. Every TRV that *does* have a
  device short-circuits before it, which is why the crash only shows up with
  helper-style thermostats.
* The `isinstance()` check guards against a wrong *type*, not against a
  *missing* attribute.

## Change

1. `config_flow.py`: `OptionsFlowHandler.__init__` initialises
   `self.model: str | None = None`, mirroring `ConfigFlow`.
2. `utils/helpers.py`: `get_device_model` reads the attribute through
   `getattr(self, "model", None)` and the docstring states the contract.
   The helper is duck-typed over five different `self` types (`ConfigFlow`,
   `OptionsFlowHandler`, the migration context built in `__init__.py`, and
   `BetterThermostat` via its `model` property). The bare read made an implicit
   contract that only one caller violated and that nothing enforces, so
   hardening it keeps a future sixth caller from reintroducing the same crash.

Behaviour for callers that do carry a model is unchanged: a present string
still wins over `"generic"`, and a non-string value is still ignored.

## Deliberately not in scope

`OptionsFlowHandler.async_step_user` ends with an unguarded
`self.trv_bundle[0]`, which raises `IndexError` when the resolved bundle is
empty (`ConfigFlow.async_step_user` has the same line). That is a separate
defect and is left untouched here.

## Verification

* New `tests/unit/test_config_flow_options_model.py`, six tests: the options
  flow runs `async_step_user` end to end and lands on the advanced form with
  `model == "generic"`; a control test does the same through `ConfigFlow`; three
  helper-level tests cover the missing attribute, the preserved string
  precedence and the ignored non-string value; one test pins both flows'
  initial `model`.
* Counterfactual: reverting only `helpers.py` fails the missing-attribute
  helper test; reverting only `config_flow.py` fails the attribute-initialisation
  test; reverting both reproduces `AttributeError: 'OptionsFlowHandler' object
  has no attribute 'model'` out of the end-to-end options-flow test.
* Full suite: `uv run pytest tests/ -q` → 2417 passed.
* `ruff check`, `ruff format --check`, `pyrefly check` → clean.

A twin PR carries the identical change to the `v2` branch line, which has the
same defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model detection for generic thermostats that lack device-registry information.
  * Prevented errors when a thermostat does not provide a model value.
  * Ensured invalid or missing model values fall back to the generic thermostat type.
* **Tests**
  * Added coverage for model resolution in configuration and options flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->