### PR TITLE
fix: re-assert a calibration offset the device did not confirm

### DIFF
--- a/custom_components/better_thermostat/adapters/deconz.py
+++ b/custom_components/better_thermostat/adapters/deconz.py
@@ -85,8 +85,24 @@ async def get_max_offset(self, entity_id):
     return 6
 
 
-async def set_offset(self, entity_id, offset):
-    """Set new target offset."""
+async def set_offset(self, entity_id, offset) -> bool:
+    """Write a calibration offset through the deCONZ configure service.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV to write to
+    offset : float
+        Calibration offset in Kelvin
+
+    Returns
+    -------
+    bool
+        True once the write went out. The offset rides on the TRV's own
+        service call, so every deCONZ TRV has the channel.
+    """
     await self.hass.services.async_call(
         "deconz",
         "configure",
@@ -95,6 +111,7 @@ async def set_offset(self, entity_id, offset):
         context=self.context,
     )
     self.real_trvs[entity_id].last_calibration = offset
+    return True
 
 
 async def set_valve(self, entity_id, valve):

--- a/custom_components/better_thermostat/adapters/delegate.py
+++ b/custom_components/better_thermostat/adapters/delegate.py
@@ -177,10 +177,16 @@ async def set_hvac_mode(self, entity_id, hvac_mode):
 async def set_offset(self, entity_id, offset) -> bool:
     """Set new target offset and record the value that was asked for.
 
-    ``last_calibration_requested`` is written only when the adapter
-    accepted the write: a swallowed failure would otherwise look like a
-    command in flight, and the caller keys its confirmation watchdog on
-    the return value.
+    An adapter answers ``True`` once the offset write went out and
+    ``False`` when the device has no offset channel to write to. Only
+    ``True`` counts as a command in flight: it is what records
+    ``last_calibration_requested`` and what tells the caller to arm the
+    confirmation watchdog. The written offset itself is not a usable
+    answer, because the legitimate value 0.0 reads the same as a device
+    that wrote nothing.
+
+    ``last_calibration_requested`` is written on a write only: a
+    swallowed failure would otherwise look like a command in flight.
 
     Parameters
     ----------
@@ -194,7 +200,8 @@ async def set_offset(self, entity_id, offset) -> bool:
     Returns
     -------
     bool
-        True when the adapter accepted the write, False when every retry raised
+        True when the adapter put the offset on the wire, False when the
+        device has no offset channel or every retry raised
     """
 
     @async_retry(retries=5)
@@ -204,11 +211,19 @@ async def set_offset(self, entity_id, offset) -> bool:
         )
 
     try:
-        await inner()
+        wrote = await inner()
     except Exception:
         _LOGGER.warning(
             "better_thermostat %s: set_local_temperature_calibration for %s failed; "
             "will retry on the next cycle",
+            getattr(self, "device_name", "unknown"),
+            entity_id,
+        )
+        return False
+    if wrote is not True:
+        _LOGGER.debug(
+            "better_thermostat %s: %s has no calibration offset channel, "
+            "nothing was written",
             getattr(self, "device_name", "unknown"),
             entity_id,
         )

--- a/custom_components/better_thermostat/adapters/delegate.py
+++ b/custom_components/better_thermostat/adapters/delegate.py
@@ -174,8 +174,28 @@ async def set_hvac_mode(self, entity_id, hvac_mode):
     )
 
 
-async def set_offset(self, entity_id, offset):
-    """Set new target offset."""
+async def set_offset(self, entity_id, offset) -> bool:
+    """Set new target offset and record the value that was asked for.
+
+    ``last_calibration_requested`` is written only when the adapter
+    accepted the write: a swallowed failure would otherwise look like a
+    command in flight, and the caller keys its confirmation watchdog on
+    the return value.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV to write to
+    offset : float
+        The offset asked for, before the adapter's own range clamp
+
+    Returns
+    -------
+    bool
+        True when the adapter accepted the write, False when every retry raised
+    """
 
     @async_retry(retries=5)
     async def inner():
@@ -184,9 +204,17 @@ async def set_offset(self, entity_id, offset):
         )
 
     try:
-        return await inner()
+        await inner()
     except Exception:
-        return None
+        _LOGGER.warning(
+            "better_thermostat %s: set_local_temperature_calibration for %s failed; "
+            "will retry on the next cycle",
+            getattr(self, "device_name", "unknown"),
+            entity_id,
+        )
+        return False
+    self.real_trvs[entity_id].last_calibration_requested = float(offset)
+    return True
 
 
 @async_retry(retries=5)

--- a/custom_components/better_thermostat/adapters/generic.py
+++ b/custom_components/better_thermostat/adapters/generic.py
@@ -26,6 +26,26 @@ _LOGGER = logging.getLogger(__name__)
 CAPABILITIES = AdapterCapabilities(offset_write=True, valve_write=False)
 
 
+def _option_to_offset(option) -> float | None:
+    """Read the offset an option of a select-backed calibration entity carries.
+
+    Parameters
+    ----------
+    option : str
+        Option as the entity publishes it, with or without the Kelvin
+        suffix (e.g. ``"-1.5k"``).
+
+    Returns
+    -------
+    float or None
+        Offset in Kelvin, or None when the option carries no number.
+    """
+    try:
+        return float(str(option).replace("k", ""))
+    except ValueError, TypeError:
+        return None
+
+
 async def get_info(self, entity_id):
     """Get info from TRV."""
     support_offset = False
@@ -254,25 +274,28 @@ async def set_offset(self, entity_id, offset) -> bool:
             # Validate and snap to closest matching option if needed
             if options:
                 if option_value not in options:
-                    try:
-                        # Parse all options and find the closest match
-                        parsed_options = {}
-                        for opt in options:
-                            try:
-                                parsed_options[opt] = float(str(opt).replace("k", ""))
-                            except ValueError, TypeError:
-                                continue
+                    # Parse all options and find the closest match
+                    parsed_options = {}
+                    for opt in options:
+                        parsed = _option_to_offset(opt)
+                        if parsed is not None:
+                            parsed_options[opt] = parsed
 
-                        if parsed_options:
-                            # Find option with minimum distance to target offset
-                            closest_option = min(
-                                parsed_options,
-                                key=lambda opt: abs(parsed_options[opt] - offset),
-                            )
-                            option_value = closest_option
-                    except ValueError, TypeError:
-                        # If parsing fails, keep original option_value and hope for the best
-                        pass
+                    if parsed_options:
+                        # Find option with minimum distance to target offset
+                        closest_option = min(
+                            parsed_options,
+                            key=lambda opt: abs(parsed_options[opt] - offset),
+                        )
+                        option_value = closest_option
+
+            # The option carries the value that goes on the wire, and the
+            # confirmation compares the device's report against it. Both the
+            # snap onto the option list and the one-decimal format move the
+            # value, so the command is read back off the option itself.
+            commanded = _option_to_offset(option_value)
+            if commanded is not None:
+                offset = commanded
 
             await self.hass.services.async_call(
                 "select",

--- a/custom_components/better_thermostat/adapters/generic.py
+++ b/custom_components/better_thermostat/adapters/generic.py
@@ -206,8 +206,24 @@ async def set_hvac_mode(self, entity_id, hvac_mode):
         )
 
 
-async def set_offset(self, entity_id, offset):
-    """Set new target offset."""
+async def set_offset(self, entity_id, offset) -> bool:
+    """Write a calibration offset to the discovered calibration entity.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV to write to
+    offset : float
+        Calibration offset in Kelvin, clamped to the device's declared range
+
+    Returns
+    -------
+    bool
+        True once the write went out, False when no calibration entity was
+        discovered for this TRV and there is nothing to write to.
+    """
     if self.real_trvs[entity_id].local_temperature_calibration_entity is not None:
         max_calibration = await get_max_offset(self, entity_id)
         min_calibration = await get_min_offset(self, entity_id)
@@ -285,9 +301,9 @@ async def set_offset(self, entity_id, offset):
                 self, entity_id, self.real_trvs[entity_id].last_hvac_mode
             )
 
-        return offset
+        return True
     else:
-        return  # Not supported
+        return False
 
 
 async def set_valve(self, entity_id, valve):

--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -165,8 +165,27 @@ async def get_max_offset(self, entity_id):
     return float(str(state.attributes.get("max", 10)))
 
 
-async def set_offset(self, entity_id, offset):
-    """Set new target offset."""
+async def set_offset(self, entity_id, offset) -> bool:
+    """Write a calibration offset to the discovered calibration entity.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV to write to
+    offset : float
+        Calibration offset in Kelvin, clamped to the device's declared range
+
+    Returns
+    -------
+    bool
+        True once the write went out, False when no calibration entity was
+        discovered for this TRV and there is nothing to write to.
+    """
+    if self.real_trvs[entity_id].local_temperature_calibration_entity is None:
+        return False
+
     max_calibration = await get_max_offset(self, entity_id)
     min_calibration = await get_min_offset(self, entity_id)
 
@@ -189,9 +208,10 @@ async def set_offset(self, entity_id, offset):
         and self.real_trvs[entity_id].last_hvac_mode != "off"
     ):
         await asyncio.sleep(3)
-        return await generic_set_hvac_mode(
+        await generic_set_hvac_mode(
             self, entity_id, self.real_trvs[entity_id].last_hvac_mode
         )
+    return True
 
 
 async def set_valve(self, entity_id, valve):

--- a/custom_components/better_thermostat/adapters/tado.py
+++ b/custom_components/better_thermostat/adapters/tado.py
@@ -79,8 +79,24 @@ async def get_max_offset(self, entity_id):
     return 10
 
 
-async def set_offset(self, entity_id, offset):
-    """Set new target offset."""
+async def set_offset(self, entity_id, offset) -> bool:
+    """Write a calibration offset through the Tado offset service.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV to write to
+    offset : float
+        Calibration offset in Kelvin, clamped to the range Tado accepts
+
+    Returns
+    -------
+    bool
+        True once the write went out. The offset rides on the TRV's own
+        service call, so every Tado TRV has the channel.
+    """
     offset = min(10, offset)
     offset = max(-10, offset)
     await self.hass.services.async_call(
@@ -91,6 +107,7 @@ async def set_offset(self, entity_id, offset):
         context=self.context,
     )
     self.real_trvs[entity_id].last_calibration = offset
+    return True
 
 
 async def set_valve(self, entity_id, valve):

--- a/custom_components/better_thermostat/adapters/zwave_js.py
+++ b/custom_components/better_thermostat/adapters/zwave_js.py
@@ -178,10 +178,26 @@ async def set_hvac_mode(self, entity_id, hvac_mode):
     return await generic_set_hvac_mode(self, entity_id, hvac_mode)
 
 
-async def set_offset(self, entity_id, offset):
-    """Set new target offset."""
+async def set_offset(self, entity_id, offset) -> bool:
+    """Write a calibration offset to the discovered calibration entity.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV to write to
+    offset : float
+        Calibration offset in Kelvin, clamped to the device's declared range
+
+    Returns
+    -------
+    bool
+        True once the write went out, False when no calibration entity was
+        discovered for this TRV and there is nothing to write to.
+    """
     if self.real_trvs[entity_id].local_temperature_calibration_entity is None:
-        return  # Not supported
+        return False
 
     max_calibration = await get_max_offset(self, entity_id)
     min_calibration = await get_min_offset(self, entity_id)
@@ -205,10 +221,10 @@ async def set_offset(self, entity_id, offset):
         and self.real_trvs[entity_id].last_hvac_mode != "off"
     ):
         await asyncio.sleep(3)
