### PR TITLE
fix: stop sending HVAC modes the TRV does not offer

### DIFF
--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -58,7 +58,7 @@ from .utils.const import (
     CalibrationType,
     MpcV2PlantPreset,
 )
-from .utils.helpers import get_device_model, get_trv_intigration
+from .utils.helpers import device_offers_mode, get_device_model, get_trv_intigration
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -227,7 +227,7 @@ def _trv_supports_auto(
     if not trv_state or not hasattr(trv_state, "attributes"):
         return False
     hvac_modes = trv_state.attributes.get("hvac_modes") or []
-    return HVACMode.AUTO in hvac_modes
+    return device_offers_mode(hvac_modes, HVACMode.AUTO)
 
 
 def _build_advanced_fields(
@@ -820,7 +820,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 hvac_modes: list[str] = []
                 if state_obj and hasattr(state_obj, "attributes"):
                     hvac_modes = state_obj.attributes.get("hvac_modes", []) or []
-                if HVACMode.OFF not in hvac_modes:
+                if not device_offers_mode(hvac_modes, HVACMode.OFF):
                     _has_off_mode = False
 
             if not _has_off_mode:

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -32,6 +32,7 @@ from custom_components.better_thermostat.utils.helpers import (
     adopt_reported_hvac_modes,
     attr_to_celsius,
     convert_to_float,
+    device_offers_mode,
     get_device_model,
     group_all_members_off,
     is_reasonable_temperature,
@@ -539,8 +540,13 @@ def convert_outbound_states(self, entity_id, hvac_mode) -> dict | None:
                 self.device_name,
                 entity_id,
             )
+        # The cache holds the device's own spelling, so whether it offers OFF is
+        # decided on the normalized list, like every other capability check.
         if hvac_mode == HVACMode.OFF and (
-            (_system_modes is not None and HVACMode.OFF not in _system_modes)
+            (
+                _system_modes is not None
+                and not device_offers_mode(_system_modes, HVACMode.OFF)
+            )
             or advanced.get("no_off_system_mode")
         ):
             _min_temp = self.real_trvs[entity_id].min_temp

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -249,6 +249,16 @@ async def trigger_trv_change(self, event):
                 str(val_pos), self.device_name, "trv_event"
             )
 
+        # The offered mode list changes at runtime on devices whose
+        # heating/cooling changeover is driven centrally. An unavailable
+        # entity reports no attributes at all, so only a non-empty list
+        # replaces the cache.
+        _modes = _org_trv_state.attributes.get("hvac_modes")
+        if isinstance(_modes, list) and _modes:
+            if _modes != trv.hvac_modes:
+                trv.unsupported_modes_logged.clear()
+            trv.hvac_modes = _modes
+
     except Exception:
         pass
 

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -214,6 +214,16 @@ async def trigger_trv_change(self, event):
     if self.ignore_states:
         return
 
+    # The offered mode list changes at runtime on devices whose
+    # heating/cooling changeover is driven centrally, so every mode is judged
+    # against the currently reported list rather than the startup snapshot.
+    # The adoption precedes the inbound remapping below because the state
+    # carried by this event is a state of the capabilities it reports:
+    # remapping it against the previous list decodes it into a mode of a
+    # device that no longer exists, and the entity mode that follows from it
+    # is emitted before any later cache update could correct it.
+    adopt_reported_hvac_modes(trv, _org_trv_state.attributes.get("hvac_modes"))
+
     try:
         mapped_state = convert_inbound_states(self, entity_id, _org_trv_state)
     except TypeError:
@@ -249,12 +259,6 @@ async def trigger_trv_change(self, event):
             trv.valve_position = convert_to_float(
                 str(val_pos), self.device_name, "trv_event"
             )
-
-        # The offered mode list changes at runtime on devices whose
-        # heating/cooling changeover is driven centrally, so the outbound
-        # mode is judged against the currently reported list rather than
-        # the startup snapshot.
-        adopt_reported_hvac_modes(trv, _org_trv_state.attributes.get("hvac_modes"))
 
     except Exception:
         pass

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -29,6 +29,7 @@ from custom_components.better_thermostat.utils.const import (
 )
 from custom_components.better_thermostat.utils.helpers import (
     TRV_SETPOINT_KEYS,
+    adopt_reported_hvac_modes,
     attr_to_celsius,
     convert_to_float,
     get_device_model,
@@ -250,14 +251,10 @@ async def trigger_trv_change(self, event):
             )
 
         # The offered mode list changes at runtime on devices whose
-        # heating/cooling changeover is driven centrally. An unavailable
-        # entity reports no attributes at all, so only a non-empty list
-        # replaces the cache.
-        _modes = _org_trv_state.attributes.get("hvac_modes")
-        if isinstance(_modes, list) and _modes:
-            if _modes != trv.hvac_modes:
-                trv.unsupported_modes_logged.clear()
-            trv.hvac_modes = _modes
+        # heating/cooling changeover is driven centrally, so the outbound
+        # mode is judged against the currently reported list rather than
+        # the startup snapshot.
+        adopt_reported_hvac_modes(trv, _org_trv_state.attributes.get("hvac_modes"))
 
     except Exception:
         pass

--- a/custom_components/better_thermostat/trv.py
+++ b/custom_components/better_thermostat/trv.py
@@ -111,6 +111,9 @@ class Trv:
     # Whether a follow-up control cycle is already scheduled for this
     # TRV's next reachability-retry window.
     reachability_retry_pending: bool = False
+    # Outbound HVAC modes already annunciated as not offered by this
+    # device, so the error is logged once per mode instead of per cycle.
+    unsupported_modes_logged: set[str] = field(default_factory=set)
 
     # -- Calibration results -----------------------------------------------
     calibration_balance: dict[str, Any] | None = None

--- a/custom_components/better_thermostat/trv.py
+++ b/custom_components/better_thermostat/trv.py
@@ -15,7 +15,10 @@ from dataclasses import dataclass, field
 from types import ModuleType
 from typing import Any, Protocol, runtime_checkable
 
+from homeassistant.components.climate.const import HVACMode
+
 from custom_components.better_thermostat.core.calibrator import CalibratorHealth
+from custom_components.better_thermostat.utils.helpers import device_offers_mode
 
 
 @runtime_checkable
@@ -168,10 +171,12 @@ class Trv:
             )
 
         # An unreported mode list counts as no-off: BT then sends min temp
