### PR TITLE
fix: re-assert an unconfirmed local calibration offset

### DIFF
--- a/custom_components/better_thermostat/adapters/deconz.py
+++ b/custom_components/better_thermostat/adapters/deconz.py
@@ -79,8 +79,24 @@ async def get_max_offset(self, entity_id):
     return 6
 
 
-async def set_offset(self, entity_id, offset):
-    """Set new target offset."""
+async def set_offset(self, entity_id, offset) -> bool:
+    """Write a calibration offset through the deCONZ configure service.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV to write to
+    offset : float
+        Calibration offset in Kelvin
+
+    Returns
+    -------
+    bool
+        True once the write went out. The offset rides on the TRV's own
+        service call, so every deCONZ TRV has the channel.
+    """
     await self.hass.services.async_call(
         "deconz",
         "configure",
@@ -89,6 +105,7 @@ async def set_offset(self, entity_id, offset):
         context=self.context,
     )
     self.real_trvs[entity_id].last_calibration = offset
+    return True
 
 
 async def set_valve(self, entity_id, valve):

--- a/custom_components/better_thermostat/adapters/delegate.py
+++ b/custom_components/better_thermostat/adapters/delegate.py
@@ -177,9 +177,16 @@ async def set_hvac_mode(self, entity_id, hvac_mode):
 async def set_offset(self, entity_id, offset) -> bool:
     """Set new target offset.
 
-    The requested value is recorded on success only, so a write that never
-    left the house neither counts as an issued command nor suppresses the
-    retry on the next control cycle.
+    An adapter answers ``True`` once the offset write went out and ``False``
+    when the device has no offset channel to write to. Only ``True`` counts
+    as a command in flight: it is what records the requested value and what
+    tells the caller to arm the confirmation watchdog. The written offset
+    itself is not a usable answer, because the legitimate value 0.0 reads
+    the same as a device that wrote nothing.
+
+    The requested value is recorded on a write only, so a command that never
+    left the house neither counts as issued nor suppresses the retry on the
+    next control cycle.
 
     Parameters
     ----------
@@ -194,8 +201,8 @@ async def set_offset(self, entity_id, offset) -> bool:
     Returns
     -------
     bool
-        True when the adapter accepted the write, False when every retry
-        raised.
+        True when the adapter put the offset on the wire, False when the
+        device has no offset channel or every retry raised.
     """
 
     @async_retry(retries=5)
@@ -205,11 +212,19 @@ async def set_offset(self, entity_id, offset) -> bool:
         )
 
     try:
-        await inner()
+        wrote = await inner()
     except Exception:
         _LOGGER.warning(
             "better_thermostat %s: set_local_temperature_calibration for %s failed; "
             "will retry on the next cycle",
+            getattr(self, "device_name", "unknown"),
+            entity_id,
+        )
+        return False
+    if wrote is not True:
+        _LOGGER.debug(
+            "better_thermostat %s: %s has no calibration offset channel, "
+            "nothing was written",
             getattr(self, "device_name", "unknown"),
             entity_id,
         )

--- a/custom_components/better_thermostat/adapters/delegate.py
+++ b/custom_components/better_thermostat/adapters/delegate.py
@@ -174,8 +174,29 @@ async def set_hvac_mode(self, entity_id, hvac_mode):
     )
 
 
-async def set_offset(self, entity_id, offset):
-    """Set new target offset."""
+async def set_offset(self, entity_id, offset) -> bool:
+    """Set new target offset.
+
+    The requested value is recorded on success only, so a write that never
+    left the house neither counts as an issued command nor suppresses the
+    retry on the next control cycle.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance.
+    entity_id : str
+        Entity id of the TRV to write the offset to.
+    offset : float
+        Calibration offset to request, before the adapter's own clamp to the
+        device's declared offset range.
+
+    Returns
+    -------
+    bool
+        True when the adapter accepted the write, False when every retry
+        raised.
+    """
 
     @async_retry(retries=5)
     async def inner():
@@ -184,9 +205,17 @@ async def set_offset(self, entity_id, offset):
         )
 
     try:
-        return await inner()
+        await inner()
     except Exception:
-        return None
+        _LOGGER.warning(
+            "better_thermostat %s: set_local_temperature_calibration for %s failed; "
+            "will retry on the next cycle",
+            getattr(self, "device_name", "unknown"),
+            entity_id,
+        )
+        return False
+    self.real_trvs[entity_id].last_calibration_requested = float(offset)
+    return True
 
 
 @async_retry(retries=5)

--- a/custom_components/better_thermostat/adapters/generic.py
+++ b/custom_components/better_thermostat/adapters/generic.py
@@ -22,6 +22,26 @@ from .base import wait_for_calibration_entity_or_timeout
 _LOGGER = logging.getLogger(__name__)
 
 
+def _option_to_offset(option) -> float | None:
+    """Read the offset an option of a select-backed calibration entity carries.
+
+    Parameters
+    ----------
+    option : str
+        Option as the entity publishes it, with or without the Kelvin
+        suffix (e.g. ``"-1.5k"``).
+
+    Returns
+    -------
+    float or None
+        Offset in Kelvin, or None when the option carries no number.
+    """
+    try:
+        return float(str(option).replace("k", ""))
+    except ValueError, TypeError:
+        return None
+
+
 async def get_info(self, entity_id):
     """Get info from TRV."""
     support_offset = False
@@ -250,25 +270,28 @@ async def set_offset(self, entity_id, offset) -> bool:
             # Validate and snap to closest matching option if needed
             if options:
                 if option_value not in options:
-                    try:
-                        # Parse all options and find the closest match
-                        parsed_options = {}
-                        for opt in options:
-                            try:
-                                parsed_options[opt] = float(str(opt).replace("k", ""))
-                            except ValueError, TypeError:
-                                continue
+                    # Parse all options and find the closest match
+                    parsed_options = {}
+                    for opt in options:
+                        parsed = _option_to_offset(opt)
+                        if parsed is not None:
+                            parsed_options[opt] = parsed
 
-                        if parsed_options:
-                            # Find option with minimum distance to target offset
-                            closest_option = min(
-                                parsed_options,
-                                key=lambda opt: abs(parsed_options[opt] - offset),
-                            )
-                            option_value = closest_option
-                    except ValueError, TypeError:
-                        # If parsing fails, keep original option_value and hope for the best
-                        pass
+                    if parsed_options:
+                        # Find option with minimum distance to target offset
+                        closest_option = min(
+                            parsed_options,
+                            key=lambda opt: abs(parsed_options[opt] - offset),
+                        )
+                        option_value = closest_option
+
+            # The option carries the value that goes on the wire, and the
+            # confirmation compares the device's report against it. Both the
+            # snap onto the option list and the one-decimal format move the
+            # value, so the command is read back off the option itself.
+            commanded = _option_to_offset(option_value)
+            if commanded is not None:
+                offset = commanded
 
             await self.hass.services.async_call(
                 "select",

--- a/custom_components/better_thermostat/adapters/generic.py
+++ b/custom_components/better_thermostat/adapters/generic.py
@@ -202,8 +202,24 @@ async def set_hvac_mode(self, entity_id, hvac_mode):
         )
 
 
-async def set_offset(self, entity_id, offset):
-    """Set new target offset."""
+async def set_offset(self, entity_id, offset) -> bool:
+    """Write a calibration offset to the discovered calibration entity.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV to write to
+    offset : float
+        Calibration offset in Kelvin, clamped to the device's declared range
+
+    Returns
+    -------
+    bool
+        True once the write went out, False when no calibration entity was
+        discovered for this TRV and there is nothing to write to.
+    """
     if self.real_trvs[entity_id].local_temperature_calibration_entity is not None:
         max_calibration = await get_max_offset(self, entity_id)
         min_calibration = await get_min_offset(self, entity_id)
@@ -281,9 +297,9 @@ async def set_offset(self, entity_id, offset):
                 self, entity_id, self.real_trvs[entity_id].last_hvac_mode
             )
 
-        return offset
+        return True
     else:
-        return  # Not supported
+        return False
 
 
 async def set_valve(self, entity_id, valve):

--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -162,8 +162,27 @@ async def get_max_offset(self, entity_id):
     return float(str(state.attributes.get("max", 10)))
 
 
-async def set_offset(self, entity_id, offset):
-    """Set new target offset."""
+async def set_offset(self, entity_id, offset) -> bool:
+    """Write a calibration offset to the discovered calibration entity.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV to write to
+    offset : float
+        Calibration offset in Kelvin, clamped to the device's declared range
+
+    Returns
+    -------
+    bool
+        True once the write went out, False when no calibration entity was
+        discovered for this TRV and there is nothing to write to.
+    """
+    if self.real_trvs[entity_id].local_temperature_calibration_entity is None:
+        return False
+
     max_calibration = await get_max_offset(self, entity_id)
     min_calibration = await get_min_offset(self, entity_id)
 
@@ -186,9 +205,10 @@ async def set_offset(self, entity_id, offset):
         and self.real_trvs[entity_id].last_hvac_mode != "off"
     ):
         await asyncio.sleep(3)
-        return await generic_set_hvac_mode(
+        await generic_set_hvac_mode(
             self, entity_id, self.real_trvs[entity_id].last_hvac_mode
         )
+    return True
 
 
 async def set_valve(self, entity_id, valve):

--- a/custom_components/better_thermostat/adapters/tado.py
+++ b/custom_components/better_thermostat/adapters/tado.py
@@ -72,8 +72,24 @@ async def get_max_offset(self, entity_id):
     return 10
 
 
-async def set_offset(self, entity_id, offset):
-    """Set new target offset."""
+async def set_offset(self, entity_id, offset) -> bool:
+    """Write a calibration offset through the Tado offset service.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV to write to
+    offset : float
+        Calibration offset in Kelvin, clamped to the range Tado accepts
+
+    Returns
+    -------
+    bool
+        True once the write went out. The offset rides on the TRV's own
+        service call, so every Tado TRV has the channel.
+    """
     offset = min(10, offset)
     offset = max(-10, offset)
     await self.hass.services.async_call(
@@ -84,6 +100,7 @@ async def set_offset(self, entity_id, offset):
         context=self.context,
     )
     self.real_trvs[entity_id].last_calibration = offset
+    return True
 
 
 async def set_valve(self, entity_id, valve):

--- a/custom_components/better_thermostat/adapters/zwave_js.py
+++ b/custom_components/better_thermostat/adapters/zwave_js.py
@@ -178,10 +178,26 @@ async def set_hvac_mode(self, entity_id, hvac_mode):
     return await generic_set_hvac_mode(self, entity_id, hvac_mode)
 
 
-async def set_offset(self, entity_id, offset):
-    """Set new target offset."""
+async def set_offset(self, entity_id, offset) -> bool:
+    """Write a calibration offset to the discovered calibration entity.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV to write to
+    offset : float
+        Calibration offset in Kelvin, clamped to the device's declared range
+
+    Returns
+    -------
+    bool
+        True once the write went out, False when no calibration entity was
+        discovered for this TRV and there is nothing to write to.
+    """
     if self.real_trvs[entity_id].local_temperature_calibration_entity is None:
-        return  # Not supported
+        return False
 
     max_calibration = await get_max_offset(self, entity_id)
     min_calibration = await get_min_offset(self, entity_id)
@@ -205,10 +221,10 @@ async def set_offset(self, entity_id, offset):
         and self.real_trvs[entity_id].last_hvac_mode != "off"
     ):
         await asyncio.sleep(3)