-        return await generic_set_hvac_mode(
+        await generic_set_hvac_mode(
             self, entity_id, self.real_trvs[entity_id].last_hvac_mode
         )
-    return offset
+    return True
 
 
 async def set_valve(self, entity_id, valve):

--- a/custom_components/better_thermostat/trv.py
+++ b/custom_components/better_thermostat/trv.py
@@ -104,6 +104,10 @@ class Trv:
     # declared be recognised as converged instead of rewritten.
     last_calibration: float | None = None
     last_calibration_requested: float | None = None
+    # Identity of the offset command currently in flight. Each accepted write
+    # takes the next number, and only the watchdog holding that number may
+    # release ``calibration_received``.
+    calibration_write_generation: int = 0
     last_valve_percent: float | None = None
     last_valve_method: str | None = None
     # Per-channel write-budget stamps (setpoint, offset, valve) so one

--- a/custom_components/better_thermostat/trv.py
+++ b/custom_components/better_thermostat/trv.py
@@ -97,7 +97,13 @@ class Trv:
     last_valve_position: float | None = None
     last_hvac_mode: str | None = None
     last_current_temperature: float | None = None
+    # ``last_calibration`` is the command the adapter actually put on the
+    # wire, after its own clamp to the device's declared offset range;
+    # ``last_calibration_requested`` is the value asked for before that
+    # clamp. Keeping them apart lets a device resting at a limit it
+    # declared be recognised as converged instead of rewritten.
     last_calibration: float | None = None
+    last_calibration_requested: float | None = None
     last_valve_percent: float | None = None
     last_valve_method: str | None = None
     # Per-channel write-budget stamps (setpoint, offset, valve) so one

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -372,6 +372,18 @@ def _calibration_match_tolerance(self, entity_id) -> float:
     OFFSET_MATCH_TOLERANCE_K is the floor: it covers devices that report
     no usable step and those whose declared step is finer than the grid
     they actually report on.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV whose offset step decides the tolerance
+
+    Returns
+    -------
+    float
+        Tolerance in Kelvin for an offset comparison
     """
     step = convert_to_float(
         str(self.real_trvs[entity_id].local_calibration_step),

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -1681,8 +1681,13 @@ async def control_trv(self, heater_entity_id=None, cycle=None):
                                     self, heater_entity_id, _calibration
                                 ):
                                     trv_entry.calibration_received = False
+                                    trv_entry.calibration_write_generation += 1
                                     self.task_manager.create_task(
-                                        check_calibration(self, heater_entity_id),
+                                        check_calibration(
+                                            self,
+                                            heater_entity_id,
+                                            trv_entry.calibration_write_generation,
+                                        ),
                                         name=f"bt_check_calibration_{heater_entity_id}",
                                     )
                             else:
@@ -1886,7 +1891,7 @@ async def check_target_temperature(self, heater_entity_id=None):
     return True
 
 
-async def check_calibration(self, heater_entity_id=None):
+async def check_calibration(self, heater_entity_id=None, generation=0):
     """Wait for TRV to confirm a calibration offset write, timeout after 6 minutes.
 
     Polls the device's reported offset every second until it is within
@@ -1907,12 +1912,21 @@ async def check_calibration(self, heater_entity_id=None):
     on an adapter error or a cancellation would silence the channel for
     the lifetime of the entity.
 
+    Only the watchdog whose generation is still the TRV's current one
+    releases the flag. A control cycle can confirm a command in-cycle and
+    write a newer offset while an earlier watchdog is still winding down;
+    releasing the gate from that earlier watchdog would open the channel
+    for a command that is still in flight and turn one re-assert per
+    confirmation window into one per write-budget slot.
+
     Parameters
     ----------
     self : BetterThermostat
         The Better Thermostat climate entity instance
     heater_entity_id : str, optional
         Entity ID of the TRV to check
+    generation : int, optional
+        Identity of the offset command this watchdog was armed for
 
     Returns
     -------
@@ -1924,6 +1938,15 @@ async def check_calibration(self, heater_entity_id=None):
     _tolerance = _calibration_match_tolerance(self, heater_entity_id)
     try:
         while True:
+            if _real_trv.calibration_write_generation != generation:
+                _LOGGER.debug(
+                    "better_thermostat %s: a newer calibration command superseded "
+                    "the one %s was being watched for, leaving the write gate to "
+                    "its watchdog",
+                    self.device_name,
+                    heater_entity_id,
+                )
+                return True
             _trv_state = self.hass.states.get(heater_entity_id)
             if _trv_state is None or _trv_state.state in (
                 STATE_UNAVAILABLE,
@@ -1962,5 +1985,6 @@ async def check_calibration(self, heater_entity_id=None):
             _timeout += 1
         await asyncio.sleep(2)
     finally:
-        _real_trv.calibration_received = True
+        if _real_trv.calibration_write_generation == generation:
+            _real_trv.calibration_received = True
     return True

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -1889,6 +1889,12 @@ async def check_calibration(self, heater_entity_id=None):
     from, and taking the device's report for it would make a dropped
     write look confirmed.
 
+    The release happens in a finally block. The mode and setpoint
+    channels write regardless of their flag, but the offset write only
+    goes out while calibration_received is True, so a watchdog that ended
+    on an adapter error or a cancellation would silence the channel for
+    the lifetime of the entity.
+
     Parameters
     ----------
     self : BetterThermostat
@@ -1904,40 +1910,45 @@ async def check_calibration(self, heater_entity_id=None):
     _timeout = 0
     _real_trv = self.real_trvs[heater_entity_id]
     _tolerance = _calibration_match_tolerance(self, heater_entity_id)
-    while True:
-        _trv_state = self.hass.states.get(heater_entity_id)
-        if _trv_state is None or _trv_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
-            _LOGGER.debug(
-                "better_thermostat %s: %s became unavailable during check_calibration",
+    try:
+        while True:
+            _trv_state = self.hass.states.get(heater_entity_id)
+            if _trv_state is None or _trv_state.state in (
+                STATE_UNAVAILABLE,
+                STATE_UNKNOWN,
+            ):
+                _LOGGER.debug(
+                    "better_thermostat %s: %s became unavailable during check_calibration",
+                    self.device_name,
+                    heater_entity_id,
+                )
+                break
+            _reported = convert_to_float(
+                str(await get_current_offset(self, heater_entity_id)),
                 self.device_name,
-                heater_entity_id,
+                "check_calibration()",
             )
-            break
-        _reported = convert_to_float(
-            str(await get_current_offset(self, heater_entity_id)),
-            self.device_name,
-            "check_calibration()",
-        )
-        if _real_trv.last_calibration is None or (
-            _reported is not None
-            and abs(_reported - float(_real_trv.last_calibration)) <= _tolerance
-        ):
-            _timeout = 0
-            break
-        if _timeout > WRITE_CONFIRM_TIMEOUT_S:
-            _LOGGER.warning(
-                "better_thermostat %s: TRV %s did not confirm the calibration offset "
-                "after %ss (wrote=%s, last reported=%s); giving up and assuming applied",
-                self.device_name,
-                heater_entity_id,
-                WRITE_CONFIRM_TIMEOUT_S,
-                _real_trv.last_calibration,
-                _reported,
-            )
-            _timeout = 0
-            break
-        await asyncio.sleep(1)
-        _timeout += 1
-    await asyncio.sleep(2)
-    _real_trv.calibration_received = True
+            if _real_trv.last_calibration is None or (
+                _reported is not None
+                and abs(_reported - float(_real_trv.last_calibration)) <= _tolerance
+            ):
+                _timeout = 0
+                break
+            if _timeout > WRITE_CONFIRM_TIMEOUT_S:
+                _LOGGER.warning(
+                    "better_thermostat %s: TRV %s did not confirm the calibration offset "
+                    "after %ss (wrote=%s, last reported=%s); giving up and assuming applied",
+                    self.device_name,
+                    heater_entity_id,
+                    WRITE_CONFIRM_TIMEOUT_S,
+                    _real_trv.last_calibration,
+                    _reported,
+                )
+                _timeout = 0
+                break
+            await asyncio.sleep(1)
+            _timeout += 1
+        await asyncio.sleep(2)
+    finally:
+        _real_trv.calibration_received = True
     return True

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -122,6 +122,12 @@ RECONCILE_VALVE_TOLERANCE_PCT = 5.0
 # Pause before re-queueing a cycle in which a TRV reported failure, so a
 # persistently failing device cannot spin the control queue.
 FAILED_CYCLE_BACKOFF_S = 2.0
+# How long a write channel waits for the device to confirm a command
+# before its watchdog releases the in-flight flag and assumes the command
+# applied. Shared by the mode, setpoint and calibration watchdogs, so a
+# device that never confirms paces its re-assert at this interval on
+# every channel.
+WRITE_CONFIRM_TIMEOUT_S = 360
 
 
 def _budget_open(last_write: float | None, now_monotonic: float) -> bool:
@@ -348,11 +354,31 @@ def _reconcile_tolerance(self, state) -> float:
     return max(RECONCILE_TOLERANCE_K, step / 2.0 + 1e-6)
 
 
+def _calibration_match_tolerance(self, entity_id) -> float:
+    """Per-device tolerance for the commanded-vs-reported offset comparison.
+
+    Devices snap a written offset onto their own step grid; a snapped
+    value sits at most half a step away from the commanded one. The base
+    tolerance covers devices that report no usable step.
+    """
+    step = convert_to_float(
+        str(self.real_trvs[entity_id].local_calibration_step),
+        self.device_name,
+        "controlling()",
+    )
+    if step is None or step <= 0:
+        return RECONCILE_TOLERANCE_K
+    # Slack against float noise when the difference is exactly half a step.
+    return max(RECONCILE_TOLERANCE_K, step / 2.0 + 1e-6)
+
+
 def _offset_diverges(self, trv) -> bool:
     """Whether the device's calibration offset left the commanded value.
 
     Compared only once the device has confirmed the last write — an
     in-flight write is the write path's business, not the reconciler's.
+    The comparison shares its tolerance with that write path, so what
+    the reconciler calls a divergence is what the gate re-asserts.
     """
     if not trv.capabilities().supports_offset_write:
         return False
@@ -368,11 +394,9 @@ def _offset_diverges(self, trv) -> bool:
     reported = convert_to_float(state.state, self.device_name, "reconcile()")
     if reported is None:
         return False
-    step = trv.local_calibration_step
-    tolerance = RECONCILE_TOLERANCE_K
-    if step is not None and step > 0:
-        tolerance = max(tolerance, step / 2.0 + 1e-6)
-    return abs(float(trv.last_calibration) - reported) > tolerance
+    return abs(float(trv.last_calibration) - reported) > _calibration_match_tolerance(
+        self, trv.entity_id
+    )
 
 
 def _valve_diverges(self, trv) -> bool:
@@ -1578,55 +1602,83 @@ async def control_trv(self, heater_entity_id=None, cycle=None):
                     )
 
                 trv_entry = self.real_trvs[heater_entity_id]
-                _old_calibration = trv_entry.last_calibration
-                if _old_calibration is None:
-                    _old_calibration = _current_calibration
+                _offset_tolerance = _calibration_match_tolerance(self, heater_entity_id)
 
-                # If current calibration already matches target, reset calibration_received
-                # to avoid it getting stuck at False when the state event was suppressed.
-                if (
-                    _calibration is not None
-                    and trv_entry.calibration_received is False
-                    and _current_calibration is not None
-                    and abs(float(_current_calibration) - float(_calibration)) < 0.5
-                ):
+                # COMMAND: what the adapter actually put on the wire. Only
+                # that value can be acknowledged; before the first write the
+                # device's own report stands in for it.
+                _last_sent = trv_entry.last_calibration
+                if _last_sent is None:
+                    _last_sent = _current_calibration
+
+                # Three-valued: an unreadable report neither confirms the
+                # command nor proves it was dropped.
+                _report_readable = (
+                    _current_calibration is not None and _last_sent is not None
+                )
+                _command_diverged = _report_readable and (
+                    abs(float(_current_calibration) - float(_last_sent))
+                    > _offset_tolerance
+                )
+                _command_confirmed = _report_readable and not _command_diverged
+
+                # A device holding what it was told has acknowledged it, even
+                # when the state event that would have said so was suppressed.
+                if trv_entry.calibration_received is False and _command_confirmed:
                     _LOGGER.debug(
-                        "better_thermostat %s: TRV %s calibration already at target (%s), "
-                        "resetting calibration_received flag",
+                        "better_thermostat %s: TRV %s device confirms the last "
+                        "calibration command (%s), releasing the write gate",
                         self.device_name,
                         heater_entity_id,
-                        _calibration,
+                        _last_sent,
                     )
                     trv_entry.calibration_received = True
 
-                _calibration_received = trv_entry.calibration_received is True
-                if _calibration is not None and _calibration_received:
-                    if _old_calibration is None:
+                if _calibration is not None and trv_entry.calibration_received is True:
+                    if _last_sent is None:
                         _LOGGER.debug(
                             "better_thermostat %s: no reference calibration for %s "
                             "yet, skipping calibration write this cycle",
                             self.device_name,
                             heater_entity_id,
                         )
-                    elif float(_old_calibration) != float(_calibration):
-                        # A deferred offset re-derives on the next control cycle
-                        # once the slot is free again.
-                        if _consume_budget(self, heater_entity_id, "offset"):
-                            _LOGGER.debug(
-                                "better_thermostat %s: TO TRV set_local_temperature_calibration: %s from: %s to: %s",
-                                self.device_name,
-                                heater_entity_id,
-                                _old_calibration,
-                                _calibration,
-                            )
-                            await set_offset(self, heater_entity_id, _calibration)
-                            trv_entry.calibration_received = False
-                        else:
-                            _schedule_budget_retry(
-                                self,
-                                heater_entity_id,
-                                _budget_remaining(self, heater_entity_id, "offset"),
-                            )
+                    else:
+                        # INTENT: the value asked for before the adapter's own
+                        # clamp. A device resting at a limit it declared keeps
+                        # reporting the clamped command, so comparing the
+                        # intent against the command would rewrite it every
+                        # cycle. Both intent values come off the same step
+                        # grid, so they compare exactly; only the report lives
+                        # on the device's grid and needs the tolerance.
+                        _last_requested = trv_entry.last_calibration_requested
+                        if _last_requested is None:
+                            _last_requested = _last_sent
+                        if float(_last_requested) != _calibration or _command_diverged:
+                            # A deferred offset re-derives on the next control cycle
+                            # once the slot is free again.
+                            if _consume_budget(self, heater_entity_id, "offset"):
+                                _LOGGER.debug(
+                                    "better_thermostat %s: TO TRV set_local_temperature_calibration: %s from: %s to: %s (device reports %s)",
+                                    self.device_name,
+                                    heater_entity_id,
+                                    _last_sent,
+                                    _calibration,
+                                    _current_calibration,
+                                )
+                                if await set_offset(
+                                    self, heater_entity_id, _calibration
+                                ):
+                                    trv_entry.calibration_received = False
+                                    self.task_manager.create_task(
+                                        check_calibration(self, heater_entity_id),
+                                        name=f"bt_check_calibration_{heater_entity_id}",
+                                    )
+                            else:
+                                _schedule_budget_retry(
+                                    self,
+                                    heater_entity_id,
+                                    _budget_remaining(self, heater_entity_id, "offset"),
+                                )
 
             # set new target temperature
             _safety_overrode_setpoint = False
@@ -1731,12 +1783,13 @@ async def check_system_mode(self, heater_entity_id=None):
         if _trv_state.state == _real_trv.last_hvac_mode:
             _timeout = 0
             break
-        if _timeout > 360:
+        if _timeout > WRITE_CONFIRM_TIMEOUT_S:
             _LOGGER.warning(
                 "better_thermostat %s: TRV %s did not confirm the system mode change "
-                "after 360s (wrote=%s, last reported=%s); giving up and assuming applied",
+                "after %ss (wrote=%s, last reported=%s); giving up and assuming applied",
                 self.device_name,
                 heater_entity_id,
+                WRITE_CONFIRM_TIMEOUT_S,
                 _real_trv.last_hvac_mode,
                 _trv_state.state,
             )
@@ -1801,12 +1854,13 @@ async def check_target_temperature(self, heater_entity_id=None):
         ):
             _timeout = 0
             break
-        if _timeout > 360:
+        if _timeout > WRITE_CONFIRM_TIMEOUT_S:
             _LOGGER.warning(
                 "better_thermostat %s: TRV %s did not confirm the target temperature "
-                "after 360s (wrote=%s, last reported=%s); giving up and assuming applied",
+                "after %ss (wrote=%s, last reported=%s); giving up and assuming applied",
                 self.device_name,
                 heater_entity_id,
+                WRITE_CONFIRM_TIMEOUT_S,
                 _real_trv.last_temperature,
                 _current_set_temperatures,
             )
@@ -1817,4 +1871,73 @@ async def check_target_temperature(self, heater_entity_id=None):
     await asyncio.sleep(2)
 
     _real_trv.target_temp_received = True
+    return True
+
+
+async def check_calibration(self, heater_entity_id=None):
+    """Wait for TRV to confirm a calibration offset write, timeout after 6 minutes.
+
+    Polls the device's reported offset every second until it is within
+    the device's own step tolerance of the value last written, or the
+    timeout is reached. Sets calibration_received when complete: the
+    write gate only re-asserts an offset once that flag is back, so a
+    device that never acknowledges is re-asserted once per timeout
+    window instead of once per control cycle.
+
+    The reported value is deliberately not adopted as the last written
+    one — that record is the integrator base the next offset is computed
+    from, and taking the device's report for it would make a dropped
+    write look confirmed.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    heater_entity_id : str, optional
+        Entity ID of the TRV to check
+
+    Returns
+    -------
+    bool
+        Always returns True
+    """
+    _timeout = 0
+    _real_trv = self.real_trvs[heater_entity_id]
+    _tolerance = _calibration_match_tolerance(self, heater_entity_id)
+    while True:
+        _trv_state = self.hass.states.get(heater_entity_id)
+        if _trv_state is None or _trv_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            _LOGGER.debug(
+                "better_thermostat %s: %s became unavailable during check_calibration",
+                self.device_name,
+                heater_entity_id,
+            )
+            break
+        _reported = convert_to_float(
+            str(await get_current_offset(self, heater_entity_id)),
+            self.device_name,
+            "check_calibration()",
+        )
+        if _real_trv.last_calibration is None or (
+            _reported is not None
+            and abs(_reported - float(_real_trv.last_calibration)) <= _tolerance
+        ):
+            _timeout = 0
+            break
+        if _timeout > WRITE_CONFIRM_TIMEOUT_S:
+            _LOGGER.warning(
+                "better_thermostat %s: TRV %s did not confirm the calibration offset "
+                "after %ss (wrote=%s, last reported=%s); giving up and assuming applied",
+                self.device_name,
+                heater_entity_id,
+                WRITE_CONFIRM_TIMEOUT_S,
+                _real_trv.last_calibration,
+                _reported,
+            )
+            _timeout = 0
+            break
+        await asyncio.sleep(1)
+        _timeout += 1
+    await asyncio.sleep(2)
+    _real_trv.calibration_received = True
     return True

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -61,6 +61,16 @@ _LOGGER = logging.getLogger(__name__)
 MIN_WRITE_INTERVAL_S = 30.0
 # Device tolerance when comparing commanded vs reported setpoints.
 RECONCILE_TOLERANCE_K = 0.05
+# Floor for the commanded-vs-reported offset comparison. Half the declared
+# offset step is the right window only while that step describes the grid the
+# device reports on; an adapter declaring a nominal 0.01 K step describes a
+# continuous range instead, and any report rounded coarser than that then reads
+# as a divergence the write gate re-asserts on every control cycle. The floor
+# covers those roundings and stays below the 0.1 K resolution a TRV reports its
+# own temperature at, so no calibration error the room can feel hides beneath
+# it. The setpoint channel's read-back tolerance describes a different
+# comparison, so the offset channel carries its own floor.
+OFFSET_MATCH_TOLERANCE_K = 0.05
 # Resend throttle for the cooler path: cooler commands go straight to the
 # service call (no reconciler in between), so an identical command is
 # suppressed while the device's state feedback lags. A changed desired value
@@ -358,8 +368,10 @@ def _calibration_match_tolerance(self, entity_id) -> float:
     """Per-device tolerance for the commanded-vs-reported offset comparison.
 
     Devices snap a written offset onto their own step grid; a snapped
-    value sits at most half a step away from the commanded one. The base
-    tolerance covers devices that report no usable step.
+    value sits at most half a step away from the commanded one.
+    OFFSET_MATCH_TOLERANCE_K is the floor: it covers devices that report
+    no usable step and those whose declared step is finer than the grid
+    they actually report on.
     """
     step = convert_to_float(
         str(self.real_trvs[entity_id].local_calibration_step),
@@ -367,9 +379,9 @@ def _calibration_match_tolerance(self, entity_id) -> float:
         "controlling()",
     )
     if step is None or step <= 0:
-        return RECONCILE_TOLERANCE_K
+        return OFFSET_MATCH_TOLERANCE_K
     # Slack against float noise when the difference is exactly half a step.
-    return max(RECONCILE_TOLERANCE_K, step / 2.0 + 1e-6)
+    return max(OFFSET_MATCH_TOLERANCE_K, step / 2.0 + 1e-6)
 
 
 def _offset_diverges(self, trv) -> bool:

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -2227,10 +2227,11 @@ class TestGroupedTrvCalibration:
             patch(_PATCHES["set_valve"], new_callable=AsyncMock),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
-            mock_get_offset.return_value = 2.0
+            mock_get_offset.return_value = 2.0  # confirms last_calibration
+            mock_set_offset.return_value = True
             mock_convert.return_value = {
                 "temperature": 21.0,
-                "local_temperature_calibration": 3.0,  # Different from current!
+                "local_temperature_calibration": 3.0,  # the intent moved
                 "local_temperature": 20.0,
                 "system_mode": "heat",
             }
@@ -2240,6 +2241,7 @@ class TestGroupedTrvCalibration:
             await control_trv(mock_bt_grouped, entity_id)
 
             mock_set_offset.assert_awaited_once_with(mock_bt_grouped, entity_id, 3.0)
+            assert mock_bt_grouped.real_trvs[entity_id].calibration_received is False
 
     @pytest.mark.anyio
     async def test_calibration_sent_when_received_true_and_differs(

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -19,8 +19,10 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homeassistant.components.climate.const import PRESET_BOOST, HVACMode
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import State
 import pytest
 
+from custom_components.better_thermostat.adapters import delegate, generic
 from custom_components.better_thermostat.core.clock import FakeClock
 from custom_components.better_thermostat.core.decide import running_kernel_state
 from custom_components.better_thermostat.core.fsm.control_mode import (
@@ -2823,3 +2825,137 @@ class TestOffsetWriteGate:
             assert await earlier_watchdog is True
 
         assert trv.calibration_received is False
+
+
+SELECT_CALIBRATION_ENTITY = "select.trv1_calibration"
+# A calibration select on a 3 K grid: an offset between two options reaches
+# the device as the nearer one.
+SELECT_OPTIONS = ["-6.0k", "-3.0k", "0.0k", "3.0k", "6.0k"]
+
+
+class _SnappingSelect:
+    """A calibration select that holds exactly the option it was handed."""
+
+    def __init__(self, selected="0.0k"):
+        """Start the entity on the option it currently holds.
+
+        Parameters
+        ----------
+        selected : str
+            Option the entity holds before the first write.
+        """
+        self.selected = selected
+        self.written = []
+
+    @property
+    def reported(self):
+        """Return the offset in Kelvin the entity publishes."""
+        return float(self.selected.replace("k", ""))
+
+    def state(self):
+        """Return the entity state the adapter reads its options off."""
+        return State(
+            SELECT_CALIBRATION_ENTITY, self.selected, {"options": list(SELECT_OPTIONS)}
+        )
+
+    async def async_call(self, domain, service, data, **kwargs):
+        """Apply a select_option call and ignore every other service.
+
+        Parameters
+        ----------
+        domain : str
+            Service domain of the call.
+        service : str
+            Service name within that domain.
+        data : dict
+            Service data; carries the option for a select_option call.
+        **kwargs : dict
+            Blocking and context arguments the caller passes on.
+        """
+        if domain == "select" and service == "select_option":
+            self.written.append(data["option"])
+            self.selected = data["option"]
+
+
+class TestSnappingSelectOffsetConverges:
+    """A device that snaps the offset onto its own option list settles.
+
+    The adapter, not the device, decides which option carries the offset,
+    so the command the gate confirms against is the option's value. The
+    intent stays what the cycle asked for, so an unchanged intent does not
+    re-arm the write once the device holds the snapped option.
+    """
+
+    def _wire(self, device):
+        """Return a thermostat whose calibration entity is ``device``.
+
+        Parameters
+        ----------
+        device : _SnappingSelect
+            The calibration select standing in for the TRV's offset channel.
+
+        Returns
+        -------
+        Mock
+            A stand-in for the Better Thermostat climate entity instance.
+        """
+        mock_self = _make_offset_self(
+            calibration_received=True,
+            last_calibration=0.0,
+            last_calibration_requested=0.0,
+            local_temperature_calibration_entity=SELECT_CALIBRATION_ENTITY,
+            # A select publishes no step, so discovery falls back to 1.0.
+            local_calibration_step=1.0,
+        )
+        mock_self.real_trvs["climate.trv1"].adapter = generic
+        trv_state = mock_self.hass.states.get.return_value
+        mock_self.hass.states.get.side_effect = lambda entity_id: (
+            device.state() if entity_id == SELECT_CALIBRATION_ENTITY else trv_state
+        )
+        mock_self.hass.services.async_call = AsyncMock(side_effect=device.async_call)
+        return mock_self
+
+    @pytest.mark.asyncio
+    async def test_the_snapped_option_is_written_once(self):
+        """Five cycles against a device holding the snapped option write once."""
+        device = _SnappingSelect()
+        mock_self = self._wire(device)
+        trv = mock_self.real_trvs["climate.trv1"]
+        # The real write path: the delegate records the intent and the
+        # adapter the command.
+        set_offset = AsyncMock(side_effect=delegate.set_offset)
+
+        for _ in range(5):
+            # The watchdog releases the gate at the end of its window.
+            trv.calibration_received = True
+            await _run_offset_cycle(
+                mock_self,
+                desired_offset=-2.0,
+                reported_offset=device.reported,
+                set_offset=set_offset,
+            )
+            mock_self.clock.advance(31.0)
+
+        assert device.written == ["-3.0k"]
+        assert trv.last_calibration == -3.0
+        assert trv.last_calibration_requested == -2.0
+
+    @pytest.mark.asyncio
+    async def test_a_new_intent_still_reaches_the_device(self):
+        """A cycle asking for another option writes it."""
+        device = _SnappingSelect()
+        mock_self = self._wire(device)
+        trv = mock_self.real_trvs["climate.trv1"]
+        set_offset = AsyncMock(side_effect=delegate.set_offset)
+
+        for desired in (-2.0, 2.0):
+            trv.calibration_received = True
+            await _run_offset_cycle(
+                mock_self,
+                desired_offset=desired,
+                reported_offset=device.reported,
+                set_offset=set_offset,
+            )
+            mock_self.clock.advance(31.0)
+
+        assert device.written == ["-3.0k", "3.0k"]

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -38,7 +38,10 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationMode,
     CalibrationType,
 )
-from custom_components.better_thermostat.utils.controlling import control_trv
+from custom_components.better_thermostat.utils.controlling import (
+    check_calibration,
+    control_trv,
+)
 
 # All delegate / helper functions that control_trv calls.  We patch them at the
 # *controlling* module level because that is where they are imported.
@@ -2768,3 +2771,55 @@ class TestOffsetWriteGate:
             mock_self.clock.advance(31.0)
 
         assert set_offset.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_each_write_arms_a_watchdog_for_its_own_command(self):
+        """Every accepted write takes the next generation."""
+        mock_self = _make_offset_self(
+            calibration_received=True,
+            last_calibration=0.0,
+            last_calibration_requested=0.0,
+        )
+        watchdog = Mock(return_value=None)
+
+        with patch(f"{_CTRL}.check_calibration", new=watchdog):
+            for _ in range(3):
+                mock_self.real_trvs["climate.trv1"].calibration_received = True
+                await _run_offset_cycle(
+                    mock_self, desired_offset=-2.0, reported_offset=0.0
+                )
+                mock_self.clock.advance(31.0)
+
+        assert [call.args[2] for call in watchdog.call_args_list] == [1, 2, 3]
+        assert mock_self.real_trvs["climate.trv1"].calibration_write_generation == 3
+
+    @pytest.mark.asyncio
+    async def test_a_superseded_watchdog_does_not_reopen_the_gate(self):
+        """The gate stays closed while the newest command is unconfirmed.
+
+        A control cycle can confirm a command in-cycle and immediately
+        write a newer one, leaving the earlier watchdog winding down. Its
+        release must not open the channel for the write still in flight.
+        """
+        mock_self = _make_offset_self(
+            calibration_received=False,
+            last_calibration=-2.0,
+            last_calibration_requested=-2.0,
+        )
+        trv = mock_self.real_trvs["climate.trv1"]
+        trv.calibration_write_generation = 1
+        earlier_watchdog = check_calibration(mock_self, "climate.trv1", 1)
+
+        # The cycle confirms -2.0 and writes -3.0, arming the newer watchdog.
+        set_offset, _ = await _run_offset_cycle(
+            mock_self, desired_offset=-3.0, reported_offset=-2.0
+        )
+
+        set_offset.assert_awaited_once_with(mock_self, "climate.trv1", -3.0)
+        assert trv.calibration_received is False
+        assert trv.calibration_write_generation == 2
+
+        with patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-2.0)):
+            assert await earlier_watchdog is True
+
+        assert trv.calibration_received is False

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -2730,3 +2730,41 @@ class TestOffsetWriteGate:
         )
 
         set_offset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_declared_step_finer_than_the_reported_grid_converges(self):