-        # instead of an OFF the device may not support.
+        # instead of an OFF the device may not support. The cached list holds
+        # the device's own spelling, so membership is decided on the normalized
+        # list, like every other capability check.
         no_off = (
             self.hvac_modes is None
-            or "off" not in self.hvac_modes
+            or not device_offers_mode(self.hvac_modes, HVACMode.OFF)
             or (self.advanced or {}).get("no_off_system_mode", False) is True
         )
         return TrvCapabilities(

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import logging
 import math
 import re
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_STEP,
@@ -42,6 +42,9 @@ from custom_components.better_thermostat.utils.const import (
     VALVE_MIN_THRESHOLD_TEMP_DIFF,
     CalibrationMode,
 )
+
+if TYPE_CHECKING:
+    from custom_components.better_thermostat.trv import Trv
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -274,7 +277,7 @@ def offered_mode_signature(trv_modes: Iterable[Any] | None) -> frozenset[str]:
     return frozenset(str(normalize_hvac_mode(mode)) for mode in trv_modes)
 
 
-def adopt_reported_hvac_modes(trv, reported_modes: Any) -> None:
+def adopt_reported_hvac_modes(trv: Trv, reported_modes: Any) -> None:
     """Cache the HVAC modes a device reports on its state.
 
     Parameters
@@ -296,7 +299,7 @@ def adopt_reported_hvac_modes(trv, reported_modes: Any) -> None:
     trv.hvac_modes = reported_modes
 
 
-def _unsupported_mode_hint(trv) -> str:
+def _unsupported_mode_hint(trv: Trv) -> str:
     """Name the remedy for a device that does not offer the mode BT wants.
 
     Parameters
@@ -325,7 +328,12 @@ def _unsupported_mode_hint(trv) -> str:
 
 
 def _clamp_to_offered_mode(
-    self, trv, entity_id, hvac_mode: str, inbound: bool, fallbacks: Sequence[str] = ()
+    self,
+    trv: Trv,
+    entity_id: str,
+    hvac_mode: str,
+    inbound: bool,
+    fallbacks: Sequence[str] = (),
 ) -> str | None:
     """Drop an outbound mode the device does not offer.
 
@@ -399,14 +407,16 @@ def _clamp_to_offered_mode(
     return None
 
 
-def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | None:
+def mode_remap(
+    self, entity_id: str, hvac_mode: str, inbound: bool = False
+) -> str | None:
     """Remap HVAC mode to correct mode if nessesary.
 
     Parameters
     ----------
     self : BetterThermostat
             The thermostat instance holding the per-TRV configuration.
-    entity_id :
+    entity_id : str
             entity id of the TRV whose mode is being remapped
     hvac_mode : str
             HVAC mode to be remapped

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from datetime import datetime
 import logging
 import math
@@ -325,7 +325,7 @@ def _unsupported_mode_hint(trv) -> str:
 
 
 def _clamp_to_offered_mode(
-    self, trv, entity_id, hvac_mode: str, inbound: bool, fallback: str | None = None
+    self, trv, entity_id, hvac_mode: str, inbound: bool, fallbacks: Sequence[str] = ()
 ) -> str | None:
     """Drop an outbound mode the device does not offer.
 
@@ -343,17 +343,18 @@ def _clamp_to_offered_mode(
     inbound : bool
             True if the mode is coming from the device, False if it is
             coming from HA.
-    fallback : str | None
-            The mode a quirk translation started from. When the translated
-            mode is unwritable but the original one is offered, writing the
-            original still puts the device into the state BT asked for.
+    fallbacks : Sequence[str]
+            The modes a quirk translation started from, most preferred
+            first. When the translated mode is unwritable but one of them is
+            offered, writing that one still puts the device into the state
+            BT asked for.
 
     Returns
     -------
     str | None
-            The mode itself when it may be written, ``fallback`` when only
-            that one is offered, ``None`` when the device offers neither
-            and its mode is to be left untouched.
+            The mode itself when it may be written, the first offered
+            fallback when only such a one is offered, ``None`` when the
+            device offers none of them and its mode is to be left untouched.
     """
     trv_modes = trv.hvac_modes
     if inbound or not trv_modes:
@@ -364,8 +365,11 @@ def _clamp_to_offered_mode(
         return hvac_mode
 
     key = str(normalize_hvac_mode(hvac_mode))
+    fallback = next(
+        (mode for mode in fallbacks if _device_offers_mode(trv_modes, mode)), None
+    )
 
-    if fallback is not None and _device_offers_mode(trv_modes, fallback):
+    if fallback is not None:
         fallback_key = f"{key}->{normalize_hvac_mode(fallback)}"
         if fallback_key not in trv.unsupported_modes_logged:
             trv.unsupported_modes_logged.add(fallback_key)
@@ -424,10 +428,28 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | 
     _heat_auto_swapped = (trv.advanced or {}).get(CONF_HEAT_AUTO_SWAPPED, False)
 
     if _heat_auto_swapped:
-        if hvac_mode == HVACMode.HEAT and not inbound:
+        # HEAT and HEAT_COOL are the same demand seen from two instances: a
+        # room with a cooler carries its heat demand as HEAT_COOL, because
+        # that is the mode such an instance offers instead of HEAT. Both name
+        # the device's heating mode, which is what the swap calls AUTO, and
+        # both fall back the same way, so which of the two arrives makes no
+        # difference to what the device receives. HEAT is preferred over
+        # HEAT_COOL as a fallback for the same reason the unswapped path
+        # prefers it: HEAT_COOL is the heating mode only of a device that
+        # offers nothing narrower.
+        if not inbound and hvac_mode in (HVACMode.HEAT, HVACMode.HEAT_COOL):
             return _clamp_to_offered_mode(
-                self, trv, entity_id, HVACMode.AUTO, inbound, fallback=HVACMode.HEAT
+                self,
+                trv,
+                entity_id,
+                HVACMode.AUTO,
+                inbound,
+                fallbacks=(HVACMode.HEAT, HVACMode.HEAT_COOL),
             )
+        # HEAT is the instance-level spelling of that demand in both cases:
+        # get_hvac_bt_mode() re-expresses it as HEAT_COOL for a room with a
+        # cooler, so the reported mode reaches the entity as HEAT_COOL there
+        # and as HEAT everywhere else.
         if hvac_mode == HVACMode.AUTO and inbound:
             return HVACMode.HEAT
         return _clamp_to_offered_mode(self, trv, entity_id, hvac_mode, inbound)

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -457,13 +457,17 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | 
     trv_modes = trv.hvac_modes
     if not trv_modes:
         return hvac_mode
-    if HVACMode.HEAT not in trv_modes and HVACMode.HEAT_COOL in trv_modes:
+    # The cache holds the device's own spelling, so the two translations are
+    # decided on the normalized list like the clamp below is.
+    offers_heat = _device_offers_mode(trv_modes, HVACMode.HEAT)
+    offers_heat_cool = _device_offers_mode(trv_modes, HVACMode.HEAT_COOL)
+    if not offers_heat and offers_heat_cool:
         # entity only supports HEAT_COOL, but not HEAT - need to translate
         if not inbound and hvac_mode == HVACMode.HEAT:
             return HVACMode.HEAT_COOL
         if inbound and hvac_mode == HVACMode.HEAT_COOL:
             return HVACMode.HEAT
-    if HVACMode.HEAT_COOL not in trv_modes and HVACMode.HEAT in trv_modes:
+    if not offers_heat_cool and offers_heat:
         # entity only supports HEAT, but not HEAT_COOL - need to translate
         if not inbound and hvac_mode == HVACMode.HEAT_COOL:
             return HVACMode.HEAT
@@ -471,13 +475,19 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | 
             return HVACMode.HEAT_COOL
 
     if hvac_mode == HVACMode.AUTO:
-        _LOGGER.error(
-            "better_thermostat %s: %s HVAC mode %s is not supported by this device, "
-            "is it possible that you forgot to set the heat auto swapped option?",
-            self.device_name,
-            entity_id,
-            hvac_mode,
-        )
+        # The mode is annunciated once per offered set, like the clamp does it,
+        # so an unswapped instance asked for AUTO every cycle says so once.
+        auto_key = str(normalize_hvac_mode(hvac_mode))
+        if auto_key not in trv.unsupported_modes_logged:
+            trv.unsupported_modes_logged.add(auto_key)
+            _LOGGER.error(
+                "better_thermostat %s: %s HVAC mode %s is not supported by this "
+                "device, is it possible that you forgot to set the heat auto "
+                "swapped option?",
+                self.device_name,
+                entity_id,
+                hvac_mode,
+            )
         return HVACMode.OFF
 
     return _clamp_to_offered_mode(self, trv, entity_id, hvac_mode, inbound)

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -254,6 +254,48 @@ def _device_offers_mode(trv_modes: Iterable[Any], hvac_mode: str) -> bool:
     return any(normalize_hvac_mode(mode) == target for mode in trv_modes)
 
 
+def offered_mode_signature(trv_modes: Iterable[Any] | None) -> frozenset[str]:
+    """Reduce a reported mode list to the set of modes it offers.
+
+    Parameters
+    ----------
+    trv_modes : Iterable[Any] | None
+            HVAC modes a device reports, in any spelling.
+
+    Returns
+    -------
+    frozenset[str]
+            Normalized mode names, so two lists that differ only in order,
+            in capitalization or in ``HVACMode`` versus ``"HVACMode.HEAT"``
+            spelling reduce to the same value.
+    """
+    if not trv_modes:
+        return frozenset()
+    return frozenset(str(normalize_hvac_mode(mode)) for mode in trv_modes)
+
+
+def adopt_reported_hvac_modes(trv, reported_modes: Any) -> None:
+    """Cache the HVAC modes a device reports on its state.
+
+    Parameters
+    ----------
+    trv : Trv
+            Per-TRV state holding the cached mode list.
+    reported_modes : Any
+            Value of the device's ``hvac_modes`` attribute. An absent or
+            empty list keeps the cached one: it means the device published
+            no capabilities in this event, not that it lost them. The modes
+            already annunciated as not offered are forgotten only when the
+            offered set really changes, so a republication in a different
+            order or a different spelling does not repeat the annunciation.
+    """
+    if not isinstance(reported_modes, list) or not reported_modes:
+        return
+    if offered_mode_signature(reported_modes) != offered_mode_signature(trv.hvac_modes):
+        trv.unsupported_modes_logged.clear()
+    trv.hvac_modes = reported_modes
+
+
 def _unsupported_mode_hint(trv) -> str:
     """Name the remedy for a device that does not offer the mode BT wants.
 
@@ -283,7 +325,7 @@ def _unsupported_mode_hint(trv) -> str:
 
 
 def _clamp_to_offered_mode(
-    self, trv, entity_id, hvac_mode: str, inbound: bool
+    self, trv, entity_id, hvac_mode: str, inbound: bool, fallback: str | None = None
 ) -> str | None:
     """Drop an outbound mode the device does not offer.
 
@@ -301,12 +343,17 @@ def _clamp_to_offered_mode(
     inbound : bool
             True if the mode is coming from the device, False if it is
             coming from HA.
+    fallback : str | None
+            The mode a quirk translation started from. When the translated
+            mode is unwritable but the original one is offered, writing the
+            original still puts the device into the state BT asked for.
 
     Returns
     -------
     str | None
-            The mode itself when it may be written, ``None`` when the
-            device's mode is to be left untouched.
+            The mode itself when it may be written, ``fallback`` when only
+            that one is offered, ``None`` when the device offers neither
+            and its mode is to be left untouched.
     """
     trv_modes = trv.hvac_modes
     if inbound or not trv_modes:
@@ -317,6 +364,23 @@ def _clamp_to_offered_mode(
         return hvac_mode
 
     key = str(normalize_hvac_mode(hvac_mode))
+
+    if fallback is not None and _device_offers_mode(trv_modes, fallback):
+        fallback_key = f"{key}->{normalize_hvac_mode(fallback)}"
+        if fallback_key not in trv.unsupported_modes_logged:
+            trv.unsupported_modes_logged.add(fallback_key)
+            _LOGGER.warning(
+                "better_thermostat %s: %s does not offer HVAC mode %s, it offers %s. "
+                "Writing %s instead. %s",
+                self.device_name,
+                entity_id,
+                hvac_mode,
+                trv_modes,
+                fallback,
+                _unsupported_mode_hint(trv),
+            )
+        return fallback
+
     if key not in trv.unsupported_modes_logged:
         trv.unsupported_modes_logged.add(key)
         _LOGGER.error(
@@ -361,7 +425,9 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | 
 
     if _heat_auto_swapped:
         if hvac_mode == HVACMode.HEAT and not inbound:
-            return _clamp_to_offered_mode(self, trv, entity_id, HVACMode.AUTO, inbound)
+            return _clamp_to_offered_mode(
+                self, trv, entity_id, HVACMode.AUTO, inbound, fallback=HVACMode.HEAT
+            )
         if hvac_mode == HVACMode.AUTO and inbound:
             return HVACMode.HEAT
         return _clamp_to_offered_mode(self, trv, entity_id, hvac_mode, inbound)

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -233,7 +233,78 @@ def normalize_hvac_mode(value: HVACMode | str) -> HVACMode | str:
     return value
 
 
-def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str:
+def _device_offers_mode(trv_modes: Iterable[Any], hvac_mode: str) -> bool:
+    """Whether the device's reported mode list contains this mode.
+
+    Parameters
+    ----------
+    trv_modes : Iterable[Any]
+            The device's reported ``hvac_modes`` list.
+    hvac_mode : str
+            The mode to look for.
+
+    Returns
+    -------
+    bool
+            ``True`` when the list carries the mode. Both sides are
+            normalized, so mode lists holding ``HVACMode`` members, plain
+            strings or ``"HVACMode.HEAT"`` spellings compare alike.
+    """
+    target = normalize_hvac_mode(hvac_mode)
+    return any(normalize_hvac_mode(mode) == target for mode in trv_modes)
+
+
+def _clamp_to_offered_mode(
+    self, trv, entity_id, hvac_mode: str, inbound: bool
+) -> str | None:
+    """Drop an outbound mode the device does not offer.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+            The thermostat instance, used for the log message.
+    trv : Trv
+            The TRV whose mode list decides, and which tracks the modes
+            already annunciated.
+    entity_id : str
+            Entity id of that TRV.
+    hvac_mode : str
+            The mode about to be written.
+    inbound : bool
+            True if the mode is coming from the device, False if it is
+            coming from HA.
+
+    Returns
+    -------
+    str | None
+            The mode itself when it may be written, ``None`` when the
+            device's mode is to be left untouched.
+    """
+    trv_modes = trv.hvac_modes
+    if inbound or not trv_modes:
+        return hvac_mode
+    if normalize_hvac_mode(hvac_mode) == HVACMode.OFF or _device_offers_mode(
+        trv_modes, hvac_mode
+    ):
+        return hvac_mode
+
+    key = str(normalize_hvac_mode(hvac_mode))
+    if key not in trv.unsupported_modes_logged:
+        trv.unsupported_modes_logged.add(key)
+        _LOGGER.error(
+            "better_thermostat %s: %s does not offer HVAC mode %s, it offers %s. "
+            "The device mode is left untouched and only the setpoint is written. "
+            "Switch the device to its heating mode, or enable the heat auto "
+            "swapped option if 'auto' means 'heat' on this device.",
+            self.device_name,
+            entity_id,
+            hvac_mode,
+            trv_modes,
+        )
+    return None
+
+
+def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | None:
     """Remap HVAC mode to correct mode if nessesary.
 
     Parameters
@@ -250,8 +321,10 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str:
 
     Returns
     -------
-    str
-            remapped mode according to device's quirks
+    str | None
+            remapped mode according to device's quirks, or ``None`` for an
+            outbound mode the device does not offer, meaning the device's
+            mode is left untouched.
     """
     trv = self.real_trvs.get(entity_id)
     if trv is None:
@@ -261,10 +334,10 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str:
 
     if _heat_auto_swapped:
         if hvac_mode == HVACMode.HEAT and not inbound:
-            return HVACMode.AUTO
+            return _clamp_to_offered_mode(self, trv, entity_id, HVACMode.AUTO, inbound)
         if hvac_mode == HVACMode.AUTO and inbound:
             return HVACMode.HEAT
-        return hvac_mode
+        return _clamp_to_offered_mode(self, trv, entity_id, hvac_mode, inbound)
 
     trv_modes = trv.hvac_modes
     if not trv_modes:
@@ -282,17 +355,17 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str:
         if inbound and hvac_mode == HVACMode.HEAT:
             return HVACMode.HEAT_COOL
 
-    if hvac_mode != HVACMode.AUTO:
-        return hvac_mode
+    if hvac_mode == HVACMode.AUTO:
+        _LOGGER.error(
+            "better_thermostat %s: %s HVAC mode %s is not supported by this device, "
+            "is it possible that you forgot to set the heat auto swapped option?",
+            self.device_name,
+            entity_id,
+            hvac_mode,
+        )
+        return HVACMode.OFF
 
-    _LOGGER.error(
-        "better_thermostat %s: %s HVAC mode %s is not supported by this device, "
-        "is it possible that you forgot to set the heat auto swapped option?",
-        self.device_name,
-        entity_id,
-        hvac_mode,
-    )
-    return HVACMode.OFF
+    return _clamp_to_offered_mode(self, trv, entity_id, hvac_mode, inbound)
 
 
 def group_all_members_off(self) -> bool:

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -233,7 +233,7 @@ def normalize_hvac_mode(value: HVACMode | str) -> HVACMode | str:
     return value
 
 
-def _device_offers_mode(trv_modes: Iterable[Any], hvac_mode: str) -> bool:
+def device_offers_mode(trv_modes: Iterable[Any], hvac_mode: str) -> bool:
     """Whether the device's reported mode list contains this mode.
 
     Parameters
@@ -359,14 +359,14 @@ def _clamp_to_offered_mode(
     trv_modes = trv.hvac_modes
     if inbound or not trv_modes:
         return hvac_mode
-    if normalize_hvac_mode(hvac_mode) == HVACMode.OFF or _device_offers_mode(
+    if normalize_hvac_mode(hvac_mode) == HVACMode.OFF or device_offers_mode(
         trv_modes, hvac_mode
     ):
         return hvac_mode
 
     key = str(normalize_hvac_mode(hvac_mode))
     fallback = next(
-        (mode for mode in fallbacks if _device_offers_mode(trv_modes, mode)), None
+        (mode for mode in fallbacks if device_offers_mode(trv_modes, mode)), None
     )
 
     if fallback is not None:
@@ -459,8 +459,8 @@ def mode_remap(self, entity_id, hvac_mode: str, inbound: bool = False) -> str | 
         return hvac_mode
     # The cache holds the device's own spelling, so the two translations are
     # decided on the normalized list like the clamp below is.
-    offers_heat = _device_offers_mode(trv_modes, HVACMode.HEAT)
-    offers_heat_cool = _device_offers_mode(trv_modes, HVACMode.HEAT_COOL)
+    offers_heat = device_offers_mode(trv_modes, HVACMode.HEAT)
+    offers_heat_cool = device_offers_mode(trv_modes, HVACMode.HEAT_COOL)
     if not offers_heat and offers_heat_cool:
         # entity only supports HEAT_COOL, but not HEAT - need to translate
         if not inbound and hvac_mode == HVACMode.HEAT:

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -254,6 +254,34 @@ def _device_offers_mode(trv_modes: Iterable[Any], hvac_mode: str) -> bool:
     return any(normalize_hvac_mode(mode) == target for mode in trv_modes)
 
 
+def _unsupported_mode_hint(trv) -> str:
+    """Name the remedy for a device that does not offer the mode BT wants.
+
+    Parameters
+    ----------
+    trv : Trv
+            The TRV whose advanced configuration decides.
+
+    Returns
+    -------
+    str
+            A sentence naming the setting that resolves the situation. The
+            heat auto swapped option decides whether BT writes ``heat`` or
+            ``auto``, so which way to turn it depends on its current
+            setting: a device without ``auto`` is only asked for ``auto``
+            because the option is already on.
+    """
+    if (trv.advanced or {}).get(CONF_HEAT_AUTO_SWAPPED, False):
+        return (
+            "Disable the heat auto swapped option unless 'auto' really is this "
+            "device's heating mode."
+        )
+    return (
+        "Switch the device to its heating mode, or enable the heat auto swapped "
+        "option if 'auto' means 'heat' on this device."
+    )
+
+
 def _clamp_to_offered_mode(
     self, trv, entity_id, hvac_mode: str, inbound: bool
 ) -> str | None:
@@ -293,13 +321,12 @@ def _clamp_to_offered_mode(
         trv.unsupported_modes_logged.add(key)
         _LOGGER.error(
             "better_thermostat %s: %s does not offer HVAC mode %s, it offers %s. "
-            "The device mode is left untouched and only the setpoint is written. "
-            "Switch the device to its heating mode, or enable the heat auto "
-            "swapped option if 'auto' means 'heat' on this device.",
+            "The device mode is left untouched and only the setpoint is written. %s",
             self.device_name,
             entity_id,
             hvac_mode,
             trv_modes,
+            _unsupported_mode_hint(trv),
         )
     return None
 

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -484,157 +484,6 @@ class TestControlTrvUnavailablePath:
             mock_set_valve.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_window_open_sets_mode_to_off(self):
-        """Test that window open sets HVAC mode to OFF."""
-        mock_self = _make_mock_self(
-            trv_state=HVACMode.HEAT,
-            trv_attrs={"temperature": 20.0},
-            window_open=True,
-            real_trvs={"climate.trv1": _default_trv_config()},
-        )
-
-        with (
-            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_hvac_mode"]) as mock_set_hvac,
-            patch(_PATCHES["override_set_hvac_mode"]) as mock_override,
-            patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
-            ),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
-            patch("asyncio.sleep", new=AsyncMock()),
-        ):
-            mock_convert.return_value = {
-                "temperature": 20.0,
-                "system_mode": HVACMode.HEAT,
-            }
-            mock_set_hvac.return_value = None
-            mock_override.return_value = False
-
-            result = await control_trv(mock_self, "climate.trv1")
-
-            assert result is True
-            # set_hvac_mode should be called with OFF
-            mock_set_hvac.assert_called_once()
-            assert mock_set_hvac.call_args[0][2] == HVACMode.OFF
-
-    @pytest.mark.asyncio
-    async def test_no_off_mode_sends_min_temp_when_off_requested(self):
-        """Test that TRV without OFF mode sends min_temp when OFF is requested."""
-        mock_self = _make_mock_self(
-            trv_state=HVACMode.HEAT,
-            trv_attrs={"temperature": 20.0},
-            call_for_heat=False,  # No heat needed -> OFF
-            real_trvs={
-                "climate.trv1": _default_trv_config(
-                    hvac_modes=[HVACMode.HEAT]  # No OFF mode!
-                )
-            },
-        )
-
-        with (
-            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
-            patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
-            ),
-            patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
-            ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch("asyncio.sleep", new=AsyncMock()),
-        ):
-            mock_convert.return_value = {
-                "temperature": 20.0,
-                "system_mode": HVACMode.HEAT,
-            }
-            mock_set_temp.return_value = None
-
-            await control_trv(mock_self, "climate.trv1")
-
-            # Should set temperature to min_temp (5.0) because OFF is not available
-            mock_set_temp.assert_called_once()
-            args = mock_set_temp.call_args[0]
-            assert args[2] == 5.0  # min_temp
-
-    @pytest.mark.asyncio
-    async def test_off_offered_in_the_device_spelling_switches_the_device_off(self):
-        """A list naming its modes ``HVACMode.OFF`` still offers OFF.
-
-        The cached list holds the device's own spelling, so the min_temp
-        substitution must not fire for a device that does offer OFF.
-        """
-        mock_self = _make_mock_self(
-            trv_state=HVACMode.HEAT,
-            trv_attrs={"temperature": 20.0},
-            call_for_heat=False,
-            real_trvs={
-                "climate.trv1": _default_trv_config(
-                    hvac_modes=["HVACMode.OFF", "HVACMode.HEAT"]
-                )
-            },
-        )
-
-        with (
-            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
-            patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
-            ),
-            patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
-            ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
-            patch("asyncio.sleep", new=AsyncMock()),
-        ):
-            mock_convert.return_value = {
-                "temperature": 20.0,
-                "system_mode": HVACMode.HEAT,
-            }
-            mock_set_temp.return_value = None
-
-            await control_trv(mock_self, "climate.trv1")
-
-            mock_set_hvac.assert_awaited_once()
-            assert mock_set_hvac.await_args[0][2] == HVACMode.OFF
-            for call in mock_set_temp.call_args_list:
-                assert call[0][2] != 5.0
-
-    @pytest.mark.asyncio
-    async def test_no_off_in_the_device_spelling_still_sends_min_temp(self):
-        """A device genuinely without OFF keeps taking the min_temp path."""
-        mock_self = _make_mock_self(
-            trv_state=HVACMode.HEAT,
-            trv_attrs={"temperature": 20.0},
-            call_for_heat=False,
-            real_trvs={
-                "climate.trv1": _default_trv_config(hvac_modes=["HVACMode.HEAT"])
-            },
-        )
-
-        with (
-            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
-            patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
-            ),
-            patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
-            ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch("asyncio.sleep", new=AsyncMock()),
-        ):
-            mock_convert.return_value = {
-                "temperature": 20.0,
-                "system_mode": HVACMode.HEAT,
-            }
-            mock_set_temp.return_value = None
-
-            await control_trv(mock_self, "climate.trv1")
-
-            mock_set_temp.assert_called_once()
-            assert mock_set_temp.call_args[0][2] == 5.0
-
-    @pytest.mark.asyncio
     async def test_ignore_trv_states_flag_set_and_reset(self):
         """Test that ignore_trv_states flag is set during processing and reset after."""
         mock_self = _make_mock_self(trv_state=STATE_UNAVAILABLE)
@@ -1228,6 +1077,159 @@ class TestControlTrvAvailablePath:
 
             # Lock should have been acquired
             lock_acquire_mock.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_window_open_sets_mode_to_off(self):
+        """Test that window open sets HVAC mode to OFF."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            window_open=True,
+            real_trvs={"climate.trv1": _default_trv_config()},
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_hvac_mode"]) as mock_set_hvac,
+            patch(_PATCHES["override_set_hvac_mode"]) as mock_override,
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_hvac.return_value = None
+            mock_override.return_value = False
+
+            result = await control_trv(mock_self, "climate.trv1")
+
+            assert result is True
+            # set_hvac_mode should be called with OFF
+            mock_set_hvac.assert_called_once()
+            assert mock_set_hvac.call_args[0][2] == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_no_off_mode_sends_min_temp_when_off_requested(self):
+        """Test that TRV without OFF mode sends min_temp when OFF is requested."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=False,  # No heat needed -> OFF
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    hvac_modes=[HVACMode.HEAT]  # No OFF mode!
+                )
+            },
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_temp.return_value = None
+
+            await control_trv(mock_self, "climate.trv1")
+
+            # Should set temperature to min_temp (5.0) because OFF is not available
+            mock_set_temp.assert_called_once()
+            args = mock_set_temp.call_args[0]
+            assert args[2] == 5.0  # min_temp
+            mock_set_hvac.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_off_offered_in_the_device_spelling_switches_the_device_off(self):
+        """A list naming its modes ``HVACMode.OFF`` still offers OFF.
+
+        The cached list holds the device's own spelling, so the min_temp
+        substitution must not fire for a device that does offer OFF.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=False,
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    hvac_modes=["HVACMode.OFF", "HVACMode.HEAT"]
+                )
+            },
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_temp.return_value = None
+
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_set_hvac.assert_awaited_once()
+            assert mock_set_hvac.await_args[0][2] == HVACMode.OFF
+            for call in mock_set_temp.call_args_list:
+                assert call[0][2] != 5.0
+
+    @pytest.mark.asyncio
+    async def test_no_off_in_the_device_spelling_still_sends_min_temp(self):
+        """A device genuinely without OFF keeps taking the min_temp path."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=False,
+            real_trvs={
+                "climate.trv1": _default_trv_config(hvac_modes=["HVACMode.HEAT"])
+            },
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_temp.return_value = None
+
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_set_temp.assert_called_once()
+            assert mock_set_temp.call_args[0][2] == 5.0
+            mock_set_hvac.assert_not_awaited()
 
 
 class TestControlTrvIgnoreFlagReset:

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -557,6 +557,84 @@ class TestControlTrvUnavailablePath:
             assert args[2] == 5.0  # min_temp
 
     @pytest.mark.asyncio
