### PR TITLE
fix: stop sending HVAC modes the TRV does not offer

### DIFF
--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -59,7 +59,7 @@ from .utils.const import (
     CalibrationType,
     MpcV2PlantPreset,
 )
-from .utils.helpers import get_device_model, get_trv_intigration
+from .utils.helpers import device_offers_mode, get_device_model, get_trv_intigration
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -229,7 +229,7 @@ def _trv_supports_auto(
     if not trv_state or not hasattr(trv_state, "attributes"):
         return False
     hvac_modes = trv_state.attributes.get("hvac_modes") or []
-    return HVACMode.AUTO in hvac_modes
+    return device_offers_mode(hvac_modes, HVACMode.AUTO)
 
 
 def _build_advanced_fields(
@@ -857,7 +857,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 hvac_modes: list[str] = []
                 if state_obj and hasattr(state_obj, "attributes"):
                     hvac_modes = state_obj.attributes.get("hvac_modes", []) or []
-                if HVACMode.OFF not in hvac_modes:
+                if not device_offers_mode(hvac_modes, HVACMode.OFF):
                     _has_off_mode = False
 
             if not _has_off_mode:

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -32,6 +32,7 @@ from custom_components.better_thermostat.utils.helpers import (
     adopt_reported_hvac_modes,
     attr_to_celsius,
     convert_to_float,
+    device_offers_mode,
     get_device_model,
     group_all_members_off,
     is_reasonable_temperature,
@@ -523,8 +524,13 @@ def convert_outbound_states(self, entity_id, hvac_mode) -> dict | None:
                 self.device_name,
                 entity_id,
             )
+        # The cache holds the device's own spelling, so whether it offers OFF is
+        # decided on the normalized list, like every other capability check.
         if hvac_mode == HVACMode.OFF and (
-            (_system_modes is not None and HVACMode.OFF not in _system_modes)
+            (
+                _system_modes is not None
+                and not device_offers_mode(_system_modes, HVACMode.OFF)
+            )
             or advanced.get("no_off_system_mode")
         ):
             _min_temp = self.real_trvs[entity_id].min_temp

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -29,6 +29,7 @@ from custom_components.better_thermostat.utils.const import (
 )
 from custom_components.better_thermostat.utils.helpers import (
     TRV_SETPOINT_KEYS,
+    adopt_reported_hvac_modes,
     attr_to_celsius,
     convert_to_float,
     get_device_model,
@@ -203,13 +204,7 @@ async def trigger_trv_change(self, event):
     # The offered HVAC modes change at runtime on devices whose heating /
     # cooling changeover is driven centrally, so the outbound mode is judged
     # against the currently reported list rather than the startup snapshot.
-    # An empty or missing list keeps the cached one: it means the device
-    # published no capabilities in this event, not that it lost them.
-    _reported_modes = _org_trv_state.attributes.get("hvac_modes")
-    if isinstance(_reported_modes, list) and _reported_modes:
-        if _reported_modes != trv.hvac_modes:
-            trv.unsupported_modes_logged.clear()
-        trv.hvac_modes = _reported_modes
+    adopt_reported_hvac_modes(trv, _org_trv_state.attributes.get("hvac_modes"))
 
     # Always cache hvac_action from the TRV state so it stays current
     try:

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -200,6 +200,17 @@ async def trigger_trv_change(self, event):
         )
         return
 
+    # The offered HVAC modes change at runtime on devices whose heating /
+    # cooling changeover is driven centrally, so the outbound mode is judged
+    # against the currently reported list rather than the startup snapshot.
+    # An empty or missing list keeps the cached one: it means the device
+    # published no capabilities in this event, not that it lost them.
+    _reported_modes = _org_trv_state.attributes.get("hvac_modes")
+    if isinstance(_reported_modes, list) and _reported_modes:
+        if _reported_modes != trv.hvac_modes:
+            trv.unsupported_modes_logged.clear()
+        trv.hvac_modes = _reported_modes
+
     # Always cache hvac_action from the TRV state so it stays current
     try:
         hvac_action_attr = _org_trv_state.attributes.get("hvac_action")

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -191,6 +191,16 @@ async def trigger_trv_change(self, event):
     if self.ignore_states:
         return
 
+    # The offered HVAC modes change at runtime on devices whose heating /
+    # cooling changeover is driven centrally, so every mode is judged against
+    # the currently reported list rather than the startup snapshot. The
+    # adoption precedes the inbound remapping below because the state carried
+    # by this event is a state of the capabilities it reports: remapping it
+    # against the previous list decodes it into a mode of a device that no
+    # longer exists, and the entity mode that follows from it is emitted
+    # before any later cache update could correct it.
+    adopt_reported_hvac_modes(trv, _org_trv_state.attributes.get("hvac_modes"))
+
     try:
         mapped_state = convert_inbound_states(self, entity_id, _org_trv_state)
     except TypeError:
@@ -200,11 +210,6 @@ async def trigger_trv_change(self, event):
             entity_id,
         )
         return
-
-    # The offered HVAC modes change at runtime on devices whose heating /
-    # cooling changeover is driven centrally, so the outbound mode is judged
-    # against the currently reported list rather than the startup snapshot.
-    adopt_reported_hvac_modes(trv, _org_trv_state.attributes.get("hvac_modes"))
 
     # Always cache hvac_action from the TRV state so it stays current
     try:

--- a/custom_components/better_thermostat/trv.py
+++ b/custom_components/better_thermostat/trv.py
@@ -61,6 +61,10 @@ class Trv:
     last_calibration: float | None = None
     last_valve_percent: float | None = None
     last_valve_method: str | None = None
+    # HVAC modes already annunciated as unsupported, so the control loop
+    # reports each one once instead of on every cycle. Cleared whenever the
+    # device reports a different mode list.
+    unsupported_modes_logged: set[str] = field(default_factory=set)
 
     # -- Calibration results -----------------------------------------------
     calibration_balance: dict[str, Any] | None = None

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -32,6 +32,7 @@ from custom_components.better_thermostat.utils.helpers import (
     SETPOINT_MATCH_TOLERANCE,
     attr_to_celsius,
     convert_to_float,
+    device_offers_mode,
     get_current_set_temperatures,
     matches_any_setpoint,
     read_setpoint_celsius,
@@ -766,8 +767,12 @@ async def control_trv(self, heater_entity_id=None):
                 await set_valve(self, heater_entity_id, 0)
 
             # Manage TRVs with no HVACMode.OFF
+            # The cache holds the device's own spelling, so whether it offers OFF
+            # is decided on the normalized list, like every other capability
+            # check. An unreported list counts as no-off.
             _hvac_modes = self.real_trvs[heater_entity_id].hvac_modes or []
-            _no_off_system_mode = (HVACMode.OFF not in _hvac_modes) or (
+            _offers_off = device_offers_mode(_hvac_modes, HVACMode.OFF)
+            _no_off_system_mode = not _offers_off or (
                 self.real_trvs[heater_entity_id].advanced.get(
                     "no_off_system_mode", False
                 )

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -255,6 +255,49 @@ def _device_offers_mode(trv_modes: Iterable[str], hvac_mode: str) -> bool:
     return any(normalize_hvac_mode(mode) == target for mode in trv_modes)
 
 
+def offered_mode_signature(trv_modes: Iterable[Any] | None) -> frozenset[str]:
+    """Reduce a reported mode list to the set of modes it offers.
+
+    Parameters
+    ----------
+    trv_modes : Iterable[Any] | None
+        HVAC modes a device reports, in any spelling.
+
+    Returns
+    -------
+    frozenset[str]
+        Normalized mode names, so two lists that differ only in order, in
+        capitalization or in ``HVACMode`` versus ``"HVACMode.HEAT"``
+        spelling reduce to the same value.
+    """
+    if not trv_modes:
+        return frozenset()
+    return frozenset(str(normalize_hvac_mode(mode)) for mode in trv_modes)
+
+
+def adopt_reported_hvac_modes(trv, reported_modes: Any) -> None:
+    """Cache the HVAC modes a device reports on its state.
+
+    An absent or empty list keeps the cached one: it means the device
+    published no capabilities in this event, not that it lost them. The
+    modes already annunciated as not offered are forgotten only when the
+    offered set really changes, so a republication in a different order or
+    a different spelling does not repeat the annunciation.
+
+    Parameters
+    ----------
+    trv : Trv
+        Per-TRV state holding the cached mode list.
+    reported_modes : Any
+        Value of the device's ``hvac_modes`` attribute.
+    """
+    if not isinstance(reported_modes, list) or not reported_modes:
+        return
+    if offered_mode_signature(reported_modes) != offered_mode_signature(trv.hvac_modes):
+        trv.unsupported_modes_logged.clear()
+    trv.hvac_modes = reported_modes
+
+
 def _unsupported_mode_hint(trv) -> str:
     """Name the remedy for a device that does not offer the mode BT wants.
 
@@ -285,7 +328,7 @@ def _unsupported_mode_hint(trv) -> str:
 
 
 def _clamp_to_offered_mode(
-    self, trv, entity_id, hvac_mode: str, inbound: bool
+    self, trv, entity_id, hvac_mode: str, inbound: bool, fallback: str | None = None
 ) -> str | None:
     """Drop an outbound HVAC mode the device does not offer.
 
@@ -295,6 +338,10 @@ def _clamp_to_offered_mode(
     "write no mode this cycle", so the setpoint still reaches the device.
     ``OFF`` is exempt because the no-off handling downstream substitutes
     the minimum temperature for it.
+
+    A ``fallback`` is the mode a quirk translation started from. When the
+    translated mode is unwritable but the original one is offered, writing
+    the original still puts the device into the state BT asked for.
 
     Parameters
     ----------
@@ -308,12 +355,15 @@ def _clamp_to_offered_mode(
         HVAC mode about to be written.
     inbound : bool
         True if the mode is coming from the device, False if it is coming from the HA.
+    fallback : str | None
+        Mode to write instead when the device offers it but not
+        ``hvac_mode``.
 
     Returns
     -------
     str | None
-        ``hvac_mode`` when it may be written, ``None`` when the device
-        does not offer it.
+        ``hvac_mode`` when it may be written, ``fallback`` when only that
+        one is offered, ``None`` when the device offers neither.
     """
     trv_modes = trv.hvac_modes
     if inbound or not trv_modes:
@@ -324,6 +374,23 @@ def _clamp_to_offered_mode(
         return hvac_mode
 
     _mode_key = str(normalize_hvac_mode(hvac_mode))
+
+    if fallback is not None and _device_offers_mode(trv_modes, fallback):
+        _fallback_key = f"{_mode_key}->{normalize_hvac_mode(fallback)}"
+        if _fallback_key not in trv.unsupported_modes_logged:
+            trv.unsupported_modes_logged.add(_fallback_key)
+            _LOGGER.warning(
+                "better_thermostat %s: %s does not offer HVAC mode %s, it offers %s. "
+                "Writing %s instead. %s",
+                self.device_name,
+                entity_id,
+                hvac_mode,
+                trv_modes,
+                fallback,
+                _unsupported_mode_hint(trv),
+            )
+        return fallback
+
     if _mode_key not in trv.unsupported_modes_logged:
         trv.unsupported_modes_logged.add(_mode_key)
         _LOGGER.error(
@@ -368,7 +435,9 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | 
 
     if _heat_auto_swapped:
         if hvac_mode == HVACMode.HEAT and not inbound:
-            return _clamp_to_offered_mode(self, trv, entity_id, HVACMode.AUTO, inbound)
+            return _clamp_to_offered_mode(
+                self, trv, entity_id, HVACMode.AUTO, inbound, fallback=HVACMode.HEAT
+            )
         if hvac_mode == HVACMode.AUTO and inbound:
             return HVACMode.HEAT
         return _clamp_to_offered_mode(self, trv, entity_id, hvac_mode, inbound)

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -233,7 +233,84 @@ def normalize_hvac_mode(value: HVACMode | str) -> HVACMode | str:
     return value
 
 
-def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str:
+def _device_offers_mode(trv_modes: Iterable[str], hvac_mode: str) -> bool:
+    """Whether a device's reported mode list contains a given HVAC mode.
+
+    Both sides are normalized so a list carrying ``HVACMode`` members,
+    plain strings or ``"HVACMode.HEAT"`` spellings compares equal.
+
+    Parameters
+    ----------
+    trv_modes : Iterable[str]
+        HVAC modes the device reports.
+    hvac_mode : str
+        HVAC mode to look for.
+
+    Returns
+    -------
+    bool
+        ``True`` when the device offers ``hvac_mode``.
+    """
+    target = normalize_hvac_mode(hvac_mode)
+    return any(normalize_hvac_mode(mode) == target for mode in trv_modes)
+
+
+def _clamp_to_offered_mode(
+    self, trv, entity_id, hvac_mode: str, inbound: bool
+) -> str | None:
+    """Drop an outbound HVAC mode the device does not offer.
+
+    Writing a mode outside the device's own list makes
+    ``climate.set_hvac_mode`` fail, which aborts the whole control cycle
+    and leaves the setpoint unwritten as well. Returning ``None`` means
+    "write no mode this cycle", so the setpoint still reaches the device.
+    ``OFF`` is exempt because the no-off handling downstream substitutes
+    the minimum temperature for it.
+
+    Parameters
+    ----------
+    self :
+        self instance of better_thermostat
+    trv : Trv
+        Per-TRV state of the device the mode is written to.
+    entity_id : str
+        Entity id of that TRV, used for the log message.
+    hvac_mode : str
+        HVAC mode about to be written.
+    inbound : bool
+        True if the mode is coming from the device, False if it is coming from the HA.
+
+    Returns
+    -------
+    str | None
+        ``hvac_mode`` when it may be written, ``None`` when the device
+        does not offer it.
+    """
+    trv_modes = trv.hvac_modes
+    if inbound or not trv_modes:
+        return hvac_mode
+    if normalize_hvac_mode(hvac_mode) == HVACMode.OFF or _device_offers_mode(
+        trv_modes, hvac_mode
+    ):
+        return hvac_mode
+
+    _mode_key = str(normalize_hvac_mode(hvac_mode))
+    if _mode_key not in trv.unsupported_modes_logged:
+        trv.unsupported_modes_logged.add(_mode_key)
+        _LOGGER.error(
+            "better_thermostat %s: %s does not offer HVAC mode %s, it offers %s. "
+            "The device mode is left untouched and only the setpoint is written. "
+            "Switch the device to its heating mode, or enable the heat auto "
+            "swapped option if 'auto' means 'heat' on this device.",
+            self.device_name,
+            entity_id,
+            hvac_mode,
+            trv_modes,
+        )
+    return None
+
+
+def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | None:
     """Remap HVAC mode to correct mode if nessesary.
 
     Parameters
@@ -250,8 +327,10 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str:
 
     Returns
     -------
-    str
-            remapped mode according to device's quirks
+    str | None
+            remapped mode according to device's quirks, or None for an
+            outbound mode the device does not offer, meaning the device's
+            mode is left untouched
     """
     trv = self.real_trvs.get(entity_id)
     if trv is None:
@@ -261,10 +340,10 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str:
 
     if _heat_auto_swapped:
         if hvac_mode == HVACMode.HEAT and not inbound:
-            return HVACMode.AUTO
+            return _clamp_to_offered_mode(self, trv, entity_id, HVACMode.AUTO, inbound)
         if hvac_mode == HVACMode.AUTO and inbound:
             return HVACMode.HEAT
-        return hvac_mode
+        return _clamp_to_offered_mode(self, trv, entity_id, hvac_mode, inbound)
 
     trv_modes = trv.hvac_modes
     if not trv_modes:
@@ -282,17 +361,17 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str:
         if inbound and hvac_mode == HVACMode.HEAT:
             return HVACMode.HEAT_COOL
 
-    if hvac_mode != HVACMode.AUTO:
-        return hvac_mode
+    if hvac_mode == HVACMode.AUTO:
+        _LOGGER.error(
+            "better_thermostat %s: %s HVAC mode %s is not supported by this device, "
+            "is it possible that you forgot to set the heat auto swapped option?",
+            self.device_name,
+            entity_id,
+            hvac_mode,
+        )
+        return HVACMode.OFF
 
-    _LOGGER.error(
-        "better_thermostat %s: %s HVAC mode %s is not supported by this device, "
-        "is it possible that you forgot to set the heat auto swapped option?",
-        self.device_name,
-        entity_id,
-        hvac_mode,
-    )
-    return HVACMode.OFF
+    return _clamp_to_offered_mode(self, trv, entity_id, hvac_mode, inbound)
 
 
 def group_all_members_off(self) -> bool:

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import datetime
 import logging
 import math
@@ -328,7 +328,7 @@ def _unsupported_mode_hint(trv) -> str:
 
 
 def _clamp_to_offered_mode(
-    self, trv, entity_id, hvac_mode: str, inbound: bool, fallback: str | None = None
+    self, trv, entity_id, hvac_mode: str, inbound: bool, fallbacks: Sequence[str] = ()
 ) -> str | None:
     """Drop an outbound HVAC mode the device does not offer.
 
@@ -339,9 +339,10 @@ def _clamp_to_offered_mode(
     ``OFF`` is exempt because the no-off handling downstream substitutes
     the minimum temperature for it.
 
-    A ``fallback`` is the mode a quirk translation started from. When the
-    translated mode is unwritable but the original one is offered, writing
-    the original still puts the device into the state BT asked for.
+    The ``fallbacks`` are the modes a quirk translation started from, most
+    preferred first. When the translated mode is unwritable but one of them
+    is offered, writing that one still puts the device into the state BT
+    asked for.
 
     Parameters
     ----------
@@ -355,15 +356,16 @@ def _clamp_to_offered_mode(
         HVAC mode about to be written.
     inbound : bool
         True if the mode is coming from the device, False if it is coming from the HA.
-    fallback : str | None
-        Mode to write instead when the device offers it but not
-        ``hvac_mode``.
+    fallbacks : Sequence[str]
+        Modes to write instead when the device offers one of them but not
+        ``hvac_mode``, in descending order of preference.
 
     Returns
     -------
     str | None
-        ``hvac_mode`` when it may be written, ``fallback`` when only that
-        one is offered, ``None`` when the device offers neither.
+        ``hvac_mode`` when it may be written, the first offered fallback
+        when only such a one is offered, ``None`` when the device offers
+        none of them.
     """
     trv_modes = trv.hvac_modes
     if inbound or not trv_modes:
@@ -374,9 +376,12 @@ def _clamp_to_offered_mode(
         return hvac_mode
 
     _mode_key = str(normalize_hvac_mode(hvac_mode))
+    _fallback = next(
+        (mode for mode in fallbacks if _device_offers_mode(trv_modes, mode)), None
+    )
 
-    if fallback is not None and _device_offers_mode(trv_modes, fallback):
-        _fallback_key = f"{_mode_key}->{normalize_hvac_mode(fallback)}"
+    if _fallback is not None:
+        _fallback_key = f"{_mode_key}->{normalize_hvac_mode(_fallback)}"
         if _fallback_key not in trv.unsupported_modes_logged:
             trv.unsupported_modes_logged.add(_fallback_key)
             _LOGGER.warning(
@@ -386,10 +391,10 @@ def _clamp_to_offered_mode(
                 entity_id,
                 hvac_mode,
                 trv_modes,
-                fallback,
+                _fallback,
                 _unsupported_mode_hint(trv),
             )
-        return fallback
+        return _fallback
 
     if _mode_key not in trv.unsupported_modes_logged:
         trv.unsupported_modes_logged.add(_mode_key)
@@ -434,10 +439,28 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | 
     _heat_auto_swapped = (trv.advanced or {}).get(CONF_HEAT_AUTO_SWAPPED, False)
 
     if _heat_auto_swapped:
-        if hvac_mode == HVACMode.HEAT and not inbound:
+        # HEAT and HEAT_COOL are the same demand seen from two instances: a
+        # room with a cooler carries its heat demand as HEAT_COOL, because
+        # that is the mode such an instance offers instead of HEAT. Both name
+        # the device's heating mode, which is what the swap calls AUTO, and
+        # both fall back the same way, so which of the two arrives makes no
+        # difference to what the device receives. HEAT is preferred over
+        # HEAT_COOL as a fallback for the same reason the unswapped path
+        # prefers it: HEAT_COOL is the heating mode only of a device that
+        # offers nothing narrower.
+        if not inbound and hvac_mode in (HVACMode.HEAT, HVACMode.HEAT_COOL):
             return _clamp_to_offered_mode(
-                self, trv, entity_id, HVACMode.AUTO, inbound, fallback=HVACMode.HEAT
+                self,
+                trv,
+                entity_id,
+                HVACMode.AUTO,
+                inbound,
+                fallbacks=(HVACMode.HEAT, HVACMode.HEAT_COOL),
             )
+        # HEAT is the instance-level spelling of that demand in both cases:
+        # get_hvac_bt_mode() re-expresses it as HEAT_COOL for a room with a
+        # cooler, so the reported mode reaches the entity as HEAT_COOL there
+        # and as HEAT everywhere else.
         if hvac_mode == HVACMode.AUTO and inbound:
             return HVACMode.HEAT
         return _clamp_to_offered_mode(self, trv, entity_id, hvac_mode, inbound)

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -468,13 +468,17 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | 
     trv_modes = trv.hvac_modes
     if not trv_modes:
         return hvac_mode
-    if HVACMode.HEAT not in trv_modes and HVACMode.HEAT_COOL in trv_modes:
+    # The cache holds the device's own spelling, so the two translations are
+    # decided on the normalized list like the clamp below is.
+    _offers_heat = _device_offers_mode(trv_modes, HVACMode.HEAT)
+    _offers_heat_cool = _device_offers_mode(trv_modes, HVACMode.HEAT_COOL)
+    if not _offers_heat and _offers_heat_cool:
         # entity only supports HEAT_COOL, but not HEAT - need to translate
         if not inbound and hvac_mode == HVACMode.HEAT:
             return HVACMode.HEAT_COOL
         if inbound and hvac_mode == HVACMode.HEAT_COOL:
             return HVACMode.HEAT
-    if HVACMode.HEAT_COOL not in trv_modes and HVACMode.HEAT in trv_modes:
+    if not _offers_heat_cool and _offers_heat:
         # entity only supports HEAT, but not HEAT_COOL - need to translate
         if not inbound and hvac_mode == HVACMode.HEAT_COOL:
             return HVACMode.HEAT
@@ -482,13 +486,19 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | 
             return HVACMode.HEAT_COOL
 
     if hvac_mode == HVACMode.AUTO:
-        _LOGGER.error(
-            "better_thermostat %s: %s HVAC mode %s is not supported by this device, "
-            "is it possible that you forgot to set the heat auto swapped option?",
-            self.device_name,
-            entity_id,
-            hvac_mode,
-        )
+        # The mode is annunciated once per offered set, like the clamp does it,
+        # so an unswapped instance asked for AUTO every cycle says so once.
+        _auto_key = str(normalize_hvac_mode(hvac_mode))
+        if _auto_key not in trv.unsupported_modes_logged:
+            trv.unsupported_modes_logged.add(_auto_key)
+            _LOGGER.error(
+                "better_thermostat %s: %s HVAC mode %s is not supported by this "
+                "device, is it possible that you forgot to set the heat auto "
+                "swapped option?",
+                self.device_name,
+                entity_id,
+                hvac_mode,
+            )
         return HVACMode.OFF
 
     return _clamp_to_offered_mode(self, trv, entity_id, hvac_mode, inbound)

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -233,7 +233,7 @@ def normalize_hvac_mode(value: HVACMode | str) -> HVACMode | str:
     return value
 
 
-def _device_offers_mode(trv_modes: Iterable[Any], hvac_mode: str) -> bool:
+def device_offers_mode(trv_modes: Iterable[Any], hvac_mode: str) -> bool:
     """Whether a device's reported mode list contains a given HVAC mode.
 
     Both sides are normalized so a list carrying ``HVACMode`` members,
@@ -370,14 +370,14 @@ def _clamp_to_offered_mode(
     trv_modes = trv.hvac_modes
     if inbound or not trv_modes:
         return hvac_mode
-    if normalize_hvac_mode(hvac_mode) == HVACMode.OFF or _device_offers_mode(
+    if normalize_hvac_mode(hvac_mode) == HVACMode.OFF or device_offers_mode(
         trv_modes, hvac_mode
     ):
         return hvac_mode
 
     _mode_key = str(normalize_hvac_mode(hvac_mode))
     _fallback = next(
-        (mode for mode in fallbacks if _device_offers_mode(trv_modes, mode)), None
+        (mode for mode in fallbacks if device_offers_mode(trv_modes, mode)), None
     )
 
     if _fallback is not None:
@@ -470,8 +470,8 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | 
         return hvac_mode
     # The cache holds the device's own spelling, so the two translations are
     # decided on the normalized list like the clamp below is.
-    _offers_heat = _device_offers_mode(trv_modes, HVACMode.HEAT)
-    _offers_heat_cool = _device_offers_mode(trv_modes, HVACMode.HEAT_COOL)
+    _offers_heat = device_offers_mode(trv_modes, HVACMode.HEAT)
+    _offers_heat_cool = device_offers_mode(trv_modes, HVACMode.HEAT_COOL)
     if not _offers_heat and _offers_heat_cool:
         # entity only supports HEAT_COOL, but not HEAT - need to translate
         if not inbound and hvac_mode == HVACMode.HEAT:

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import logging
 import math
 import re
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_STEP,
@@ -42,6 +42,9 @@ from custom_components.better_thermostat.utils.const import (
     VALVE_MIN_THRESHOLD_TEMP_DIFF,
     CalibrationMode,
 )
+
+if TYPE_CHECKING:
+    from custom_components.better_thermostat.trv import Trv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -275,7 +278,7 @@ def offered_mode_signature(trv_modes: Iterable[Any] | None) -> frozenset[str]:
     return frozenset(str(normalize_hvac_mode(mode)) for mode in trv_modes)
 
 
-def adopt_reported_hvac_modes(trv, reported_modes: Any) -> None:
+def adopt_reported_hvac_modes(trv: Trv, reported_modes: Any) -> None:
     """Cache the HVAC modes a device reports on its state.
 
     An absent or empty list keeps the cached one: it means the device
@@ -298,7 +301,7 @@ def adopt_reported_hvac_modes(trv, reported_modes: Any) -> None:
     trv.hvac_modes = reported_modes
 
 
-def _unsupported_mode_hint(trv) -> str:
+def _unsupported_mode_hint(trv: Trv) -> str:
     """Name the remedy for a device that does not offer the mode BT wants.
 
     The heat auto swapped option is what decides whether BT writes ``heat``
@@ -328,7 +331,12 @@ def _unsupported_mode_hint(trv) -> str:
 
 
 def _clamp_to_offered_mode(
-    self, trv, entity_id, hvac_mode: str, inbound: bool, fallbacks: Sequence[str] = ()
+    self,
+    trv: Trv,
+    entity_id: str,
+    hvac_mode: str,
+    inbound: bool,
+    fallbacks: Sequence[str] = (),
 ) -> str | None:
     """Drop an outbound HVAC mode the device does not offer.
 
@@ -410,14 +418,16 @@ def _clamp_to_offered_mode(
     return None
 
 
-def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | None:
+def mode_remap(
+    self, entity_id: str, hvac_mode: str, inbound: bool = False
+) -> str | None:
     """Remap HVAC mode to correct mode if nessesary.
 
     Parameters
     ----------
     self :
             self instance of better_thermostat
-    entity_id :
+    entity_id : str
             entity id of the TRV whose mode is being remapped
     hvac_mode : str
             HVAC mode to be remapped

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -255,6 +255,35 @@ def _device_offers_mode(trv_modes: Iterable[str], hvac_mode: str) -> bool:
     return any(normalize_hvac_mode(mode) == target for mode in trv_modes)
 
 
+def _unsupported_mode_hint(trv) -> str:
+    """Name the remedy for a device that does not offer the mode BT wants.
+
+    The heat auto swapped option is what decides whether BT writes ``heat``
+    or ``auto``, so which way to turn it depends on its current setting: a
+    device without ``auto`` is only asked for ``auto`` because the option is
+    already on.
+
+    Parameters
+    ----------
+    trv : Trv
+        Per-TRV state carrying the advanced configuration.
+
+    Returns
+    -------
+    str
+        A sentence naming the setting that resolves the situation.
+    """
+    if (trv.advanced or {}).get(CONF_HEAT_AUTO_SWAPPED, False):
+        return (
+            "Disable the heat auto swapped option unless 'auto' really is this "
+            "device's heating mode."
+        )
+    return (
+        "Switch the device to its heating mode, or enable the heat auto swapped "
+        "option if 'auto' means 'heat' on this device."
+    )
+
+
 def _clamp_to_offered_mode(
     self, trv, entity_id, hvac_mode: str, inbound: bool
 ) -> str | None:
@@ -299,13 +328,12 @@ def _clamp_to_offered_mode(
         trv.unsupported_modes_logged.add(_mode_key)
         _LOGGER.error(
             "better_thermostat %s: %s does not offer HVAC mode %s, it offers %s. "
-            "The device mode is left untouched and only the setpoint is written. "
-            "Switch the device to its heating mode, or enable the heat auto "
-            "swapped option if 'auto' means 'heat' on this device.",
+            "The device mode is left untouched and only the setpoint is written. %s",
             self.device_name,
             entity_id,
             hvac_mode,
             trv_modes,
+            _unsupported_mode_hint(trv),
         )
     return None
 

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -233,7 +233,7 @@ def normalize_hvac_mode(value: HVACMode | str) -> HVACMode | str:
     return value
 
 
-def _device_offers_mode(trv_modes: Iterable[str], hvac_mode: str) -> bool:
+def _device_offers_mode(trv_modes: Iterable[Any], hvac_mode: str) -> bool:
     """Whether a device's reported mode list contains a given HVAC mode.
 
     Both sides are normalized so a list carrying ``HVACMode`` members,
@@ -241,8 +241,8 @@ def _device_offers_mode(trv_modes: Iterable[str], hvac_mode: str) -> bool:
 
     Parameters
     ----------
-    trv_modes : Iterable[str]
-        HVAC modes the device reports.
+    trv_modes : Iterable[Any]
+        HVAC modes the device reports, in any spelling.
     hvac_mode : str
         HVAC mode to look for.
 

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -992,6 +992,43 @@ class TestControlTrvAvailablePath:
             # Lock should have been acquired
             lock_acquire_mock.assert_awaited()
 
+    @pytest.mark.asyncio
+    async def test_unsupported_heat_mode_writes_only_the_setpoint(self):
+        """A device offering no heating mode keeps its mode and gets the setpoint.
+
+        The full outbound conversion runs so the payload really is the one a
+        wall thermostat with ``[auto, cool, off]`` produces for a heat demand.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.AUTO,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=True,
+            bt_target_temp=22.0,
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    hvac_modes=[HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF],
+                    hvac_mode=HVACMode.AUTO,
+                    last_hvac_mode=HVACMode.AUTO,
+                )
+            },
+        )
+
+        with (
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch(_PATCHES["set_temperature"], new=AsyncMock()) as mock_set_temp,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_set_hvac.assert_not_awaited()
+            mock_set_temp.assert_awaited_once_with(mock_self, "climate.trv1", 22.0)
+
 
 # ---------------------------------------------------------------------------
 # Boost mode with safety override (from test_boost_mode.py)

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -1029,6 +1029,51 @@ class TestControlTrvAvailablePath:
             mock_set_hvac.assert_not_awaited()
             mock_set_temp.assert_awaited_once_with(mock_self, "climate.trv1", 22.0)
 
+    @pytest.mark.asyncio
+    async def test_swapped_device_without_auto_still_gets_heat(self):
+        """A swapped valve offering only off/heat is switched to heat.
+
+        The full outbound conversion runs, so this is the payload a device
+        sitting in OFF receives on a heat demand.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.OFF,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=True,
+            bt_target_temp=22.0,
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+                    hvac_mode=HVACMode.OFF,
+                    last_hvac_mode=HVACMode.OFF,
+                    advanced={
+                        "calibration_mode": CalibrationMode.NO_CALIBRATION,
+                        "calibration": CalibrationType.TARGET_TEMP_BASED,
+                        "no_off_system_mode": False,
+                        "heat_auto_swapped": True,
+                    },
+                )
+            },
+        )
+
+        with (
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch(_PATCHES["set_temperature"], new=AsyncMock()) as mock_set_temp,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_set_hvac.assert_awaited_once_with(
+                mock_self, "climate.trv1", HVACMode.HEAT
+            )
+            mock_set_temp.assert_awaited_once_with(mock_self, "climate.trv1", 22.0)
+
 
 # ---------------------------------------------------------------------------
 # Boost mode with safety override (from test_boost_mode.py)

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -499,6 +499,88 @@ class TestControlTrvUnavailablePath:
             assert args[2] == 5.0  # min_temp
 
     @pytest.mark.asyncio
+    async def test_off_offered_in_the_device_spelling_switches_the_device_off(self):
+        """A list naming its modes ``HVACMode.OFF`` still offers OFF.
+
+        The cached list holds the device's own spelling, so the min_temp
+        substitution must not fire for a device that does offer OFF.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=False,
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    hvac_modes=["HVACMode.OFF", "HVACMode.HEAT"]
+                )
+            },
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["handle_contact_open"]) as mock_window,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_temp.return_value = None
+            mock_window.return_value = HVACMode.HEAT
+
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_set_hvac.assert_awaited_once()
+            assert mock_set_hvac.await_args[0][2] == HVACMode.OFF
+            for call in mock_set_temp.call_args_list:
+                assert call[0][2] != 5.0
+
+    @pytest.mark.asyncio
+    async def test_no_off_in_the_device_spelling_still_sends_min_temp(self):
+        """A device genuinely without OFF keeps taking the min_temp path."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=False,
+            real_trvs={
+                "climate.trv1": _default_trv_config(hvac_modes=["HVACMode.HEAT"])
+            },
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["handle_contact_open"]) as mock_window,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_temp.return_value = None
+            mock_window.return_value = HVACMode.HEAT
+
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_set_temp.assert_called_once()
+            assert mock_set_temp.call_args[0][2] == 5.0
+
+    @pytest.mark.asyncio
     async def test_none_hvac_modes_does_not_crash(self):
         """A TRV reporting no hvac_modes (None) must not crash control_trv.
 

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -421,208 +421,6 @@ class TestControlTrvUnavailablePath:
             mock_set_valve.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_window_open_sets_mode_to_off(self):
-        """Test that window open sets HVAC mode to OFF."""
-        mock_self = _make_mock_self(
-            trv_state=HVACMode.HEAT,
-            trv_attrs={"temperature": 20.0},
-            window_open=True,
-            real_trvs={"climate.trv1": _default_trv_config()},
-        )
-
-        with (
-            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_hvac_mode"]) as mock_set_hvac,
-            patch(_PATCHES["override_set_hvac_mode"]) as mock_override,
-            patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
-            ),
-            patch(_PATCHES["handle_contact_open"]) as mock_window,
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
-            patch("asyncio.sleep", new=AsyncMock()),
-        ):
-            mock_convert.return_value = {
-                "temperature": 20.0,
-                "system_mode": HVACMode.HEAT,
-            }
-            mock_set_hvac.return_value = None
-            mock_override.return_value = False
-            # handle_contact_open returns OFF when window is open
-            mock_window.return_value = HVACMode.OFF
-
-            result = await control_trv(mock_self, "climate.trv1")
-
-            assert result is True
-            # set_hvac_mode should be called with OFF
-            mock_set_hvac.assert_called_once()
-            assert mock_set_hvac.call_args[0][2] == HVACMode.OFF
-
-    @pytest.mark.asyncio
-    async def test_no_off_mode_sends_min_temp_when_off_requested(self):
-        """Test that TRV without OFF mode sends min_temp when OFF is requested."""
-        mock_self = _make_mock_self(
-            trv_state=HVACMode.HEAT,
-            trv_attrs={"temperature": 20.0},
-            call_for_heat=False,  # No heat needed -> OFF
-            real_trvs={
-                "climate.trv1": _default_trv_config(
-                    hvac_modes=[HVACMode.HEAT]  # No OFF mode!
-                )
-            },
-        )
-
-        with (
-            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
-            patch(_PATCHES["handle_contact_open"]) as mock_window,
-            patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
-            ),
-            patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
-            ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch("asyncio.sleep", new=AsyncMock()),
-        ):
-            mock_convert.return_value = {
-                "temperature": 20.0,
-                "system_mode": HVACMode.HEAT,
-            }
-            mock_set_temp.return_value = None
-            mock_window.return_value = HVACMode.HEAT
-
-            await control_trv(mock_self, "climate.trv1")
-
-            # Should set temperature to min_temp (5.0) because OFF is not available
-            mock_set_temp.assert_called_once()
-            args = mock_set_temp.call_args[0]
-            assert args[2] == 5.0  # min_temp
-
-    @pytest.mark.asyncio
-    async def test_off_offered_in_the_device_spelling_switches_the_device_off(self):
-        """A list naming its modes ``HVACMode.OFF`` still offers OFF.
-
-        The cached list holds the device's own spelling, so the min_temp
-        substitution must not fire for a device that does offer OFF.
-        """
-        mock_self = _make_mock_self(
-            trv_state=HVACMode.HEAT,
-            trv_attrs={"temperature": 20.0},
-            call_for_heat=False,
-            real_trvs={
-                "climate.trv1": _default_trv_config(
-                    hvac_modes=["HVACMode.OFF", "HVACMode.HEAT"]
-                )
-            },
-        )
-
-        with (
-            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
-            patch(_PATCHES["handle_contact_open"]) as mock_window,
-            patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
-            ),
-            patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
-            ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
-            patch("asyncio.sleep", new=AsyncMock()),
-        ):
-            mock_convert.return_value = {
-                "temperature": 20.0,
-                "system_mode": HVACMode.HEAT,
-            }
-            mock_set_temp.return_value = None
-            mock_window.return_value = HVACMode.HEAT
-
-            await control_trv(mock_self, "climate.trv1")
-
-            mock_set_hvac.assert_awaited_once()
-            assert mock_set_hvac.await_args[0][2] == HVACMode.OFF
-            for call in mock_set_temp.call_args_list:
-                assert call[0][2] != 5.0
-
-    @pytest.mark.asyncio
-    async def test_no_off_in_the_device_spelling_still_sends_min_temp(self):
-        """A device genuinely without OFF keeps taking the min_temp path."""
-        mock_self = _make_mock_self(
-            trv_state=HVACMode.HEAT,
-            trv_attrs={"temperature": 20.0},
-            call_for_heat=False,
-            real_trvs={
-                "climate.trv1": _default_trv_config(hvac_modes=["HVACMode.HEAT"])
-            },
-        )
-
-        with (
-            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
-            patch(_PATCHES["handle_contact_open"]) as mock_window,
-            patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
-            ),
-            patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
-            ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch("asyncio.sleep", new=AsyncMock()),
-        ):
-            mock_convert.return_value = {
-                "temperature": 20.0,
-                "system_mode": HVACMode.HEAT,
-            }
-            mock_set_temp.return_value = None
-            mock_window.return_value = HVACMode.HEAT
-
-            await control_trv(mock_self, "climate.trv1")
-
-            mock_set_temp.assert_called_once()
-            assert mock_set_temp.call_args[0][2] == 5.0
-
-    @pytest.mark.asyncio
-    async def test_none_hvac_modes_does_not_crash(self):
-        """A TRV reporting no hvac_modes (None) must not crash control_trv.
-
-        ``Trv.hvac_modes`` defaults to None and stays None when a TRV exposes
-        no ``hvac_modes`` attribute. The membership check for HVACMode.OFF must
-        tolerate that instead of raising TypeError; a None list is treated as
-        "no OFF mode available", so an OFF request falls back to min_temp.
-        """
-        mock_self = _make_mock_self(
-            trv_state=HVACMode.HEAT,
-            trv_attrs={"temperature": 20.0},
-            call_for_heat=False,  # No heat needed -> OFF
-            real_trvs={"climate.trv1": _default_trv_config(hvac_modes=None)},
-        )
-
-        with (
-            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
-            patch(_PATCHES["handle_contact_open"]) as mock_window,
-            patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
-            ),
-            patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
-            ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch("asyncio.sleep", new=AsyncMock()),
-        ):
-            mock_convert.return_value = {
-                "temperature": 20.0,
-                "system_mode": HVACMode.HEAT,
-            }
-            mock_set_temp.return_value = None
-            mock_window.return_value = HVACMode.HEAT
-
-            await control_trv(mock_self, "climate.trv1")
-
-            # None hvac_modes -> treated as no OFF mode -> min_temp (5.0) sent.
-            mock_set_temp.assert_called_once()
-            assert mock_set_temp.call_args[0][2] == 5.0
-
-    @pytest.mark.asyncio
     async def test_ignore_trv_states_flag_set_and_reset(self):
         """Test that ignore_trv_states flag is set during processing and reset after."""
         mock_self = _make_mock_self(trv_state=STATE_UNAVAILABLE)
@@ -1155,6 +953,211 @@ class TestControlTrvAvailablePath:
                 mock_self, "climate.trv1", HVACMode.HEAT
             )
             mock_set_temp.assert_awaited_once_with(mock_self, "climate.trv1", 22.0)
