### PR TITLE
fix(v2): agree on one default calibration mode

### DIFF
--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -59,6 +59,7 @@ from custom_components.better_thermostat.utils.calibration.tpi import (
 from custom_components.better_thermostat.utils.const import (
     CONF_MPC_V2_PLANT_PRESET,
     CONF_PROTECT_OVERHEATING,
+    DEFAULT_CALIBRATION_MODE,
     CalibrationMode,
     CalibrationType,
     MpcV2PlantPreset,
@@ -1172,7 +1173,7 @@ def calculate_calibration_local(self, entity_id) -> float | None:
 
     _calibration_mode = normalize_calibration_mode(
         self.real_trvs[entity_id].advanced.get(
-            "calibration_mode", CalibrationMode.MPC_CALIBRATION
+            "calibration_mode", DEFAULT_CALIBRATION_MODE
         )
     )
     if _calibration_mode is None:
@@ -1402,7 +1403,7 @@ def calculate_calibration_setpoint(self, entity_id) -> float | None:
 
     _calibration_mode = normalize_calibration_mode(
         self.real_trvs[entity_id].advanced.get(
-            "calibration_mode", CalibrationMode.MPC_CALIBRATION
+            "calibration_mode", DEFAULT_CALIBRATION_MODE
         )
     )
     if _calibration_mode is None:

--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -1177,7 +1177,7 @@ def calculate_calibration_local(self, entity_id) -> float | None:
         )
     )
     if _calibration_mode is None:
-        _calibration_mode = CalibrationMode.MPC_CALIBRATION
+        _calibration_mode = DEFAULT_CALIBRATION_MODE
     traits = _traits_for(_calibration_mode)
 
     _cur_external_temp = effective_room_temp(self)
@@ -1407,7 +1407,7 @@ def calculate_calibration_setpoint(self, entity_id) -> float | None:
         )
     )
     if _calibration_mode is None:
-        _calibration_mode = CalibrationMode.MPC_CALIBRATION
+        _calibration_mode = DEFAULT_CALIBRATION_MODE
     traits = _traits_for(_calibration_mode)
 
     if self.bt_target_temp is None:

--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -54,6 +54,7 @@ from .utils.const import (
     CONF_WEATHER,
     CONF_WINDOW_TIMEOUT,
     CONF_WINDOW_TIMEOUT_AFTER,
+    DEFAULT_CALIBRATION_MODE,
     CalibrationMode,
     CalibrationType,
     MpcV2PlantPreset,
@@ -89,11 +90,11 @@ CALIBRATION_MODE_SELECTOR = selector.SelectSelector(
     selector.SelectSelectorConfig(
         options=[
             selector.SelectOptionDict(
-                value=CalibrationMode.HEATING_POWER_CALIBRATION, label="(AI) Time Based"
+                value=CalibrationMode.HEATING_POWER_CALIBRATION,
+                label="(AI) Time Based (Default)",
             ),
             selector.SelectOptionDict(
-                value=CalibrationMode.DEFAULT,
-                label="External Sensor Offset Only (Default)",
+                value=CalibrationMode.DEFAULT, label="External Sensor Offset Only"
             ),
             selector.SelectOptionDict(
                 value=CalibrationMode.MPC_CALIBRATION, label="MPC Predictive (Beta)"
@@ -103,7 +104,7 @@ CALIBRATION_MODE_SELECTOR = selector.SelectSelector(
                 label="(AI) MPC v2 (QP + Kalman, experimental)",
             ),
             selector.SelectOptionDict(
-                value=CalibrationMode.AGGRESIVE_CALIBRATION, label="Agressive"
+                value=CalibrationMode.AGGRESIVE_CALIBRATION, label="Aggressive"
             ),
             selector.SelectOptionDict(
                 value=CalibrationMode.TPI_CALIBRATION, label="TPI Controller"
@@ -252,7 +253,7 @@ def _build_advanced_fields(
             elif balance_mode in ("heuristic", "none"):
                 # For other balance modes, set calibration_mode to default if not set
                 if "calibration_mode" not in source:
-                    source["calibration_mode"] = CalibrationMode.MPC_CALIBRATION.value
+                    source["calibration_mode"] = DEFAULT_CALIBRATION_MODE.value
                 # Remove old balance_mode
                 source.pop("balance_mode", None)
 
@@ -306,9 +307,7 @@ def _build_advanced_fields(
     ordered[
         vol.Required(
             CONF_CALIBRATION_MODE,
-            default=get_value(
-                CONF_CALIBRATION_MODE, CalibrationMode.HEATING_POWER_CALIBRATION
-            ),
+            default=get_value(CONF_CALIBRATION_MODE, DEFAULT_CALIBRATION_MODE),
         )
     ] = CALIBRATION_MODE_SELECTOR
 
@@ -355,7 +354,7 @@ def _normalize_advanced_submission(
     normalized: dict[str, Any] = dict(data)
     normalized[CONF_CALIBRATION] = normalized.get(CONF_CALIBRATION, default_calibration)
     normalized[CONF_CALIBRATION_MODE] = normalized.get(
-        CONF_CALIBRATION_MODE, CalibrationMode.HEATING_POWER_CALIBRATION
+        CONF_CALIBRATION_MODE, DEFAULT_CALIBRATION_MODE
     )
     normalized[CONF_PROTECT_OVERHEATING] = _as_bool(
         normalized.get(CONF_PROTECT_OVERHEATING), False

--- a/custom_components/better_thermostat/utils/const.py
+++ b/custom_components/better_thermostat/utils/const.py
@@ -152,6 +152,12 @@ class CalibrationMode(StrEnum):
     PID_CALIBRATION = "pid_calibration"
 
 
+# The calibration mode a TRV runs in when its config carries none. Read by
+# the config flow (form default and normalisation) and by every runtime
+# fallback, so a stored config without the key behaves like a fresh one.
+DEFAULT_CALIBRATION_MODE: Final = CalibrationMode.HEATING_POWER_CALIBRATION
+
+
 # Plausibility bounds for incoming temperature readings (Celsius).
 # Values outside this window are treated as marker / garbage readings
 # (for example, AVM Fritz!DECT exposes 126.5 / 127 °C when the thermostat

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -32,6 +32,7 @@ from custom_components.better_thermostat.model_fixes.model_quirks import (
     override_set_temperature,
 )
 from custom_components.better_thermostat.utils.const import (
+    DEFAULT_CALIBRATION_MODE,
     CalibrationMode,
     CalibrationType,
 )
@@ -1371,7 +1372,7 @@ async def control_trv(self, heater_entity_id=None, cycle=None):
             _calibration = _remapped_states.get("local_temperature_calibration", None)
 
             _calibration_mode = self.real_trvs[heater_entity_id].advanced.get(
-                "calibration_mode", CalibrationMode.MPC_CALIBRATION
+                "calibration_mode", DEFAULT_CALIBRATION_MODE
             )
             _calibration_type = self.real_trvs[heater_entity_id].advanced.get(
                 "calibration", CalibrationType.TARGET_TEMP_BASED

--- a/tests/unit/test_calibration_mode_default.py
+++ b/tests/unit/test_calibration_mode_default.py
@@ -10,11 +10,16 @@ offered as the default.
 from __future__ import annotations
 
 import inspect
+from unittest.mock import MagicMock
+
+import pytest
 
 from custom_components.better_thermostat import (
     calibration as calibration_module,
     config_flow as config_flow_module,
 )
+from custom_components.better_thermostat.calibration import calculate_calibration_local
+from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils import controlling as controlling_module
 from custom_components.better_thermostat.utils.const import (
     DEFAULT_CALIBRATION_MODE,
@@ -22,6 +27,46 @@ from custom_components.better_thermostat.utils.const import (
 )
 
 _RUNTIME_MODULES = (calibration_module, controlling_module)
+
+
+def _thermostat_without_target(stored_mode: object) -> MagicMock:
+    """A thermostat carrying *stored_mode* and no target temperature.
+
+    Without a target, only a mode that needs none produces a value, which
+    makes the resolved mode observable from the return value alone.
+    """
+    bt = MagicMock()
+    bt.name = "better_thermostat"
+    bt.device_name = "Test BT"
+    bt.tolerance = 0.5
+    bt.attr_hvac_action = None
+    bt.hvac_action = None
+    bt.cur_temp = 20.0
+    bt.bt_target_temp = None
+
+    quirks = MagicMock()
+    quirks.fix_local_calibration.side_effect = lambda _self, _entity_id, offset: float(
+        offset
+    )
+
+    bt.real_trvs = {
+        "climate.trv": Trv.from_legacy_dict(
+            "climate.trv",
+            {
+                "advanced": {"calibration_mode": stored_mode},
+                "current_temperature": 22.0,
+                "last_calibration": 2.0,
+                "local_calibration_step": 0.1,
+                "local_calibration_min": -5.0,
+                "local_calibration_max": 5.0,
+                "target_temp_step": 0.5,
+                "min_temp": 5.0,
+                "max_temp": 30.0,
+                "model_quirks": quirks,
+            },
+        )
+    }
+    return bt
 
 
 def test_default_is_a_known_mode():
@@ -45,6 +90,28 @@ def test_no_runtime_fallback_hardcodes_a_mode():
             f"{module.__name__} hardcodes a calibration-mode fallback"
         )
         assert '"calibration_mode", DEFAULT_CALIBRATION_MODE' in source
+        assert "_calibration_mode = CalibrationMode." not in source, (
+            f"{module.__name__} rewrites an unresolved mode to a named one "
+            "instead of the shared default"
+        )
+
+
+@pytest.mark.parametrize("stored_mode", [None, 3], ids=["null", "unmappable-number"])
+def test_unresolvable_stored_mode_falls_back_to_the_shared_default(
+    monkeypatch, stored_mode
+):
+    """A stored mode that normalizes to ``None`` resolves to the shared default.
+
+    The default is swapped for a mode that works without a target, so a
+    returned value proves the fallback read the constant rather than
+    naming a mode of its own.
+    """
+    monkeypatch.setattr(
+        calibration_module, "DEFAULT_CALIBRATION_MODE", CalibrationMode.DEFAULT
+    )
+    thermostat = _thermostat_without_target(stored_mode)
+
+    assert calculate_calibration_local(thermostat, "climate.trv") == 0.0
 
 
 def test_config_flow_uses_the_shared_default():

--- a/tests/unit/test_calibration_mode_default.py
+++ b/tests/unit/test_calibration_mode_default.py
@@ -25,6 +25,10 @@ from custom_components.better_thermostat.utils.const import (
     DEFAULT_CALIBRATION_MODE,
     CalibrationMode,
 )
+from custom_components.better_thermostat.utils.helpers import (
+    is_calibration_mode,
+    normalize_calibration_mode,
+)
 
 _RUNTIME_MODULES = (calibration_module, controlling_module)
 
@@ -112,6 +116,30 @@ def test_unresolvable_stored_mode_falls_back_to_the_shared_default(
     thermostat = _thermostat_without_target(stored_mode)
 
     assert calculate_calibration_local(thermostat, "climate.trv") == 0.0
+
+
+def test_a_named_but_unknown_mode_does_not_become_the_default(monkeypatch):
+    """A string naming a mode this version does not know stays unresolved.
+
+    ``normalize_calibration_mode`` hands an unrecognized string back
+    unchanged instead of returning ``None``, and that is the answer the
+    rest of the code reads: ``is_calibration_mode`` reports ``False`` for
+    it against every mode. A config that names something is not a config
+    that names nothing, so it does not take the shared default.
+    """
+    assert normalize_calibration_mode("a mode from another version") == (
+        "a mode from another version"
+    )
+    assert not is_calibration_mode(
+        "a mode from another version", DEFAULT_CALIBRATION_MODE
+    )
+
+    monkeypatch.setattr(
+        calibration_module, "DEFAULT_CALIBRATION_MODE", CalibrationMode.DEFAULT
+    )
+    thermostat = _thermostat_without_target("a mode from another version")
+
+    assert calculate_calibration_local(thermostat, "climate.trv") is None
 
 
 def test_config_flow_uses_the_shared_default():

--- a/tests/unit/test_calibration_mode_default.py
+++ b/tests/unit/test_calibration_mode_default.py
@@ -1,0 +1,70 @@
+"""One default calibration mode, agreed on by every site that names one.
+
+Three places used to disagree: the dropdown label marked
+``External Sensor Offset Only`` as the default, the config flow preselected
+Time Based, and the runtime fell back to MPC Predictive. A stored config
+without ``calibration_mode`` therefore ran a Beta algorithm the UI never
+offered as the default.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from custom_components.better_thermostat import calibration as calibration_module
+from custom_components.better_thermostat import config_flow as config_flow_module
+from custom_components.better_thermostat.utils import controlling as controlling_module
+from custom_components.better_thermostat.utils.const import (
+    DEFAULT_CALIBRATION_MODE,
+    CalibrationMode,
+)
+
+_RUNTIME_MODULES = (calibration_module, controlling_module)
+
+
+def test_default_is_a_known_mode():
+    """The shared default has to be a real member of the enum."""
+    assert DEFAULT_CALIBRATION_MODE in set(CalibrationMode)
+
+
+def test_default_is_not_a_beta_mode():
+    """The silent default must not be one of the modes labelled Beta."""
+    assert DEFAULT_CALIBRATION_MODE not in {
+        CalibrationMode.MPC_CALIBRATION,
+        CalibrationMode.MPC_V2_CALIBRATION,
+    }
+
+
+def test_no_runtime_fallback_hardcodes_a_mode():
+    """Runtime fallbacks read the shared default instead of naming a mode."""
+    for module in _RUNTIME_MODULES:
+        source = inspect.getsource(module)
+        assert '"calibration_mode", CalibrationMode.' not in source, (
+            f"{module.__name__} hardcodes a calibration-mode fallback"
+        )
+        assert '"calibration_mode", DEFAULT_CALIBRATION_MODE' in source
+
+
+def test_config_flow_uses_the_shared_default():
+    """The form default and the submission normaliser read the same constant."""
+    source = inspect.getsource(config_flow_module)
+    assert "CONF_CALIBRATION_MODE, DEFAULT_CALIBRATION_MODE" in source
+    assert (
+        "CONF_CALIBRATION_MODE, CalibrationMode.HEATING_POWER_CALIBRATION" not in source
+    )
+
+
+def test_only_the_real_default_is_labelled_default():
+    """Exactly one dropdown entry carries the (Default) marker, and it is the default."""
+    options = config_flow_module.CALIBRATION_MODE_SELECTOR.config["options"]
+    marked = [opt for opt in options if "(Default)" in opt["label"]]
+    assert len(marked) == 1
+    assert marked[0]["value"] == DEFAULT_CALIBRATION_MODE
+
+
+def test_every_mode_is_offered_exactly_once():
+    """The selector stays a faithful listing of the enum."""
+    options = config_flow_module.CALIBRATION_MODE_SELECTOR.config["options"]
+    values = [opt["value"] for opt in options]
+    assert len(values) == len(set(values))
+    assert set(values) == set(CalibrationMode)

--- a/tests/unit/test_calibration_mode_default.py
+++ b/tests/unit/test_calibration_mode_default.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import inspect
 
-from custom_components.better_thermostat import calibration as calibration_module
-from custom_components.better_thermostat import config_flow as config_flow_module
+from custom_components.better_thermostat import (
+    calibration as calibration_module,
+    config_flow as config_flow_module,
+)
 from custom_components.better_thermostat.utils import controlling as controlling_module
 from custom_components.better_thermostat.utils.const import (
     DEFAULT_CALIBRATION_MODE,


### PR DESCRIPTION
Part of #2205.

## What was wrong

Three values claimed to be the default calibration mode, across seven sites:

| Site | Value |
| --- | --- |
| Dropdown label `(Default)` marker | `External Sensor Offset Only` |
| Config-flow form default and `_normalize_advanced_submission` | Time Based |
| `balance_mode` migration backfill | MPC Predictive |
| Runtime fallbacks in `calibration.py` (x2) and `controlling.py` | MPC Predictive |
| `docs/Configuration/algorithms.md` | AI Time Based |

## Behaviour change, please read before merging

`_normalize_advanced_submission` only runs when the advanced page is submitted; nothing fills the key at load time. A config entry whose per-TRV `advanced` block has no `calibration_mode` therefore ran **MPC Predictive**, which the selector itself labels Beta, while the options page showed Time Based preselected and the docs said the same.

After this change those entries run Time Based. That is the point of the fix, but it does mean an install carried over from before the option existed changes algorithm on upgrade. It changes to the one its own UI has been claiming all along.

If you would rather converge the other way and make MPC the documented default, that is a one-line change to `DEFAULT_CALIBRATION_MODE` plus a docs edit, and the tests here still hold except `test_default_is_not_a_beta_mode`.

## What changed

`DEFAULT_CALIBRATION_MODE` in `utils/const.py` is now the single source, read by the config-flow default, the submission normaliser, the `balance_mode` migration and all three runtime fallbacks. The `(Default)` marker moves onto the entry it describes. `Agressive` gains its missing `g`.

## Blast radius

`gitnexus impact` rates `calculate_calibration_local` HIGH: 60 symbols, three execution flows (`control_queue`, `async_added_to_hass`, `control_trv`). No signature or control flow changes here, only the value a `.get()` falls back to, so the radius is behavioural rather than structural. It is the reason this is a draft.

## Tests

New `tests/unit/test_calibration_mode_default.py` pins the convergence so it cannot drift apart again: the shared default is a real enum member and not a Beta mode, no runtime fallback names a mode of its own, the config flow reads the shared constant, exactly one dropdown entry is marked `(Default)` and it is the default, and the selector lists every mode once.

4532 tests pass.

Paired with the develop change in the companion PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized the default calibration mode across thermostat setup and runtime operation.
  * Thermostats without a configured calibration mode now use heating-power calibration.
  * Updated calibration mode labels and spelling in the configuration interface.
  * Improved handling of calibration settings during migration, advanced setup, and form submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->