+        """A device rounding coarser than it declares is written once.
+
+        The device declares a 0.01 K offset step but publishes its offset
+        on a 0.05 K grid. Half the declared step is narrower than that
+        grid, so without the floor every cycle would read the rounding as
+        a divergence and re-assert the same command forever.
+        """
+        mock_self = _make_offset_self(
+            calibration_received=True,
+            last_calibration=0.0,
+            last_calibration_requested=0.0,
+            local_calibration_step=0.01,
+        )
+        reported = {"value": 0.0}
+
+        async def _write_and_round(_self, entity_id, offset):
+            """Take the command and publish it on the device's own grid."""
+            trv = mock_self.real_trvs[entity_id]
+            trv.last_calibration = offset
+            trv.last_calibration_requested = offset
+            reported["value"] = round(round(offset / 0.05) * 0.05, 6)
+            return True
+
+        set_offset = AsyncMock(side_effect=_write_and_round)
+        for _ in range(20):
+            mock_self.real_trvs["climate.trv1"].calibration_received = True
+            await _run_offset_cycle(
+                mock_self,
+                desired_offset=-2.32,
+                reported_offset=reported["value"],
+                set_offset=set_offset,
+            )
+            mock_self.clock.advance(31.0)
+
+        assert set_offset.await_count == 1

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -2509,7 +2509,7 @@ class TestOffsetWriteGate:
 
     @pytest.mark.asyncio
     async def test_unconfirmed_offset_is_written_once_the_report_confirms(self):