-        return await generic_set_hvac_mode(
+        await generic_set_hvac_mode(
             self, entity_id, self.real_trvs[entity_id].last_hvac_mode
         )
-    return offset
+    return True
 
 
 async def set_valve(self, entity_id, valve):

--- a/custom_components/better_thermostat/trv.py
+++ b/custom_components/better_thermostat/trv.py
@@ -58,7 +58,11 @@ class Trv:
     last_valve_position: float | None = None
     last_hvac_mode: str | None = None
     last_current_temperature: float | None = None
+    # ``last_calibration`` is the command the adapter actually wrote after its
+    # own clamp to the declared offset range; ``last_calibration_requested`` is
+    # the value that was asked for before that clamp.
     last_calibration: float | None = None
+    last_calibration_requested: float | None = None
     last_valve_percent: float | None = None
     last_valve_method: str | None = None
 

--- a/custom_components/better_thermostat/trv.py
+++ b/custom_components/better_thermostat/trv.py
@@ -63,6 +63,10 @@ class Trv:
     # the value that was asked for before that clamp.
     last_calibration: float | None = None
     last_calibration_requested: float | None = None
+    # Identity of the offset command currently in flight. Each accepted write
+    # takes the next number, and only the watchdog holding that number may
+    # release ``calibration_received``.
+    calibration_write_generation: int = 0
     last_valve_percent: float | None = None
     last_valve_method: str | None = None
 

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -1138,6 +1138,11 @@ async def check_calibration(self, heater_entity_id=None):
     from, and adopting a dropped write's report would make the next cycle treat
     it as confirmed.
 
+    The flag is released in a finally block. Unlike the system mode and target
+    temperature channels, whose writes go out regardless of their flag, the
+    offset write only happens while calibration_received is True, so a watchdog
+    that ended without releasing it would wedge the channel for good.
+
     Parameters
     ----------
     self : BetterThermostat
@@ -1153,40 +1158,45 @@ async def check_calibration(self, heater_entity_id=None):
     _timeout = 0
     _real_trv = self.real_trvs[heater_entity_id]
     _tolerance = _calibration_match_tolerance(self, heater_entity_id)
-    while True:
-        _trv_state = self.hass.states.get(heater_entity_id)
-        if _trv_state is None or _trv_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
-            _LOGGER.debug(
-                "better_thermostat %s: %s became unavailable during check_calibration",
+    try:
+        while True:
+            _trv_state = self.hass.states.get(heater_entity_id)
+            if _trv_state is None or _trv_state.state in (
+                STATE_UNAVAILABLE,
+                STATE_UNKNOWN,
+            ):
+                _LOGGER.debug(
+                    "better_thermostat %s: %s became unavailable during check_calibration",
+                    self.device_name,
+                    heater_entity_id,
+                )
+                break
+            _reported = convert_to_float(
+                str(await get_current_offset(self, heater_entity_id)),
                 self.device_name,
-                heater_entity_id,
+                "check_calibration()",
             )
-            break
-        _reported = convert_to_float(
-            str(await get_current_offset(self, heater_entity_id)),
-            self.device_name,
-            "check_calibration()",
-        )
-        if _real_trv.last_calibration is None or (
-            _reported is not None
-            and abs(_reported - float(_real_trv.last_calibration)) <= _tolerance
-        ):
-            _timeout = 0
-            break
-        if _timeout > WRITE_CONFIRM_TIMEOUT_S:
-            _LOGGER.warning(
-                "better_thermostat %s: TRV %s did not confirm the calibration offset "
-                "after %ss (wrote=%s, last reported=%s); giving up and assuming applied",
-                self.device_name,
-                heater_entity_id,
-                WRITE_CONFIRM_TIMEOUT_S,
-                _real_trv.last_calibration,
-                _reported,
-            )
-            _timeout = 0
-            break
-        await asyncio.sleep(1)
-        _timeout += 1
-    await asyncio.sleep(2)
-    _real_trv.calibration_received = True
+            if _real_trv.last_calibration is None or (
+                _reported is not None
+                and abs(_reported - float(_real_trv.last_calibration)) <= _tolerance
+            ):
+                _timeout = 0
+                break
+            if _timeout > WRITE_CONFIRM_TIMEOUT_S:
+                _LOGGER.warning(
+                    "better_thermostat %s: TRV %s did not confirm the calibration offset "
+                    "after %ss (wrote=%s, last reported=%s); giving up and assuming applied",
+                    self.device_name,
+                    heater_entity_id,
+                    WRITE_CONFIRM_TIMEOUT_S,
+                    _real_trv.last_calibration,
+                    _reported,
+                )
+                _timeout = 0
+                break
+            await asyncio.sleep(1)
+            _timeout += 1
+        await asyncio.sleep(2)
+    finally:
+        _real_trv.calibration_received = True
     return True

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -54,6 +54,12 @@ _LOGGER = logging.getLogger(__name__)
 # time the band costs is finer than the user can express in the target anyway.
 COOLER_MODE_HYSTERESIS_K = 0.2
 
+# How long a write channel waits for the device to confirm a command before it
+# releases the in-flight flag and accepts the next write. Shared by the system
+# mode, target temperature and calibration watchdogs so all three channels give
+# a slow device the same window.
+WRITE_CONFIRM_TIMEOUT_S = 360
+
 
 def _is_boost_heating_active(self) -> bool:
     """Check if boost mode is active and heating is needed.
@@ -299,6 +305,37 @@ def _device_setpoint_tolerance(self, state) -> float:
         == UnitOfTemperature.FAHRENHEIT
     ):
         step = round(step * 5.0 / 9.0, 4)
+    # Slack against float noise when the difference is exactly half a step.
+    return max(SETPOINT_MATCH_TOLERANCE, step / 2.0 + 1e-6)
+
+
+def _calibration_match_tolerance(self, entity_id) -> float:
+    """Return the tolerance for comparing a written offset to a reported one.
+
+    A device snaps a written offset onto its own step grid, so a snapped value
+    sits at most half a step away from the value that was commanded.
+    SETPOINT_MATCH_TOLERANCE is the floor: it covers the read-back grid for
+    devices that report no usable step.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV whose offset step decides the tolerance
+
+    Returns
+    -------
+    float
+        Tolerance in Kelvin for an offset comparison
+    """
+    step = convert_to_float(
+        str(self.real_trvs[entity_id].local_calibration_step),
+        self.device_name,
+        "controlling()",
+    )
+    if step is None or step <= 0:
+        return SETPOINT_MATCH_TOLERANCE
     # Slack against float noise when the difference is exactly half a step.
     return max(SETPOINT_MATCH_TOLERANCE, step / 2.0 + 1e-6)
 
@@ -835,40 +872,74 @@ async def control_trv(self, heater_entity_id=None):
 
                 _calibration = float(str(_calibration))
 
-                _old_calibration = self.real_trvs[heater_entity_id].last_calibration
-                if _old_calibration is None:
-                    _old_calibration = _current_calibration
+                trv_entry = self.real_trvs[heater_entity_id]
+                _offset_tolerance = _calibration_match_tolerance(self, heater_entity_id)
 
-                # If current calibration already matches target, reset calibration_received
-                # to avoid it getting stuck at False when the state event was suppressed.
-                if (
-                    self.real_trvs[heater_entity_id].calibration_received is False
-                    and _current_calibration is not None
-                    and abs(float(_current_calibration) - float(_calibration)) < 0.5
-                ):
+                # The offset channel carries three values: the INTENT this
+                # cycle computed (_calibration), the COMMAND the adapter put on
+                # the wire after its own clamp (last_calibration), and the
+                # REPORT the device publishes (_current_calibration). A write
+                # goes out when the intent moved away from the last requested
+                # value, or when the report diverged from the command. A report
+                # that equals a clamped command means the device sits at a limit
+                # it declared, and that is not a reason to write.
+                _last_sent = trv_entry.last_calibration
+                if _last_sent is None:
+                    _last_sent = _current_calibration
+
+                # An unreadable report neither confirms nor diverges.
+                _report_readable = (
+                    _current_calibration is not None and _last_sent is not None
+                )
+                _command_diverged = _report_readable and (
+                    abs(float(_current_calibration) - float(_last_sent))
+                    > _offset_tolerance
+                )
+                _command_confirmed = _report_readable and not _command_diverged
+
+                if trv_entry.calibration_received is False and _command_confirmed:
                     _LOGGER.debug(
-                        "better_thermostat %s: TRV %s calibration already at target (%s), "
-                        "resetting calibration_received flag",
+                        "better_thermostat %s: TRV %s device confirms the last "
+                        "calibration command (%s), resetting calibration_received flag",
                         self.device_name,
                         heater_entity_id,
-                        _calibration,
+                        _last_sent,
                     )
-                    self.real_trvs[heater_entity_id].calibration_received = True
+                    trv_entry.calibration_received = True
 
-                if self.real_trvs[
-                    heater_entity_id
-                ].calibration_received is True and float(_old_calibration) != float(
-                    _calibration
-                ):
-                    _LOGGER.debug(
-                        "better_thermostat %s: TO TRV set_local_temperature_calibration: %s from: %s to: %s",
-                        self.device_name,
-                        heater_entity_id,
-                        _old_calibration,
-                        _calibration,
-                    )
-                    await set_offset(self, heater_entity_id, _calibration)
-                    self.real_trvs[heater_entity_id].calibration_received = False
+                if trv_entry.calibration_received is True:
+                    if _last_sent is None:
+                        _LOGGER.debug(
+                            "better_thermostat %s: no reference calibration for %s yet, "
+                            "skipping calibration write this cycle",
+                            self.device_name,
+                            heater_entity_id,
+                        )
+                    else:
+                        # Intent and last requested value come off the same
+                        # step grid, so they compare exactly; the tolerance
+                        # belongs where the two different grids of command and
+                        # report meet.
+                        _last_requested = trv_entry.last_calibration_requested
+                        if _last_requested is None:
+                            _last_requested = _last_sent
+                        if float(_last_requested) != _calibration or _command_diverged:
+                            _LOGGER.debug(
+                                "better_thermostat %s: TO TRV "
+                                "set_local_temperature_calibration: %s from: %s to: %s "
+                                "(device reports %s)",
+                                self.device_name,
+                                heater_entity_id,
+                                _last_sent,
+                                _calibration,
+                                _current_calibration,
+                            )
+                            if await set_offset(self, heater_entity_id, _calibration):
+                                trv_entry.calibration_received = False
+                                self.task_manager.create_task(
+                                    check_calibration(self, heater_entity_id),
+                                    name=f"bt_check_calibration_{heater_entity_id}",
+                                )
 
             # set new target temperature
             if _temperature is not None and (
@@ -962,12 +1033,13 @@ async def check_system_mode(self, heater_entity_id=None):
         if _trv_state.state == _real_trv.last_hvac_mode:
             _timeout = 0
             break
-        if _timeout > 360:
+        if _timeout > WRITE_CONFIRM_TIMEOUT_S:
             _LOGGER.warning(
                 "better_thermostat %s: TRV %s did not confirm the system mode change "
-                "after 360s (wrote=%s, last reported=%s); giving up and assuming applied",
+                "after %ss (wrote=%s, last reported=%s); giving up and assuming applied",
                 self.device_name,
                 heater_entity_id,
+                WRITE_CONFIRM_TIMEOUT_S,
                 _real_trv.last_hvac_mode,
                 _trv_state.state,
             )
@@ -1032,12 +1104,13 @@ async def check_target_temperature(self, heater_entity_id=None):
         ):
             _timeout = 0
             break
-        if _timeout > 360:
+        if _timeout > WRITE_CONFIRM_TIMEOUT_S:
             _LOGGER.warning(
                 "better_thermostat %s: TRV %s did not confirm the target temperature "
-                "after 360s (wrote=%s, last reported=%s); giving up and assuming applied",
+                "after %ss (wrote=%s, last reported=%s); giving up and assuming applied",
                 self.device_name,
                 heater_entity_id,
+                WRITE_CONFIRM_TIMEOUT_S,
                 _real_trv.last_temperature,
                 _current_set_temperatures,
             )
@@ -1048,4 +1121,72 @@ async def check_target_temperature(self, heater_entity_id=None):
     await asyncio.sleep(2)
 
     _real_trv.target_temp_received = True
+    return True
+
+
+async def check_calibration(self, heater_entity_id=None):
+    """Wait for TRV to confirm the calibration offset, timeout after 6 minutes.
+
+    Polls the TRV's reported offset every second until it matches
+    last_calibration within the tolerance the device's own offset step allows,
+    or the timeout is reached. Sets calibration_received when complete, which
+    is what releases the write gate for the next offset command; without it a
+    device that never acknowledges an offset wedges the channel.
+
+    The reported value is deliberately not adopted into last_calibration on
+    timeout: last_calibration is the reference the local calibration integrates
+    from, and adopting a dropped write's report would make the next cycle treat
+    it as confirmed.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    heater_entity_id : str, optional
+        Entity ID of the TRV to check
+
+    Returns
+    -------
+    bool
+        Always returns True
+    """
+    _timeout = 0
+    _real_trv = self.real_trvs[heater_entity_id]
+    _tolerance = _calibration_match_tolerance(self, heater_entity_id)
+    while True:
+        _trv_state = self.hass.states.get(heater_entity_id)
+        if _trv_state is None or _trv_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            _LOGGER.debug(
+                "better_thermostat %s: %s became unavailable during check_calibration",
+                self.device_name,
+                heater_entity_id,
+            )
+            break
+        _reported = convert_to_float(
+            str(await get_current_offset(self, heater_entity_id)),
+            self.device_name,
+            "check_calibration()",
+        )
+        if _real_trv.last_calibration is None or (
+            _reported is not None
+            and abs(_reported - float(_real_trv.last_calibration)) <= _tolerance
+        ):
+            _timeout = 0
+            break
+        if _timeout > WRITE_CONFIRM_TIMEOUT_S:
+            _LOGGER.warning(
+                "better_thermostat %s: TRV %s did not confirm the calibration offset "
+                "after %ss (wrote=%s, last reported=%s); giving up and assuming applied",
+                self.device_name,
+                heater_entity_id,
+                WRITE_CONFIRM_TIMEOUT_S,
+                _real_trv.last_calibration,
+                _reported,
+            )
+            _timeout = 0
+            break
+        await asyncio.sleep(1)
+        _timeout += 1
+    await asyncio.sleep(2)
+    _real_trv.calibration_received = True
     return True

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -948,8 +948,13 @@ async def control_trv(self, heater_entity_id=None):
                             )
                             if await set_offset(self, heater_entity_id, _calibration):
                                 trv_entry.calibration_received = False
+                                trv_entry.calibration_write_generation += 1
                                 self.task_manager.create_task(
-                                    check_calibration(self, heater_entity_id),
+                                    check_calibration(
+                                        self,
+                                        heater_entity_id,
+                                        trv_entry.calibration_write_generation,
+                                    ),
                                     name=f"bt_check_calibration_{heater_entity_id}",
                                 )
 
@@ -1136,7 +1141,7 @@ async def check_target_temperature(self, heater_entity_id=None):
     return True
 
 
-async def check_calibration(self, heater_entity_id=None):
+async def check_calibration(self, heater_entity_id=None, generation=0):
     """Wait for TRV to confirm the calibration offset, timeout after 6 minutes.
 
     Polls the TRV's reported offset every second until it matches
@@ -1155,12 +1160,21 @@ async def check_calibration(self, heater_entity_id=None):
     offset write only happens while calibration_received is True, so a watchdog
     that ended without releasing it would wedge the channel for good.
 
+    Only the watchdog whose generation is still the TRV's current one releases
+    the flag. A control cycle can confirm a command in-cycle and write a newer
+    offset while an earlier watchdog is still winding down; releasing the gate
+    from that earlier watchdog would open the channel for a command that is
+    still in flight and turn one re-assert per confirmation window into one per
+    control cycle.
+
     Parameters
     ----------
     self : BetterThermostat
         The Better Thermostat climate entity instance
     heater_entity_id : str, optional
         Entity ID of the TRV to check
+    generation : int, optional
+        Identity of the offset command this watchdog was armed for
 
     Returns
     -------
@@ -1172,6 +1186,15 @@ async def check_calibration(self, heater_entity_id=None):
     _tolerance = _calibration_match_tolerance(self, heater_entity_id)
     try:
         while True:
+            if _real_trv.calibration_write_generation != generation:
+                _LOGGER.debug(
+                    "better_thermostat %s: a newer calibration command superseded "
+                    "the one %s was being watched for, leaving the write gate to "
+                    "its watchdog",
+                    self.device_name,
+                    heater_entity_id,
+                )
+                return True
             _trv_state = self.hass.states.get(heater_entity_id)
             if _trv_state is None or _trv_state.state in (
                 STATE_UNAVAILABLE,
@@ -1210,5 +1233,6 @@ async def check_calibration(self, heater_entity_id=None):
             _timeout += 1
         await asyncio.sleep(2)
     finally:
-        _real_trv.calibration_received = True
+        if _real_trv.calibration_write_generation == generation:
+            _real_trv.calibration_received = True
     return True

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -60,6 +60,17 @@ COOLER_MODE_HYSTERESIS_K = 0.2
 # a slow device the same window.
 WRITE_CONFIRM_TIMEOUT_S = 360
 
+# Floor for the commanded-vs-reported offset comparison. Half the declared
+# offset step is the right window only while that step describes the grid the
+# device reports on; an adapter declaring a nominal 0.01 K step describes a
+# continuous range instead, and any report rounded coarser than that then reads
+# as a divergence the write gate re-asserts on every control cycle. The floor
+# covers those roundings and stays below the 0.1 K resolution a TRV reports its
+# own temperature at, so no calibration error the room can feel hides beneath
+# it. The setpoint channel's read-back tolerance describes a different
+# comparison, so the offset channel carries its own floor.
+OFFSET_MATCH_TOLERANCE_K = 0.05
+
 
 def _is_boost_heating_active(self) -> bool:
     """Check if boost mode is active and heating is needed.
@@ -314,8 +325,9 @@ def _calibration_match_tolerance(self, entity_id) -> float:
 
     A device snaps a written offset onto its own step grid, so a snapped value
     sits at most half a step away from the value that was commanded.
-    SETPOINT_MATCH_TOLERANCE is the floor: it covers the read-back grid for
-    devices that report no usable step.
+    OFFSET_MATCH_TOLERANCE_K is the floor: it covers devices that report no
+    usable step and those whose declared step is finer than the grid they
+    actually report on.
 
     Parameters
     ----------
@@ -335,9 +347,9 @@ def _calibration_match_tolerance(self, entity_id) -> float:
         "controlling()",
     )
     if step is None or step <= 0:
-        return SETPOINT_MATCH_TOLERANCE
+        return OFFSET_MATCH_TOLERANCE_K
     # Slack against float noise when the difference is exactly half a step.
-    return max(SETPOINT_MATCH_TOLERANCE, step / 2.0 + 1e-6)
+    return max(OFFSET_MATCH_TOLERANCE_K, step / 2.0 + 1e-6)
 
 
 async def control_cooler(self):

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -13,7 +13,9 @@ Absorbed tests from:
 """
 
 import asyncio
+from contextlib import contextmanager
 import inspect
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homeassistant.components.climate.const import PRESET_BOOST, HVACMode
@@ -1605,6 +1607,7 @@ def mock_bt_grouped():
     bt.tolerance = 0.5
     bt._temp_lock = asyncio.Lock()
     bt.calculate_heating_power = AsyncMock()
+    bt.task_manager = Mock(create_task=Mock(side_effect=_close_coro))
 
     bt.real_trvs = {
         "climate.trv_1": Trv.from_legacy_dict(
@@ -1662,10 +1665,15 @@ class TestGroupedTrvCalibration:
     """
 
     @pytest.mark.anyio
-    async def test_calibration_received_stays_false_when_mismatch(
+    async def test_confirmed_command_releases_flag_and_writes_new_intent(
         self, mock_bt_grouped
     ):
-        """Test that calibration_received stays False when calibration differs."""
+        """A confirmed command releases the flag and the new intent is written.
+
+        The device reports the offset it was last commanded, so the write is
+        acknowledged and the stuck flag is released; BT wants a different
+        offset now, which is exactly when a write has to go out.
+        """
         entity_id = "climate.trv_3"
 
         mock_trv_state = MagicMock()
@@ -1684,10 +1692,11 @@ class TestGroupedTrvCalibration:
             patch(_PATCHES["set_valve"], new_callable=AsyncMock),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
-            mock_get_offset.return_value = 2.0
+            mock_get_offset.return_value = 2.0  # confirms last_calibration
+            mock_set_offset.return_value = True
             mock_convert.return_value = {
                 "temperature": 21.0,
-                "local_temperature_calibration": 3.0,  # Different from current!
+                "local_temperature_calibration": 3.0,  # the intent moved
                 "local_temperature": 20.0,
                 "system_mode": "heat",
             }
@@ -1696,8 +1705,8 @@ class TestGroupedTrvCalibration:
 
             await control_trv(mock_bt_grouped, entity_id)
 
+            mock_set_offset.assert_awaited_once_with(mock_bt_grouped, entity_id, 3.0)
             assert mock_bt_grouped.real_trvs[entity_id].calibration_received is False
-            mock_set_offset.assert_not_called()
 
     @pytest.mark.anyio
     async def test_calibration_sent_when_received_true_and_differs(
@@ -1738,9 +1747,21 @@ class TestGroupedTrvCalibration:
             assert mock_bt_grouped.real_trvs[entity_id].calibration_received is False
 
     @pytest.mark.anyio
-    async def test_calibration_tolerance_within_half_degree(self, mock_bt_grouped):
-        """Test that calibration within 0.5 degree tolerance is considered matching."""
+    @pytest.mark.parametrize(
+        "step,reported,released",
+        [(0.5, 2.2, True), (0.5, 2.3, False), (1.0, 2.5, True)],
+    )
+    async def test_confirmation_window_is_half_the_device_offset_step(
+        self, mock_bt_grouped, step, reported, released
+    ):
+        """The confirmation window is half the device's own offset step.
+
+        A device snaps a commanded offset onto its own grid, so a report up to
+        half a step away from the command still confirms it, and anything
+        beyond that is a divergence.
+        """
         entity_id = "climate.trv_3"
+        mock_bt_grouped.real_trvs[entity_id].local_calibration_step = step
 
         mock_trv_state = MagicMock()
         mock_trv_state.state = "heat"
@@ -1758,7 +1779,7 @@ class TestGroupedTrvCalibration:
             patch(_PATCHES["set_valve"], new_callable=AsyncMock),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
-            mock_get_offset.return_value = 2.3
+            mock_get_offset.return_value = reported
             mock_convert.return_value = {
                 "temperature": 21.0,
                 "local_temperature_calibration": 2.0,
@@ -1770,7 +1791,7 @@ class TestGroupedTrvCalibration:
 
             await control_trv(mock_bt_grouped, entity_id)
 
-            assert mock_bt_grouped.real_trvs[entity_id].calibration_received is True
+            assert mock_bt_grouped.real_trvs[entity_id].calibration_received is released
 
     @pytest.mark.anyio
     async def test_calibration_tolerance_outside_half_degree(self, mock_bt_grouped):
@@ -1806,3 +1827,386 @@ class TestGroupedTrvCalibration:
             await control_trv(mock_bt_grouped, entity_id)
 
             assert mock_bt_grouped.real_trvs[entity_id].calibration_received is False
+
+
+# ---------------------------------------------------------------------------
+# Calibration write gate (issue #2174)
+# ---------------------------------------------------------------------------
+
+
+def _offset_trv(**overrides):
+    """Return a LOCAL_BASED real_trvs entry driven by the offset write gate."""
+    cfg = {
+        "ignore_trv_states": False,
+        "hvac_modes": [HVACMode.HEAT, HVACMode.OFF],
+        "min_temp": 5.0,
+        "max_temp": 30.0,
+        "temperature": 20.0,
+        "current_temperature": 20.0,
+        "last_temperature": 20.0,
+        "last_hvac_mode": HVACMode.HEAT,
+        "system_mode_received": True,
+        "target_temp_received": True,
+        "hvac_mode": HVACMode.HEAT,
+        "advanced": {
+            "calibration_mode": CalibrationMode.DEFAULT,
+            "calibration": CalibrationType.LOCAL_BASED,
+            "no_off_system_mode": False,
+        },
+    }
+    cfg.update(overrides)
+    return Trv.from_legacy_dict("climate.trv1", cfg)
+
+
+@contextmanager
+def _offset_cycle(
+    reported,
+    desired_offset,
+    desired_temperature=20.0,
+    system_mode=HVACMode.HEAT,
+    offset_write_succeeds=True,
+):
+    """Patch control_trv's collaborators around the offset write gate.
+
+    ``reported`` is what the device publishes as its current offset,
+    ``desired_offset`` what this cycle wants to hold.
+    """
+    mocks = SimpleNamespace(
+        convert=Mock(
+            return_value={
+                "temperature": desired_temperature,
+                "local_temperature_calibration": desired_offset,
+                "local_temperature": 20.0,
+                "system_mode": system_mode,
+            }
+        ),
+        get_offset=AsyncMock(return_value=reported),
+        set_offset=AsyncMock(return_value=offset_write_succeeds),
+        set_temperature=AsyncMock(),
+        set_hvac_mode=AsyncMock(),
+    )
+    with (
+        patch(_PATCHES["convert_outbound_states"], new=mocks.convert),
+        patch(_PATCHES["get_current_offset"], new=mocks.get_offset),
+        patch(_PATCHES["set_offset"], new=mocks.set_offset),
+        patch(_PATCHES["set_temperature"], new=mocks.set_temperature),
+        patch(_PATCHES["set_hvac_mode"], new=mocks.set_hvac_mode),
+        patch(_PATCHES["set_valve"], new=AsyncMock()),
+        patch(_PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)),
+        patch(_PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)),
+        patch("asyncio.sleep", new=AsyncMock()),
+    ):
+        yield mocks
+
+
+def _watchdog_names(mock_self):
+    """Return the names of every background task control_trv created."""
+    return [
+        call.kwargs.get("name")
+        for call in mock_self.task_manager.create_task.call_args_list
+    ]
+
+
+class TestCalibrationWriteGate:
+    """The offset write gate compares the device report against the command.
+
+    Issue #2174: an offset computed for a local-calibration TRV was never
+    written because the gate compared BT's intent against the value BT had
+    last sent, so an unconfirmed write left the channel wedged.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unconfirmed_write_is_reasserted(self):
+        """An offset that the device never took is written again."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=0.0, calibration_received=False
+                )
+            },
+        )
+
+        with _offset_cycle(reported=0.0, desired_offset=-2.0) as mocks:
+            result = await control_trv(mock_self, "climate.trv1")
+
+        assert result is True
+        mocks.set_offset.assert_awaited_once_with(mock_self, "climate.trv1", -2.0)
+
+    @pytest.mark.asyncio
+    async def test_write_arms_the_calibration_watchdog(self):
+        """A write clears the flag and hands the release to the watchdog."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=0.0, calibration_received=False
+                )
+            },
+        )
+
+        with _offset_cycle(reported=0.0, desired_offset=-2.0):
+            await control_trv(mock_self, "climate.trv1")
+
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is False
+        assert "bt_check_calibration_climate.trv1" in _watchdog_names(mock_self)
+
+    @pytest.mark.asyncio
+    async def test_channel_does_not_wedge_across_cycles(self):
+        """A device that silently drops every offset gets one write per cycle.
+
+        The adapter and the delegate record the write, so from the second
+        cycle on the only thing that can arm a write is the report having
+        diverged from the recorded command.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=0.0, calibration_received=True
+                )
+            },
+        )
+
+        with _offset_cycle(reported=0.0, desired_offset=-2.0) as mocks:
+
+            async def _record_write(_self, entity_id, offset):
+                """Record what the adapter and the delegate record on a write."""
+                trv = _self.real_trvs[entity_id]
+                trv.last_calibration = offset
+                trv.last_calibration_requested = offset
+                return True
+
+            mocks.set_offset.side_effect = _record_write
+
+            for _ in range(3):
+                # The watchdog releases the flag when the device stays silent.
+                mock_self.real_trvs["climate.trv1"].calibration_received = True
+                await control_trv(mock_self, "climate.trv1")
+
+        assert mocks.set_offset.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_confirmed_offset_is_not_rewritten(self):
+        """A device holding the requested offset receives nothing."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=-2.0,
+                    last_calibration_requested=-2.0,
+                    calibration_received=True,
+                )
+            },
+        )
+
+        with _offset_cycle(reported=-2.0, desired_offset=-2.0) as mocks:
+            await control_trv(mock_self, "climate.trv1")
+
+        mocks.set_offset.assert_not_awaited()
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+
+    @pytest.mark.asyncio
+    async def test_adapter_clamp_does_not_become_a_retry_loop(self):
+        """A device resting at a limit it declared is left alone.
+
+        The adapter clamped the requested -5.0 to the device's -3.0 minimum,
+        so the report equals the command even though it differs from the
+        intent. Comparing intent against command would rewrite every cycle.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=-3.0,
+                    last_calibration_requested=-5.0,
+                    calibration_received=True,
+                )
+            },
+        )
+
+        with _offset_cycle(reported=-3.0, desired_offset=-5.0) as mocks:
+            for _ in range(5):
+                await control_trv(mock_self, "climate.trv1")
+
+        mocks.set_offset.assert_not_awaited()
+        assert "bt_check_calibration_climate.trv1" not in _watchdog_names(mock_self)
+
+    @pytest.mark.asyncio
+    async def test_intent_moving_past_the_clamp_still_writes(self):
+        """A new intent reaches the device even while it sits at a clamp."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=-3.0,
+                    last_calibration_requested=-5.0,
+                    calibration_received=True,
+                )
+            },
+        )
+
+        with _offset_cycle(reported=-3.0, desired_offset=-6.0) as mocks:
+            await control_trv(mock_self, "climate.trv1")
+
+        mocks.set_offset.assert_awaited_once_with(mock_self, "climate.trv1", -6.0)
+
+    @pytest.mark.asyncio
+    async def test_dropped_write_is_reasserted(self):
+        """A report that diverged from the command re-sends the command."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=-2.0,
+                    last_calibration_requested=-2.0,
+                    calibration_received=True,
+                )
+            },
+        )
+
+        with _offset_cycle(reported=0.0, desired_offset=-2.0) as mocks:
+            await control_trv(mock_self, "climate.trv1")
+
+        mocks.set_offset.assert_awaited_once_with(mock_self, "climate.trv1", -2.0)
+
+    @pytest.mark.asyncio
+    async def test_fine_step_device_detects_a_small_divergence(self):
+        """On a 0.1 step device a 0.3 K divergence is not a grid artifact."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=-2.0,
+                    local_calibration_step=0.1,
+                    calibration_received=True,
+                )
+            },
+        )
+
+        with _offset_cycle(reported=-1.7, desired_offset=-2.0) as mocks:
+            await control_trv(mock_self, "climate.trv1")
+
+        mocks.set_offset.assert_awaited_once_with(mock_self, "climate.trv1", -2.0)
+
+    @pytest.mark.asyncio
+    async def test_coarse_step_device_accepts_a_half_step_snap(self):
+        """On a 1.0 step device a half-step snap confirms the command."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=-2.0,
+                    local_calibration_step=1.0,
+                    calibration_received=True,
+                )
+            },
+        )
+
+        with _offset_cycle(reported=-2.5, desired_offset=-2.0) as mocks:
+            await control_trv(mock_self, "climate.trv1")
+
+        mocks.set_offset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_write_keeps_the_channel_open(self):
+        """A write the adapter refused arms no watchdog and is retried."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=0.0, calibration_received=True
+                )
+            },
+        )
+
+        with _offset_cycle(
+            reported=0.0, desired_offset=-2.0, offset_write_succeeds=False
+        ) as mocks:
+            await control_trv(mock_self, "climate.trv1")
+
+            assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+            assert "bt_check_calibration_climate.trv1" not in _watchdog_names(mock_self)
+
+            await control_trv(mock_self, "climate.trv1")
+
+        assert mocks.set_offset.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_calibration_mode_skips_the_whole_block(self):
+        """NO_CALIBRATION neither reads nor writes the offset entity."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=0.0,
+                    calibration_received=True,
+                    advanced={
+                        "calibration_mode": CalibrationMode.NO_CALIBRATION,
+                        "calibration": CalibrationType.LOCAL_BASED,
+                        "no_off_system_mode": False,
+                    },
+                )
+            },
+        )
+
+        with _offset_cycle(reported=0.0, desired_offset=-2.0) as mocks:
+            await control_trv(mock_self, "climate.trv1")
+
+        mocks.get_offset.assert_not_awaited()
+        mocks.set_offset.assert_not_awaited()
+        assert "bt_check_calibration_climate.trv1" not in _watchdog_names(mock_self)
+
+    @pytest.mark.asyncio
+    async def test_off_mode_skips_the_whole_block(self):
+        """An OFF cycle writes no offset even when the report diverged."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            bt_hvac_mode=HVACMode.OFF,
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=-2.0, calibration_received=True
+                )
+            },
+        )
+
+        with _offset_cycle(
+            reported=0.0, desired_offset=-2.0, system_mode=HVACMode.OFF
+        ) as mocks:
+            await control_trv(mock_self, "climate.trv1")
+
+        mocks.set_offset.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unreadable_report_without_reference_skips_the_write(self):
+        """No reference and no readable report skips the offset, not the cycle."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=None, calibration_received=True
+                )
+            },
+        )
+
+        with _offset_cycle(
+            reported="not-a-number", desired_offset=-2.0, desired_temperature=21.0
+        ) as mocks:
+            result = await control_trv(mock_self, "climate.trv1")
+
+        assert result is True
+        mocks.set_offset.assert_not_awaited()
+        mocks.set_temperature.assert_awaited_once_with(mock_self, "climate.trv1", 21.0)

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -20,8 +20,10 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homeassistant.components.climate.const import PRESET_BOOST, HVACMode
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import State
 import pytest
 
+from custom_components.better_thermostat.adapters import delegate, generic
 from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils.const import (
     CalibrationMode,
@@ -2321,3 +2323,134 @@ class TestCalibrationWriteGate:
         assert result is True
         mocks.set_offset.assert_not_awaited()
         mocks.set_temperature.assert_awaited_once_with(mock_self, "climate.trv1", 21.0)
+
+
+SELECT_CALIBRATION_ENTITY = "select.trv1_calibration"
+# A calibration select on a 3 K grid: an offset between two options reaches
+# the device as the nearer one.
+SELECT_OPTIONS = ["-6.0k", "-3.0k", "0.0k", "3.0k", "6.0k"]
+
+
+class _SnappingSelect:
+    """A calibration select that holds exactly the option it was handed."""
+
+    def __init__(self, selected="0.0k"):
+        """Start the entity on the option it currently holds.
+
+        Parameters
+        ----------
+        selected : str
+            Option the entity holds before the first write.
+        """
+        self.selected = selected
+        self.written = []
+
+    @property
+    def reported(self):
+        """Return the offset in Kelvin the entity publishes."""
+        return float(self.selected.replace("k", ""))
+
+    def state(self):
+        """Return the entity state the adapter reads its options off."""
+        return State(
+            SELECT_CALIBRATION_ENTITY, self.selected, {"options": list(SELECT_OPTIONS)}
+        )
+
+    async def async_call(self, domain, service, data, **kwargs):
+        """Apply a select_option call and ignore every other service.
+
+        Parameters
+        ----------
+        domain : str
+            Service domain of the call.
+        service : str
+            Service name within that domain.
+        data : dict
+            Service data; carries the option for a select_option call.
+        **kwargs : dict
+            Blocking and context arguments the caller passes on.
+        """
+        if domain == "select" and service == "select_option":
+            self.written.append(data["option"])
+            self.selected = data["option"]
+
+
+class TestSnappingSelectOffsetConverges:
+    """A device that snaps the offset onto its own option list settles.
+
+    The adapter, not the device, decides which option carries the offset,
+    so the command the gate confirms against is the option's value. The
+    intent stays what the cycle asked for, so an unchanged intent does not
+    re-arm the write once the device holds the snapped option.
+    """
+
+    def _wire(self, device):
+        """Return a thermostat whose calibration entity is ``device``.
+
+        Parameters
+        ----------
+        device : _SnappingSelect
+            The calibration select standing in for the TRV's offset channel.
+
+        Returns
+        -------
+        Mock
+            A stand-in for the Better Thermostat climate entity instance.
+        """
+        trv = _offset_trv(
+            last_calibration=0.0,
+            last_calibration_requested=0.0,
+            calibration_received=True,
+            local_temperature_calibration_entity=SELECT_CALIBRATION_ENTITY,
+            # A select publishes no step, so discovery falls back to 1.0.
+            local_calibration_step=1.0,
+        )
+        trv.adapter = generic
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={"climate.trv1": trv},
+        )
+        trv_state = mock_self.hass.states.get.return_value
+        mock_self.hass.states.get.side_effect = lambda entity_id: (
+            device.state() if entity_id == SELECT_CALIBRATION_ENTITY else trv_state
+        )
+        mock_self.hass.services.async_call = AsyncMock(side_effect=device.async_call)
+        return mock_self
+
+    @pytest.mark.asyncio
+    async def test_the_snapped_option_is_written_once(self):
+        """Five cycles against a device holding the snapped option write once."""
+        device = _SnappingSelect()
+        mock_self = self._wire(device)
+        trv = mock_self.real_trvs["climate.trv1"]
+
+        for _ in range(5):
+            # The watchdog releases the gate at the end of its window.
+            trv.calibration_received = True
+            with _offset_cycle(reported=device.reported, desired_offset=-2.0) as mocks:
+                # The real write path: the delegate records the intent and
+                # the adapter the command.
+                mocks.set_offset.side_effect = delegate.set_offset
+                await control_trv(mock_self, "climate.trv1")
+
+        assert device.written == ["-3.0k"]
+        assert trv.last_calibration == -3.0
+        assert trv.last_calibration_requested == -2.0
+
+    @pytest.mark.asyncio
+    async def test_a_new_intent_still_reaches_the_device(self):
+        """A cycle asking for another option writes it."""
+        device = _SnappingSelect()
+        mock_self = self._wire(device)
+        trv = mock_self.real_trvs["climate.trv1"]
+
+        for desired in (-2.0, 2.0):
+            trv.calibration_received = True
+            with _offset_cycle(
+                reported=device.reported, desired_offset=desired
+            ) as mocks:
+                mocks.set_offset.side_effect = delegate.set_offset
+                await control_trv(mock_self, "climate.trv1")
+
+        assert device.written == ["-3.0k", "3.0k"]

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -1833,7 +1833,7 @@ class TestGroupedTrvCalibration:
 
 
 # ---------------------------------------------------------------------------
-# Calibration write gate (issue #2174)
+# Calibration write gate: intent, command and the device's report
 # ---------------------------------------------------------------------------
 
 
@@ -1913,9 +1913,10 @@ def _watchdog_names(mock_self):
 class TestCalibrationWriteGate:
     """The offset write gate compares the device report against the command.
 
