### PR TITLE
fix: resolve a device-less thermostat model in the options flow

### DIFF
--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -914,6 +914,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         # Dynamic config structures use Any as they store heterogeneous data
         self.trv_bundle: list[dict[str, Any]] = []
         self.device_name = ""
+        self.model: str | None = None
         self._last_step = False
         self.updated_config: dict[str, Any] = {}
         self._active_trv_config: dict[str, Any] | None = None

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -1665,6 +1665,20 @@ async def get_device_model(self, entity_id: str) -> str:
     """Determine the device model from the Device Registry entry.
 
     Priority: model_id > model (before parens) > model > config > "generic"
+
+    Parameters
+    ----------
+    self :
+            any object exposing ``hass`` and ``device_name``. A ``model``
+            attribute is optional and only consulted as a fallback; callers
+            without one fall through to ``"generic"``.
+    entity_id :
+            entity id of the TRV to look up
+
+    Returns
+    -------
+    str
+            the detected model, or ``"generic"`` when nothing is known
     """
     selected: str | None = None
     source: str = "none"
@@ -1719,8 +1733,13 @@ async def get_device_model(self, entity_id: str) -> str:
         pass
 
     # Final fallback: configured model, then generic
-    if not selected and isinstance(self.model, str) and len(self.model.strip()) >= 2:
-        selected = self.model.strip()
+    configured_model = getattr(self, "model", None)
+    if (
+        not selected
+        and isinstance(configured_model, str)
+        and len(configured_model.strip()) >= 2
+    ):
+        selected = configured_model.strip()
         source = "config.model"
     if not selected:
         selected = "generic"