-        """An unacknowledged write no longer wedges the channel.
+        """An unacknowledged write leaves the channel open.
 
         The device reports exactly what it was last told, so nothing is
         in flight; the pending intent must reach it.

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -2143,6 +2143,7 @@ def mock_bt_grouped():
     bt.calculate_heating_power = AsyncMock()
 
     bt.kernel_state = _kernel_state_for(bt)
+    bt.task_manager = Mock(create_task=Mock(side_effect=_close_coro))
     bt.real_trvs = {
         "climate.trv_1": Trv.from_legacy_dict(
             "climate.trv_1",
@@ -2199,10 +2200,15 @@ class TestGroupedTrvCalibration:
     """
 
     @pytest.mark.anyio
-    async def test_calibration_received_stays_false_when_mismatch(
+    async def test_confirmed_command_releases_the_gate_and_writes_the_new_intent(
         self, mock_bt_grouped
     ):
-        """Test that calibration_received stays False when calibration differs."""
+        """A device holding its last command accepts a changed intent.
+
+        The report equals the value last written, so the unacknowledged
+        write is confirmed; the gate opens and the new intent goes out
+        instead of the channel stalling on a flag nobody clears.
+        """
         entity_id = "climate.trv_3"
 
         mock_trv_state = MagicMock()
@@ -2233,8 +2239,7 @@ class TestGroupedTrvCalibration:
 
             await control_trv(mock_bt_grouped, entity_id)
 
-            assert mock_bt_grouped.real_trvs[entity_id].calibration_received is False
-            mock_set_offset.assert_not_called()
+            mock_set_offset.assert_awaited_once_with(mock_bt_grouped, entity_id, 3.0)
 
     @pytest.mark.anyio
     async def test_calibration_sent_when_received_true_and_differs(
@@ -2324,9 +2329,21 @@ class TestGroupedTrvCalibration:
             mock_set_temp.assert_called_once()
 
     @pytest.mark.anyio
-    async def test_calibration_tolerance_within_half_degree(self, mock_bt_grouped):
-        """Test that calibration within 0.5 degree tolerance is considered matching."""
+    @pytest.mark.parametrize(
+        ("step", "reported", "released"),
+        [(0.5, 2.2, True), (0.5, 2.3, False), (1.0, 2.5, True)],
+    )
+    async def test_confirmation_window_is_half_the_device_step(
+        self, mock_bt_grouped, step, reported, released
+    ):
+        """A report within half the device's own offset step confirms.
+
+        That is the distance a device can move a written value by
+        snapping it onto its own grid, so it is the width of the window
+        in which the report still counts as the command.
+        """
         entity_id = "climate.trv_3"
+        mock_bt_grouped.real_trvs[entity_id].local_calibration_step = step
 
         mock_trv_state = MagicMock()
         mock_trv_state.state = "heat"
@@ -2344,7 +2361,7 @@ class TestGroupedTrvCalibration:
             patch(_PATCHES["set_valve"], new_callable=AsyncMock),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
-            mock_get_offset.return_value = 2.3
+            mock_get_offset.return_value = reported
             mock_convert.return_value = {
                 "temperature": 21.0,
                 "local_temperature_calibration": 2.0,
@@ -2356,7 +2373,7 @@ class TestGroupedTrvCalibration:
 
             await control_trv(mock_bt_grouped, entity_id)
 
-            assert mock_bt_grouped.real_trvs[entity_id].calibration_received is True
+            assert mock_bt_grouped.real_trvs[entity_id].calibration_received is released
 
     @pytest.mark.anyio
     async def test_calibration_tolerance_outside_half_degree(self, mock_bt_grouped):
@@ -2392,3 +2409,322 @@ class TestGroupedTrvCalibration:
             await control_trv(mock_bt_grouped, entity_id)
 
             assert mock_bt_grouped.real_trvs[entity_id].calibration_received is False
+
+
+# ---------------------------------------------------------------------------
+# Offset write gate: intent, command and the device's report
+# ---------------------------------------------------------------------------
+
+
+def _offset_trv_config(**overrides):
+    """Return a Trv configured for offset (LOCAL_BASED) calibration."""
+    cfg = {
+        "ignore_trv_states": False,
+        "hvac_modes": [HVACMode.HEAT, HVACMode.OFF],
+        "min_temp": 5.0,
+        "max_temp": 30.0,
+        "temperature": 20.0,
+        "last_temperature": 20.0,
+        "last_hvac_mode": HVACMode.HEAT,
+        "hvac_mode": HVACMode.HEAT,
+        "system_mode_received": False,
+        "target_temp_received": False,
+        "calibration_received": True,
+        "last_calibration": 0.0,
+        "local_calibration_min": -7.0,
+        "local_calibration_max": 7.0,
+        "local_calibration_step": 0.5,
+        "local_temperature_calibration_entity": "number.trv1_offset",
+        "advanced": {
+            "calibration_mode": CalibrationMode.DEFAULT,
+            "calibration": CalibrationType.LOCAL_BASED,
+            "no_off_system_mode": False,
+        },
+    }
+    cfg.update(overrides)
+    return Trv.from_legacy_dict("climate.trv1", cfg)
+
+
+def _make_offset_self(**overrides):
+    """Mock BetterThermostat driving one offset-calibrated TRV."""
+    return _make_mock_self(
+        trv_state=HVACMode.HEAT,
+        trv_attrs={"temperature": 20.0},
+        real_trvs={"climate.trv1": _offset_trv_config(**overrides)},
+    )
+
+
+async def _run_offset_cycle(
+    mock_self, desired_offset, reported_offset, set_offset=None, system_mode=None
+):
+    """Run one control_trv cycle for the offset-calibrated TRV."""
+    if set_offset is None:
+        set_offset = AsyncMock(return_value=True)
+    with (
+        patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+        patch(
+            _PATCHES["get_current_offset"], new=AsyncMock(return_value=reported_offset)
+        ) as mock_get_offset,
+        patch(_PATCHES["set_offset"], new=set_offset),
+        patch(_PATCHES["set_temperature"], new=AsyncMock()),
+        patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+        patch(_PATCHES["set_valve"], new=AsyncMock()),
+        patch(_PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)),
+        patch(_PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        mock_convert.return_value = {
+            "temperature": 20.0,
+            "local_temperature_calibration": desired_offset,
+            "local_temperature": 20.0,
+            "system_mode": system_mode or HVACMode.HEAT,
+        }
+        await control_trv(mock_self, "climate.trv1")
+    return set_offset, mock_get_offset
+
+
+def _accepted_write(mock_self):
+    """Bookkeeping of an accepted write: the command and the intent.
+
+    The adapter records the value it put on the wire and the delegate
+    the value asked for, both before the device has said anything.
+    """
+
+    async def _set_offset(_self, entity_id, offset):
+        trv = mock_self.real_trvs[entity_id]
+        trv.last_calibration = offset
+        trv.last_calibration_requested = offset
+        return True
+
+    return AsyncMock(side_effect=_set_offset)
+
+
+class TestOffsetWriteGate:
+    """The offset channel re-asserts what the device did not take."""
+
+    @pytest.mark.asyncio
+    async def test_unconfirmed_offset_is_written_once_the_report_confirms(self):
+        """An unacknowledged write no longer wedges the channel.
+
+        The device reports exactly what it was last told, so nothing is
+        in flight; the pending intent must reach it.
+        """
+        mock_self = _make_offset_self(calibration_received=False, last_calibration=0.0)
+
+        set_offset, _ = await _run_offset_cycle(
+            mock_self, desired_offset=-2.0, reported_offset=0.0
+        )
+
+        set_offset.assert_awaited_once_with(mock_self, "climate.trv1", -2.0)
+
+    @pytest.mark.asyncio
+    async def test_write_arms_the_confirmation_watchdog(self):
+        """A write closes the gate and schedules the release that reopens it."""
+        mock_self = _make_offset_self(calibration_received=False, last_calibration=0.0)
+        tasks = []
+        mock_self.task_manager.create_task = Mock(
+            side_effect=lambda coro, name=None: (
+                (coro.close(), tasks.append(name)) and Mock()
+            )
+        )
+
+        await _run_offset_cycle(mock_self, desired_offset=-2.0, reported_offset=0.0)
+
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is False
+        assert "bt_check_calibration_climate.trv1" in tasks
+
+    @pytest.mark.asyncio
+    async def test_silently_dropped_write_is_reasserted_every_released_cycle(self):
+        """A device that keeps reporting the old offset is written to again.
+
+        The divergence arm never wedges: each cycle that finds the gate
+        open and the report away from the command re-sends the command.
+        """
+        mock_self = _make_offset_self(calibration_received=True, last_calibration=0.0)
+        set_offset = _accepted_write(mock_self)
+
+        for _ in range(3):
+            mock_self.real_trvs["climate.trv1"].calibration_received = True
+            await _run_offset_cycle(
+                mock_self,
+                desired_offset=-2.0,
+                reported_offset=0.0,
+                set_offset=set_offset,
+            )
+            mock_self.clock.advance(31.0)
+
+        assert set_offset.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_converged_offset_is_not_rewritten(self):
+        """Intent, command and report agreeing produces no write."""
+        mock_self = _make_offset_self(
+            calibration_received=True,
+            last_calibration=-2.0,
+            last_calibration_requested=-2.0,
+        )
+
+        set_offset, _ = await _run_offset_cycle(
+            mock_self, desired_offset=-2.0, reported_offset=-2.0
+        )
+
+        set_offset.assert_not_awaited()
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+
+    @pytest.mark.asyncio
+    async def test_declared_clamp_is_not_rewritten(self):
+        """An adapter clamp the device honours is convergence, not a miss.
+
+        The device holds the clamped command it was given, so the intent
+        that exceeded its range must not be re-sent on every cycle.
+        """
+        mock_self = _make_offset_self(
+            calibration_received=True,
+            last_calibration=-3.0,
+            last_calibration_requested=-5.0,
+        )
+        set_offset = AsyncMock(return_value=True)
+
+        for _ in range(5):
+            await _run_offset_cycle(
+                mock_self,
+                desired_offset=-5.0,
+                reported_offset=-3.0,
+                set_offset=set_offset,
+            )
+            mock_self.clock.advance(31.0)
+
+        set_offset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_new_intent_past_a_clamp_is_written_once(self):
+        """A changed intent still reaches a device resting at its clamp."""
+        mock_self = _make_offset_self(
+            calibration_received=True,
+            last_calibration=-3.0,
+            last_calibration_requested=-5.0,
+        )
+
+        set_offset, _ = await _run_offset_cycle(
+            mock_self, desired_offset=-6.0, reported_offset=-3.0
+        )
+
+        set_offset.assert_awaited_once_with(mock_self, "climate.trv1", -6.0)
+
+    @pytest.mark.asyncio
+    async def test_dropped_write_is_reasserted_against_an_unchanged_intent(self):
+        """The report, not the intent, decides whether the command arrived."""
+        mock_self = _make_offset_self(
+            calibration_received=True,
+            last_calibration=-2.0,
+            last_calibration_requested=-2.0,
+        )
+
+        set_offset, _ = await _run_offset_cycle(
+            mock_self, desired_offset=-2.0, reported_offset=0.0
+        )
+
+        set_offset.assert_awaited_once_with(mock_self, "climate.trv1", -2.0)
+
+    @pytest.mark.asyncio
+    async def test_report_beyond_half_a_step_counts_as_diverged(self):
+        """On a fine grid a small deviation is already a lost write."""
+        mock_self = _make_offset_self(
+            calibration_received=True,
+            last_calibration=-2.0,
+            last_calibration_requested=-2.0,
+            local_calibration_step=0.1,
+        )
+
+        set_offset, _ = await _run_offset_cycle(
+            mock_self, desired_offset=-2.0, reported_offset=-1.7
+        )
+
+        set_offset.assert_awaited_once_with(mock_self, "climate.trv1", -2.0)
+
+    @pytest.mark.asyncio
+    async def test_report_within_half_a_step_counts_as_confirmed(self):
+        """On a coarse grid the same deviation is the device's own snap."""
+        mock_self = _make_offset_self(
+            calibration_received=True,
+            last_calibration=-2.0,
+            last_calibration_requested=-2.0,
+            local_calibration_step=1.0,
+        )
+
+        set_offset, _ = await _run_offset_cycle(
+            mock_self, desired_offset=-2.0, reported_offset=-2.5
+        )
+
+        set_offset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_write_keeps_the_gate_open_and_retries(self):
+        """A write the adapter refused arms nothing and is retried."""
+        mock_self = _make_offset_self(calibration_received=True, last_calibration=0.0)
+        tasks = []
+        mock_self.task_manager.create_task = Mock(
+            side_effect=lambda coro, name=None: (
+                (coro.close(), tasks.append(name)) and Mock()
+            )
+        )
+        set_offset = AsyncMock(return_value=False)
+
+        await _run_offset_cycle(
+            mock_self, desired_offset=-2.0, reported_offset=0.0, set_offset=set_offset
+        )
+
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+        assert not [name for name in tasks if name.startswith("bt_check_calibration")]
+
+        mock_self.clock.advance(31.0)
+        await _run_offset_cycle(
+            mock_self, desired_offset=-2.0, reported_offset=0.0, set_offset=set_offset
+        )
+
+        assert set_offset.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_calibration_mode_leaves_the_channel_alone(self):
+        """NO_CALIBRATION reads no offset, writes none and arms nothing."""
+        mock_self = _make_offset_self(
+            calibration_received=False,
+            last_calibration=0.0,
+            advanced={
+                "calibration_mode": CalibrationMode.NO_CALIBRATION,
+                "calibration": CalibrationType.LOCAL_BASED,
+                "no_off_system_mode": False,
+            },
+        )
+        tasks = []
+        mock_self.task_manager.create_task = Mock(
+            side_effect=lambda coro, name=None: (
+                (coro.close(), tasks.append(name)) and Mock()
+            )
+        )
+
+        set_offset, get_offset = await _run_offset_cycle(
+            mock_self, desired_offset=-2.0, reported_offset=0.0
+        )
+
+        set_offset.assert_not_awaited()
+        get_offset.assert_not_awaited()
+        assert not [name for name in tasks if name.startswith("bt_check_calibration")]
+
+    @pytest.mark.asyncio
+    async def test_off_mode_leaves_the_channel_alone(self):
+        """An OFF TRV keeps its offset even when the report diverged."""
+        mock_self = _make_offset_self(
+            calibration_received=True,
+            last_calibration=-2.0,
+            last_calibration_requested=-2.0,
+        )
+
+        set_offset, _ = await _run_offset_cycle(
+            mock_self,
+            desired_offset=-2.0,
+            reported_offset=0.0,
+            system_mode=HVACMode.OFF,
+        )
+
+        set_offset.assert_not_awaited()

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -24,6 +24,7 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.controlling import (
+    OFFSET_MATCH_TOLERANCE_K,
     RECONCILE_TOLERANCE_K,
     WRITE_CONFIRM_TIMEOUT_S,
     _calibration_match_tolerance,
@@ -860,12 +861,21 @@ class TestCalibrationMatchTolerance:
         tolerance = _calibration_match_tolerance(self._mock_self(1.0), "climate.trv1")
         assert tolerance == pytest.approx(0.5, abs=1e-5)
 
-    def test_unusable_step_falls_back_to_the_base_tolerance(self):
+    def test_unusable_step_falls_back_to_the_floor(self):
         """Without a usable step there is no grid to derive a tolerance from."""
         tolerance = _calibration_match_tolerance(self._mock_self(0), "climate.trv1")
-        assert tolerance == RECONCILE_TOLERANCE_K
+        assert tolerance == OFFSET_MATCH_TOLERANCE_K
 
-    def test_step_below_the_base_tolerance_does_not_narrow_it(self):
-        """The read-back grid stays the floor for very fine offset steps."""
+    def test_step_below_the_floor_does_not_narrow_it(self):
+        """A declared step finer than the reported grid does not narrow it."""
         tolerance = _calibration_match_tolerance(self._mock_self(0.01), "climate.trv1")
-        assert tolerance == RECONCILE_TOLERANCE_K
+        assert tolerance == OFFSET_MATCH_TOLERANCE_K
+
+    def test_the_floor_is_the_offset_channel_s_own(self):
+        """The offset floor is pinned; the setpoint channel keeps its own."""
+        from custom_components.better_thermostat.utils.helpers import (
+            SETPOINT_MATCH_TOLERANCE,
+        )
+
+        assert OFFSET_MATCH_TOLERANCE_K == 0.05
+        assert SETPOINT_MATCH_TOLERANCE == 0.01

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -11,10 +11,11 @@ applied in control_trv (see test_control_trv.py).
 """
 
 import asyncio
-from unittest.mock import MagicMock, Mock
+import logging
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfTemperature
 import pytest
 
 from custom_components.better_thermostat.trv import Trv
@@ -24,12 +25,17 @@ from custom_components.better_thermostat.utils.const import (
 )
 from custom_components.better_thermostat.utils.controlling import (
     RECONCILE_TOLERANCE_K,
+    WRITE_CONFIRM_TIMEOUT_S,
+    _calibration_match_tolerance,
     _get_valve_control,
     _reconcile_tolerance,
+    check_calibration,
     check_system_mode,
     check_target_temperature,
 )
 from tests.factories import make_snapshot
+
+_CTRL = "custom_components.better_thermostat.utils.controlling"
 
 
 def _boost_snapshot():
@@ -620,3 +626,212 @@ class TestReconcileTolerance:
             self._state({"target_temp_step": 0.5}),
         )
         assert tolerance == pytest.approx(0.25, abs=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# check_calibration
+# ---------------------------------------------------------------------------
+
+
+def _sleep_recorder():
+    """Patch asyncio.sleep to a no-op that records requested durations."""
+    durations = []
+
+    async def _sleep(duration):
+        durations.append(duration)
+
+    return durations, patch("asyncio.sleep", new=AsyncMock(side_effect=_sleep))
+
+
+class TestCheckCalibration:
+    """The calibration watchdog always releases the offset write gate.
+
+    Without it, an offset the device never acknowledges leaves
+    calibration_received False for the lifetime of the entity and no
+    further offset is ever written.
+    """
+
+    @staticmethod
+    def _mock_self(live_state=HVACMode.HEAT, **trv_overrides):
+        """Build a mock BetterThermostat around one offset-writing TRV."""
+        mock_state = Mock()
+        mock_state.state = live_state
+
+        mock_hass = Mock()
+        mock_hass.states.get.return_value = (
+            mock_state if live_state is not None else None
+        )
+
+        cfg = {
+            "last_calibration": -2.0,
+            "local_calibration_step": 0.5,
+            "calibration_received": False,
+        }
+        cfg.update(trv_overrides)
+
+        mock_self = Mock()
+        mock_self.device_name = "test_thermostat"
+        mock_self.hass = mock_hass
+        mock_self.real_trvs = {
+            "climate.trv1": Trv.from_legacy_dict("climate.trv1", cfg)
+        }
+        return mock_self
+
+    @pytest.mark.asyncio
+    async def test_matching_offset_confirms_immediately(self, caplog):
+        """A device already holding the written offset confirms at once."""
+        mock_self = self._mock_self()
+        durations, sleep_patch = _sleep_recorder()
+
+        with (
+            caplog.at_level(logging.WARNING, logger=_CTRL),
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-2.0)),
+            sleep_patch,
+        ):
+            result = await check_calibration(mock_self, "climate.trv1")
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+        assert 1 not in durations
+        assert caplog.records == []
+
+    @pytest.mark.asyncio
+    async def test_half_a_step_away_confirms(self):
+        """The device's own grid snap is a confirmation, not a miss."""
+        mock_self = self._mock_self(local_calibration_step=1.0)
+        durations, sleep_patch = _sleep_recorder()
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-2.5)),
+            sleep_patch,
+        ):
+            await check_calibration(mock_self, "climate.trv1")
+
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+        assert 1 not in durations
+
+    @pytest.mark.asyncio
+    async def test_offset_confirmed_after_a_delay_logs_no_warning(self, caplog):
+        """A late confirmation ends the wait without an annunciation."""
+        mock_self = self._mock_self()
+        reports = [-1.0, -1.0, -1.0, -2.0]
+        durations, sleep_patch = _sleep_recorder()
+
+        with (
+            caplog.at_level(logging.WARNING, logger=_CTRL),
+            patch(
+                f"{_CTRL}.get_current_offset",
+                new=AsyncMock(side_effect=lambda *_: reports.pop(0)),
+            ),
+            sleep_patch,
+        ):
+            await check_calibration(mock_self, "climate.trv1")
+
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+        assert durations.count(1) == 3
+        assert caplog.records == []
+
+    @pytest.mark.asyncio
+    async def test_unconfirmed_offset_times_out_and_still_releases(self, caplog):
+        """A device that never takes the offset releases the gate anyway.
+
+        The release is what paces the re-assert: the write gate only
+        re-sends once the flag is back, so an unacknowledged offset is
+        retried once per confirmation window, not once per cycle.
+        """
+        mock_self = self._mock_self()
+        durations, sleep_patch = _sleep_recorder()
+
+        with (
+            caplog.at_level(logging.WARNING, logger=_CTRL),
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-1.0)),
+            sleep_patch,
+        ):
+            result = await check_calibration(mock_self, "climate.trv1")
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+        assert durations.count(1) == WRITE_CONFIRM_TIMEOUT_S + 1
+        assert "did not confirm the calibration offset" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_unparseable_report_is_not_a_confirmation(self, caplog):
+        """A garbage reading confirms nothing and runs into the timeout."""
+        mock_self = self._mock_self()
+        durations, sleep_patch = _sleep_recorder()
+
+        with (
+            caplog.at_level(logging.WARNING, logger=_CTRL),
+            patch(
+                f"{_CTRL}.get_current_offset",
+                new=AsyncMock(return_value="not-a-number"),
+            ),
+            sleep_patch,
+        ):
+            await check_calibration(mock_self, "climate.trv1")
+
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+        assert durations.count(1) == WRITE_CONFIRM_TIMEOUT_S + 1
+        assert "did not confirm the calibration offset" in caplog.text
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("live_state", [None, STATE_UNAVAILABLE, STATE_UNKNOWN])
+    async def test_unreachable_trv_ends_the_wait(self, live_state):
+        """A TRV that dropped out cannot confirm; the gate opens regardless."""
+        mock_self = self._mock_self(live_state=live_state)
+        durations, sleep_patch = _sleep_recorder()
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-1.0)),
+            sleep_patch,
+        ):
+            result = await check_calibration(mock_self, "climate.trv1")
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+        assert 1 not in durations
+
+    @pytest.mark.asyncio
+    async def test_without_a_written_offset_the_wait_ends_at_once(self):
+        """Nothing was commanded, so there is nothing to confirm."""
+        mock_self = self._mock_self(last_calibration=None)
+        durations, sleep_patch = _sleep_recorder()
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-1.0)),
+            sleep_patch,
+        ):
+            await check_calibration(mock_self, "climate.trv1")
+
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+        assert 1 not in durations
+
+
+class TestCalibrationMatchTolerance:
+    """Tests for _calibration_match_tolerance()."""
+
+    @staticmethod
+    def _mock_self(step):
+        mock_self = MagicMock()
+        mock_self.device_name = "Test"
+        mock_self.real_trvs = {
+            "climate.trv1": Trv.from_legacy_dict(
+                "climate.trv1", {"local_calibration_step": step}
+            )
+        }
+        return mock_self
+
+    def test_step_yields_half_a_step(self):
+        """A snapped offset sits at most half a step from the command."""
+        tolerance = _calibration_match_tolerance(self._mock_self(1.0), "climate.trv1")
+        assert tolerance == pytest.approx(0.5, abs=1e-5)
+
+    def test_unusable_step_falls_back_to_the_base_tolerance(self):
+        """Without a usable step there is no grid to derive a tolerance from."""
+        tolerance = _calibration_match_tolerance(self._mock_self(0), "climate.trv1")
+        assert tolerance == RECONCILE_TOLERANCE_K
+
+    def test_step_below_the_base_tolerance_does_not_narrow_it(self):
+        """The read-back grid stays the floor for very fine offset steps."""
+        tolerance = _calibration_match_tolerance(self._mock_self(0.01), "climate.trv1")
+        assert tolerance == RECONCILE_TOLERANCE_K

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -842,6 +842,90 @@ class TestCheckCalibration:
         assert mock_self.real_trvs["climate.trv1"].calibration_received is True
 
 