+
+    @pytest.mark.asyncio
+    async def test_window_open_sets_mode_to_off(self):
+        """Test that window open sets HVAC mode to OFF."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            window_open=True,
+            real_trvs={"climate.trv1": _default_trv_config()},
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_hvac_mode"]) as mock_set_hvac,
+            patch(_PATCHES["override_set_hvac_mode"]) as mock_override,
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["handle_contact_open"]) as mock_window,
+            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_hvac.return_value = None
+            mock_override.return_value = False
+            # handle_contact_open returns OFF when window is open
+            mock_window.return_value = HVACMode.OFF
+
+            result = await control_trv(mock_self, "climate.trv1")
+
+            assert result is True
+            # set_hvac_mode should be called with OFF
+            mock_set_hvac.assert_called_once()
+            assert mock_set_hvac.call_args[0][2] == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_no_off_mode_sends_min_temp_when_off_requested(self):
+        """Test that TRV without OFF mode sends min_temp when OFF is requested."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=False,  # No heat needed -> OFF
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    hvac_modes=[HVACMode.HEAT]  # No OFF mode!
+                )
+            },
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["handle_contact_open"]) as mock_window,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_temp.return_value = None
+            mock_window.return_value = HVACMode.HEAT
+
+            await control_trv(mock_self, "climate.trv1")
+
+            # Should set temperature to min_temp (5.0) because OFF is not available
+            mock_set_temp.assert_called_once()
+            args = mock_set_temp.call_args[0]
+            assert args[2] == 5.0  # min_temp
+            mock_set_hvac.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_off_offered_in_the_device_spelling_switches_the_device_off(self):
+        """A list naming its modes ``HVACMode.OFF`` still offers OFF.
+
+        The cached list holds the device's own spelling, so the min_temp
+        substitution must not fire for a device that does offer OFF.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=False,
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    hvac_modes=["HVACMode.OFF", "HVACMode.HEAT"]
+                )
+            },
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["handle_contact_open"]) as mock_window,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_temp.return_value = None
+            mock_window.return_value = HVACMode.HEAT
+
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_set_hvac.assert_awaited_once()
+            assert mock_set_hvac.await_args[0][2] == HVACMode.OFF
+            for call in mock_set_temp.call_args_list:
+                assert call[0][2] != 5.0
+
+    @pytest.mark.asyncio
+    async def test_no_off_in_the_device_spelling_still_sends_min_temp(self):
+        """A device genuinely without OFF keeps taking the min_temp path."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=False,
+            real_trvs={
+                "climate.trv1": _default_trv_config(hvac_modes=["HVACMode.HEAT"])
+            },
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["handle_contact_open"]) as mock_window,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_temp.return_value = None
+            mock_window.return_value = HVACMode.HEAT
+
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_set_temp.assert_called_once()
+            assert mock_set_temp.call_args[0][2] == 5.0
+            mock_set_hvac.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_none_hvac_modes_does_not_crash(self):
+        """A TRV reporting no hvac_modes (None) must not crash control_trv.
+
+        ``Trv.hvac_modes`` defaults to None and stays None when a TRV exposes
+        no ``hvac_modes`` attribute. The membership check for HVACMode.OFF must
+        tolerate that instead of raising TypeError; a None list is treated as
+        "no OFF mode available", so an OFF request falls back to min_temp.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=False,  # No heat needed -> OFF
+            real_trvs={"climate.trv1": _default_trv_config(hvac_modes=None)},
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["handle_contact_open"]) as mock_window,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_temp.return_value = None
+            mock_window.return_value = HVACMode.HEAT
+
+            await control_trv(mock_self, "climate.trv1")
+
+            # None hvac_modes -> treated as no OFF mode -> min_temp (5.0) sent.
+            mock_set_temp.assert_called_once()
+            assert mock_set_temp.call_args[0][2] == 5.0
+            mock_set_hvac.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_config_flow_offered_modes.py
+++ b/tests/unit/test_config_flow_offered_modes.py
@@ -1,0 +1,114 @@
+"""Tests for the config flow's reads of a device's offered HVAC modes.
+
+A climate entity publishes its capability list in its own spelling, so both
+the AUTO probe and the OFF gate must compare normalized. A device naming its
+modes ``HVACMode.OFF`` offers OFF just as one naming them ``off`` does.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.climate.const import HVACMode
+import pytest
+
+from custom_components.better_thermostat.config_flow import (
+    ConfigFlow,
+    _trv_supports_auto,
+)
+
+
+def _flow_with_modes(modes):
+    """Build a flow whose single TRV reports the given mode list."""
+    state = MagicMock()
+    state.attributes = {"hvac_modes": modes}
+
+    flow = MagicMock()
+    flow.hass.states.get.return_value = state
+    return flow
+
+
+class TestTrvSupportsAuto:
+    """The AUTO probe reads the device's own spelling."""
+
+    def test_auto_offered_as_plain_string(self):
+        """A plain ``auto`` is recognized."""
+        assert _trv_supports_auto(_flow_with_modes(["off", "auto"]), "climate.trv")
+
+    def test_auto_offered_in_the_device_spelling(self):
+        """An ``HVACMode.AUTO`` spelling is recognized just the same."""
+        assert _trv_supports_auto(
+            _flow_with_modes(["HVACMode.OFF", "HVACMode.AUTO"]), "climate.trv"
+        )
+
+    def test_auto_absent_in_the_device_spelling(self):
+        """A device genuinely without AUTO is still reported as lacking it."""
+        assert not _trv_supports_auto(
+            _flow_with_modes(["HVACMode.OFF", "HVACMode.HEAT"]), "climate.trv"
+        )
+
+
+def _advanced_flow(modes):
+    """Build a ConfigFlow parked on the last TRV of a one-TRV bundle."""
+    flow = ConfigFlow()
+    flow.hass = MagicMock()
+    state = MagicMock()
+    state.attributes = {"hvac_modes": modes}
+    flow.hass.states.get.return_value = state
+    flow.i = 0
+    flow.trv_bundle = [{"trv": "climate.trv", "advanced": {}}]
+    flow._active_trv_config = flow.trv_bundle[0]
+    return flow
+
+
+async def _run_advanced(flow):
+    """Submit the advanced step and return the confirm_type it hands on."""
+    confirm = AsyncMock(return_value="confirm")
+    with (
+        patch(
+            "custom_components.better_thermostat.config_flow._prepare_advanced_context",
+            new=AsyncMock(
+                return_value={
+                    "trv_id": "climate.trv",
+                    "default_calibration": "target_temp_based",
+                    "homematic": False,
+                    "has_auto": False,
+                    "info": {},
+                }
+            ),
+        ),
+        patch(
+            "custom_components.better_thermostat.config_flow._normalize_advanced_submission",
+            return_value={},
+        ),
+        patch.object(ConfigFlow, "async_step_confirm", new=confirm),
+    ):
+        await flow.async_step_advanced({})
+    return confirm.await_args[0][1] if len(confirm.await_args[0]) > 1 else None
+
+
+class TestOffModeGate:
+    """The OFF gate reads the device's own spelling."""
+
+    @pytest.mark.asyncio
+    async def test_off_offered_as_plain_string_passes_the_gate(self):
+        """A plain ``off`` reaches confirm without the no_off_mode notice."""
+        assert await _run_advanced(_advanced_flow(["off", "heat"])) is None
+
+    @pytest.mark.asyncio
+    async def test_off_offered_in_the_device_spelling_passes_the_gate(self):
+        """An ``HVACMode.OFF`` spelling passes the gate just the same."""
+        assert (
+            await _run_advanced(_advanced_flow(["HVACMode.OFF", "HVACMode.HEAT"]))
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_device_without_off_still_raises_the_notice(self):
+        """A device genuinely without OFF still gets the no_off_mode notice."""
+        assert await _run_advanced(_advanced_flow(["HVACMode.HEAT"])) == "no_off_mode"
+
+
+def test_hvac_mode_enum_members_are_recognized():
+    """A list holding HVACMode members keeps working."""
+    assert _trv_supports_auto(
+        _flow_with_modes([HVACMode.OFF, HVACMode.AUTO]), "climate.trv"
+    )

--- a/tests/unit/test_helpers_mode_remap.py
+++ b/tests/unit/test_helpers_mode_remap.py
@@ -381,3 +381,41 @@ class TestModeRemapUnsupportedOutboundMode:
 
         result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
         assert result == HVACMode.HEAT
+
+    def test_hint_names_disabling_the_swap_when_it_is_on(self, caplog):
+        """A swapped device without AUTO is told to turn the swap off."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        )
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            assert (
+                mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+                is None
+            )
+
+        records = _unsupported_records(caplog)
+        assert len(records) == 1
+        message = records[0].getMessage()
+        assert "Disable the heat auto swapped option" in message
+        assert "enable the heat auto swapped" not in message
+
+    def test_hint_names_enabling_the_swap_when_it_is_off(self, caplog):
+        """An unswapped device is told about the option it has not set."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=self.CHANGEOVER_MODES)
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            assert (
+                mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+                is None
+            )
+
+        records = _unsupported_records(caplog)
+        assert len(records) == 1
+        message = records[0].getMessage()
+        assert "enable the heat auto swapped option" in message
+        assert "Disable the heat auto swapped option" not in message

--- a/tests/unit/test_helpers_mode_remap.py
+++ b/tests/unit/test_helpers_mode_remap.py
@@ -5,10 +5,23 @@ between Better Thermostat and TRVs. This includes handling quirks like
 heat_auto_swapped devices and TRVs that only support HEAT_COOL but not HEAT.
 """
 
+import logging
+
 from homeassistant.components.climate.const import HVACMode
 
 from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils.helpers import mode_remap
+
+HELPERS_LOGGER = "custom_components.better_thermostat.utils.helpers"
+
+
+def _unsupported_records(caplog):
+    """Return the log records annunciating an unsupported HVAC mode."""
+    return [
+        record
+        for record in caplog.records
+        if "does not offer HVAC mode" in record.getMessage()
+    ]
 
 
 class MockThermostat:
@@ -80,7 +93,11 @@ class TestModeRemapHeatAutoSwapped:
     def test_other_modes_unchanged_when_swapped(self):
         """Test that other modes are unchanged when heat_auto_swapped."""
         mock_bt = MockThermostat()
-        mock_bt.add_trv("climate.test", heat_auto_swapped=True)
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO, HVACMode.COOL],
+        )
 
         # OFF should stay OFF
         result = mode_remap(mock_bt, "climate.test", HVACMode.OFF, inbound=False)
@@ -210,3 +227,157 @@ class TestModeRemapEdgeCases:
 
         result = mode_remap(mock_bt, "climate.test", HVACMode.FAN_ONLY, inbound=False)
         assert result == HVACMode.FAN_ONLY
+
+
+class TestModeRemapUnsupportedOutboundMode:
+    """An outbound mode the device does not offer resolves to no mode write."""
+
+    CHANGEOVER_MODES = [HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF]
+
+    def test_heat_cool_not_offered_returns_none(self):
+        """HEAT_COOL is dropped when the device lists neither HEAT nor HEAT_COOL."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=self.CHANGEOVER_MODES)
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+        assert result is None
+
+    def test_heat_not_offered_returns_none(self):
+        """HEAT is dropped when the device only offers auto, cool and off."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=self.CHANGEOVER_MODES)
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result is None
+
+    def test_offered_mode_passes_through(self):
+        """A mode the device does list is written unchanged."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=self.CHANGEOVER_MODES)
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.COOL, inbound=False)
+        assert result == HVACMode.COOL
+
+    def test_off_is_exempt_from_the_clamp(self):
+        """OFF survives on a device without OFF so min_temp can substitute."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=[HVACMode.AUTO, HVACMode.HEAT])
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.OFF, inbound=False)
+        assert result == HVACMode.OFF
+
+    def test_inbound_modes_are_never_clamped(self):
+        """Values reported by the device pass through even when unlisted."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=[HVACMode.OFF, HVACMode.HEAT])
+
+        assert mode_remap(mock_bt, "climate.test", "cool", inbound=True) == "cool"
+        assert mode_remap(mock_bt, "climate.test", "dry", inbound=True) == "dry"
+
+    def test_inbound_auto_still_reports_off(self):
+        """The AUTO branch keeps precedence over the inbound exemption."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=[HVACMode.OFF, HVACMode.HEAT])
+
+        result = mode_remap(mock_bt, "climate.test", "auto", inbound=True)
+        assert result == HVACMode.OFF
+
+    def test_dry_not_offered_returns_none(self):
+        """A heat-only device does not receive DRY."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=[HVACMode.OFF, HVACMode.HEAT])
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.DRY, inbound=False)
+        assert result is None
+
+    def test_auto_branch_wins_over_the_clamp(self, caplog):
+        """AUTO reports OFF and names the heat auto swapped option."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=self.CHANGEOVER_MODES)
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            result = mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=False)
+
+        assert result == HVACMode.OFF
+        swap_hints = [
+            record
+            for record in caplog.records
+            if "heat auto swapped" in record.getMessage()
+        ]
+        assert len(swap_hints) == 1
+
+    def test_error_is_logged_once_per_mode(self, caplog):
+        """Repeated cycles annunciate each unsupported mode a single time."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=self.CHANGEOVER_MODES)
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            for _ in range(5):
+                assert (
+                    mode_remap(
+                        mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False
+                    )
+                    is None
+                )
+
+            assert len(_unsupported_records(caplog)) == 1
+
+            assert (
+                mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+                is None
+            )
+            assert len(_unsupported_records(caplog)) == 2
+
+    def test_swapped_auto_not_offered_returns_none(self):
+        """A swapped device without AUTO does not receive AUTO either."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result is None
+
+    def test_swapped_auto_offered_passes_through(self):
+        """A swapped device listing AUTO still receives AUTO for HEAT."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result == HVACMode.AUTO
+
+    def test_swapped_inbound_auto_survives_an_auto_less_list(self):
+        """The inbound swap does not depend on AUTO being listed."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=True)
+        assert result == HVACMode.HEAT
+
+    def test_unreported_mode_list_is_not_clamped(self):
+        """hvac_modes=None keeps the pass-through for no-system-mode devices."""
+        mock_bt = MockThermostat()
+        mock_bt.real_trvs["climate.test"] = Trv.from_legacy_dict(
+            "climate.test", {"advanced": {"heat_auto_swapped": False}}
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+        assert result == HVACMode.HEAT_COOL
+
+    def test_plain_string_mode_list_is_normalized(self):
+        """A list of plain strings matches HVACMode members."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=["heat", "off"])
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result == HVACMode.HEAT