-    Issue #2174: an offset computed for a local-calibration TRV was never
-    written because the gate compared BT's intent against the value BT had
-    last sent, so an unconfirmed write left the channel wedged.
+    The intent this cycle computed is compared against the value last
+    requested, and the device's report against the command that was put on
+    the wire, so an unconfirmed write is re-asserted rather than leaving
+    the channel wedged.
     """
 
     @pytest.mark.asyncio

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -27,7 +27,10 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationMode,
     CalibrationType,
 )
-from custom_components.better_thermostat.utils.controlling import control_trv
+from custom_components.better_thermostat.utils.controlling import (
+    check_calibration,
+    control_trv,
+)
 
 # All delegate / helper functions that control_trv calls.  We patch them at the
 # *controlling* module level because that is where they are imported.
@@ -2232,6 +2235,69 @@ class TestCalibrationWriteGate:
                 writes += mocks.set_offset.await_count
 
         assert writes == 1
+
+    @pytest.mark.asyncio
+    async def test_each_write_arms_a_watchdog_for_its_own_command(self):
+        """Every accepted write takes the next generation."""
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=0.0,
+                    last_calibration_requested=0.0,
+                    calibration_received=True,
+                )
+            },
+        )
+        watchdog = Mock(return_value=None)
+
+        with (
+            _offset_cycle(reported=0.0, desired_offset=-2.0),
+            patch(f"{_CTRL}.check_calibration", new=watchdog),
+        ):
+            for _ in range(3):
+                mock_self.real_trvs["climate.trv1"].calibration_received = True
+                await control_trv(mock_self, "climate.trv1")
+
+        assert [call.args[2] for call in watchdog.call_args_list] == [1, 2, 3]
+        assert mock_self.real_trvs["climate.trv1"].calibration_write_generation == 3
+
+    @pytest.mark.asyncio
+    async def test_a_superseded_watchdog_does_not_reopen_the_gate(self):
+        """The gate stays closed while the newest command is unconfirmed.
+
+        A control cycle can confirm a command in-cycle and immediately
+        write a newer one, leaving the earlier watchdog winding down. Its
+        release must not open the channel for the write still in flight.
+        """
+        trv = _offset_trv(
+            last_calibration=-2.0,
+            last_calibration_requested=-2.0,
+            calibration_received=False,
+        )
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={"climate.trv1": trv},
+        )
+        trv.calibration_write_generation = 1
+        earlier_watchdog = check_calibration(mock_self, "climate.trv1", 1)
+
+        # The cycle confirms -2.0 and writes -3.0, arming the newer watchdog.
+        with _offset_cycle(reported=-2.0, desired_offset=-3.0) as mocks:
+            await control_trv(mock_self, "climate.trv1")
+
+            mocks.set_offset.assert_awaited_once_with(mock_self, "climate.trv1", -3.0)
+            assert trv.calibration_received is False
+            assert trv.calibration_write_generation == 2
+
+            with patch(
+                _PATCHES["get_current_offset"], new=AsyncMock(return_value=-2.0)
+            ):
+                assert await earlier_watchdog is True
+
+        assert trv.calibration_received is False
 
     @pytest.mark.asyncio
     async def test_unreadable_report_without_reference_skips_the_write(self):

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -2190,6 +2190,50 @@ class TestCalibrationWriteGate:
         mocks.set_offset.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_declared_step_finer_than_the_reported_grid_converges(self):
+        """A device rounding coarser than it declares is written once.
+
+        The device declares a 0.01 K offset step but publishes its offset
+        on a 0.05 K grid. Half the declared step is narrower than that
+        grid, so without the floor every cycle would read the rounding as
+        a divergence and re-assert the same command forever.
+        """
+        mock_self = _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            real_trvs={
+                "climate.trv1": _offset_trv(
+                    last_calibration=0.0,
+                    last_calibration_requested=0.0,
+                    local_calibration_step=0.01,
+                    calibration_received=True,
+                )
+            },
+        )
+        reported = {"value": 0.0}
+
+        async def _write_and_round(_self, entity_id, offset):
+            """Take the command and publish it on the device's own grid."""
+            trv = _self.real_trvs[entity_id]
+            trv.last_calibration = offset
+            trv.last_calibration_requested = offset
+            reported["value"] = round(round(offset / 0.05) * 0.05, 6)
+            return True
+
+        writes = 0
+        for _ in range(20):
+            with _offset_cycle(
+                reported=reported["value"], desired_offset=-2.32
+            ) as mocks:
+                mocks.set_offset.side_effect = _write_and_round
+                # The watchdog releases the gate at the end of its window.
+                mock_self.real_trvs["climate.trv1"].calibration_received = True
+                await control_trv(mock_self, "climate.trv1")
+                writes += mocks.set_offset.await_count
+
+        assert writes == 1
+
+    @pytest.mark.asyncio
     async def test_unreadable_report_without_reference_skips_the_write(self):
         """No reference and no readable report skips the offset, not the cycle."""
         mock_self = _make_mock_self(

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -907,6 +907,40 @@ class TestCheckCalibration:
         assert result is True
         assert mock_self.real_trvs["climate.trv1"].calibration_received is True
 
+    @pytest.mark.asyncio
+    async def test_adapter_error_still_releases_the_write_gate(self):
+        """An adapter that raises mid-poll does not wedge the offset channel.
+
+        The offset write only goes out while calibration_received is True, so a
+        watchdog that ended without releasing it would silence the channel for
+        good.
+        """
+        mock_self = _calibration_mock_self(HVACMode.HEAT, last_calibration=-2.0)
+
+        async def _raise(_self, _entity_id):
+            raise RuntimeError("adapter unavailable")
+
+        with patch(f"{_CTRL}.get_current_offset", new=_raise):
+            with pytest.raises(RuntimeError):
+                await check_calibration(mock_self, "climate.trv1")
+
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+
+    @pytest.mark.asyncio
+    async def test_cancellation_still_releases_the_write_gate(self):
+        """A cancelled watchdog leaves the offset channel writable."""
+        mock_self = _calibration_mock_self(HVACMode.HEAT, last_calibration=-2.0)
+
+        with patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=0.0)):
+            task = asyncio.create_task(check_calibration(mock_self, "climate.trv1"))
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+
 
 # ---------------------------------------------------------------------------
 # All three write watchdogs share one confirmation window

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -23,7 +23,9 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.controlling import (
+    OFFSET_MATCH_TOLERANCE_K,
     WRITE_CONFIRM_TIMEOUT_S,
+    _calibration_match_tolerance,
     _get_valve_control,
     check_calibration,
     check_system_mode,
@@ -940,6 +942,45 @@ class TestCheckCalibration:
                 await task
 
         assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+
+
+class TestCalibrationMatchTolerance:
+    """Tests for _calibration_match_tolerance()."""
+
+    @staticmethod
+    def _mock_self(step):
+        mock_self = MagicMock()
+        mock_self.device_name = "Test"
+        mock_self.real_trvs = {
+            "climate.trv1": Trv.from_legacy_dict(
+                "climate.trv1", {"local_calibration_step": step}
+            )
+        }
+        return mock_self
+
+    def test_step_yields_half_a_step(self):
+        """A snapped offset sits at most half a step from the command."""
+        tolerance = _calibration_match_tolerance(self._mock_self(1.0), "climate.trv1")
+        assert tolerance == pytest.approx(0.5, abs=1e-5)
+
+    def test_unusable_step_falls_back_to_the_floor(self):
+        """Without a usable step there is no grid to derive a tolerance from."""
+        tolerance = _calibration_match_tolerance(self._mock_self(0), "climate.trv1")
+        assert tolerance == OFFSET_MATCH_TOLERANCE_K
+
+    def test_step_below_the_floor_does_not_narrow_it(self):
+        """A declared step finer than the reported grid does not narrow it."""
+        tolerance = _calibration_match_tolerance(self._mock_self(0.01), "climate.trv1")
+        assert tolerance == OFFSET_MATCH_TOLERANCE_K
+
+    def test_the_floor_is_the_offset_channel_s_own(self):
+        """The offset floor is pinned; the setpoint channel keeps its own."""
+        from custom_components.better_thermostat.utils.helpers import (
+            SETPOINT_MATCH_TOLERANCE,
+        )
+
+        assert OFFSET_MATCH_TOLERANCE_K == 0.05
+        assert SETPOINT_MATCH_TOLERANCE == 0.01
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -752,7 +752,7 @@ def _instant_sleep():
         controlling_module.asyncio.sleep = original
 
 
-def _calibration_mock_self(live_state, last_calibration, step=0.5):
+def _calibration_mock_self(live_state, last_calibration, step=0.5, generation=0):
     """Build a mock BetterThermostat with a live TRV state and one Trv."""
     mock_state = Mock()
     mock_state.state = live_state
@@ -770,6 +770,7 @@ def _calibration_mock_self(live_state, last_calibration, step=0.5):
                 "last_calibration": last_calibration,
                 "local_calibration_step": step,
                 "calibration_received": False,
+                "calibration_write_generation": generation,
             },
         )
     }