+class TestCheckCalibrationGeneration:
+    """Only the watchdog of the command in flight may open the write gate."""
+
+    @pytest.mark.asyncio
+    async def test_superseded_watchdog_leaves_the_gate_closed(self, caplog):
+        """A newer command in flight keeps the channel closed."""
+        mock_self = TestCheckCalibration._mock_self(
+            last_calibration=-3.0, calibration_write_generation=2
+        )
+        durations, sleep_patch = _sleep_recorder()
+
+        with (
+            caplog.at_level(logging.WARNING, logger=_CTRL),
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-3.0)),
+            sleep_patch,
+        ):
+            result = await check_calibration(mock_self, "climate.trv1", 1)
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is False
+        assert caplog.records == []
+        assert durations == []
+
+    @pytest.mark.asyncio
+    async def test_superseded_watchdog_leaves_the_gate_closed_on_an_error(self):
+        """An adapter error in a superseded watchdog opens nothing either."""
+        mock_self = TestCheckCalibration._mock_self(
+            last_calibration=-3.0, calibration_write_generation=1
+        )
+
+        async def _supersede_then_raise(_self, _entity_id):
+            """Overtake this watchdog inside the poll it then fails on."""
+            mock_self.real_trvs["climate.trv1"].calibration_write_generation = 2
+            raise RuntimeError("adapter unavailable")
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=_supersede_then_raise),
+            pytest.raises(RuntimeError),
+        ):
+            await check_calibration(mock_self, "climate.trv1", 1)
+
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is False
+
+    @pytest.mark.asyncio
+    async def test_owning_watchdog_still_releases_the_gate(self):
+        """The watchdog of the command in flight releases as before."""
+        mock_self = TestCheckCalibration._mock_self(
+            last_calibration=-3.0, calibration_write_generation=2
+        )
+        _, sleep_patch = _sleep_recorder()
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-3.0)),
+            sleep_patch,
+        ):
+            result = await check_calibration(mock_self, "climate.trv1", 2)
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+
+    @pytest.mark.asyncio
+    async def test_superseded_mid_wait_stops_polling(self):
+        """A watchdog overtaken while waiting stops instead of timing out."""
+        mock_self = TestCheckCalibration._mock_self(
+            last_calibration=-3.0, calibration_write_generation=1
+        )
+        durations, sleep_patch = _sleep_recorder()
+        polls = []
+
+        async def _get_offset(_self, _entity_id):
+            polls.append(len(polls))
+            if len(polls) == 3:
+                mock_self.real_trvs["climate.trv1"].calibration_write_generation = 2
+            return 0.0
+
+        with patch(f"{_CTRL}.get_current_offset", new=_get_offset), sleep_patch:
+            result = await check_calibration(mock_self, "climate.trv1", 1)
+
+        assert result is True
+        assert len(polls) == 3
+        assert durations.count(1) == 3
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is False
+
+
 class TestCalibrationMatchTolerance:
     """Tests for _calibration_match_tolerance()."""
 

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -887,7 +887,7 @@ class TestCheckCalibrationGeneration:
 
     @pytest.mark.asyncio
     async def test_owning_watchdog_still_releases_the_gate(self):