--- a/tests/unit/test_helpers_mode_remap.py
+++ b/tests/unit/test_helpers_mode_remap.py
@@ -8,9 +8,11 @@ heat_auto_swapped devices and TRVs that only support HEAT_COOL but not HEAT.
 import logging
 
 from homeassistant.components.climate.const import HVACMode
+import pytest
 
 from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils.helpers import (
+    adopt_reported_hvac_modes,
     get_hvac_bt_mode,
     mode_remap,
 )
@@ -24,6 +26,15 @@ def _unsupported_records(caplog):
         record
         for record in caplog.records
         if "does not offer HVAC mode" in record.getMessage()
+    ]
+
+
+def _forgotten_swap_records(caplog):
+    """Return the log records naming the heat auto swapped option as unset."""
+    return [
+        record
+        for record in caplog.records
+        if "forgot to set the heat auto swapped option" in record.getMessage()
     ]
 
 
@@ -163,6 +174,85 @@ class TestModeRemapHeatCoolTranslation:
 
         result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
         assert result == HVACMode.HEAT_COOL
+
+
+class TestModeRemapTranslationOnAReportedSpelling:
+    """The HEAT / HEAT_COOL translation reads the device's own spelling.
+
+    The mode list is cached exactly as the device reports it, so a device
+    naming its modes ``HVACMode.HEAT`` or ``Heat`` is translated like one
+    naming them ``heat``.
+    """
+
+    HEAT_ONLY = [
+        pytest.param(["HVACMode.OFF", "HVACMode.HEAT"], id="prefixed"),
+        pytest.param(["OFF", "Heat"], id="mixed_case"),
+    ]
+    HEAT_COOL_ONLY = [
+        pytest.param(["HVACMode.OFF", "HVACMode.HEAT_COOL"], id="prefixed"),
+        pytest.param(["OFF", "Heat_Cool"], id="mixed_case"),
+    ]
+
+    @pytest.mark.parametrize("hvac_modes", HEAT_ONLY)
+    def test_outbound_heat_cool_becomes_heat(self, hvac_modes, caplog):
+        """A heat-only device receives HEAT rather than no mode at all."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=hvac_modes)
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            result = mode_remap(
+                mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False
+            )
+
+        assert result == HVACMode.HEAT
+        assert _unsupported_records(caplog) == []
+
+    @pytest.mark.parametrize("hvac_modes", HEAT_ONLY)
+    def test_inbound_heat_becomes_heat_cool(self, hvac_modes):
+        """A heat-only device's HEAT is decoded as HEAT_COOL."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=hvac_modes)
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=True)
+        assert result == HVACMode.HEAT_COOL
+
+    @pytest.mark.parametrize("hvac_modes", HEAT_COOL_ONLY)
+    def test_outbound_heat_becomes_heat_cool(self, hvac_modes, caplog):
+        """A HEAT_COOL-only device receives HEAT_COOL rather than no mode."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=hvac_modes)
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+
+        assert result == HVACMode.HEAT_COOL
+        assert _unsupported_records(caplog) == []
+
+    @pytest.mark.parametrize("hvac_modes", HEAT_COOL_ONLY)
+    def test_inbound_heat_cool_becomes_heat(self, hvac_modes):
+        """A HEAT_COOL-only device's HEAT_COOL is decoded as HEAT."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=hvac_modes)
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=True)
+        assert result == HVACMode.HEAT
+
+    def test_a_device_offering_both_is_not_translated(self):
+        """Offering both spellings of the heating mode translates neither."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            hvac_modes=["HVACMode.OFF", "HVACMode.HEAT", "HVACMode.HEAT_COOL"],
+        )
+
+        assert (
+            mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+            == HVACMode.HEAT
+        )
+        assert (
+            mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+            == HVACMode.HEAT_COOL
+        )
 
 
 class TestModeRemapEdgeCases:
@@ -308,6 +398,39 @@ class TestModeRemapUnsupportedOutboundMode:
             if "heat auto swapped" in record.getMessage()
         ]
         assert len(swap_hints) == 1
+
+    def test_the_auto_error_is_annunciated_once(self, caplog):
+        """Every outbound AUTO cycle keeps reporting OFF, but logs once."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=self.CHANGEOVER_MODES)
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            for _ in range(5):
+                assert (
+                    mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=False)
+                    == HVACMode.OFF
+                )
+
+        assert len(_forgotten_swap_records(caplog)) == 1
+
+    def test_a_changed_offered_set_annunciates_auto_again(self, caplog):
+        """A genuine capability change re-arms the AUTO annunciation."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=self.CHANGEOVER_MODES)
+        trv = mock_bt.real_trvs["climate.test"]
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            assert (
+                mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=False)
+                == HVACMode.OFF
+            )
+            adopt_reported_hvac_modes(trv, [HVACMode.OFF, HVACMode.COOL])
+            assert (
+                mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=False)
+                == HVACMode.OFF
+            )
+
+        assert len(_forgotten_swap_records(caplog)) == 2
 
     def test_error_is_logged_once_per_mode(self, caplog):
         """Repeated cycles annunciate each unsupported mode a single time."""

--- a/tests/unit/test_helpers_mode_remap.py
+++ b/tests/unit/test_helpers_mode_remap.py
@@ -392,12 +392,8 @@ class TestModeRemapUnsupportedOutboundMode:
             result = mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=False)
 
         assert result == HVACMode.OFF
-        swap_hints = [
-            record
-            for record in caplog.records
-            if "heat auto swapped" in record.getMessage()
-        ]
-        assert len(swap_hints) == 1
+        assert len(_forgotten_swap_records(caplog)) == 1
+        assert _unsupported_records(caplog) == []
 
     def test_the_auto_error_is_annunciated_once(self, caplog):
         """Every outbound AUTO cycle keeps reporting OFF, but logs once."""

--- a/tests/unit/test_helpers_mode_remap.py
+++ b/tests/unit/test_helpers_mode_remap.py
@@ -10,7 +10,10 @@ import logging
 from homeassistant.components.climate.const import HVACMode
 
 from custom_components.better_thermostat.trv import Trv
-from custom_components.better_thermostat.utils.helpers import mode_remap
+from custom_components.better_thermostat.utils.helpers import (
+    get_hvac_bt_mode,
+    mode_remap,
+)
 
 HELPERS_LOGGER = "custom_components.better_thermostat.utils.helpers"
 
@@ -526,3 +529,149 @@ class TestModeRemapSwapFallback:
         records = _fallback_records(caplog)
         assert len(records) == 1
         assert "Disable the heat auto swapped option" in records[0].getMessage()
+
+
+class TestModeRemapSwappedDeviceInACoolerRoom:
+    """A swapped radiator sharing a room with a separate cooler.
+
+    Such an instance offers HEAT_COOL in place of HEAT, so HEAT_COOL is the
+    mode its heat demand is carried in and the mode every TRV in that room is
+    driven with.
+    """
+
+    def test_heat_cool_reaches_a_swapped_device_as_auto(self):
+        """A room-level heat demand arrives as the device's heating mode."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.AUTO],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+        assert result == HVACMode.AUTO
+
+    def test_heat_cool_falls_back_to_heat_when_auto_is_missing(self):
+        """The swap's output is unwritable, so the unswapped mode is written."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+        assert result == HVACMode.HEAT
+
+    def test_heat_cool_survives_on_a_device_that_offers_only_that(self):
+        """HEAT_COOL is the last resort, ahead of writing no mode at all.
+
+        The unswapped path already treats HEAT_COOL as the heating mode of a
+        device offering nothing narrower; the swap resolves it the same way.
+        """
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT_COOL],
+        )
+
+        assert (
+            mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+            == HVACMode.HEAT_COOL
+        )
+        assert (
+            mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+            == HVACMode.HEAT_COOL
+        )
+
+    def test_heat_outranks_heat_cool_as_a_fallback(self):
+        """A radiator offering both receives the single-setpoint mode."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT, HVACMode.HEAT_COOL],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+        assert result == HVACMode.HEAT
+
+    def test_heat_cool_is_dropped_when_neither_mode_is_offered(self, caplog):
+        """A device offering none of the three keeps its own, and says so once."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.COOL],
+        )
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            result = mode_remap(
+                mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False
+            )
+
+        assert result is None
+        records = _unsupported_records(caplog)
+        assert len(records) == 1
+        # The mode named is the one the swap asked for, not the room's.
+        assert "HVAC mode auto" in records[0].getMessage()
+
+    def test_heat_and_heat_cool_reach_the_device_identically(self):
+        """The two spellings of the same demand produce the same write.
+
+        A caller that narrows HEAT_COOL to HEAT before calling — which is what
+        a device carrying both the heating and the cooling role receives — and
+        one that passes the room's mode through reach the same device mode, so
+        the narrowing neither adds to nor subtracts from what arrives.
+        """
+        for hvac_modes in (
+            [HVACMode.OFF, HVACMode.AUTO],
+            [HVACMode.OFF, HVACMode.HEAT],
+            [HVACMode.OFF, HVACMode.HEAT_COOL],
+            [HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO],
+            [HVACMode.OFF, HVACMode.HEAT, HVACMode.HEAT_COOL],
+            [HVACMode.OFF, HVACMode.COOL],
+            [HVACMode.OFF, HVACMode.AUTO, HVACMode.HEAT_COOL],
+        ):
+            mock_bt = MockThermostat()
+            mock_bt.add_trv(
+                "climate.test", heat_auto_swapped=True, hvac_modes=hvac_modes
+            )
+
+            via_heat = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+            via_heat_cool = mode_remap(
+                mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False
+            )
+            assert via_heat == via_heat_cool, hvac_modes
+
+    def test_inbound_auto_becomes_heat_for_a_cooler_room_too(self):
+        """The device's heating mode is adopted as the instance's HEAT.
+
+        HEAT is what the instance stores for "the room wants heat" whether or
+        not a cooler is configured; a room with one re-expresses it as
+        HEAT_COOL when it publishes its own mode.
+        """
+        mock_bt = MockThermostat()
+        mock_bt.map_on_hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.AUTO],
+        )
+
+        adopted = mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=True)
+        assert adopted == HVACMode.HEAT
+        assert get_hvac_bt_mode(mock_bt, adopted) == HVACMode.HEAT_COOL
+
+    def test_inbound_heat_cool_is_not_translated_by_the_swap(self):
+        """A reported HEAT_COOL passes the swapped branch unchanged."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.AUTO],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=True)
+        assert result == HVACMode.HEAT_COOL