@@ -942,6 +943,85 @@ class TestCheckCalibration:
                 await task
 
         assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+
+
+class TestCheckCalibrationGeneration:
+    """Only the watchdog of the command in flight may open the write gate."""
+
+    @pytest.mark.asyncio
+    async def test_superseded_watchdog_leaves_the_gate_closed(self, caplog):
+        """A newer command in flight keeps the channel closed."""
+        mock_self = _calibration_mock_self(
+            HVACMode.HEAT, last_calibration=-3.0, generation=2
+        )
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-3.0)),
+            _instant_sleep(),
+        ):
+            result = await check_calibration(mock_self, "climate.trv1", 1)
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is False
+        assert "did not confirm the calibration offset" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_superseded_watchdog_leaves_the_gate_closed_on_an_error(self):
+        """An adapter error in a superseded watchdog opens nothing either."""
+        mock_self = _calibration_mock_self(
+            HVACMode.HEAT, last_calibration=-3.0, generation=1
+        )
+
+        async def _supersede_then_raise(_self, _entity_id):
+            """Overtake this watchdog inside the poll it then fails on."""
+            mock_self.real_trvs["climate.trv1"].calibration_write_generation = 2
+            raise RuntimeError("adapter unavailable")
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=_supersede_then_raise),
+            _instant_sleep(),
+            pytest.raises(RuntimeError),
+        ):
+            await check_calibration(mock_self, "climate.trv1", 1)
+
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is False
+
+    @pytest.mark.asyncio
+    async def test_owning_watchdog_still_releases_the_gate(self):
+        """The watchdog of the command in flight releases as before."""
+        mock_self = _calibration_mock_self(
+            HVACMode.HEAT, last_calibration=-3.0, generation=2
+        )
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-3.0)),
+            _instant_sleep(),
+        ):
+            result = await check_calibration(mock_self, "climate.trv1", 2)
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+
+    @pytest.mark.asyncio
+    async def test_superseded_mid_wait_stops_polling(self):
+        """A watchdog overtaken while waiting stops instead of timing out."""
+        mock_self = _calibration_mock_self(
+            HVACMode.HEAT, last_calibration=-3.0, generation=1
+        )
+        polls = []
+
+        async def _get_offset(_self, _entity_id):
+            polls.append(len(polls))
+            if len(polls) == 3:
+                mock_self.real_trvs["climate.trv1"].calibration_write_generation = 2
+            return 0.0
+
+        with patch(f"{_CTRL}.get_current_offset", new=_get_offset), _instant_sleep():
+            result = await check_calibration(mock_self, "climate.trv1", 1)
+
+        assert result is True
+        assert len(polls) == 3
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is False
 
 
 class TestCalibrationMatchTolerance:

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -988,7 +988,7 @@ class TestCheckCalibrationGeneration:
 
     @pytest.mark.asyncio
     async def test_owning_watchdog_still_releases_the_gate(self):