+    async def test_off_offered_in_the_device_spelling_switches_the_device_off(self):
+        """A list naming its modes ``HVACMode.OFF`` still offers OFF.
+
+        The cached list holds the device's own spelling, so the min_temp
+        substitution must not fire for a device that does offer OFF.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=False,
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    hvac_modes=["HVACMode.OFF", "HVACMode.HEAT"]
+                )
+            },
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_temp.return_value = None
+
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_set_hvac.assert_awaited_once()
+            assert mock_set_hvac.await_args[0][2] == HVACMode.OFF
+            for call in mock_set_temp.call_args_list:
+                assert call[0][2] != 5.0
+
+    @pytest.mark.asyncio
+    async def test_no_off_in_the_device_spelling_still_sends_min_temp(self):
+        """A device genuinely without OFF keeps taking the min_temp path."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=False,
+            real_trvs={
+                "climate.trv1": _default_trv_config(hvac_modes=["HVACMode.HEAT"])
+            },
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            mock_set_temp.return_value = None
+
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_set_temp.assert_called_once()
+            assert mock_set_temp.call_args[0][2] == 5.0
+
+    @pytest.mark.asyncio
     async def test_ignore_trv_states_flag_set_and_reset(self):
         """Test that ignore_trv_states flag is set during processing and reset after."""
         mock_self = _make_mock_self(trv_state=STATE_UNAVAILABLE)

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -662,6 +662,51 @@ class TestControlTrvAvailablePath:
             mock_set_temp.assert_awaited_once_with(mock_self, "climate.trv1", 22.0)
 
     @pytest.mark.asyncio