--- a/tests/unit/test_helpers_mode_remap.py
+++ b/tests/unit/test_helpers_mode_remap.py
@@ -329,12 +329,12 @@ class TestModeRemapUnsupportedOutboundMode:
             assert len(_unsupported_records(caplog)) == 2
 
     def test_swapped_auto_not_offered_returns_none(self):
-        """A swapped device without AUTO does not receive AUTO either."""
+        """A swapped device offering neither AUTO nor HEAT gets no mode."""
         mock_bt = MockThermostat()
         mock_bt.add_trv(
             "climate.test",
             heat_auto_swapped=True,
-            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+            hvac_modes=[HVACMode.OFF, HVACMode.COOL],
         )
 
         result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
@@ -383,12 +383,12 @@ class TestModeRemapUnsupportedOutboundMode:
         assert result == HVACMode.HEAT
 
     def test_hint_names_disabling_the_swap_when_it_is_on(self, caplog):
-        """A swapped device without AUTO is told to turn the swap off."""
+        """A swapped device offering neither AUTO nor HEAT names the swap."""
         mock_bt = MockThermostat()
         mock_bt.add_trv(
             "climate.test",
             heat_auto_swapped=True,
-            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+            hvac_modes=[HVACMode.OFF, HVACMode.COOL],
         )
 
         with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