--- a/tests/unit/test_config_flow_options_model.py
+++ b/tests/unit/test_config_flow_options_model.py
@@ -1,0 +1,174 @@
+"""Tests for model resolution in the options flow.
+
+Swapping the configured thermostat of an existing entry to an entity without a
+device-registry device (a ``generic_thermostat``, for example) sends the
+options flow down the "new TRV" branch, where the model has to be resolved from
+scratch. Model resolution falls back to the flow's own ``model`` attribute, so
+the options flow must carry one and ``get_device_model`` must tolerate callers
+that do not.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.const import CONF_NAME
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.config_flow import (
+    ConfigFlow,
+    OptionsFlowHandler,
+)
+from custom_components.better_thermostat.utils.const import CONF_HEATER, CONF_SENSOR
+from custom_components.better_thermostat.utils.helpers import get_device_model
+
+GENERIC_TRV = "climate.generic_thermostat"
+STORED_TRV = "climate.stored_trv"
+
+
+class _CallerWithoutModel:
+    """Duck-typed ``get_device_model`` caller that carries no model attribute."""
+
+    def __init__(self, hass):
+        self.hass = hass
+        self.device_name = "Living Room"
+
+
+class _CallerWithModel(_CallerWithoutModel):
+    """Duck-typed ``get_device_model`` caller that carries a configured model."""
+
+    def __init__(self, hass, model):
+        super().__init__(hass)
+        self.model = model
+
+
+def _make_config_entry():
+    entry = MagicMock()
+    entry.data = {
+        CONF_NAME: "Living Room",
+        CONF_HEATER: [
+            {"trv": STORED_TRV, "integration": "mqtt", "model": "TRVZB", "advanced": {}}
+        ],
+        CONF_SENSOR: "sensor.living_room_temperature",
+    }
+    return entry
+
+
+def _make_hass():
+    hass = MagicMock()
+    hass.states.get.return_value = State(
+        GENERIC_TRV, "heat", {"hvac_modes": ["heat", "off"]}
+    )
+    return hass
+
+
+def _make_adapter():
+    adapter = MagicMock()
+    adapter.get_info = AsyncMock(
+        return_value={"support_offset": False, "support_valve": False}
+    )
+    return adapter
+
+
+def _patch_empty_registries():
+    """Patch both registries so the entity resolves to no device."""
+    entity_registry = MagicMock()
+    entity_registry.async_get.return_value = None
+    return (
+        patch(
+            "custom_components.better_thermostat.utils.helpers.er.async_get",
+            return_value=entity_registry,
+        ),
+        patch(
+            "custom_components.better_thermostat.utils.helpers.dr.async_get",
+            return_value=MagicMock(),
+        ),
+    )
+
+
+def _submission():
+    return {
+        CONF_NAME: "Living Room",
+        CONF_HEATER: [GENERIC_TRV],
+        CONF_SENSOR: "sensor.living_room_temperature",
+    }
+
+
+@pytest.mark.asyncio
+async def test_options_flow_swap_to_generic_thermostat_resolves_generic_model():
+    """Swapping to a device-less thermostat advances the flow with model 'generic'."""
+    flow = OptionsFlowHandler(_make_config_entry())
+    flow.hass = _make_hass()
+    patch_er, patch_dr = _patch_empty_registries()
+
+    with (
+        patch_er,
+        patch_dr,
+        patch(
+            "custom_components.better_thermostat.config_flow.load_adapter",
+            AsyncMock(return_value=_make_adapter()),
+        ),
+    ):
+        result = await flow.async_step_user(_submission())
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "advanced"
+    assert [trv["trv"] for trv in flow.trv_bundle] == [GENERIC_TRV]
+    assert flow.trv_bundle[0]["model"] == "generic"
+
+
+@pytest.mark.asyncio
+async def test_config_flow_swap_to_generic_thermostat_resolves_generic_model():
+    """The create flow resolves the same model for a device-less thermostat."""
+    flow = ConfigFlow()
+    flow.hass = _make_hass()
+    patch_er, patch_dr = _patch_empty_registries()
+
+    with (
+        patch_er,
+        patch_dr,
+        patch(
+            "custom_components.better_thermostat.config_flow.load_adapter",
+            AsyncMock(return_value=_make_adapter()),
+        ),
+    ):
+        result = await flow.async_step_user(_submission())
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "advanced"
+    assert flow.trv_bundle[0]["model"] == "generic"
+
+
+def test_options_flow_handler_starts_without_a_model():
+    """The options flow exposes the same initial model attribute as the config flow."""
+    assert OptionsFlowHandler(_make_config_entry()).model is None
+    assert ConfigFlow().model is None
+
+
+@pytest.mark.asyncio
+async def test_get_device_model_without_model_attribute_returns_generic():
+    """A caller that carries no model attribute falls through to 'generic'."""
+    caller = _CallerWithoutModel(MagicMock())
+    patch_er, patch_dr = _patch_empty_registries()
+
+    with patch_er, patch_dr:
+        assert await get_device_model(caller, GENERIC_TRV) == "generic"
+
+
+@pytest.mark.asyncio
+async def test_get_device_model_prefers_configured_model_over_generic():
+    """A caller with a configured model keeps it when the registry knows nothing."""
+    caller = _CallerWithModel(MagicMock(), "TRVZB")
+    patch_er, patch_dr = _patch_empty_registries()
+
+    with patch_er, patch_dr:
+        assert await get_device_model(caller, STORED_TRV) == "TRVZB"
+
+
+@pytest.mark.asyncio
+async def test_get_device_model_ignores_non_string_configured_model():
+    """A configured model of the wrong type is not used as a fallback."""
+    caller = _CallerWithModel(MagicMock(), 42)
+    patch_er, patch_dr = _patch_empty_registries()
+
+    with patch_er, patch_dr:
+        assert await get_device_model(caller, STORED_TRV) == "generic"


### PR DESCRIPTION
Fixes #2172 on the `v2` line.

## Symptom

Changing the thermostat entity of an existing Better Thermostat entry to a Home Assistant `generic_thermostat` aborts the options dialog with an unknown error. The log shows:

```text
File "/config/custom_components/better_thermostat/config_flow.py", line 1020, in async_step_user
  "model": await get_device_model(self, trv_id),
File "/config/custom_components/better_thermostat/utils/helpers.py", line 1002, in get_device_model
  if not selected and isinstance(self.model, str) and len(self.model.strip()) >= 2:
AttributeError: 'OptionsFlowHandler' object has no attribute 'model'
```

## Mechanism

`get_device_model` resolves a model along `model_id > model (before parens) > model > config > "generic"`. Everything up to the config step comes from the device registry. A `generic_thermostat` is a helper entity with no device, so the registry lookup yields nothing and resolution reaches the configured-model step, which reads `self.model` off the caller.

Five call sites pass a `self` into this helper: `ConfigFlow`, `OptionsFlowHandler`, the ad-hoc `MigrationContext` in `__init__.py`, `BetterThermostat` (via its `model` property), and the zwave_js adapter. Only `OptionsFlowHandler` never defines the attribute: `ConfigFlow.__init__` sets `self.model = None`, `OptionsFlowHandler.__init__` does not. The create flow therefore works and only the options flow crashes, which is why this only shows up when editing an existing entry.

## Change

Two halves, because the contract was broken from both sides:

1. `OptionsFlowHandler.__init__` initialises `self.model: str | None = None`, mirroring `ConfigFlow`.
2. `get_device_model` reads the configured model through `getattr(self, "model", None)`, so any caller without the attribute falls through to `"generic"` rather than raising. The docstring now states that the attribute is optional.

The second half alone would fix the reported crash; it is included so the helper's contract holds for every duck-typed caller rather than depending on each one remembering the attribute. The first half alone would fix it too, and keeps the two flow classes symmetrical.

## What this deliberately does not do

- No change to the resolution order or to any value returned when a device *is* found. For callers that do supply a `model`, behaviour is byte-for-byte what it was.
- No attempt to give a `generic_thermostat` a more specific model than `"generic"`. There is no device registry entry to derive one from, and `"generic"` is the correct answer: it selects the generic adapter, which is what a `generic_thermostat` needs.
- No migration. Existing entries are untouched.

## Verification

New `tests/unit/test_config_flow_options_model.py` (6 tests):

- the options flow swapping to a device-less thermostat completes `async_step_user`, advances to the `advanced` step and resolves `"generic"`
- the config flow resolves the same entity identically (control: this path was never broken)
- `OptionsFlowHandler` and `ConfigFlow` both start with `model is None`
- `get_device_model` with a caller that has no `model` attribute returns `"generic"`
- `get_device_model` with a caller that has one still prefers it (control: the fallback is not weakened)
- a non-string configured model is ignored (control)

Counterfactual: with both production hunks reverted to `origin/v2`, 3 of the 6 fail with the reported `AttributeError` and the 3 control tests pass. With the change, all 6 pass.

Full suite `uv run pytest tests/ -q`: 4369 passed. `ruff check`, `ruff format --check` and `pyrefly check` are all clean.

## Related

Twin PR for the `develop` line: #2194. The defect is byte-identical on both branches; both PRs carry the same production diff and the same test file, so the lines stay converged instead of drifting apart at the next sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat model detection when no device model is configured.
  * Devices without a model now safely use the generic thermostat behavior instead of causing an error.

* **Tests**
  * Added coverage for model resolution in configuration and options flows.
  * Added validation for missing, valid, and non-string model values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