+    async def test_swapped_device_without_auto_still_gets_heat(self):
+        """A swapped valve offering only off/heat is switched to heat.
+
+        The full outbound conversion runs, so this is the payload a device
+        sitting in OFF receives on a heat demand.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.OFF,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=True,
+            bt_target_temp=22.0,
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+                    hvac_mode=HVACMode.OFF,
+                    last_hvac_mode=HVACMode.OFF,
+                    advanced={
+                        "calibration_mode": CalibrationMode.NO_CALIBRATION,
+                        "calibration": CalibrationType.TARGET_TEMP_BASED,
+                        "no_off_system_mode": False,
+                        "heat_auto_swapped": True,
+                    },
+                )
+            },
+        )
+
+        with (
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_mode,
+            patch(_PATCHES["set_temperature"], new=AsyncMock()) as mock_set_temp,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_set_mode.assert_awaited_once_with(
+                mock_self, "climate.trv1", HVACMode.HEAT
+            )
+            mock_set_temp.assert_awaited_once_with(mock_self, "climate.trv1", 22.0)
+
+    @pytest.mark.asyncio
     async def test_set_temperature_quirk_skips_generic_adapter(self):
         """A model quirk that handles the write suppresses the adapter call."""
         mock_self = _make_mock_self(

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -624,18 +624,27 @@ class TestControlTrvAvailablePath:
             assert result is True
 
     @pytest.mark.asyncio
-    async def test_suppressed_system_mode_writes_only_the_setpoint(self):
-        """A payload without a system mode sends the setpoint and nothing else.
+    async def test_unsupported_heat_mode_writes_only_the_setpoint(self):
+        """A device offering no heating mode keeps its mode and gets the setpoint.
 
-        This is what a device that offers none of BT's heating modes gets:
-        its own mode stays untouched while the setpoint keeps flowing.
+        The full outbound conversion runs so the payload really is the one a
+        wall thermostat with ``[auto, cool, off]`` produces for a heat demand.
         """
         mock_self = _make_mock_self(
-            trv_state=HVACMode.HEAT, trv_attrs={"temperature": 20.0}
+            trv_state=HVACMode.AUTO,
+            trv_attrs={"temperature": 20.0},
+            call_for_heat=True,
+            bt_target_temp=22.0,
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    hvac_modes=[HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF],
+                    hvac_mode=HVACMode.AUTO,
+                    last_hvac_mode=HVACMode.AUTO,
+                )
+            },
         )
 
         with (
-            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
                 _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
             ) as mock_override_mode,
@@ -646,13 +655,11 @@ class TestControlTrvAvailablePath:
             patch(_PATCHES["set_temperature"], new=AsyncMock()) as mock_set_temp,
             patch("asyncio.sleep", new=AsyncMock()),
         ):
-            mock_convert.return_value = {"temperature": 21.0, "system_mode": None}
-
             await control_trv(mock_self, "climate.trv1")
 
             mock_override_mode.assert_not_awaited()
             mock_set_mode.assert_not_awaited()
-            mock_set_temp.assert_awaited_once_with(mock_self, "climate.trv1", 21.0)
+            mock_set_temp.assert_awaited_once_with(mock_self, "climate.trv1", 22.0)
 
     @pytest.mark.asyncio
     async def test_set_temperature_quirk_skips_generic_adapter(self):

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -624,6 +624,37 @@ class TestControlTrvAvailablePath:
             assert result is True
 
     @pytest.mark.asyncio