@@ -419,3 +419,110 @@ class TestModeRemapUnsupportedOutboundMode:
         message = records[0].getMessage()
         assert "enable the heat auto swapped option" in message
         assert "Disable the heat auto swapped option" not in message
+
+
+def _fallback_records(caplog):
+    """Return the log records announcing the unswapped fallback."""
+    return [
+        record
+        for record in caplog.records
+        if "Writing heat instead" in record.getMessage()
+    ]
+
+
+class TestModeRemapSwapFallback:
+    """A swapped device without AUTO still receives the mode BT wants."""
+
+    def test_heat_is_written_when_auto_is_missing(self):
+        """The swap's output is unwritable, so the original HEAT is written."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result == HVACMode.HEAT
+
+    def test_auto_still_wins_when_the_device_offers_it(self):
+        """The swap keeps its effect on the devices it was meant for."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result == HVACMode.AUTO
+
+    def test_no_fallback_when_heat_is_not_offered_either(self):
+        """The fallback never resurrects a mode the device does not offer."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.COOL],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result is None
+
+    def test_fallback_matches_a_prefixed_mode_spelling(self):
+        """A mode list spelled "HVACMode.HEAT" is recognised as offering HEAT."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=["HVACMode.OFF", "HVACMode.HEAT"],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result == HVACMode.HEAT
+
+    def test_fallback_does_not_fire_inbound(self):
+        """An inbound AUTO keeps becoming HEAT without consulting the list."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.COOL],
+        )
+
+        assert (
+            mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=True)
+            == HVACMode.HEAT
+        )
+        assert mode_remap(mock_bt, "climate.test", "dry", inbound=True) == "dry"
+
+    def test_fallback_leaves_the_auto_error_branch_alone(self, caplog):
+        """An unswapped device still answers AUTO with OFF and its own error."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=[HVACMode.OFF, HVACMode.HEAT])
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            result = mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=False)
+
+        assert result == HVACMode.OFF
+        assert not _fallback_records(caplog)
+
+    def test_fallback_is_announced_once(self, caplog):
+        """Repeated cycles announce the substitution a single time."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        )
+
+        with caplog.at_level(logging.WARNING, logger=HELPERS_LOGGER):
+            for _ in range(5):
+                assert (
+                    mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+                    == HVACMode.HEAT
+                )
+
+        records = _fallback_records(caplog)
+        assert len(records) == 1
+        assert "Disable the heat auto swapped option" in records[0].getMessage()

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -27,6 +27,7 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationMode,
     CalibrationType,
 )
+from custom_components.better_thermostat.utils.helpers import mode_remap
 
 ENTITY_ID = "climate.test_trv"
 
@@ -627,6 +628,74 @@ class TestHvacModesCache:
             await trigger_trv_change(mock_bt, event)
 
         assert mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged == {"heat_cool"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "republished",
+        [
+            ["cool", "off", "auto"],
+            [HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF],
+            ["HVACMode.AUTO", "HVACMode.COOL", "HVACMode.OFF"],
+            ["AUTO", "Cool", "OFF"],
+        ],
+        ids=["reordered", "enum_members", "prefixed", "mixed_case"],
+    )
+    async def test_same_capabilities_keep_the_annunciated_modes(
+        self, mock_bt, republished
+    ):
+        """The same offered modes in another spelling are not a change."""
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = ["auto", "cool", "off"]
+        mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged = {"heat_cool"}
+        trv_state = _make_state(attributes={"hvac_modes": republished})
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged == {"heat_cool"}
+
+    @pytest.mark.asyncio
+    async def test_reordered_republication_does_not_repeat_the_error(
+        self, mock_bt, caplog
+    ):
+        """A flapping mode list keeps the annunciation at once per mode."""
+        helpers_logger = "custom_components.better_thermostat.utils.helpers"
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = ["auto", "cool", "off"]
+
+        def _errors():
+            return [
+                record
+                for record in caplog.records
+                if "does not offer HVAC mode" in record.getMessage()
+            ]
+
+        trv_state = _make_state(attributes={"hvac_modes": ["cool", "off", "auto"]})
+        mock_bt.hass.states.get.return_value = trv_state
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with caplog.at_level(logging.ERROR, logger=helpers_logger):
+            assert (
+                mode_remap(mock_bt, ENTITY_ID, HVACMode.HEAT_COOL, inbound=False)
+                is None
+            )
+            assert len(_errors()) == 1
+
+            with patch(
+                "custom_components.better_thermostat.events.trv.convert_inbound_states",
+                return_value=HVACMode.HEAT,
+            ):
+                await trigger_trv_change(mock_bt, event)
+
+            assert (
+                mode_remap(mock_bt, ENTITY_ID, HVACMode.HEAT_COOL, inbound=False)
+                is None
+            )
+            assert len(_errors()) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -1970,6 +1970,52 @@ class TestConvertOutboundStates:
         assert result["temperature"] == 5.0
         assert result["system_mode"] is None
 
+    def test_off_offered_in_the_device_spelling_switches_the_device_off(self, mock_bt):
+        """A list naming its modes ``HVACMode.OFF`` still offers OFF.
+
+        The cache holds the device's own spelling, so the min_temp
+        substitution must not fire for a device that does offer OFF.
+        """
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = ["HVACMode.OFF", "HVACMode.HEAT"]
+        mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
+
+        with (
+            patch(
+                "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+                return_value=0.0,
+            ),
+            patch(
+                "custom_components.better_thermostat.events.trv.mode_remap",
+                return_value=HVACMode.OFF,
+            ),
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
+
+        assert result is not None
+        assert result["system_mode"] == HVACMode.OFF
+        assert result["temperature"] == 19.0
+
+    def test_no_off_in_the_device_spelling_still_uses_min_temp(self, mock_bt):
+        """A device genuinely without OFF keeps taking the min_temp path."""
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = ["HVACMode.HEAT"]
+        mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
+
+        with (
+            patch(
+                "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+                return_value=0.0,
+            ),
+            patch(
+                "custom_components.better_thermostat.events.trv.mode_remap",
+                return_value=HVACMode.OFF,
+            ),
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
+
+        assert result is not None
+        assert result["temperature"] == 5.0
+        assert result["system_mode"] is None
+
     def test_unsupported_mode_writes_only_the_setpoint(self, mock_bt):
         """A device without a heating mode gets the setpoint and no mode."""
         mock_bt.real_trvs[ENTITY_ID].hvac_modes = [

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -1943,6 +1943,23 @@ class TestConvertOutboundStates:
         assert result["system_mode"] is None
         assert result["temperature"] == mock_bt.bt_target_temp
 
+    def test_swapped_device_in_a_cooler_room_is_switched_on(self, mock_bt):
+        """A room-level HEAT_COOL reaches a swapped radiator as its own mode."""
+        mock_bt.cooler_entity_id = "climate.the_ac"
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.OFF, HVACMode.AUTO]
+        mock_bt.real_trvs[ENTITY_ID].advanced["heat_auto_swapped"] = True
+        mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+            return_value=0.0,
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.HEAT_COOL)
+
+        assert result is not None
+        assert result["system_mode"] == HVACMode.AUTO
+        assert result["temperature"] == mock_bt.bt_target_temp
+
     def test_off_without_off_mode_still_falls_back_to_min_temp(self, mock_bt):
         """OFF escapes the clamp so the min_temp substitution keeps working."""
         mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.AUTO, HVACMode.HEAT]

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -541,6 +541,94 @@ class TestHvacActionAndValvePosition:
         assert mock_bt.real_trvs[ENTITY_ID].valve_position == 75.0
 
 
+class TestHvacModesCache:
+    """Tests for the cached list of HVAC modes the device offers."""
+
+    @pytest.mark.asyncio
+    async def test_reported_modes_replace_the_cached_list(self, mock_bt):
+        """The offered modes are taken from the TRV state on every event."""
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.OFF, HVACMode.COOL]
+        trv_state = _make_state(attributes={"hvac_modes": ["off", "heat"]})
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].hvac_modes == ["off", "heat"]
+
+    @pytest.mark.asyncio
+    async def test_absent_modes_attribute_keeps_the_cached_list(self, mock_bt):
+        """An event without the attribute does not wipe the known capabilities."""
+        trv_state = _make_state()
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].hvac_modes == [HVACMode.OFF, HVACMode.HEAT]
+
+    @pytest.mark.asyncio
+    async def test_empty_modes_attribute_keeps_the_cached_list(self, mock_bt):
+        """An empty list is treated as "nothing reported", not as "no modes"."""
+        trv_state = _make_state(attributes={"hvac_modes": []})
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].hvac_modes == [HVACMode.OFF, HVACMode.HEAT]
+
+    @pytest.mark.asyncio
+    async def test_changed_mode_list_clears_the_annunciated_modes(self, mock_bt):
+        """A genuine capability change lets the unsupported-mode error fire again."""
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.OFF, HVACMode.COOL]
+        mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged = {"heat"}
+        trv_state = _make_state(attributes={"hvac_modes": ["off", "heat"]})
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged == set()
+
+    @pytest.mark.asyncio
+    async def test_unchanged_mode_list_keeps_the_annunciated_modes(self, mock_bt):
+        """Repeating the same list keeps the error suppressed across cycles."""
+        mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged = {"heat_cool"}
+        trv_state = _make_state(attributes={"hvac_modes": ["off", "heat"]})
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged == {"heat_cool"}
+
+
 # ---------------------------------------------------------------------------
 # 4. HVAC mode update
 # ---------------------------------------------------------------------------
@@ -1760,6 +1848,58 @@ class TestConvertOutboundStates:
                 "custom_components.better_thermostat.events.trv.mode_remap",
                 return_value=HVACMode.OFF,
             ),
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
+
+        assert result is not None
+        assert result["temperature"] == 5.0
+        assert result["system_mode"] is None
+
+    def test_unsupported_mode_writes_only_the_setpoint(self, mock_bt):
+        """A device without a heating mode gets the setpoint and no mode."""
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [
+            HVACMode.AUTO,
+            HVACMode.COOL,
+            HVACMode.OFF,
+        ]
+        mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+            return_value=0.0,
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.HEAT_COOL)
+
+        assert result is not None
+        assert result["system_mode"] is None
+        assert result["temperature"] == mock_bt.bt_target_temp
+
+    def test_off_without_off_mode_still_falls_back_to_min_temp(self, mock_bt):
+        """OFF escapes the clamp so the min_temp substitution keeps working."""
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.AUTO, HVACMode.HEAT]
+        mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+            return_value=None,
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
+
+        assert result == {
+            "temperature": 5.0,
+            "local_temperature": 18.0,
+            "system_mode": None,
+        }
+
+    def test_no_off_system_mode_device_still_parks_at_min_temp(self, mock_bt):
+        """The no_off_system_mode substitution survives the clamp."""
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
+        mock_bt.real_trvs[ENTITY_ID].advanced["no_off_system_mode"] = True
+        mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+            return_value=0.0,
         ):
             result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
 

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -697,6 +697,52 @@ class TestHvacModesCache:
             )
             assert len(_errors()) == 1
 
+    @pytest.mark.asyncio
+    async def test_a_capability_change_decodes_the_state_that_carried_it(self, mock_bt):
+        """A device switching to HEAT_COOL is decoded against its new list.
+
+        The reported state belongs to the capabilities reported alongside it,
+        so the mode the entity takes over is the one the new list translates
+        to and not the one the previous list would have produced.
+        """
+        mock_bt.bt_hvac_mode = HVACMode.OFF
+        trv_state = _make_state(
+            state_str="heat_cool",
+            attributes={"hvac_modes": [HVACMode.OFF, HVACMode.HEAT_COOL]},
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=_make_state())
+
+        await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].hvac_modes == [
+            HVACMode.OFF,
+            HVACMode.HEAT_COOL,
+        ]
+        assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+
+    @pytest.mark.asyncio
+    async def test_modes_cached_in_the_device_spelling_still_translate(self, mock_bt):
+        """A mode list reported as ``HVACMode.HEAT`` reaches the translation."""
+        trv_state = _make_state(
+            attributes={"hvac_modes": ["HVACMode.OFF", "HVACMode.HEAT"]}
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].hvac_modes == [
+            "HVACMode.OFF",
+            "HVACMode.HEAT",
+        ]
+        assert (
+            mode_remap(mock_bt, ENTITY_ID, HVACMode.HEAT_COOL, inbound=False)
+            == HVACMode.HEAT
+        )
+
 
 # ---------------------------------------------------------------------------
 # 4. HVAC mode update


### PR DESCRIPTION
Fixes the first defect of #2175 on the `develop` line.

## Symptom

The reporter runs a HomeMatic IP HmIP-STHD wall thermostat whose `hvac_modes`
read `["auto", "cool", "off"]`: the device has no `heat` and no `heat_cool`
mode, because the central heating/cooling changeover is in cooling and `cool`
is that device's manual-setpoint mode. Better Thermostat asks for a heat
demand, `mode_remap` hands back `heat_cool` (or `heat`), and the subsequent
`climate.set_hvac_mode` fails with `not_valid_hvac_mode`. The exception aborts
the control cycle, so the setpoint is never written either. The room stays
uncontrolled and the log fills with the same error on every cycle.

## Mechanism

`mode_remap` already makes two capability-driven decisions from the device's
own mode list (HEAT→HEAT_COOL when the device lacks HEAT, HEAT_COOL→HEAT when
it lacks HEAT_COOL), but there is no general "does the device offer this at
all" check. Any mode outside those two translations falls through untouched
and is written verbatim.

## What this changes

`mode_remap` clamps an outbound mode against the device's mode list. A mode
the device does not offer resolves to `None`, which means "write no mode this
cycle". That is not a new encoding: `convert_outbound_states` already emits
`system_mode: None` on its no-system-mode and no-off branches, and
`control_trv`'s send guard is already `if _new_hvac_mode is not None and ...`
while the setpoint guard is `_new_hvac_mode != HVACMode.OFF or
_no_off_system_mode`, which `None` satisfies. So the invalid mode write
disappears and the setpoint keeps flowing: the clean single-setpoint fallback
the issue asks for.

Deliberate non-guesses. BT does not fall back to another mode, because every
candidate is a guess it is not entitled to make:

- `auto` is precisely the guess the `heat_auto_swapped` option exists to make
  explicit, and on HomeMatic/RaspberryMatic it hands control to the device's
  weekly programme, which overrides BT's setpoint at each profile switch point.
- `cool` cannot be distinguished from a real air conditioner, where it would
  actively cool the room.
- `off` is measurably worse than today: for `[auto, cool, off]`,
  `_no_off_system_mode` is `False`, so `control_trv` would actually send
  `set_hvac_mode(off)` every cycle and the room would never heat.

Instead the situation is annunciated once per (device, mode) at ERROR level,
naming the exact knob that resolves it (`heat_auto_swapped`), and the
device's mode is left alone.

OFF is exempt from the clamp. Clamping OFF on a device without OFF would stop
`convert_outbound_states`' `if hvac_mode == HVACMode.OFF and (OFF not in
_system_modes or advanced["no_off_system_mode"])` branch from firing and the
min_temp substitution would be lost. Inbound values are exempt too: they
describe what the device reports, not what BT writes.

The cached mode list is now refreshed from every TRV state event. It was
written exactly once, in `climate.py startup()`, so it was a snapshot; on the
reporter's hardware the list changes at runtime when the central
changeover flips, and clamping against a stale snapshot would suppress a mode
the device now offers. An empty or missing `hvac_modes` attribute keeps the
cached list (an integration that publishes no capabilities in one event has
not lost them). A changed list clears the per-device set of already-annunciated
modes, so the error re-fires when the situation changes.

## What this deliberately does not do

- It does not fix the second defect in #2175 (the wrapper's `target_temp_high`
  being periodically overwritten back to `min_temp`). That is a separate
  setpoint-side defect and needs its own analysis.
- It does not by itself heat a room whose device sits in OFF with no offered
  heating mode; BT has nothing valid to send. That equals today's effective
  behaviour (the service call raises, the device keeps its mode), so it is not
  a regression, but affected users still have to enable `heat_auto_swapped`
  or set the device mode themselves. The error message says exactly that.
- It does not raise a repairs-registry issue, add config-flow-time validation
  of the mode list, add once-per-device suppression to the pre-existing AUTO
  error branch, add a symmetric COOL↔HEAT_COOL translation, or touch
  `events/cooler.py` (which never calls `mode_remap`).
- `convert_outbound_states` and `control_trv` are unchanged.

## Verification

- Full suite: 2434 passed (baseline on `develop`: 2411 passed, +23 new tests).
  `ruff check`, `ruff format --check` and `pyrefly check` are clean (0 errors).
- Counterfactual: with the three production files stashed, 9 of the new tests
  fail, e.g. `assert <HVACMode.HEAT_COOL: 'heat_cool'> is None` in
  `test_heat_cool_not_offered_returns_none` and `Expected mock to not have been
  awaited. Awaited 1 times.` in
  `test_unsupported_heat_mode_writes_only_the_setpoint`, which drives the real
  `convert_outbound_states` through `control_trv` for a `[auto, cool, off]`
  device and asserts `set_hvac_mode` is never awaited while `set_temperature`
  gets 22.0.
- The remaining new tests pin behaviour that must not change: both
  heat_auto_swapped directions, both HEAT↔HEAT_COOL translations, the AUTO
  error branch (which still wins over the clamp), `hvac_modes=None`,
  plain-string mode lists, and the two no-off `min_temp` payloads.

One existing test changed: `test_other_modes_unchanged_when_swapped` used the
default `hvac_modes=[OFF, HEAT, AUTO]` and then asserted that COOL passes
through, a mode the mock device does not list. `HVACMode.COOL` is added to
that fixture's list so the test keeps asserting its stated intent (the swap
leaves other modes alone) instead of relying on the missing clamp.

A twin PR carrying the same fix for the `v2` branch line exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unsupported HVAC modes from being sent to thermostat valves.
  * Continued applying setpoint changes when a requested mode is unavailable.
  * Improved handling of `OFF`, inbound modes, and alternate HVAC-mode representations.
  * Preserved safe behavior when devices provide incomplete capability information.
  * Updated available HVAC modes as device capabilities change.
  * Reduced duplicate error messages and provided clearer unsupported-mode guidance.
  * Improved fallback behavior for swapped or grouped thermostat valves.

* **Tests**
  * Expanded coverage for mode validation, fallback behavior, capability updates, grouping, and setpoint handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