-        """The watchdog of the command in flight releases as before."""
+        """The watchdog whose generation is still current releases the gate."""
         mock_self = TestCheckCalibration._mock_self(
             last_calibration=-3.0, calibration_write_generation=2
         )

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -806,6 +806,40 @@ class TestCheckCalibration:
         assert mock_self.real_trvs["climate.trv1"].calibration_received is True
         assert 1 not in durations
 
+    @pytest.mark.asyncio
+    async def test_adapter_error_still_releases_the_write_gate(self):
+        """An adapter raising mid-poll does not wedge the offset channel.
+
+        The offset write only goes out while calibration_received is
+        True, so a watchdog that ended without releasing it would
+        silence the channel for the lifetime of the entity.
+        """
+        mock_self = self._mock_self()
+
+        async def _raise(_self, _entity_id):
+            raise RuntimeError("adapter unavailable")
+
+        with patch(f"{_CTRL}.get_current_offset", new=_raise):
+            with pytest.raises(RuntimeError):
+                await check_calibration(mock_self, "climate.trv1")
+
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+
+    @pytest.mark.asyncio
+    async def test_cancellation_still_releases_the_write_gate(self):
+        """A cancelled watchdog leaves the offset channel writable."""
+        mock_self = self._mock_self()
+
+        with patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=0.0)):
+            task = asyncio.create_task(check_calibration(mock_self, "climate.trv1"))
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+
 
 class TestCalibrationMatchTolerance:
     """Tests for _calibration_match_tolerance()."""