-        """The watchdog of the command in flight releases as before."""
+        """The watchdog whose generation is still current releases the gate."""
         mock_self = _calibration_mock_self(
             HVACMode.HEAT, last_calibration=-3.0, generation=2
         )

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -4,13 +4,15 @@ Tests for:
 - handle_contact_open()
 - check_system_mode()
 - check_target_temperature()
+- check_calibration()
 
 Absorbed tests from:
 - tests/test_window_no_off_mode.py (TestHandleWindowOpen, TestWindowCloseRestoresHeating)
 """
 
 import asyncio
-from unittest.mock import MagicMock, Mock
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
 import pytest
@@ -21,7 +23,9 @@ from custom_components.better_thermostat.utils.const import (
     CalibrationType,
 )
 from custom_components.better_thermostat.utils.controlling import (
+    WRITE_CONFIRM_TIMEOUT_S,
     _get_valve_control,
+    check_calibration,
     check_system_mode,
     check_target_temperature,
     handle_contact_open,
@@ -716,3 +720,259 @@ class TestGetValveControlBoostMaxOpening:
             CalibrationType.DIRECT_VALVE_BASED,
         )
         assert bal == {"valve_percent": 100, "apply_valve": True}
+
+
+# ---------------------------------------------------------------------------
+# check_calibration
+# ---------------------------------------------------------------------------
+
+_CTRL = "custom_components.better_thermostat.utils.controlling"
+
+
+@contextmanager
+def _instant_sleep():
+    """Run a watchdog poll loop without spending wall-clock time.
+
+    Yields the list of sleep durations the loop asked for.
+    """
+    import custom_components.better_thermostat.utils.controlling as controlling_module
+
+    durations = []
+
+    async def _sleep(duration):
+        durations.append(duration)
+
+    original = controlling_module.asyncio.sleep
+    controlling_module.asyncio.sleep = _sleep
+    try:
+        yield durations
+    finally:
+        controlling_module.asyncio.sleep = original
+
+
+def _calibration_mock_self(live_state, last_calibration, step=0.5):
+    """Build a mock BetterThermostat with a live TRV state and one Trv."""
+    mock_state = Mock()
+    mock_state.state = live_state
+
+    mock_hass = Mock()
+    mock_hass.states.get.return_value = mock_state if live_state is not None else None
+
+    mock_self = Mock()
+    mock_self.device_name = "test_thermostat"
+    mock_self.hass = mock_hass
+    mock_self.real_trvs = {
+        "climate.trv1": Trv.from_legacy_dict(
+            "climate.trv1",
+            {
+                "last_calibration": last_calibration,
+                "local_calibration_step": step,
+                "calibration_received": False,
+            },
+        )
+    }
+    return mock_self
+
+
+class TestCheckCalibration:
+    """Test check_calibration function."""
+
+    @pytest.mark.asyncio
+    async def test_offset_matches_immediately(self, caplog):
+        """A report equal to the command confirms without a warning."""
+        mock_self = _calibration_mock_self(HVACMode.HEAT, last_calibration=-2.0)
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-2.0)),
+            _instant_sleep(),
+        ):
+            result = await check_calibration(mock_self, "climate.trv1")
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+        assert "did not confirm the calibration offset" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_half_step_snap_confirms(self, caplog):
+        """A report half a step off the command is the device's own grid."""
+        mock_self = _calibration_mock_self(
+            HVACMode.HEAT, last_calibration=-2.0, step=1.0
+        )
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-2.5)),
+            _instant_sleep(),
+        ):
+            result = await check_calibration(mock_self, "climate.trv1")
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+        assert "did not confirm the calibration offset" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_offset_matches_after_delay(self, caplog):
+        """A report that arrives late still confirms without a warning."""
+        mock_self = _calibration_mock_self(HVACMode.HEAT, last_calibration=-2.0)
+        reported = [0.0]
+
+        async def _get_offset(_self, _entity_id):
+            return reported[0]
+
+        async def _apply_offset():
+            await asyncio.sleep(0.1)
+            reported[0] = -2.0
+
+        update_task = asyncio.create_task(_apply_offset())
+
+        with patch(f"{_CTRL}.get_current_offset", new=_get_offset):
+            result = await check_calibration(mock_self, "climate.trv1")
+
+        await update_task
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+        assert "did not confirm the calibration offset" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_offset_never_confirmed_times_out(self, caplog):
+        """A report that never converges warns and still releases the flag."""
+        mock_self = _calibration_mock_self(HVACMode.HEAT, last_calibration=-2.0)
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-1.0)),
+            _instant_sleep(),
+        ):
+            result = await check_calibration(mock_self, "climate.trv1")
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+        assert "did not confirm the calibration offset" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_unparseable_report_is_not_a_confirmation(self, caplog):
+        """An unreadable report is not treated as an acknowledgment."""
+        mock_self = _calibration_mock_self(HVACMode.HEAT, last_calibration=-2.0)
+
+        with (
+            patch(
+                f"{_CTRL}.get_current_offset",
+                new=AsyncMock(return_value="not-a-number"),
+            ),
+            _instant_sleep(),
+        ):
+            result = await check_calibration(mock_self, "climate.trv1")
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+        assert "did not confirm the calibration offset" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_unavailable_state_treated_as_done(self):
+        """An unavailable TRV ends the wait and still sets the flag."""
+        mock_self = _calibration_mock_self("unavailable", last_calibration=-2.0)
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=0.0)),
+            _instant_sleep(),
+        ):
+            result = await check_calibration(mock_self, "climate.trv1")
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+
+    @pytest.mark.asyncio
+    async def test_missing_state_treated_as_done(self):
+        """A missing TRV state ends the wait and still sets the flag."""
+        mock_self = _calibration_mock_self(None, last_calibration=-2.0)
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=0.0)),
+            _instant_sleep(),
+        ):
+            result = await check_calibration(mock_self, "climate.trv1")
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+
+    @pytest.mark.asyncio
+    async def test_no_command_to_confirm_ends_immediately(self):
+        """Without a recorded command there is nothing to wait for."""
+        mock_self = _calibration_mock_self(HVACMode.HEAT, last_calibration=None)
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=0.0)),
+            _instant_sleep(),
+        ):
+            result = await check_calibration(mock_self, "climate.trv1")
+
+        assert result is True
+        assert mock_self.real_trvs["climate.trv1"].calibration_received is True
+
+
+# ---------------------------------------------------------------------------
+# All three write watchdogs share one confirmation window
+# ---------------------------------------------------------------------------
+
+
+class TestWriteConfirmTimeout:
+    """Every write channel polls for WRITE_CONFIRM_TIMEOUT_S before giving up."""
+
+    @pytest.mark.asyncio
+    async def test_system_mode_polls_for_the_shared_window(self):
+        """check_system_mode polls one second at a time up to the window."""
+        mock_state = Mock()
+        mock_state.state = HVACMode.OFF
+
+        mock_hass = Mock()
+        mock_hass.states.get.return_value = mock_state
+
+        mock_self = Mock()
+        mock_self.device_name = "test_thermostat"
+        mock_self.hass = mock_hass
+        mock_self.real_trvs = {
+            "climate.trv1": Trv.from_legacy_dict(
+                "climate.trv1",
+                {"last_hvac_mode": HVACMode.HEAT, "system_mode_received": False},
+            )
+        }
+
+        with _instant_sleep() as durations:
+            await check_system_mode(mock_self, "climate.trv1")
+
+        assert durations.count(1) == WRITE_CONFIRM_TIMEOUT_S + 1
+
+    @pytest.mark.asyncio
+    async def test_target_temperature_polls_for_the_shared_window(self):
+        """check_target_temperature polls one second at a time up to the window."""
+        mock_state = Mock()
+        mock_state.attributes = {"temperature": 20.0}
+
+        mock_hass = Mock()
+        mock_hass.states.get.return_value = mock_state
+
+        mock_self = Mock()
+        mock_self.device_name = "test_thermostat"
+        mock_self.hass = mock_hass
+        mock_self.real_trvs = {
+            "climate.trv1": Trv.from_legacy_dict(
+                "climate.trv1",
+                {"last_temperature": 21.0, "target_temp_received": False},
+            )
+        }
+
+        with _instant_sleep() as durations:
+            await check_target_temperature(mock_self, "climate.trv1")
+
+        assert durations.count(1) == WRITE_CONFIRM_TIMEOUT_S + 1
+
+    @pytest.mark.asyncio
+    async def test_calibration_polls_for_the_shared_window(self):
+        """check_calibration polls one second at a time up to the window."""
+        mock_self = _calibration_mock_self(HVACMode.HEAT, last_calibration=-2.0)
+
+        with (
+            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-1.0)),
+            _instant_sleep() as durations,
+        ):
+            await check_calibration(mock_self, "climate.trv1")
+
+        assert durations.count(1) == WRITE_CONFIRM_TIMEOUT_S + 1