+    async def test_suppressed_system_mode_writes_only_the_setpoint(self):
+        """A payload without a system mode sends the setpoint and nothing else.
+
+        This is what a device that offers none of BT's heating modes gets:
+        its own mode stays untouched while the setpoint keeps flowing.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT, trv_attrs={"temperature": 20.0}
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(
+                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+            ) as mock_override_mode,
+            patch(
+                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+            ),
+            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_mode,
+            patch(_PATCHES["set_temperature"], new=AsyncMock()) as mock_set_temp,
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {"temperature": 21.0, "system_mode": None}
+
+            await control_trv(mock_self, "climate.trv1")
+
+            mock_override_mode.assert_not_awaited()
+            mock_set_mode.assert_not_awaited()
+            mock_set_temp.assert_awaited_once_with(mock_self, "climate.trv1", 21.0)
+
+    @pytest.mark.asyncio
     async def test_set_temperature_quirk_skips_generic_adapter(self):
         """A model quirk that handles the write suppresses the adapter call."""
         mock_self = _make_mock_self(

--- a/tests/unit/test_config_flow_offered_modes.py
+++ b/tests/unit/test_config_flow_offered_modes.py
@@ -1,0 +1,114 @@
+"""Tests for the config flow's reads of a device's offered HVAC modes.
+
+A climate entity publishes its capability list in its own spelling, so both
+the AUTO probe and the OFF gate must compare normalized. A device naming its
+modes ``HVACMode.OFF`` offers OFF just as one naming them ``off`` does.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.climate.const import HVACMode
+import pytest
+
+from custom_components.better_thermostat.config_flow import (
+    ConfigFlow,
+    _trv_supports_auto,
+)
+
+
+def _flow_with_modes(modes):
+    """Build a flow whose single TRV reports the given mode list."""
+    state = MagicMock()
+    state.attributes = {"hvac_modes": modes}
+
+    flow = MagicMock()
+    flow.hass.states.get.return_value = state
+    return flow
+
+
+class TestTrvSupportsAuto:
+    """The AUTO probe reads the device's own spelling."""
+
+    def test_auto_offered_as_plain_string(self):
+        """A plain ``auto`` is recognized."""
+        assert _trv_supports_auto(_flow_with_modes(["off", "auto"]), "climate.trv")
+
+    def test_auto_offered_in_the_device_spelling(self):
+        """An ``HVACMode.AUTO`` spelling is recognized just the same."""
+        assert _trv_supports_auto(
+            _flow_with_modes(["HVACMode.OFF", "HVACMode.AUTO"]), "climate.trv"
+        )
+
+    def test_auto_absent_in_the_device_spelling(self):
+        """A device genuinely without AUTO is still reported as lacking it."""
+        assert not _trv_supports_auto(
+            _flow_with_modes(["HVACMode.OFF", "HVACMode.HEAT"]), "climate.trv"
+        )
+
+
+def _advanced_flow(modes):
+    """Build a ConfigFlow parked on the last TRV of a one-TRV bundle."""
+    flow = ConfigFlow()
+    flow.hass = MagicMock()
+    state = MagicMock()
+    state.attributes = {"hvac_modes": modes}
+    flow.hass.states.get.return_value = state
+    flow.i = 0
+    flow.trv_bundle = [{"trv": "climate.trv", "advanced": {}}]
+    flow._active_trv_config = flow.trv_bundle[0]
+    return flow
+
+
+async def _run_advanced(flow):
+    """Submit the advanced step and return the confirm_type it hands on."""
+    confirm = AsyncMock(return_value="confirm")
+    with (
+        patch(
+            "custom_components.better_thermostat.config_flow._prepare_advanced_context",
+            new=AsyncMock(
+                return_value={
+                    "trv_id": "climate.trv",
+                    "default_calibration": "target_temp_based",
+                    "homematic": False,
+                    "has_auto": False,
+                    "info": {},
+                }
+            ),
+        ),
+        patch(
+            "custom_components.better_thermostat.config_flow._normalize_advanced_submission",
+            return_value={},
+        ),
+        patch.object(ConfigFlow, "async_step_confirm", new=confirm),
+    ):
+        await flow.async_step_advanced({})
+    return confirm.await_args[0][1] if len(confirm.await_args[0]) > 1 else None
+
+
+class TestOffModeGate:
+    """The OFF gate reads the device's own spelling."""
+
+    @pytest.mark.asyncio
+    async def test_off_offered_as_plain_string_passes_the_gate(self):
+        """A plain ``off`` reaches confirm without the no_off_mode notice."""
+        assert await _run_advanced(_advanced_flow(["off", "heat"])) is None
+
+    @pytest.mark.asyncio
+    async def test_off_offered_in_the_device_spelling_passes_the_gate(self):
+        """An ``HVACMode.OFF`` spelling passes the gate just the same."""
+        assert (
+            await _run_advanced(_advanced_flow(["HVACMode.OFF", "HVACMode.HEAT"]))
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_device_without_off_still_raises_the_notice(self):
+        """A device genuinely without OFF still gets the no_off_mode notice."""
+        assert await _run_advanced(_advanced_flow(["HVACMode.HEAT"])) == "no_off_mode"
+
+
+def test_hvac_mode_enum_members_are_recognized():
+    """A list holding HVACMode members keeps working."""
+    assert _trv_supports_auto(
+        _flow_with_modes([HVACMode.OFF, HVACMode.AUTO]), "climate.trv"
+    )

--- a/tests/unit/test_helpers_mode_remap.py
+++ b/tests/unit/test_helpers_mode_remap.py
@@ -107,13 +107,25 @@ class TestModeRemapHeatAutoSwapped:
         result = mode_remap(mock_bt, "climate.test", HVACMode.COOL, inbound=False)
         assert result == HVACMode.COOL
 
-    def test_swapped_heat_dropped_when_device_has_no_auto(self):
-        """A swapped device without AUTO gets no mode written at all."""
+    def test_swapped_heat_falls_back_when_device_has_no_auto(self):
+        """A swapped device without AUTO receives the unswapped HEAT."""
         mock_bt = MockThermostat()
         mock_bt.add_trv(
             "climate.test",
             heat_auto_swapped=True,
             hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result == HVACMode.HEAT
+
+    def test_swapped_heat_dropped_when_device_offers_neither(self):
+        """A swapped device with neither AUTO nor HEAT gets no mode written."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.COOL],
         )
 
         result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
@@ -390,12 +402,12 @@ class TestModeRemapUnsupportedOutboundMode:
             assert len(errors) == 2
 
     def test_hint_names_disabling_the_swap_when_it_is_on(self, caplog):
-        """A swapped device without AUTO is told to turn the swap off."""
+        """A swapped device offering neither AUTO nor HEAT names the swap."""
         mock_bt = MockThermostat()
         mock_bt.add_trv(
             "climate.test",
             heat_auto_swapped=True,
-            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+            hvac_modes=[HVACMode.OFF, HVACMode.COOL],
         )
 
         with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
@@ -428,3 +440,110 @@ class TestModeRemapUnsupportedOutboundMode:
         message = records[0].getMessage()
         assert "enable the heat auto swapped option" in message
         assert "Disable the heat auto swapped option" not in message
+
+
+def _fallback_records(caplog):
+    """Return the log records announcing the unswapped fallback."""
+    return [
+        record
+        for record in caplog.records
+        if "Writing heat instead" in record.getMessage()
+    ]
+
+
+class TestModeRemapSwapFallback:
+    """A swapped device without AUTO still receives the mode BT wants."""
+
+    def test_heat_is_written_when_auto_is_missing(self):
+        """The swap's output is unwritable, so the original HEAT is written."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result == HVACMode.HEAT
+
+    def test_auto_still_wins_when_the_device_offers_it(self):
+        """The swap keeps its effect on the devices it was meant for."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result == HVACMode.AUTO
+
+    def test_no_fallback_when_heat_is_not_offered_either(self):
+        """The fallback never resurrects a mode the device does not offer."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.COOL],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result is None
+
+    def test_fallback_matches_a_prefixed_mode_spelling(self):
+        """A mode list spelled "HVACMode.HEAT" is recognised as offering HEAT."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=["HVACMode.OFF", "HVACMode.HEAT"],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result == HVACMode.HEAT
+
+    def test_fallback_does_not_fire_inbound(self):
+        """An inbound AUTO keeps becoming HEAT without consulting the list."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.COOL],
+        )
+
+        assert (
+            mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=True)
+            == HVACMode.HEAT
+        )
+        assert mode_remap(mock_bt, "climate.test", "dry", inbound=True) == "dry"
+
+    def test_fallback_leaves_the_auto_error_branch_alone(self, caplog):
+        """An unswapped device still answers AUTO with OFF and its own error."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=[HVACMode.OFF, HVACMode.HEAT])
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            result = mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=False)
+
+        assert result == HVACMode.OFF
+        assert not _fallback_records(caplog)
+
+    def test_fallback_is_announced_once(self, caplog):
+        """Repeated cycles announce the substitution a single time."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        )
+
+        with caplog.at_level(logging.WARNING, logger=HELPERS_LOGGER):
+            for _ in range(5):
+                assert (
+                    mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+                    == HVACMode.HEAT
+                )
+
+        records = _fallback_records(caplog)
+        assert len(records) == 1
+        assert "Disable the heat auto swapped option" in records[0].getMessage()

--- a/tests/unit/test_helpers_mode_remap.py
+++ b/tests/unit/test_helpers_mode_remap.py
@@ -12,6 +12,17 @@ from homeassistant.components.climate.const import HVACMode
 from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils.helpers import mode_remap
 
+HELPERS_LOGGER = "custom_components.better_thermostat.utils.helpers"
+
+
+def _unsupported_records(caplog):
+    """Return the log records annunciating an unsupported HVAC mode."""
+    return [
+        record
+        for record in caplog.records
+        if "does not offer HVAC mode" in record.getMessage()
+    ]
+
 
 class MockThermostat:
     """Mock Better Thermostat instance for testing."""
@@ -377,3 +388,43 @@ class TestModeRemapUnsupportedOutboundMode:
 
             errors = [rec for rec in caplog.records if rec.levelno == logging.ERROR]
             assert len(errors) == 2
+
+    def test_hint_names_disabling_the_swap_when_it_is_on(self, caplog):
+        """A swapped device without AUTO is told to turn the swap off."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        )
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            assert (
+                mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+                is None
+            )
+
+        records = _unsupported_records(caplog)
+        assert len(records) == 1
+        message = records[0].getMessage()
+        assert "Disable the heat auto swapped option" in message
+        assert "enable the heat auto swapped" not in message
+
+    def test_hint_names_enabling_the_swap_when_it_is_off(self, caplog):
+        """An unswapped device is told about the option it has not set."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test", hvac_modes=[HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF]
+        )
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            assert (
+                mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+                is None
+            )
+
+        records = _unsupported_records(caplog)
+        assert len(records) == 1
+        message = records[0].getMessage()
+        assert "enable the heat auto swapped option" in message
+        assert "Disable the heat auto swapped option" not in message

--- a/tests/unit/test_helpers_mode_remap.py
+++ b/tests/unit/test_helpers_mode_remap.py
@@ -10,7 +10,10 @@ import logging
 from homeassistant.components.climate.const import HVACMode
 
 from custom_components.better_thermostat.trv import Trv
-from custom_components.better_thermostat.utils.helpers import mode_remap
+from custom_components.better_thermostat.utils.helpers import (
+    get_hvac_bt_mode,
+    mode_remap,
+)
 
 HELPERS_LOGGER = "custom_components.better_thermostat.utils.helpers"
 
@@ -547,3 +550,149 @@ class TestModeRemapSwapFallback:
         records = _fallback_records(caplog)
         assert len(records) == 1
         assert "Disable the heat auto swapped option" in records[0].getMessage()