--- a/tests/unit/test_adapter_offset_contract.py
+++ b/tests/unit/test_adapter_offset_contract.py
@@ -1,0 +1,104 @@
+"""Every adapter answers a calibration offset write with a plain boolean.
+
+The delegate keys the confirmation watchdog and the recorded intent on that
+answer, so it has to separate "the write went out" from "this device has no
+offset channel". A written offset cannot carry that: the legitimate value
+0.0 reads the same as a device that wrote nothing.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.adapters import (
+    deconz,
+    generic,
+    mqtt,
+    tado,
+    zwave_js,
+)
+from custom_components.better_thermostat.trv import Trv
+
+ENTITY_ID = "climate.trv"
+CALIBRATION_ENTITY = "number.trv_local_temperature_calibration"
+
+# Adapters that write through a discovered number entity, and therefore have
+# an unsupported path when discovery found none.
+ENTITY_ADAPTERS = (generic, mqtt, zwave_js)
+# Adapters whose offset rides on the ecosystem's own service call.
+SERVICE_ADAPTERS = (deconz, tado)
+
+
+def _mock_self(calibration_entity=CALIBRATION_ENTITY):
+    """Build a thermostat whose service calls are recorded, not executed.
+
+    Parameters
+    ----------
+    calibration_entity : str or None
+        Entity ID of the discovered calibration number entity, or None to
+        model a TRV for which discovery found none.
+
+    Returns
+    -------
+    MagicMock
+        A stand-in for the Better Thermostat climate entity instance.
+    """
+    mock_self = MagicMock()
+    mock_self.device_name = "Test BT"
+    mock_self.context = None
+    mock_self.hass = MagicMock()
+    mock_self.hass.services.async_call = AsyncMock()
+    mock_self.hass.states.get = lambda requested: (
+        State(CALIBRATION_ENTITY, "0.0", {"min": -5.0, "max": 5.0, "step": 0.5})
+        if requested == CALIBRATION_ENTITY
+        else State(ENTITY_ID, "heat", {"offset": 0.0, "offset_celsius": 0.0})
+    )
+    trv = Trv(entity_id=ENTITY_ID)
+    trv.local_temperature_calibration_entity = calibration_entity
+    trv.local_calibration_min = -5.0
+    trv.local_calibration_max = 5.0
+    mock_self.real_trvs = {ENTITY_ID: trv}
+    return mock_self
+
+
+class TestOffsetWriteReportsTrue:
+    """A write that went out is reported as one, whatever value it carried."""
+
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS + SERVICE_ADAPTERS)
+    @pytest.mark.parametrize("offset", [0.0, -2.5])
+    @pytest.mark.asyncio
+    async def test_write_reports_true(self, adapter, offset):
+        """The answer is True, not the offset that was written."""
+        mock_self = _mock_self()
+
+        result = await adapter.set_offset(mock_self, ENTITY_ID, offset)
+
+        assert result is True
+        assert mock_self.hass.services.async_call.await_count == 1
+
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS + SERVICE_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_written_offset_is_recorded_as_the_command(self, adapter):
+        """The value that went on the wire is kept apart from the answer."""
+        mock_self = _mock_self()
+
+        await adapter.set_offset(mock_self, ENTITY_ID, -2.5)
+
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration == -2.5
+
+
+class TestNoOffsetChannelReportsFalse:
+    """A TRV without a calibration entity gets no write and no false claim."""
+
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_missing_calibration_entity_reports_false(self, adapter):
+        """Nothing is written and nothing is claimed to have been."""
+        mock_self = _mock_self(calibration_entity=None)
+
+        result = await adapter.set_offset(mock_self, ENTITY_ID, -2.0)
+
+        assert result is False
+        mock_self.hass.services.async_call.assert_not_awaited()
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration is None

--- a/tests/unit/test_adapter_offset_contract.py
+++ b/tests/unit/test_adapter_offset_contract.py
@@ -22,6 +22,10 @@ from custom_components.better_thermostat.trv import Trv
 
 ENTITY_ID = "climate.trv"
 CALIBRATION_ENTITY = "number.trv_local_temperature_calibration"
+SELECT_CALIBRATION_ENTITY = "select.trv_local_temperature_calibration"
+# A calibration select whose options sit on a 3 K grid, so a request that
+# falls between two of them reaches the device as a neighbouring option.
+SELECT_OPTIONS = ["-6.0k", "-3.0k", "0.0k", "3.0k", "6.0k"]
 
 # Adapters that write through a discovered number entity, and therefore have
 # an unsupported path when discovery found none.
@@ -86,6 +90,97 @@ class TestOffsetWriteReportsTrue:
         await adapter.set_offset(mock_self, ENTITY_ID, -2.5)
 
         assert mock_self.real_trvs[ENTITY_ID].last_calibration == -2.5
+
+
+def _mock_self_with_select(options=SELECT_OPTIONS):
+    """Build a thermostat whose calibration entity is a select.
+
+    Parameters
+    ----------
+    options : list of str
+        Options the select entity offers, as it publishes them.
+
+    Returns
+    -------
+    MagicMock
+        A stand-in for the Better Thermostat climate entity instance.
+    """
+    mock_self = MagicMock()
+    mock_self.device_name = "Test BT"
+    mock_self.context = None
+    mock_self.hass = MagicMock()
+    mock_self.hass.services.async_call = AsyncMock()
+    mock_self.hass.states.get = lambda requested: (
+        State(SELECT_CALIBRATION_ENTITY, "0.0k", {"options": list(options)})
+        if requested == SELECT_CALIBRATION_ENTITY
+        else State(ENTITY_ID, "heat", {})
+    )
+    trv = Trv(entity_id=ENTITY_ID)
+    trv.local_temperature_calibration_entity = SELECT_CALIBRATION_ENTITY
+    mock_self.real_trvs = {ENTITY_ID: trv}
+    return mock_self
+
+
+def _selected_option(mock_self):
+    """Return the option the recorded service call carried."""
+    return mock_self.hass.services.async_call.await_args.args[2]["option"]
+
+
+class TestSelectOffsetRecordsWhatItSelected:
+    """A select write records the offset the chosen option carries.
+
+    The confirmation compares the device's report against the recorded
+    command, so a command that never went on the wire would leave the two
+    permanently apart and re-assert the write every cycle.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_request_between_options_reaches_the_closest_one(self):
+        """The option nearest the request is what the device is told."""
+        mock_self = _mock_self_with_select()
+
+        result = await generic.set_offset(mock_self, ENTITY_ID, -2.0)
+
+        assert result is True
+        assert _selected_option(mock_self) == "-3.0k"
+
+    @pytest.mark.asyncio
+    async def test_the_snapped_option_is_the_recorded_command(self):
+        """The command is the snapped option's value, not the request."""
+        mock_self = _mock_self_with_select()
+
+        await generic.set_offset(mock_self, ENTITY_ID, -2.0)
+
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration == -3.0
+
+    @pytest.mark.asyncio
+    async def test_the_adapter_leaves_the_requested_intent_alone(self):
+        """Recording the intent stays the delegate's business."""
+        mock_self = _mock_self_with_select()
+
+        await generic.set_offset(mock_self, ENTITY_ID, -2.0)
+
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration_requested is None
+
+    @pytest.mark.asyncio
+    async def test_an_offered_option_is_recorded_as_it_is(self):
+        """A request the select offers verbatim needs no correction."""
+        mock_self = _mock_self_with_select()
+
+        await generic.set_offset(mock_self, ENTITY_ID, -3.0)
+
+        assert _selected_option(mock_self) == "-3.0k"
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration == -3.0
+
+    @pytest.mark.asyncio
+    async def test_the_option_format_decides_the_command(self):
+        """An option carries one decimal, so that is what was commanded."""
+        mock_self = _mock_self_with_select(options=["-2.3k", "-2.2k"])
+
+        await generic.set_offset(mock_self, ENTITY_ID, -2.26)
+
+        assert _selected_option(mock_self) == "-2.3k"
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration == -2.3
 
 
 class TestNoOffsetChannelReportsFalse:

--- a/tests/unit/test_delegate_set_offset.py
+++ b/tests/unit/test_delegate_set_offset.py
@@ -3,6 +3,9 @@
 ``last_calibration_requested`` is the offset asked for; the adapter
 records the value it actually put on the wire in ``last_calibration``.
 Only a write the adapter accepted counts as either.
+
+Both records, and the True the caller arms its confirmation watchdog on,
+follow the adapter's boolean answer: only a write that went out counts.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -53,6 +56,26 @@ async def test_failed_write_records_nothing(bt):
 
     assert result is False
     assert bt.real_trvs[ENTITY_ID].last_calibration_requested is None
+
+
+@pytest.mark.asyncio
+async def test_device_without_an_offset_channel_records_nothing(bt):
+    """An adapter that wrote nothing arms neither the gate nor the record."""
+    bt.real_trvs[ENTITY_ID].adapter.set_offset = AsyncMock(return_value=False)
+
+    result = await set_offset(bt, ENTITY_ID, -2.0)
+
+    assert result is False
+    assert bt.real_trvs[ENTITY_ID].last_calibration_requested is None
+
+
+@pytest.mark.asyncio
+async def test_a_written_zero_offset_is_still_a_write(bt):
+    """The answer, not the value written, decides what counts as a command."""
+    result = await set_offset(bt, ENTITY_ID, 0.0)
+
+    assert result is True
+    assert bt.real_trvs[ENTITY_ID].last_calibration_requested == 0.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_delegate_set_offset.py
+++ b/tests/unit/test_delegate_set_offset.py
@@ -16,6 +16,10 @@ from custom_components.better_thermostat.adapters.delegate import set_offset
 from custom_components.better_thermostat.trv import Trv
 
 ENTITY_ID = "climate.trv"
+# The retry decorator doubles a one-second base delay per attempt.
+RETRY_BACKOFF_S = [1.0, 2.0, 4.0, 8.0, 16.0]
+# The decorator spreads each delay by up to 20 % in either direction.
+RETRY_JITTER = 0.2
 
 
 @pytest.fixture
@@ -45,17 +49,30 @@ async def test_failed_write_records_nothing(bt):
     """An adapter raising on every retry leaves the intent unrecorded.
 
     A recorded intent would suppress the retry on the next cycle for a
-    write that never left the house.
+    write that never left the house. The backoff between the attempts is
+    recorded rather than slept through, so the retry schedule is asserted
+    without spending it.
     """
     bt.real_trvs[ENTITY_ID].adapter.set_offset = AsyncMock(
         side_effect=ConnectionError("boom")
     )
+    delays = []
 
-    with patch("asyncio.sleep", new=AsyncMock()):
+    async def _record_delay(seconds):
+        delays.append(seconds)
+
+    with patch("asyncio.sleep", new=_record_delay):
         result = await set_offset(bt, ENTITY_ID, -2.0)
 
     assert result is False
     assert bt.real_trvs[ENTITY_ID].last_calibration_requested is None