--- a/tests/unit/test_adapter_offset_contract.py
+++ b/tests/unit/test_adapter_offset_contract.py
@@ -1,0 +1,104 @@
+"""Every adapter answers a calibration offset write with a plain boolean.
+
+The delegate keys the confirmation watchdog and the recorded intent on that
+answer, so it has to separate "the write went out" from "this device has no
+offset channel". A written offset cannot carry that: the legitimate value
+0.0 reads the same as a device that wrote nothing.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.adapters import (
+    deconz,
+    generic,
+    mqtt,
+    tado,
+    zwave_js,
+)
+from custom_components.better_thermostat.trv import Trv
+
+ENTITY_ID = "climate.trv"
+CALIBRATION_ENTITY = "number.trv_local_temperature_calibration"
+
+# Adapters that write through a discovered number entity, and therefore have
+# an unsupported path when discovery found none.
+ENTITY_ADAPTERS = (generic, mqtt, zwave_js)
+# Adapters whose offset rides on the ecosystem's own service call.
+SERVICE_ADAPTERS = (deconz, tado)
+
+
+def _mock_self(calibration_entity=CALIBRATION_ENTITY):
+    """Build a thermostat whose service calls are recorded, not executed.
+
+    Parameters
+    ----------
+    calibration_entity : str or None
+        Entity ID of the discovered calibration number entity, or None to
+        model a TRV for which discovery found none.
+
+    Returns
+    -------
+    MagicMock
+        A stand-in for the Better Thermostat climate entity instance.
+    """
+    mock_self = MagicMock()
+    mock_self.device_name = "Test BT"
+    mock_self.context = None
+    mock_self.hass = MagicMock()
+    mock_self.hass.services.async_call = AsyncMock()
+    mock_self.hass.states.get = lambda requested: (
+        State(CALIBRATION_ENTITY, "0.0", {"min": -5.0, "max": 5.0, "step": 0.5})
+        if requested == CALIBRATION_ENTITY
+        else State(ENTITY_ID, "heat", {"offset": 0.0, "offset_celsius": 0.0})
+    )
+    trv = Trv(entity_id=ENTITY_ID)
+    trv.local_temperature_calibration_entity = calibration_entity
+    trv.local_calibration_min = -5.0
+    trv.local_calibration_max = 5.0
+    mock_self.real_trvs = {ENTITY_ID: trv}
+    return mock_self
+
+
+class TestOffsetWriteReportsTrue:
+    """A write that went out is reported as one, whatever value it carried."""
+
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS + SERVICE_ADAPTERS)
+    @pytest.mark.parametrize("offset", [0.0, -2.5])
+    @pytest.mark.asyncio
+    async def test_write_reports_true(self, adapter, offset):
+        """The answer is True, not the offset that was written."""
+        mock_self = _mock_self()
+
+        result = await adapter.set_offset(mock_self, ENTITY_ID, offset)
+
+        assert result is True
+        assert mock_self.hass.services.async_call.await_count == 1
+
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS + SERVICE_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_written_offset_is_recorded_as_the_command(self, adapter):
+        """The value that went on the wire is kept apart from the answer."""
+        mock_self = _mock_self()
+
+        await adapter.set_offset(mock_self, ENTITY_ID, -2.5)
+
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration == -2.5
+
+
+class TestNoOffsetChannelReportsFalse:
+    """A TRV without a calibration entity gets no write and no false claim."""
+
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_missing_calibration_entity_reports_false(self, adapter):
+        """Nothing is written and nothing is claimed to have been."""
+        mock_self = _mock_self(calibration_entity=None)
+
+        result = await adapter.set_offset(mock_self, ENTITY_ID, -2.0)
+
+        assert result is False
+        mock_self.hass.services.async_call.assert_not_awaited()
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration is None

--- a/tests/unit/test_adapter_offset_contract.py
+++ b/tests/unit/test_adapter_offset_contract.py
@@ -22,6 +22,10 @@ from custom_components.better_thermostat.trv import Trv
 
 ENTITY_ID = "climate.trv"
 CALIBRATION_ENTITY = "number.trv_local_temperature_calibration"
+SELECT_CALIBRATION_ENTITY = "select.trv_local_temperature_calibration"
+# A calibration select whose options sit on a 3 K grid, so a request that
+# falls between two of them reaches the device as a neighbouring option.
+SELECT_OPTIONS = ["-6.0k", "-3.0k", "0.0k", "3.0k", "6.0k"]
 
 # Adapters that write through a discovered number entity, and therefore have
 # an unsupported path when discovery found none.
@@ -86,6 +90,97 @@ class TestOffsetWriteReportsTrue:
         await adapter.set_offset(mock_self, ENTITY_ID, -2.5)
 
         assert mock_self.real_trvs[ENTITY_ID].last_calibration == -2.5
+
+
+def _mock_self_with_select(options=SELECT_OPTIONS):
+    """Build a thermostat whose calibration entity is a select.
+
+    Parameters
+    ----------
+    options : list of str
+        Options the select entity offers, as it publishes them.
+
+    Returns
+    -------
+    MagicMock
+        A stand-in for the Better Thermostat climate entity instance.
+    """
+    mock_self = MagicMock()
+    mock_self.device_name = "Test BT"
+    mock_self.context = None
+    mock_self.hass = MagicMock()
+    mock_self.hass.services.async_call = AsyncMock()
+    mock_self.hass.states.get = lambda requested: (
+        State(SELECT_CALIBRATION_ENTITY, "0.0k", {"options": list(options)})
+        if requested == SELECT_CALIBRATION_ENTITY
+        else State(ENTITY_ID, "heat", {})
+    )
+    trv = Trv(entity_id=ENTITY_ID)
+    trv.local_temperature_calibration_entity = SELECT_CALIBRATION_ENTITY
+    mock_self.real_trvs = {ENTITY_ID: trv}
+    return mock_self
+
+
+def _selected_option(mock_self):
+    """Return the option the recorded service call carried."""
+    return mock_self.hass.services.async_call.await_args.args[2]["option"]
+
+
+class TestSelectOffsetRecordsWhatItSelected:
+    """A select write records the offset the chosen option carries.
+
+    The confirmation compares the device's report against the recorded
+    command, so a command that never went on the wire would leave the two
+    permanently apart and re-assert the write every cycle.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_request_between_options_reaches_the_closest_one(self):
+        """The option nearest the request is what the device is told."""
+        mock_self = _mock_self_with_select()
+
+        result = await generic.set_offset(mock_self, ENTITY_ID, -2.0)
+
+        assert result is True
+        assert _selected_option(mock_self) == "-3.0k"
+
+    @pytest.mark.asyncio
+    async def test_the_snapped_option_is_the_recorded_command(self):
+        """The command is the snapped option's value, not the request."""
+        mock_self = _mock_self_with_select()
+
+        await generic.set_offset(mock_self, ENTITY_ID, -2.0)
+
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration == -3.0
+
+    @pytest.mark.asyncio
+    async def test_the_adapter_leaves_the_requested_intent_alone(self):
+        """Recording the intent stays the delegate's business."""
+        mock_self = _mock_self_with_select()
+
+        await generic.set_offset(mock_self, ENTITY_ID, -2.0)
+
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration_requested is None
+
+    @pytest.mark.asyncio
+    async def test_an_offered_option_is_recorded_as_it_is(self):
+        """A request the select offers verbatim needs no correction."""
+        mock_self = _mock_self_with_select()
+
+        await generic.set_offset(mock_self, ENTITY_ID, -3.0)
+
+        assert _selected_option(mock_self) == "-3.0k"
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration == -3.0
+
+    @pytest.mark.asyncio
+    async def test_the_option_format_decides_the_command(self):
+        """An option carries one decimal, so that is what was commanded."""
+        mock_self = _mock_self_with_select(options=["-2.3k", "-2.2k"])
+
+        await generic.set_offset(mock_self, ENTITY_ID, -2.26)
+
+        assert _selected_option(mock_self) == "-2.3k"
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration == -2.3
 
 
 class TestNoOffsetChannelReportsFalse:

--- a/tests/unit/test_delegate_set_offset.py
+++ b/tests/unit/test_delegate_set_offset.py
@@ -10,7 +10,7 @@ Both records, and the True the caller arms its confirmation watchdog on, follow
 the adapter's boolean answer: only a write that went out counts.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -18,6 +18,10 @@ from custom_components.better_thermostat.adapters.delegate import set_offset
 from custom_components.better_thermostat.trv import Trv
 
 ENTITY_ID = "climate.trv"
+# The retry decorator doubles a one-second base delay per attempt.
+RETRY_BACKOFF_S = [1.0, 2.0, 4.0, 8.0, 16.0]
+# The decorator spreads each delay by up to 20 % in either direction.
+RETRY_JITTER = 0.2
 
 
 @pytest.fixture
@@ -46,16 +50,32 @@ async def test_successful_write_records_the_requested_offset(bt):
 
 @pytest.mark.asyncio
 async def test_failed_write_leaves_the_requested_offset_untouched(bt):
-    """A write that raised on every retry records nothing and reports failure."""
+    """A write that raised on every retry records nothing and reports failure.
+
+    The backoff between the attempts is recorded rather than slept through,
+    so the retry schedule is asserted without spending it.
+    """
     bt.real_trvs[ENTITY_ID].last_calibration_requested = -1.0
     bt.real_trvs[ENTITY_ID].adapter.set_offset = AsyncMock(
         side_effect=RuntimeError("device refused")
     )
+    delays = []
 
-    result = await set_offset(bt, ENTITY_ID, -2.0)
+    async def _record_delay(seconds):
+        delays.append(seconds)
+
+    with patch("asyncio.sleep", new=_record_delay):
+        result = await set_offset(bt, ENTITY_ID, -2.0)
 
     assert result is False
     assert bt.real_trvs[ENTITY_ID].last_calibration_requested == -1.0