+
+
+class TestModeRemapSwappedDeviceInACoolerRoom:
+    """A swapped radiator sharing a room with a separate cooler.
+
+    Such an instance offers HEAT_COOL in place of HEAT, so HEAT_COOL is the
+    mode its heat demand is carried in and the mode every TRV in that room is
+    driven with.
+    """
+
+    def test_heat_cool_reaches_a_swapped_device_as_auto(self):
+        """A room-level heat demand arrives as the device's heating mode."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.AUTO],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+        assert result == HVACMode.AUTO
+
+    def test_heat_cool_falls_back_to_heat_when_auto_is_missing(self):
+        """The swap's output is unwritable, so the unswapped mode is written."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+        assert result == HVACMode.HEAT
+
+    def test_heat_cool_survives_on_a_device_that_offers_only_that(self):
+        """HEAT_COOL is the last resort, ahead of writing no mode at all.
+
+        The unswapped path already treats HEAT_COOL as the heating mode of a
+        device offering nothing narrower; the swap resolves it the same way.
+        """
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT_COOL],
+        )
+
+        assert (
+            mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+            == HVACMode.HEAT_COOL
+        )
+        assert (
+            mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+            == HVACMode.HEAT_COOL
+        )
+
+    def test_heat_outranks_heat_cool_as_a_fallback(self):
+        """A radiator offering both receives the single-setpoint mode."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT, HVACMode.HEAT_COOL],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+        assert result == HVACMode.HEAT
+
+    def test_heat_cool_is_dropped_when_neither_mode_is_offered(self, caplog):
+        """A device offering none of the three keeps its own, and says so once."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.COOL],
+        )
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            result = mode_remap(
+                mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False
+            )
+
+        assert result is None
+        records = _unsupported_records(caplog)
+        assert len(records) == 1
+        # The mode named is the one the swap asked for, not the room's.
+        assert "HVAC mode auto" in records[0].getMessage()
+
+    def test_heat_and_heat_cool_reach_the_device_identically(self):
+        """The two spellings of the same demand produce the same write.
+
+        A caller that narrows HEAT_COOL to HEAT before calling — which is what
+        a device carrying both the heating and the cooling role receives — and
+        one that passes the room's mode through reach the same device mode, so
+        the narrowing neither adds to nor subtracts from what arrives.
+        """
+        for hvac_modes in (
+            [HVACMode.OFF, HVACMode.AUTO],
+            [HVACMode.OFF, HVACMode.HEAT],
+            [HVACMode.OFF, HVACMode.HEAT_COOL],
+            [HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO],
+            [HVACMode.OFF, HVACMode.HEAT, HVACMode.HEAT_COOL],
+            [HVACMode.OFF, HVACMode.COOL],
+            [HVACMode.OFF, HVACMode.AUTO, HVACMode.HEAT_COOL],
+        ):
+            mock_bt = MockThermostat()
+            mock_bt.add_trv(
+                "climate.test", heat_auto_swapped=True, hvac_modes=hvac_modes
+            )
+
+            via_heat = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+            via_heat_cool = mode_remap(
+                mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False
+            )
+            assert via_heat == via_heat_cool, hvac_modes
+
+    def test_inbound_auto_becomes_heat_for_a_cooler_room_too(self):
+        """The device's heating mode is adopted as the instance's HEAT.
+
+        HEAT is what the instance stores for "the room wants heat" whether or
+        not a cooler is configured; a room with one re-expresses it as
+        HEAT_COOL when it publishes its own mode.
+        """
+        mock_bt = MockThermostat()
+        mock_bt.map_on_hvac_mode = HVACMode.HEAT_COOL
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.AUTO],
+        )
+
+        adopted = mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=True)
+        assert adopted == HVACMode.HEAT
+        assert get_hvac_bt_mode(mock_bt, adopted) == HVACMode.HEAT_COOL
+
+    def test_inbound_heat_cool_is_not_translated_by_the_swap(self):
+        """A reported HEAT_COOL passes the swapped branch unchanged."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.AUTO],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=True)
+        assert result == HVACMode.HEAT_COOL

--- a/tests/unit/test_helpers_mode_remap.py
+++ b/tests/unit/test_helpers_mode_remap.py
@@ -8,9 +8,11 @@ heat_auto_swapped devices and TRVs that only support HEAT_COOL but not HEAT.
 import logging
 
 from homeassistant.components.climate.const import HVACMode
+import pytest
 
 from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils.helpers import (
+    adopt_reported_hvac_modes,
     get_hvac_bt_mode,
     mode_remap,
 )
@@ -24,6 +26,15 @@ def _unsupported_records(caplog):
         record
         for record in caplog.records
         if "does not offer HVAC mode" in record.getMessage()
+    ]
+
+
+def _forgotten_swap_records(caplog):
+    """Return the log records naming the heat auto swapped option as unset."""
+    return [
+        record
+        for record in caplog.records
+        if "forgot to set the heat auto swapped option" in record.getMessage()
     ]
 
 
@@ -213,6 +224,85 @@ class TestModeRemapHeatCoolTranslation:
         assert result == HVACMode.HEAT_COOL
 
 
+class TestModeRemapTranslationOnAReportedSpelling:
+    """The HEAT / HEAT_COOL translation reads the device's own spelling.
+
+    The mode list is cached exactly as the device reports it, so a device
+    naming its modes ``HVACMode.HEAT`` or ``Heat`` is translated like one
+    naming them ``heat``.
+    """
+
+    HEAT_ONLY = [
+        pytest.param(["HVACMode.OFF", "HVACMode.HEAT"], id="prefixed"),
+        pytest.param(["OFF", "Heat"], id="mixed_case"),
+    ]
+    HEAT_COOL_ONLY = [
+        pytest.param(["HVACMode.OFF", "HVACMode.HEAT_COOL"], id="prefixed"),
+        pytest.param(["OFF", "Heat_Cool"], id="mixed_case"),
+    ]
+
+    @pytest.mark.parametrize("hvac_modes", HEAT_ONLY)
+    def test_outbound_heat_cool_becomes_heat(self, hvac_modes, caplog):
+        """A heat-only device receives HEAT rather than no mode at all."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=hvac_modes)
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            result = mode_remap(
+                mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False
+            )
+
+        assert result == HVACMode.HEAT
+        assert _unsupported_records(caplog) == []
+
+    @pytest.mark.parametrize("hvac_modes", HEAT_ONLY)
+    def test_inbound_heat_becomes_heat_cool(self, hvac_modes):
+        """A heat-only device's HEAT is decoded as HEAT_COOL."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=hvac_modes)
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=True)
+        assert result == HVACMode.HEAT_COOL
+
+    @pytest.mark.parametrize("hvac_modes", HEAT_COOL_ONLY)
+    def test_outbound_heat_becomes_heat_cool(self, hvac_modes, caplog):
+        """A HEAT_COOL-only device receives HEAT_COOL rather than no mode."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=hvac_modes)
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+
+        assert result == HVACMode.HEAT_COOL
+        assert _unsupported_records(caplog) == []
+
+    @pytest.mark.parametrize("hvac_modes", HEAT_COOL_ONLY)
+    def test_inbound_heat_cool_becomes_heat(self, hvac_modes):
+        """A HEAT_COOL-only device's HEAT_COOL is decoded as HEAT."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=hvac_modes)
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=True)
+        assert result == HVACMode.HEAT
+
+    def test_a_device_offering_both_is_not_translated(self):
+        """Offering both spellings of the heating mode translates neither."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            hvac_modes=["HVACMode.OFF", "HVACMode.HEAT", "HVACMode.HEAT_COOL"],
+        )
+
+        assert (
+            mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+            == HVACMode.HEAT
+        )
+        assert (
+            mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+            == HVACMode.HEAT_COOL
+        )
+
+
 class TestModeRemapEdgeCases:
     """Test edge cases and potential bugs."""
 
@@ -384,6 +474,43 @@ class TestModeRemapUnsupportedOutboundMode:
         errors = [rec for rec in caplog.records if rec.levelno == logging.ERROR]
         assert len(errors) == 1
         assert "heat auto swapped option" in errors[0].getMessage()
+
+    def test_the_auto_error_is_annunciated_once(self, caplog):
+        """Every outbound AUTO cycle keeps reporting OFF, but logs once."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test", hvac_modes=[HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF]
+        )
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            for _ in range(5):
+                assert (
+                    mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=False)
+                    == HVACMode.OFF
+                )
+
+        assert len(_forgotten_swap_records(caplog)) == 1
+
+    def test_a_changed_offered_set_annunciates_auto_again(self, caplog):
+        """A genuine capability change re-arms the AUTO annunciation."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test", hvac_modes=[HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF]
+        )
+        trv = mock_bt.real_trvs["climate.test"]
+
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
+            assert (
+                mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=False)
+                == HVACMode.OFF
+            )
+            adopt_reported_hvac_modes(trv, [HVACMode.OFF, HVACMode.COOL])
+            assert (
+                mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=False)
+                == HVACMode.OFF
+            )
+
+        assert len(_forgotten_swap_records(caplog)) == 2
 
     def test_error_is_logged_once_per_mode(self, caplog):
         """Repeated cycles annunciate each unsupported mode exactly once."""

--- a/tests/unit/test_helpers_mode_remap.py
+++ b/tests/unit/test_helpers_mode_remap.py
@@ -461,19 +461,18 @@ class TestModeRemapUnsupportedOutboundMode:
         assert result == HVACMode.HEAT
 
     def test_auto_branch_wins_over_the_clamp(self, caplog):
-        """AUTO keeps returning OFF and its own error even when offered."""
+        """AUTO reports OFF and names the heat auto swapped option."""
         mock_bt = MockThermostat()
         mock_bt.add_trv(
             "climate.test", hvac_modes=[HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF]
         )
 
-        with caplog.at_level(logging.ERROR):
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
             result = mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=False)
 
         assert result == HVACMode.OFF
-        errors = [rec for rec in caplog.records if rec.levelno == logging.ERROR]
-        assert len(errors) == 1
-        assert "heat auto swapped option" in errors[0].getMessage()
+        assert len(_forgotten_swap_records(caplog)) == 1
+        assert _unsupported_records(caplog) == []
 
     def test_the_auto_error_is_annunciated_once(self, caplog):
         """Every outbound AUTO cycle keeps reporting OFF, but logs once."""
@@ -513,23 +512,28 @@ class TestModeRemapUnsupportedOutboundMode:
         assert len(_forgotten_swap_records(caplog)) == 2
 
     def test_error_is_logged_once_per_mode(self, caplog):
-        """Repeated cycles annunciate each unsupported mode exactly once."""
+        """Repeated cycles annunciate each unsupported mode a single time."""
         mock_bt = MockThermostat()
         mock_bt.add_trv(
             "climate.test", hvac_modes=[HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF]
         )
 
-        with caplog.at_level(logging.ERROR):
+        with caplog.at_level(logging.ERROR, logger=HELPERS_LOGGER):
             for _ in range(5):
-                mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+                assert (
+                    mode_remap(
+                        mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False
+                    )
+                    is None
+                )
 
-            errors = [rec for rec in caplog.records if rec.levelno == logging.ERROR]
-            assert len(errors) == 1
+            assert len(_unsupported_records(caplog)) == 1
 
-            mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
-
-            errors = [rec for rec in caplog.records if rec.levelno == logging.ERROR]
-            assert len(errors) == 2
+            assert (
+                mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+                is None
+            )
+            assert len(_unsupported_records(caplog)) == 2
 
     def test_hint_names_disabling_the_swap_when_it_is_on(self, caplog):
         """A swapped device offering neither AUTO nor HEAT names the swap."""

--- a/tests/unit/test_helpers_mode_remap.py
+++ b/tests/unit/test_helpers_mode_remap.py
@@ -5,6 +5,8 @@ between Better Thermostat and TRVs. This includes handling quirks like
 heat_auto_swapped devices and TRVs that only support HEAT_COOL but not HEAT.
 """
 
+import logging
+
 from homeassistant.components.climate.const import HVACMode
 
 from custom_components.better_thermostat.trv import Trv
@@ -80,7 +82,11 @@ class TestModeRemapHeatAutoSwapped:
     def test_other_modes_unchanged_when_swapped(self):
         """Test that other modes are unchanged when heat_auto_swapped."""
         mock_bt = MockThermostat()
-        mock_bt.add_trv("climate.test", heat_auto_swapped=True)
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO, HVACMode.COOL],
+        )
 
         # OFF should stay OFF
         result = mode_remap(mock_bt, "climate.test", HVACMode.OFF, inbound=False)
@@ -89,6 +95,42 @@ class TestModeRemapHeatAutoSwapped:
         # COOL should stay COOL
         result = mode_remap(mock_bt, "climate.test", HVACMode.COOL, inbound=False)
         assert result == HVACMode.COOL
+
+    def test_swapped_heat_dropped_when_device_has_no_auto(self):
+        """A swapped device without AUTO gets no mode written at all."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result is None
+
+    def test_swapped_heat_becomes_auto_when_device_offers_auto(self):
+        """A swapped device offering AUTO still receives AUTO for HEAT."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result == HVACMode.AUTO
+
+    def test_inbound_swap_survives_an_auto_less_mode_list(self):
+        """The inbound AUTO->HEAT swap is never clamped by the mode list."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test",
+            heat_auto_swapped=True,
+            hvac_modes=[HVACMode.OFF, HVACMode.HEAT],
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=True)
+        assert result == HVACMode.HEAT
 
     def test_heat_auto_swap_takes_precedence(self):
         """Test that heat_auto_swapped takes precedence over other remapping."""
@@ -210,3 +252,128 @@ class TestModeRemapEdgeCases:
 
         result = mode_remap(mock_bt, "climate.test", HVACMode.FAN_ONLY, inbound=False)
         assert result == HVACMode.FAN_ONLY