+    assert (
+        bt.real_trvs[ENTITY_ID].adapter.set_offset.await_count
+        == len(RETRY_BACKOFF_S) + 1
+    )
+    assert len(delays) == len(RETRY_BACKOFF_S)
+    for actual, base in zip(delays, RETRY_BACKOFF_S, strict=True):
+        assert base * (1 - RETRY_JITTER) <= actual <= base * (1 + RETRY_JITTER)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_delegate_set_offset.py
+++ b/tests/unit/test_delegate_set_offset.py
@@ -1,0 +1,74 @@
+"""The delegate's set_offset separates the intent from the command.
+
+``last_calibration_requested`` is the offset asked for; the adapter
+records the value it actually put on the wire in ``last_calibration``.
+Only a write the adapter accepted counts as either.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.adapters.delegate import set_offset
+from custom_components.better_thermostat.trv import Trv
+
+ENTITY_ID = "climate.trv"
+
+
+@pytest.fixture
+def bt():
+    """Mock thermostat whose adapter accepts every offset write."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.hass = MagicMock()
+    trv = Trv(entity_id=ENTITY_ID, local_calibration_min=-3.0)
+    trv.adapter = MagicMock()
+    trv.adapter.set_offset = AsyncMock(return_value=True)
+    mock.real_trvs = {ENTITY_ID: trv}
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_accepted_write_records_the_requested_offset(bt):
+    """A successful write reports success and remembers what was asked for."""
+    result = await set_offset(bt, ENTITY_ID, -2.0)
+
+    assert result is True
+    assert bt.real_trvs[ENTITY_ID].last_calibration_requested == -2.0
+
+
+@pytest.mark.asyncio
+async def test_failed_write_records_nothing(bt):
+    """An adapter raising on every retry leaves the intent unrecorded.
+
+    A recorded intent would suppress the retry on the next cycle for a
+    write that never left the house.
+    """
+    bt.real_trvs[ENTITY_ID].adapter.set_offset = AsyncMock(
+        side_effect=ConnectionError("boom")
+    )
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        result = await set_offset(bt, ENTITY_ID, -2.0)
+
+    assert result is False
+    assert bt.real_trvs[ENTITY_ID].last_calibration_requested is None
+
+
+@pytest.mark.asyncio
+async def test_clamped_write_keeps_intent_and_command_apart(bt):
+    """An adapter clamping to its minimum records both values."""
+
+    async def _clamping_set_offset(_self, entity_id, offset):
+        trv = bt.real_trvs[entity_id]
+        trv.last_calibration = max(offset, trv.local_calibration_min)
+        return True
+
+    bt.real_trvs[ENTITY_ID].adapter.set_offset = AsyncMock(
+        side_effect=_clamping_set_offset
+    )
+
+    await set_offset(bt, ENTITY_ID, -5.0)
+
+    assert bt.real_trvs[ENTITY_ID].last_calibration == -3.0
+    assert bt.real_trvs[ENTITY_ID].last_calibration_requested == -5.0

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -638,3 +638,68 @@ class TestValveWriteBudget:
         bt.clock.advance(30.0)
         _, set_valve = await self._run(bt, percent=60)
         set_valve.assert_called_once()
+
+
+class TestOffsetReconcileHandoff:
+    """What the reconciler calls a divergence, the write path re-asserts.
+
+    Both sides compare the device's report against the value last
+    written, with the same tolerance, so a queued cycle is not a no-op
+    that leaves the tick re-queueing forever.
+    """
+
+    def _diverged_offset_bt(self):
+        bt = _control_bt()
+        trv = bt.real_trvs["climate.trv"]
+        trv.advanced = {
+            "calibration_mode": CalibrationMode.DEFAULT,
+            "calibration": CalibrationType.LOCAL_BASED,
+            "no_off_system_mode": False,
+        }
+        trv.local_temperature_calibration_entity = "number.offset"
+        trv.local_calibration_step = 0.5
+        trv.last_calibration = 2.0
+        trv.last_calibration_requested = 2.0
+        trv.calibration_received = True
+
+        trv_state = bt.hass.states.get.return_value
+        offset_state = Mock()
+        offset_state.state = "0.0"
+        offset_state.attributes = {}
+        bt.hass.states.get.side_effect = lambda entity_id: (
+            offset_state if entity_id == "number.offset" else trv_state
+        )
+        return bt
+
+    @pytest.mark.asyncio
+    async def test_diverged_offset_queues_a_cycle(self):
+        """A confirmed offset the device dropped is a divergence."""
+        bt = self._diverged_offset_bt()
+        await reconcile_tick(bt)
+        bt.control_queue_task.put_nowait.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_the_queued_cycle_rewrites_the_offset(self):
+        """The cycle the tick asks for actually re-sends the offset."""
+        bt = self._diverged_offset_bt()
+        with (
+            patch(f"{_CTRL}.convert_outbound_states") as conv,
+            patch(f"{_CTRL}._get_valve_control", return_value=(None, None)),
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=0.0)),
+            patch(f"{_CTRL}.set_offset", new=AsyncMock(return_value=True)) as set_off,
+            patch(f"{_CTRL}.set_temperature", new=AsyncMock()),
+            patch(f"{_CTRL}.set_hvac_mode", new=AsyncMock()),
+            patch(f"{_CTRL}.override_set_hvac_mode", new=AsyncMock(return_value=False)),
+            patch(
+                f"{_CTRL}.override_set_temperature", new=AsyncMock(return_value=False)
+            ),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            conv.return_value = {
+                "temperature": 21.0,
+                "local_temperature_calibration": 2.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            await control_trv(bt, "climate.trv")
+
+        set_off.assert_awaited_once_with(bt, "climate.trv", 2.0)

--- a/tests/unit/test_trv_object.py
+++ b/tests/unit/test_trv_object.py
@@ -21,6 +21,8 @@ class TestTypedAccess:
         assert trv.calibration_received is True
         assert trv.ignore_trv_states is False
         assert trv.current_temperature is None
+        assert trv.last_calibration is None
+        assert trv.last_calibration_requested is None
         assert trv.advanced == {}
         assert trv.extra == {}
 
@@ -59,6 +61,16 @@ class TestExtraScratchpad:
         assert trv.current_temperature == 21.0
         assert trv.advanced == {"child_lock": True}
         assert trv.extra == {"_quirk_scratch": 3}
+
+    def test_from_legacy_dict_maps_the_requested_calibration(self):
+        """The pre-clamp offset intent is a typed field, not a scratch key."""
+        trv = Trv.from_legacy_dict(
+            "climate.trv",
+            {"last_calibration": -3.0, "last_calibration_requested": -5.0},
+        )
+        assert trv.last_calibration == -3.0
+        assert trv.last_calibration_requested == -5.0
+        assert trv.extra == {}
 
     def test_from_legacy_dict_explicit_entity_id_wins(self):
         """An ``entity_id`` key in the dict yields to the explicit argument."""


### PR DESCRIPTION
Fixes #2174 on the `v2` line. The twin PR against `develop` is on branch `fix/calibration-write-reassert`.

## Symptom

On a floor-heating thermostat the reporter's log stops producing `TO TRV set_local_temperature_calibration` lines entirely. BT keeps computing a new offset every cycle, the device keeps its old one, and the room drifts. Nothing recovers without a restart.

## Mechanism

The offset channel tracked two values where it needs three:

* `_calibration`: what BT wants this cycle (INTENT)
* `real_trvs[x].last_calibration`: what the adapter actually put on the wire after its own min/max clamp (COMMAND)
* the number entity's value, read a few lines above as `_current_calibration` (REPORT)

The gate compared INTENT against COMMAND and never looked at REPORT, and it only ran at all while `calibration_received is True`. That flag is cleared on every write and, for offsets, was only ever restored by `events/trv.py`, which re-reads the offset solely for `calibration == 0` (TARGET_TEMP_BASED under the `climate.py` encoding), i.e. never for an offset-based TRV. The two consequences:

* a write whose service call raised was swallowed by `delegate.set_offset`, yet the flag had already been cleared, so the channel is wedged for the lifetime of the entity;
* a write the device silently dropped was invisible, because the gate compared against BT's own record of what it sent, never against what the device reports.

On `v2` there are three things around that gate, none of which closes the gap: `_through_safety_hull(..., offset=...)` only clamps; the per-TRV write budget retries a write the *budget* deferred, not one the *device* dropped; and `_offset_diverges` does compare against the read-back but returns early on `calibration_received is not True`, blind in exactly the reported case. `v2` therefore has an extra symptom: once the flag does get healed, `reconcile_tick` detects the divergence and queues a control cycle whose write gate then refuses to write, every five minutes, forever.

## What this changes

* **Three-value gate.** REPORT vs COMMAND decides confirmation and divergence; INTENT vs the recorded pre-clamp intent decides whether something new needs sending. A confirmed report releases `calibration_received` (this subsumes the old `< 0.5` self-heal and re-targets it from the intent to the command); a diverged report re-asserts the command.
* **`last_calibration_requested`** on `Trv`: the value asked for before the adapter's clamp. Without it, a device resting at a limit it declared would be rewritten on every cycle. The executed counter-example writes 10 times in 10 cycles.
* **`delegate.set_offset` returns `bool`** and records the intent only on success, so a failed write no longer closes the gate or arms a watchdog. `control_trv` is the only caller on both lines.
* **`check_calibration`**, the offset channel's confirmation watchdog, modelled member-for-member on `check_system_mode` / `check_target_temperature`, all three now sharing the extracted `WRITE_CONFIRM_TIMEOUT_S = 360`. It guarantees the in-flight flag comes back, and because the write is gated on that flag, it *is* the resend pacer: a device that acknowledges nothing gets one re-assert per ~362 s (further paced by the 30 s offset budget), not one per cycle. That is strictly gentler than the setpoint path, which re-sends on every cycle while `matches_any_setpoint` fails.
* **Tolerance = half the device's own offset step**, floored at `RECONCILE_TOLERANCE_K`, extracted into `_calibration_match_tolerance`. The old `0.5` literal is merely the `Trv` dataclass default and is wrong in both directions: on a 0.1-step device it hides a 0.4 K error, on a 1.0-step deconz device it rejects a legitimate half-step snap. `_offset_diverges` now calls the same helper, keeping its current numbers, so the reconciler and the write path agree on what a divergence is: a queued reconcile cycle actually writes.

## Deliberately not changed

* `events/trv.py` stays as it is, including the `trv.calibration == 0` branch that re-reads `last_calibration` for the wrong calibration type. That looks like an off-by-one worth fixing but must not be fixed here: refreshing `last_calibration` from the device's report would collapse COMMAND into REPORT and kill the divergence arm silently. Separate ticket.
* The ack path in `events/trv.py` stays as a second, faster confirmation route alongside the watchdog.
* No new keepalive: `v2` keeps its existing `reconcile_tick` and write budget; the only new periodic traffic is the watchdog-paced re-assert.
* Unchanged: `calibration.py`'s integrator, the startup-only read of `local_calibration_min/max/step`, every adapter's habit of returning `0.0` for an unavailable calibration entity, and the identical structural exposure on the setpoint channel (whose two clamp sources agree today, so it is not producing a bug).

## Clamp vs. dropped write

A *declared*-range clamp is not re-asserted: mqtt/generic re-read the entity's live min/max on every write, so `last_calibration` equals what the device holds, the report confirms it, and the pre-clamp intent keeps the intent arm quiet. An *undeclared* firmware limit is by construction indistinguishable from a dropped write; there the change deliberately re-asserts, bounded by the watchdog window, and each attempt logs the existing "did not confirm ... giving up and assuming applied" warning that tells the user which of the two it is. That is new WARNING volume on such devices.

## Verification

* Full suite: 4395 passed (baseline on `origin/v2`: 4363; +32 new tests, no regressions). `ruff check`, `ruff format --check`, `pyrefly check` clean.
* Counterfactual executed by stashing the three production files and re-running: 16 of the new/rewritten tests fail without them, including the #2174 regression (`set_offset` awaited 0 times), the dropped-write re-assert, the delegate's intent bookkeeping, and the reconcile→write handoff; `tests/unit/controlling/test_helpers.py` fails to import at all (`WRITE_CONFIRM_TIMEOUT_S`).
* Two existing tests changed semantics and were rewritten, not patched around: `test_calibration_received_stays_false_when_mismatch` (its assertion *was* the stall: the device confirmably holds what it was told while BT wants something else, which is precisely when a write must go out) and `test_calibration_tolerance_within_half_degree` (a report 0.3 off the command with a 0.5 step is no longer "confirmed"; the window is now ±0.25, and the rewrite is parametrised over the step). A reviewer seeing those two turn red on the old code should read it as the fix landing.
* `tests/unit/test_reconciler.py`'s existing offset tests, including `test_unconfirmed_offset_write_is_left_to_the_write_path`, still pass unchanged; two new ones pin that a divergence both queues a cycle and gets written by it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat calibration-offset handling across supported integrations.
  * Clearly distinguishes requested, device-adjusted, and reported calibration values.
  * Prevents duplicate writes and safely retries or recovers when devices are unavailable.
  * Added confirmation monitoring to detect successful, delayed, superseded, or failed calibration updates.
  * Improved handling of unsupported calibration controls and zero-value offsets.

* **Tests**
  * Expanded coverage for calibration writes, retries, device rounding, tolerance matching, timeouts, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->