+    assert (
+        bt.real_trvs[ENTITY_ID].adapter.set_offset.await_count
+        == len(RETRY_BACKOFF_S) + 1
+    )
+    assert len(delays) == len(RETRY_BACKOFF_S)
+    for actual, base in zip(delays, RETRY_BACKOFF_S, strict=True):
+        assert base * (1 - RETRY_JITTER) <= actual <= base * (1 + RETRY_JITTER)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_delegate_set_offset.py
+++ b/tests/unit/test_delegate_set_offset.py
@@ -1,0 +1,75 @@
+"""The delegate records the offset it asked for, separate from what was sent.
+
+``last_calibration`` is what the adapter put on the wire after its own clamp to
+the device's declared offset range; ``last_calibration_requested`` is the value
+that was asked for before that clamp. Keeping the two apart is what lets the
+write gate tell a device resting at a declared limit from one that dropped the
+write.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.better_thermostat.adapters.delegate import set_offset
+from custom_components.better_thermostat.trv import Trv
+
+ENTITY_ID = "climate.trv"
+
+
+@pytest.fixture
+def bt():
+    """Mock thermostat whose adapter accepts every offset write."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.hass = MagicMock()
+    trv = Trv(
+        entity_id=ENTITY_ID, local_calibration_min=-3.0, local_calibration_max=3.0
+    )
+    trv.adapter = MagicMock()
+    trv.adapter.set_offset = AsyncMock(return_value=True)
+    mock.real_trvs = {ENTITY_ID: trv}
+    return mock
+
+
+@pytest.mark.asyncio
+async def test_successful_write_records_the_requested_offset(bt):
+    """A write the adapter accepted records the requested value."""
+    result = await set_offset(bt, ENTITY_ID, -2.0)
+
+    assert result is True
+    assert bt.real_trvs[ENTITY_ID].last_calibration_requested == -2.0
+
+
+@pytest.mark.asyncio
+async def test_failed_write_leaves_the_requested_offset_untouched(bt):
+    """A write that raised on every retry records nothing and reports failure."""
+    bt.real_trvs[ENTITY_ID].last_calibration_requested = -1.0
+    bt.real_trvs[ENTITY_ID].adapter.set_offset = AsyncMock(
+        side_effect=RuntimeError("device refused")
+    )
+
+    result = await set_offset(bt, ENTITY_ID, -2.0)
+
+    assert result is False
+    assert bt.real_trvs[ENTITY_ID].last_calibration_requested == -1.0
+
+
+@pytest.mark.asyncio
+async def test_clamped_write_keeps_the_pre_clamp_intent(bt):
+    """An adapter clamp moves the command, not the recorded intent."""
+
+    async def _clamping_set_offset(_self, entity_id, offset):
+        trv = _self.real_trvs[entity_id]
+        trv.last_calibration = max(float(trv.local_calibration_min), float(offset))
+        return True
+
+    bt.real_trvs[ENTITY_ID].adapter.set_offset = AsyncMock(
+        side_effect=_clamping_set_offset
+    )
+
+    result = await set_offset(bt, ENTITY_ID, -5.0)
+
+    assert result is True
+    assert bt.real_trvs[ENTITY_ID].last_calibration == -3.0
+    assert bt.real_trvs[ENTITY_ID].last_calibration_requested == -5.0

--- a/tests/unit/test_delegate_set_offset.py
+++ b/tests/unit/test_delegate_set_offset.py
@@ -5,6 +5,9 @@ the device's declared offset range; ``last_calibration_requested`` is the value
 that was asked for before that clamp. Keeping the two apart is what lets the
 write gate tell a device resting at a declared limit from one that dropped the
 write.
+
+Both records, and the True the caller arms its confirmation watchdog on, follow
+the adapter's boolean answer: only a write that went out counts.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -53,6 +56,26 @@ async def test_failed_write_leaves_the_requested_offset_untouched(bt):
 
     assert result is False
     assert bt.real_trvs[ENTITY_ID].last_calibration_requested == -1.0
+
+
+@pytest.mark.asyncio
+async def test_device_without_an_offset_channel_records_nothing(bt):
+    """An adapter that wrote nothing arms neither the gate nor the record."""
+    bt.real_trvs[ENTITY_ID].adapter.set_offset = AsyncMock(return_value=False)
+
+    result = await set_offset(bt, ENTITY_ID, -2.0)
+
+    assert result is False
+    assert bt.real_trvs[ENTITY_ID].last_calibration_requested is None
+
+
+@pytest.mark.asyncio
+async def test_a_written_zero_offset_is_still_a_write(bt):
+    """The answer, not the value written, decides what counts as a command."""
+    result = await set_offset(bt, ENTITY_ID, 0.0)
+
+    assert result is True
+    assert bt.real_trvs[ENTITY_ID].last_calibration_requested == 0.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_trv_object.py
+++ b/tests/unit/test_trv_object.py
@@ -21,6 +21,7 @@ class TestTypedAccess:
         assert trv.calibration_received is True
         assert trv.ignore_trv_states is False
         assert trv.current_temperature is None
+        assert trv.last_calibration_requested is None
         assert trv.advanced == {}
         assert trv.extra == {}
 
@@ -59,6 +60,16 @@ class TestExtraScratchpad:
         assert trv.current_temperature == 21.0
         assert trv.advanced == {"child_lock": True}
         assert trv.extra == {"_quirk_scratch": 3}
+
+    def test_from_legacy_dict_maps_requested_calibration_onto_the_field(self):
+        """``last_calibration_requested`` is a typed field, not an extra."""
+        trv = Trv.from_legacy_dict(
+            "climate.trv",
+            {"last_calibration": -3.0, "last_calibration_requested": -5.0},
+        )
+        assert trv.last_calibration == -3.0
+        assert trv.last_calibration_requested == -5.0
+        assert trv.extra == {}
 
     def test_from_legacy_dict_ignores_entity_id_key(self):
         """A legacy ``entity_id`` key never collides with the argument."""


### PR DESCRIPTION
Fixes #2174.

## Symptom

On a TRV with local (offset) calibration, BT computes an offset every cycle but
never writes it. The user's log shows the calibration value being calculated and
no `TO TRV set_local_temperature_calibration` line ever following it: the
calibration entity keeps whatever value it had, so the room runs off the TRV's
own internal sensor.

Reproduced by execution on `develop`: with `calibration_received=False`,
`last_calibration=0.0`, the device reporting `0.0` and a desired offset of
`-2.0`, ten consecutive `control_trv` cycles award `set_offset` **zero** times
and leave the flag at `False`.

## Mechanism

The write gate compared BT's **intent** against the value BT had **last sent**
(`last_calibration`), and never against what the device **reports**
(`_current_calibration`, which the same block fetches a few lines earlier). Two
consequences:

1. There was no bounded way back from an unconfirmed write. `calibration_received`
   is cleared on every write and the only path back to `True` ran through
   `events/trv.py`. For a device that stops reporting its internal temperature
   (offline, dead battery, report-on-change device in a stable room), or after a
   service call that raised (which `delegate.set_offset` swallowed), the flag
   stays `False` and the channel is wedged for the lifetime of the entity.
   `check_system_mode` and `check_target_temperature` have had a watchdog for
   this for a long time; the offset channel had none.
2. A device that silently drops the write is invisible. `last_calibration` is a
   record of intent written by the adapter at command time; nothing outside
   startup ever reconciles it against the entity, so once BT believes it sent
   `-2.0` it will not send it again even while the device reports `0.0`.

## What this changes

The offset channel now keeps the three values a reliable write channel needs
apart:

| | value | field |
|---|---|---|
| INTENT | what this cycle wants | `last_calibration_requested` (new) |
| COMMAND | what went on the wire after the adapter's clamp | `last_calibration` |
| REPORT | what the device says it holds | read via `get_current_offset` |

- A write goes out when the intent moved away from the last requested value, **or**
  when the report diverged from the command.
- `check_calibration`, a third watchdog modelled member-for-member on its two
  siblings (same task-name scheme, same 1 s poll, same trailing 2 s, same
  "giving up and assuming applied" warning). It guarantees
  `calibration_received` is released within a bounded window, and it doubles as
  the resend pacer: a device that drops offsets gets **one** re-assert per
  window, not one per control cycle.
- The 360 s window of all three watchdogs is now one constant,
  `WRITE_CONFIRM_TIMEOUT_S`.
- The comparison tolerance is derived from the device's own offset step (half a
  step, floored at the existing `SETPOINT_MATCH_TOLERANCE`) instead of the
  hard-coded `0.5`. `0.5` is only the `Trv` dataclass default for
  `local_calibration_step` and is wrong in both directions: on a 0.1-step device
  it hides a real 0.4 K error, and on a 1.0-step deconz device it rejects a
  legitimate one-step snap of exactly 0.5 and would arm a permanent retry.
- `delegate.set_offset` returns whether the adapter accepted the write and
  records the requested value on success only. A swallowed failure no longer
  clears the in-flight flag and no longer arms a watchdog for a write that never
  left the house.
- Develop-only crash fixed as part of the same block: with
  `last_calibration=None` and an unparseable reported offset, `float(None)`
  raised `TypeError` out of `control_trv` and the setpoint write for that cycle
  was lost. `v2` already guards this; `develop` now adopts the same guard.

### The clamp is not a retry loop

This is the property the whole intent/command split exists for. When the adapter
clamps a requested `-5.0` to the device's declared `-3.0` minimum, the report
equals the command, so the divergence arm stays quiet, and
`last_calibration_requested` holds the pre-clamp `-5.0`, so the intent arm stays
quiet too. Executed: **1 write, then silence**. The naive version of this fix
(gating on the reported value alone) writes on 10 of 10 cycles.
`test_adapter_clamp_does_not_become_a_retry_loop` asserts silence across five
consecutive cycles.

An **undeclared** firmware limit (a device refusing a value inside the range it
advertises) is by construction indistinguishable from a dropped write. There the
change deliberately re-asserts, bounded to one write per watchdog window, and
emits the warning that tells the user which of the two it is.

## What it deliberately does not do

- Does not touch `events/trv.py`. The `trv.calibration == 0` branch that re-reads
  `last_calibration` is the wrong code for `LOCAL_BASED` under the numeric
  encoding in `climate.py`, but it must **not** be "fixed" alongside this:
  re-reading `last_calibration` from the device would collapse COMMAND into
  REPORT and kill the divergence arm silently. Separate ticket.
- Does not re-read `local_calibration_min/max/step` per cycle; they keep coming
  from the single startup read.
- Does not change `calibration.py`: the integrator, its clamp and the
  direction-aware rounding are untouched.
- Does not fix that every adapter's `get_current_offset` returns `0.0` for an
  unavailable calibration entity.
- Does not apply the same split to the setpoint channel, which has the identical
  structural exposure but whose two clamp sources agree today.

## Two existing tests changed semantics

Both were encoding the bug and are rewritten, not deleted:

- `test_calibration_received_stays_false_when_mismatch` →
  `test_confirmed_command_releases_flag_and_writes_new_intent`. Its old assertion
  *was* the stall: the device confirmably holds what it was told and BT wants
  something else, which is precisely when a write must go out.
- `test_calibration_tolerance_within_half_degree` →
  `test_confirmation_window_is_half_the_device_offset_step`. With a 0.5 step the
  confirm window is now ±0.25, so a report 0.3 off the command is no longer
  "confirmed"; with a 1.0 step a report 0.5 off now is.

## Verification

- Full suite: **2441 passed** (baseline on this branch point: 2411 passed).
- `ruff check`, `ruff format --check`, `pyrefly check` (0 errors) all clean.
- Counterfactual: with the three production files reverted and the tests kept,
  **11 of the new/rewritten tests fail**, including
  `TypeError: float() argument must be a string or a real number, not 'NoneType'`
  for the `last_calibration=None` case and
  `Expected set_offset to have been awaited once. Awaited 0 times.` for the
  #2174 regression itself.
- The gate was additionally simulated over ten device behaviours (healthy,
  stuck intent, moving intent, declared-range clamp with matching and with stale
  wider bounds, drifting intent against a clamp, honest-step snap, silently
  dropped writes, undeclared firmware limit, lost watchdog task); all ten
  produce the intended write counts.

A twin PR carries the same change to the `v2` line, where it additionally makes
the existing reconciler effective: `_offset_diverges` is exactly the new
`_command_diverged` predicate, so a reconcile-queued cycle now actually writes
instead of being a no-op.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved thermostat calibration tracking for requested, applied, and reported offset values.
  * Added confirmation monitoring for calibration, HVAC mode, and target-temperature changes.
  * Calibration now accounts for device-specific adjustment steps, device-adjusted values, and selectable calibration settings.
  * Calibration updates now clearly report whether an offset was successfully applied.

* **Bug Fixes**
  * Improved retries and timeout handling for unconfirmed or failed thermostat updates.
  * Prevented failed calibration writes from being recorded as successful.
  * Improved handling of unavailable, delayed, or invalid device reports.
  * Prevented outdated confirmation checks from interfering with newer thermostat commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