+
+
+class TestModeRemapUnsupportedOutboundMode:
+    """Outbound modes the device does not offer are dropped, not sent."""
+
+    def test_heat_cool_dropped_on_auto_cool_off_device(self):
+        """HEAT_COOL is not written to a device offering auto/cool/off."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test", hvac_modes=[HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF]
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+        assert result is None
+
+    def test_heat_dropped_on_auto_cool_off_device(self):
+        """HEAT is not written to a device offering auto/cool/off."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test", hvac_modes=[HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF]
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result is None
+
+    def test_offered_mode_still_passes_through(self):
+        """An offered mode reaches the device unchanged."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test", hvac_modes=[HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF]
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.COOL, inbound=False)
+        assert result == HVACMode.COOL
+
+    def test_dry_dropped_on_off_heat_device(self):
+        """DRY is not written to a device offering off/heat."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=[HVACMode.OFF, HVACMode.HEAT])
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.DRY, inbound=False)
+        assert result is None
+
+    def test_off_is_exempt_from_the_clamp(self):
+        """OFF survives even when the device does not list it.
+
+        convert_outbound_states needs the literal OFF to substitute the
+        device's minimum temperature.
+        """
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=[HVACMode.AUTO, HVACMode.HEAT])
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.OFF, inbound=False)
+        assert result == HVACMode.OFF
+
+    def test_inbound_modes_are_never_clamped(self):
+        """Values reported by the device pass through untouched."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=[HVACMode.OFF, HVACMode.HEAT])
+
+        assert mode_remap(mock_bt, "climate.test", "cool", inbound=True) == "cool"
+        assert mode_remap(mock_bt, "climate.test", "dry", inbound=True) == "dry"
+
+    def test_inbound_auto_still_reaches_the_auto_branch(self):
+        """An inbound AUTO the device does not offer keeps returning OFF.
+
+        The AUTO branch does not distinguish direction, and convert_inbound_states
+        maps the result to "not a mode BT tracks".
+        """
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=[HVACMode.OFF, HVACMode.HEAT])
+
+        assert mode_remap(mock_bt, "climate.test", "auto", inbound=True) == HVACMode.OFF
+
+    def test_unreported_mode_list_disables_the_clamp(self):
+        """hvac_modes=None keeps the pass-through for no-system-mode devices."""
+        mock_bt = MockThermostat()
+        mock_bt.real_trvs["climate.test"] = Trv.from_legacy_dict(
+            "climate.test", {"advanced": {"heat_auto_swapped": False}}
+        )
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+        assert result == HVACMode.HEAT_COOL
+
+    def test_plain_string_mode_list_is_normalized(self):
+        """A mode list of plain strings matches HVACMode members."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=["heat", "off"])
+
+        result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+        assert result == HVACMode.HEAT
+
+    def test_auto_branch_wins_over_the_clamp(self, caplog):
+        """AUTO keeps returning OFF and its own error even when offered."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test", hvac_modes=[HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF]
+        )
+
+        with caplog.at_level(logging.ERROR):
+            result = mode_remap(mock_bt, "climate.test", HVACMode.AUTO, inbound=False)
+
+        assert result == HVACMode.OFF
+        errors = [rec for rec in caplog.records if rec.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert "heat auto swapped option" in errors[0].getMessage()
+
+    def test_error_is_logged_once_per_mode(self, caplog):
+        """Repeated cycles annunciate each unsupported mode exactly once."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv(
+            "climate.test", hvac_modes=[HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF]
+        )
+
+        with caplog.at_level(logging.ERROR):
+            for _ in range(5):
+                mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=False)
+
+            errors = [rec for rec in caplog.records if rec.levelno == logging.ERROR]
+            assert len(errors) == 1
+
+            mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=False)
+
+            errors = [rec for rec in caplog.records if rec.levelno == logging.ERROR]
+            assert len(errors) == 2

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -27,6 +27,7 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationMode,
     CalibrationType,
 )
+from custom_components.better_thermostat.utils.helpers import mode_remap
 
 ENTITY_ID = "climate.test_trv"
 
@@ -749,6 +750,86 @@ class TestHvacActionAndValvePosition:
             await trigger_trv_change(mock_bt, event)
 
         assert mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged == {"heat_cool"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "republished",
+        [
+            ["cool", "off", "auto"],
+            [HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF],
+            ["HVACMode.AUTO", "HVACMode.COOL", "HVACMode.OFF"],
+            ["AUTO", "Cool", "OFF"],
+        ],
+        ids=["reordered", "enum_members", "prefixed", "mixed_case"],
+    )
+    async def test_same_capabilities_keep_the_annunciation_set(
+        self, mock_bt, republished
+    ):
+        """The same offered modes in another spelling are not a change."""
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "hvac_modes": republished,
+            }
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = ["auto", "cool", "off"]
+        mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged = {"heat_cool"}
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged == {"heat_cool"}
+
+    @pytest.mark.asyncio
+    async def test_reordered_republication_does_not_repeat_the_error(
+        self, mock_bt, caplog
+    ):
+        """A flapping mode list keeps the annunciation at once per mode."""
+        helpers_logger = "custom_components.better_thermostat.utils.helpers"
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = ["auto", "cool", "off"]
+
+        def _errors():
+            return [
+                record
+                for record in caplog.records
+                if "does not offer HVAC mode" in record.getMessage()
+            ]
+
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "hvac_modes": ["cool", "off", "auto"],
+            }
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with caplog.at_level(logging.ERROR, logger=helpers_logger):
+            assert (
+                mode_remap(mock_bt, ENTITY_ID, HVACMode.HEAT_COOL, inbound=False)
+                is None
+            )
+            assert len(_errors()) == 1
+
+            with patch(
+                "custom_components.better_thermostat.events.trv.convert_inbound_states",
+                return_value=HVACMode.HEAT,
+            ):
+                await trigger_trv_change(mock_bt, event)
+
+            assert (
+                mode_remap(mock_bt, ENTITY_ID, HVACMode.HEAT_COOL, inbound=False)
+                is None
+            )
+            assert len(_errors()) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -638,6 +638,10 @@ class TestHvacActionAndValvePosition:
 
         assert mock_bt.real_trvs[ENTITY_ID].valve_position == 75.0
 
+
+class TestHvacModesCache:
+    """Tests for the cached list of HVAC modes the device offers."""
+
     @pytest.mark.asyncio
     async def test_hvac_modes_cached_from_attribute(self, mock_bt):
         """Cache the offered mode list so a runtime change is picked up."""

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -703,6 +703,53 @@ class TestHvacActionAndValvePosition:
 
         assert mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged == set()
 
+    @pytest.mark.asyncio
+    async def test_empty_hvac_modes_keeps_the_cached_list(self, mock_bt):
+        """An empty list means "nothing reported", not "no modes offered"."""
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "hvac_modes": [],
+            }
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].hvac_modes == [HVACMode.OFF, HVACMode.HEAT]
+
+    @pytest.mark.asyncio
+    async def test_unchanged_mode_list_keeps_the_annunciation_set(self, mock_bt):
+        """Repeating the same list keeps the error suppressed across cycles."""
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "hvac_modes": ["off", "heat"],
+            }
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = ["off", "heat"]
+        mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged = {"heat_cool"}
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged == {"heat_cool"}
+
 
 # ---------------------------------------------------------------------------
 # 4. HVAC mode update

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -2147,6 +2147,23 @@ class TestConvertOutboundStates:
         assert result["system_mode"] is None
         assert result["temperature"] == mock_bt.bt_target_temp
 
+    def test_swapped_device_in_a_cooler_room_is_switched_on(self, mock_bt):
+        """A room-level HEAT_COOL reaches a swapped radiator as its own mode."""
+        mock_bt.cooler_entity_id = "climate.the_ac"
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.OFF, HVACMode.AUTO]
+        mock_bt.real_trvs[ENTITY_ID].advanced["heat_auto_swapped"] = True
+        mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+            return_value=0.0,
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.HEAT_COOL)
+
+        assert result is not None
+        assert result["system_mode"] == HVACMode.AUTO
+        assert result["temperature"] == mock_bt.bt_target_temp
+
     def test_off_without_off_in_mode_list_still_substitutes_min_temp(self, mock_bt):
         """OFF stays exempt from the clamp so the min-temp branch fires."""
         mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.AUTO, HVACMode.HEAT]

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -831,6 +831,60 @@ class TestHvacActionAndValvePosition:
             )
             assert len(_errors()) == 1
 
+    @pytest.mark.asyncio
+    async def test_a_capability_change_decodes_the_state_that_carried_it(self, mock_bt):
+        """A device switching to HEAT_COOL is decoded against its new list.
+
+        The reported state belongs to the capabilities reported alongside it,
+        so the mode the entity takes over is the one the new list translates
+        to and not the one the previous list would have produced.
+        """
+        mock_bt.bt_hvac_mode = HVACMode.OFF
+        trv_state = _make_state(
+            state_str="heat_cool",
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "hvac_modes": [HVACMode.OFF, HVACMode.HEAT_COOL],
+            },
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=_make_state())
+
+        await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].hvac_modes == [
+            HVACMode.OFF,
+            HVACMode.HEAT_COOL,
+        ]
+        assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+
+    @pytest.mark.asyncio
+    async def test_modes_cached_in_the_device_spelling_still_translate(self, mock_bt):
+        """A mode list reported as ``HVACMode.HEAT`` reaches the translation."""
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "hvac_modes": ["HVACMode.OFF", "HVACMode.HEAT"],
+            }
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].hvac_modes == [
+            "HVACMode.OFF",
+            "HVACMode.HEAT",
+        ]
+        assert (
+            mode_remap(mock_bt, ENTITY_ID, HVACMode.HEAT_COOL, inbound=False)
+            == HVACMode.HEAT
+        )
+
 
 # ---------------------------------------------------------------------------
 # 4. HVAC mode update

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -2178,6 +2178,52 @@ class TestConvertOutboundStates:
         assert result["temperature"] == 5.0
         assert result["system_mode"] is None
 
+    def test_off_offered_in_the_device_spelling_switches_the_device_off(self, mock_bt):
+        """A list naming its modes ``HVACMode.OFF`` still offers OFF.
+
+        The cache holds the device's own spelling, so the min_temp
+        substitution must not fire for a device that does offer OFF.
+        """
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = ["HVACMode.OFF", "HVACMode.HEAT"]
+        mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
+
+        with (
+            patch(
+                "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+                return_value=0.0,
+            ),
+            patch(
+                "custom_components.better_thermostat.events.trv.mode_remap",
+                return_value=HVACMode.OFF,
+            ),
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
+
+        assert result is not None
+        assert result["system_mode"] == HVACMode.OFF
+        assert result["temperature"] == 19.0
+
+    def test_no_off_in_the_device_spelling_still_uses_min_temp(self, mock_bt):
+        """A device genuinely without OFF keeps taking the min_temp path."""
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = ["HVACMode.HEAT"]
+        mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
+
+        with (
+            patch(
+                "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+                return_value=0.0,
+            ),
+            patch(
+                "custom_components.better_thermostat.events.trv.mode_remap",
+                return_value=HVACMode.OFF,
+            ),
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
+
+        assert result is not None
+        assert result["temperature"] == 5.0
+        assert result["system_mode"] is None
+
     def test_unsupported_mode_suppresses_system_mode_but_keeps_setpoint(self, mock_bt):
         """A mode the device does not offer drops out of the payload.
 

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -637,6 +637,72 @@ class TestHvacActionAndValvePosition:
 
         assert mock_bt.real_trvs[ENTITY_ID].valve_position == 75.0
 
+    @pytest.mark.asyncio
+    async def test_hvac_modes_cached_from_attribute(self, mock_bt):
+        """Cache the offered mode list so a runtime change is picked up."""
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "hvac_modes": ["off", "heat"],
+            }
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.OFF, HVACMode.AUTO]
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].hvac_modes == ["off", "heat"]
+
+    @pytest.mark.asyncio
+    async def test_missing_hvac_modes_keeps_the_cached_list(self, mock_bt):
+        """A state without the attribute leaves the cached mode list intact."""
+        trv_state = _make_state(
+            attributes={"current_temperature": 18.0, "temperature": 19.0}
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].hvac_modes == [HVACMode.OFF, HVACMode.HEAT]
+
+    @pytest.mark.asyncio
+    async def test_changed_mode_list_clears_the_annunciation_set(self, mock_bt):
+        """A genuine capability change lets the unsupported-mode error re-fire."""
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "hvac_modes": ["off", "heat"],
+            }
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.OFF, HVACMode.AUTO]
+        mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged = {"heat"}
+
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].unsupported_modes_logged == set()
+
 
 # ---------------------------------------------------------------------------
 # 4. HVAC mode update
@@ -1923,6 +1989,63 @@ class TestConvertOutboundStates:
                 "custom_components.better_thermostat.events.trv.mode_remap",
                 return_value=HVACMode.OFF,
             ),
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
+
+        assert result is not None
+        assert result["temperature"] == 5.0
+        assert result["system_mode"] is None
+
+    def test_unsupported_mode_suppresses_system_mode_but_keeps_setpoint(self, mock_bt):
+        """A mode the device does not offer drops out of the payload.
+
+        The real mode_remap runs here; the setpoint must survive the
+        suppressed mode write.
+        """
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [
+            HVACMode.AUTO,
+            HVACMode.COOL,
+            HVACMode.OFF,
+        ]
+        mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+            return_value=0.0,
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.HEAT_COOL)
+
+        assert result is not None
+        assert result["system_mode"] is None
+        assert result["temperature"] == mock_bt.bt_target_temp
+
+    def test_off_without_off_in_mode_list_still_substitutes_min_temp(self, mock_bt):
+        """OFF stays exempt from the clamp so the min-temp branch fires."""
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.AUTO, HVACMode.HEAT]
+        mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+            return_value=0.0,
+        ):
+            result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
+
+        assert result == {
+            "temperature": 5.0,
+            "local_temperature": 18.0,
+            "system_mode": None,
+            "local_temperature_calibration": 0.0,
+        }
+
+    def test_off_with_no_off_system_mode_flag_still_substitutes_min_temp(self, mock_bt):
+        """The no_off_system_mode path is unaffected by the clamp."""
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = [HVACMode.OFF, HVACMode.HEAT]
+        mock_bt.real_trvs[ENTITY_ID].advanced["no_off_system_mode"] = True
+        mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.calculate_calibration_local",
+            return_value=0.0,
         ):
             result = convert_outbound_states(mock_bt, ENTITY_ID, HVACMode.OFF)
 

--- a/tests/unit/test_trv_object.py
+++ b/tests/unit/test_trv_object.py
@@ -144,6 +144,22 @@ class TestTrvCapabilities:
         trv.hvac_modes = ["heat", "auto"]
         assert trv.capabilities().supports_off_mode is False
 
+    def test_off_offered_in_the_device_spelling_enables_off(self):
+        """A list naming its modes ``HVACMode.OFF`` still offers OFF.
+
+        The cached list holds the device's own spelling, so the capability
+        is decided on the normalized list.
+        """
+        trv = _make()
+        trv.hvac_modes = ["HVACMode.HEAT", "HVACMode.OFF"]
+        assert trv.capabilities().supports_off_mode is True
+
+    def test_no_off_in_the_device_spelling_disables_off(self):
+        """A device genuinely without OFF still yields no OFF capability."""
+        trv = _make()
+        trv.hvac_modes = ["HVACMode.HEAT", "HVACMode.AUTO"]
+        assert trv.capabilities().supports_off_mode is False
+
     def test_no_off_system_mode_config_disables_off(self):
         """The explicit no_off_system_mode config wins over the mode list."""
         trv = _make()


### PR DESCRIPTION
Fixes the first defect of #2175, on the `v2` line. Twin of #2198, which carries the same change against `develop`.

## Symptom

The reporter runs an HmIP-STHD whose central heating/cooling changeover (`HeatingCoolingMode`, exposed as `select.<room>_betriebsmodus_ch1`) is in cooling. In that state the climate entity reports `hvac_modes: [auto, cool, off]`. Every control cycle BT calls `climate.set_hvac_mode` with `heat_cool`, the service call raises, and the log fills with the same error. The setpoint write that follows it never happens.

## Mechanism

`mode_remap()` already reads `trv.hvac_modes` and already makes two capability-driven decisions with it: `HEAT -> HEAT_COOL` for a device without `heat`, and `HEAT_COOL -> HEAT` for a device without `heat_cool`. Both are membership tests against that list. What was missing is the general case: a device that offers neither. For `[auto, cool, off]` both translation blocks fall through, `hvac_mode` is not `auto`, and the function returns the caller's mode verbatim. `convert_outbound_states` puts it in the payload and `control_trv` sends it.

## What the change does

The clamp goes into `mode_remap`, next to the two existing capability translations, because that is the only layer carrying the inbound/outbound distinction and the clamp must be outbound-only. An outbound mode the device does not offer now yields `None`.

`None` is not a new encoding. `convert_outbound_states` already sets `hvac_mode = None` on its no-system-mode and no-off branches, `handle_contact_open` already returns `_remapped_states.get("system_mode", None)`, `control_trv`'s send guard is already `if _new_hvac_mode is not None and ...`, and its setpoint guard `_new_hvac_mode != HVACMode.OFF or _trv_has_no_off` is satisfied by `None`. So the payload for the reporter's device goes from `{'system_mode': heat_cool, 'temperature': 21.0}` to `{'system_mode': None, 'temperature': 21.0}`: the invalid mode write disappears, the setpoint still goes out. That is the single-setpoint fallback the issue asks for.

There is no fallback mode, deliberately. `auto` is exactly the guess the `heat_auto_swapped` option exists to make the user declare explicitly, and it would hand control to the device's weekly programme, which overrides BT's setpoint at every profile switch point on HomeMatic hardware. `cool` cannot be distinguished from a real air conditioner, where it would actively cool the room. `off` is measurably worse than today: for `[auto, cool, off]` the device does have an off mode, so `control_trv` would really send `set_hvac_mode(off)` every cycle and the room would never heat (worse than the current failed call, which at least leaves the device's mode alone).

`OFF` is exempt from the clamp. Clamping it would starve `convert_outbound_states`' `if hvac_mode == HVACMode.OFF and (OFF not in _system_modes or advanced["no_off_system_mode"])` branch and lose the minimum-temperature substitution. Verified by comparing payloads before and after on this branch, including v2's `_no_off_system_mode(trv)` / `trv.capabilities().supports_off_mode` routing:

```
[off,heat] + no_off flag, demand off  -> {'temperature': 5.0,  'system_mode': None}  _no_off_system_mode=True   (unchanged)
[auto,heat], demand off               -> {'temperature': 5.0,  'system_mode': None}  _no_off_system_mode=True   (unchanged)
[auto,cool,off], demand off           -> {'temperature': 21.0, 'system_mode': off}   _no_off_system_mode=False  (unchanged)
[auto,cool,off], demand heat_cool     -> {'temperature': 21.0, 'system_mode': None}  was: system_mode=heat_cool
[auto,cool,off], demand heat          -> {'temperature': 21.0, 'system_mode': None}  was: system_mode=heat
```

The annunciation is an `error`, matching the sibling AUTO branch in the same function: both mean "BT cannot express its intent on this device and the user must change something". It names `heat_auto_swapped` as the knob that turns the ambiguity into a working configuration, and it is suppressed after the first occurrence per TRV and per mode, because control cycles repeat and the issue log shows the same line every cycle. The set of already-annunciated modes is a new `Trv` field, `unsupported_modes_logged`, with the same name and default on both branch lines.

`trigger_trv_change` now refreshes `trv.hvac_modes` from the TRV state on every event, in the existing block that caches `hvac_action` and `valve_position`. `trv.hvac_modes` was written exactly once, in `climate.py startup()`, and on the reporter's hardware flipping the central changeover swaps `cool` for `heat` in the entity's list at runtime. Clamping against a stale snapshot would suppress a mode the device now offers. Only a non-empty list replaces the cache (an unavailable entity reports empty attributes and must not wipe it to `None`), and a change to the list clears the annunciation set so the error re-fires when the situation really changes.

## What it deliberately does not do

- It does not fix the second defect of #2175 (the wrapper's `target_temp_high` being periodically written back to `min_temp`). That is a setpoint-side defect and needs its own analysis.
- It does not raise a repairs-registry issue. The infrastructure exists in `watcher.py`/`temperature.py`, but it would need `strings.json`, every translation file and an issue-clearing lifecycle, which would swamp the safety fix.
- It does not heat a room whose device sits in `off` with no offered heating mode: BT has nothing valid to send there. That equals today's effective behaviour, so it is not a regression; the error message is what does the real work for those users.
- It does not add once-per-device suppression to the pre-existing AUTO error branch, add a symmetric `COOL <-> HEAT_COOL` translation, touch `events/cooler.py` (which never calls `mode_remap`), or validate the mode list at config-flow time.

## Verification

- Full suite on this branch: **4384 passed, 0 failed** (baseline on `origin/v2`: 4363 passed). 21 tests added.
- `uv run ruff check`: clean. `uv run ruff format --check`: clean. `uv run pyrefly check`: 0 errors.
- Counterfactual: reverting only the three production files and re-running the touched test files gives **8 failed, 152 passed**. The headline failure is exactly the reported symptom, `AssertionError: assert <HVACMode.HEAT_COOL: 'heat_cool'> is None`. The remaining 13 new tests pin behaviour that must not change (the OFF exemption, the no-off min-temp substitution, inbound pass-through, the AUTO branch still winning over the clamp, `hvac_modes=None` still disabling the clamp) and pass in both directions by design.

## Note for reviewers: one existing test changes

`TestModeRemapHeatAutoSwapped::test_other_modes_unchanged_when_swapped` asserted that `COOL` passes through on a fixture whose mode list is `[off, heat, auto]`, a mode the mock device never had. Its stated intent is that the swap leaves modes other than HEAT/AUTO alone, so the fixture gains `HVACMode.COOL` and keeps asserting exactly that. Exempting the `heat_auto_swapped` path from the clamp to avoid touching the fixture would have been the wrong trade: a swapped device is precisely the kind with an odd mode list.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thermostat compatibility with devices that report HVAC modes using alternate spellings or formats.
  - Correctly detects **AUTO** and **OFF** support during setup and operation.
  - Prevents unsupported mode commands and applies safer HEAT, HEAT_COOL, or setpoint fallbacks.
  - Updates mode handling when device capabilities change.
  - Reduces duplicate warnings for unsupported HVAC modes.

- **Tests**
  - Added coverage for mode normalization, fallback behavior, capability changes, and OFF-mode handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->