### PR TITLE
docs: add a preset reference and a central-thermostat guide

### DIFF
--- a/docs/Configuration/algorithms.md
+++ b/docs/Configuration/algorithms.md
@@ -189,7 +189,7 @@ Not all TRVs support offset-based calibration. Better Thermostat will automatica
 
 ## Direct valve control
 
-Some TRV devices support **direct valve control**, where Better Thermostat can directly set the valve opening percentage (0-100%) instead of only adjusting target temperatures or offsets. That gives the algorithms finer control, which matters most for MPC and PID.
+Some TRV devices support **direct valve control**, where Better Thermostat can directly set the valve opening percentage (0-100%) instead of only adjusting target temperatures or offsets. That sends the selected algorithm's valve decision straight to the TRV, instead of letting the TRV's own controller decide what to do with a setpoint.
 
 ### What direct valve control is
 
@@ -214,9 +214,9 @@ Better Thermostat automatically detects if your TRV supports direct valve contro
 
 When direct valve control is available:
 
-- **MPC Predictive**: Calculates optimal valve opening based on predicted temperature changes. This is where direct valve control shines - the algorithm can precisely control heating power.
+- **MPC Predictive**: Calculates a valve opening from its prediction of where the room is heading, and that opening is written as it stands.
 
-- **PID Controller**: Directly outputs valve position based on temperature error and trends. Very effective with direct valve control.
+- **PID Controller**: Directly outputs valve position based on temperature error and trends.
 
 - **TPI Controller**: Sets valve opening based on heating duty cycle calculations.
 

--- a/docs/Configuration/algorithms.md
+++ b/docs/Configuration/algorithms.md
@@ -22,7 +22,7 @@ Start here if you are unsure:
 
 ### Normal
 
-Normal mode uses your external temperature sensor to correct the TRV's internal sensor. The TRV reads the actual room temperature from your external sensor and adjusts accordingly.
+Normal mode uses your external temperature sensor to correct the TRV's internal one. Better Thermostat compares the two readings and sends the TRV an offset, or a setpoint that already carries the difference; the TRV keeps running on its own sensor and never sees yours.
 
 It is simple, reliable, works with most TRVs and costs almost nothing to run. In exchange it does not optimise for efficiency and does not adapt to the room.
 
@@ -61,7 +61,7 @@ MPC (Model Predictive Control) predicts how your room temperature will change ov
 
 From that prediction it picks the correction that reaches your target smoothly instead of driving hard and correcting afterward, and it keeps updating the model as the room behaves. With direct valve control that correction is a valve opening; without it, the correction reaches the valve through the setpoint the TRV sees.
 
-Of all the modes it is the best at avoiding overshoot and the most economical with energy. It is also the most complex, and it reacts deliberately rather than quickly, which can read as sluggish at first. Give it about a day of operation before judging it.
+It aims at arriving at the target rather than at arriving quickly, which is the whole point of predicting ahead. It is the most complex of the modes and it reacts deliberately rather than fast, which can read as sluggish at first. Give it about a day of operation before judging it.
 
 Pick it when you overshoot regularly, when efficiency matters more to you than reaction speed, and when your heating system itself is reasonably stable.
 

--- a/docs/Configuration/algorithms.md
+++ b/docs/Configuration/algorithms.md
@@ -58,7 +58,7 @@ MPC (Model Predictive Control) predicts how your room temperature will change ov
 - Temperature trends
 - Learned thermal properties of your room (how fast it heats and cools)
 
-From that prediction it picks the valve opening that reaches your target smoothly instead of driving hard and correcting afterward, and it keeps updating the model as the room behaves.
+From that prediction it picks the correction that reaches your target smoothly instead of driving hard and correcting afterward, and it keeps updating the model as the room behaves. With direct valve control that correction is a valve opening; without it, the correction reaches the valve through the setpoint the TRV sees.
 
 Of all the modes it is the best at avoiding overshoot and the most economical with energy. It is also the most complex, and it reacts deliberately rather than quickly, which can read as sluggish at first. Give it about a day of operation before judging it.
 

--- a/docs/Configuration/algorithms.md
+++ b/docs/Configuration/algorithms.md
@@ -247,7 +247,7 @@ For MQTT/Zigbee2MQTT users, you can also check if your TRV exposes entities like
 
 ### What it buys you
 
-The algorithm sets the valve opening itself rather than asking the TRV's own logic for it, so the response arrives without a detour and the room's reaction is a cleaner signal to learn from. Valve position is not heat output — flow temperature and the valve's own authority still sit in between — but it is the finest handle Better Thermostat can get, and a finer handle leaves less room for overshoot. Every mode runs without it.
+The algorithm sets the valve opening itself rather than asking the TRV's own logic for it, so the response arrives without a detour and the room's reaction is a cleaner signal to learn from. Valve position is not heat output — flow temperature and the valve's own authority still sit in between — but it is the most direct handle Better Thermostat can get on the device. Every mode runs without it.
 
 ### If you are buying new TRVs
 

--- a/docs/Configuration/algorithms.md
+++ b/docs/Configuration/algorithms.md
@@ -247,7 +247,7 @@ For MQTT/Zigbee2MQTT users, you can also check if your TRV exposes entities like
 
 ### What it buys you
 
-The algorithm sets the valve opening itself rather than asking the TRV's own logic for it, so the response arrives without a detour and the room's reaction is a cleaner signal to learn from. Valve position is not heat output — flow temperature and the valve's own authority still sit in between — but it is the finest handle Better Thermostat can get, and a finer handle leaves less room for overshoot. MPC and PID gain the most from it; every mode runs without it.
+The algorithm sets the valve opening itself rather than asking the TRV's own logic for it, so the response arrives without a detour and the room's reaction is a cleaner signal to learn from. Valve position is not heat output — flow temperature and the valve's own authority still sit in between — but it is the finest handle Better Thermostat can get, and a finer handle leaves less room for overshoot. Every mode runs without it.
 
 ### If you are buying new TRVs
 

--- a/docs/Configuration/algorithms.md
+++ b/docs/Configuration/algorithms.md
@@ -6,117 +6,63 @@ slug: calibration_algorithms
 
 Better Thermostat offers several calibration algorithms (also called "Calibration Modes") that control how your TRV (Thermostatic Radiator Valve) is adjusted to maintain your desired temperature. Each algorithm has different characteristics and is suited for different situations.
 
-## Choosing the Right Algorithm
+## Choosing an algorithm
 
-If you're unsure which algorithm to use, here's a quick guide:
+Start here if you are unsure:
 
-- **Just starting out?** Try **AI Time Based** (default) - it works well for most situations
-- **Room heats too slowly?** Try **Aggressive**
-- **Temperature overshoots often?** Try **MPC Predictive** (⚠️ beta)
-- **Have technical knowledge and want fine control?** Try **PID Controller** 
-- **Want something simple and reliable?** Try **Normal** or **TPI Controller**
+| Your situation | Algorithm |
+| --- | --- |
+| Setting up for the first time | AI Time Based (default) |
+| Room heats too slowly | Aggressive |
+| Temperature overshoots often | MPC Predictive |
+| You want fine control and know PID tuning | PID Controller |
+| You want something simple | Normal or TPI Controller |
 
-## Algorithm Descriptions
+## The algorithms
 
 ### Normal
 
-**Best for:** Simple, straightforward temperature control
+Normal mode uses your external temperature sensor to correct the TRV's internal sensor. The TRV reads the actual room temperature from your external sensor and adjusts accordingly.
 
-**How it works:** Normal mode uses your external temperature sensor to correct the TRV's internal sensor. The TRV reads the actual room temperature from your external sensor and adjusts accordingly.
+It is simple, reliable, works with most TRVs and costs almost nothing to run. In exchange it does not optimise for efficiency and does not adapt to the room.
 
-**Pros:**
-
-- Simple and reliable
-- Works well with most TRVs
-- Low computational overhead
-
-**Cons:**
-
-- May not optimize for efficiency
-- Doesn't adapt to room characteristics
-
-**When to use:** This is a good starting point if you want reliable temperature control without any complexity.
+Use it as a starting point when you want reliable control and no complexity.
 
 ---
 
 ### Aggressive
 
-**Best for:** Rooms that heat slowly or need faster temperature changes
+Aggressive works like Normal but pushes the TRV harder: it reports the internal temperature much lower than it is while heating, and higher while cooling, so the TRV runs at full power until the target is reached.
 
-**How it works:** Similar to Normal mode, but it pushes the TRV harder by setting the internal temperature sensor reading much lower (when heating) or higher (when cooling) than actual. This makes the TRV work at full power to reach your target faster.
+That gets a slow or poorly insulated room warm quickly. The cost is overshoot, wasted energy when the speed was not needed, and more valve movement.
 
-**Pros:**
-
-- Reaches target temperature quickly
-- Good for poorly insulated rooms
-- Effective for rapid warmup
-
-**Cons:**
-
-- May overshoot the target temperature
-- Can waste energy if not needed
-- More frequent valve adjustments
-
-**When to use:** Your room takes a long time to heat up, or you need to quickly change temperature (e.g., coming home to a cold house).
+Use it when the room takes a long time to warm up, or when you need a fast change, such as coming home to a cold house.
 
 ---
 
 ### AI Time Based
 
-**Best for:** Most users - balances comfort and efficiency (Default)
+This is the default, and the right choice for most rooms.
 
-**How it works:** This algorithm learns your room's heating characteristics over time. It uses your external temperature sensor but calculates calibration values using a custom algorithm that improves on the TRV's built-in logic. It adapts to your room's thermal properties.
+It learns your room's heating characteristics over time. It still reads your external temperature sensor, but derives the calibration from its own model rather than leaving the decision to the TRV's built-in logic, so it adapts to how fast your room actually heats and cools.
 
-**Pros:**
-
-- Automatically adapts to your room
-- Balances comfort and energy efficiency
-- Reduces temperature overshooting
-- Works well in varying conditions
-
-**Cons:**
-
-- Takes a few days to fully learn your room
-- May not be optimal during the learning period
-
-**When to use:** This is the recommended default for most users. Expect good results after 2-3 days as it learns your room's behavior.
+Once settled it balances comfort against energy use, keeps overshoot down and copes with changing conditions. The trade-off is the learning phase: expect two to three days before the results are good, and accept that behaviour in that window is not yet tuned.
 
 ---
 
 ### MPC Predictive
 
-**Best for:** Stable, efficient heating with minimal overshooting
-
-**How it works:** MPC (Model Predictive Control) is an advanced algorithm that predicts how your room temperature will change over the next hour based on:
+MPC (Model Predictive Control) predicts how your room temperature will change over the next hour, from three inputs:
 
 - Current valve position
 - Temperature trends
-- Learned thermal properties of your room (how fast it heats/cools)
+- Learned thermal properties of your room (how fast it heats and cools)
 
-It calculates the optimal valve opening to reach your target temperature smoothly without overshooting. It continuously learns and adapts to your room's behavior.
+From that prediction it picks the valve opening that reaches your target smoothly instead of driving hard and correcting afterwards, and it keeps updating the model as the room behaves.
 
-**Pros:**
+Of all the modes it is the best at avoiding overshoot and the most economical with energy. It is also the most complex, and it reacts deliberately rather than quickly, which can read as sluggish at first. Give it about a day of operation before judging it.
 
-- Excellent at preventing temperature overshoot
-- Very energy efficient
-- Smooth temperature control
-- Learns room heating/cooling characteristics
-- Predictive - anticipates temperature changes
-
-**Cons:**
-
-- Most complex algorithm
-- Requires a short learning period (typically 1 day for fine-tuned performance)
-- May seem slow to react initially (by design)
-
-**When to use:**
-
-- You experience frequent temperature overshoots
-- Energy efficiency is a priority
-- You want the most sophisticated control
-- Your heating system is relatively stable
-
-**Note:** MPC learns quickly - expect fine-tuned performance after just 1 day of operation. Initial behavior may seem conservative as it gathers data, but it rapidly adapts to your room's thermal characteristics. **This algorithm is considered stable and production-ready.**
+Pick it when you overshoot regularly, when efficiency matters more to you than reaction speed, and when your heating system itself is reasonably stable.
 
 ---
 
@@ -124,42 +70,23 @@ It calculates the optimal valve opening to reach your target temperature smoothl
 
 ⚠️ **Beta Status:** The PID Controller is currently in beta and may require further fine-tuning in the algorithm. While it's functional and includes auto-tuning capabilities, you may experience some edge cases that need optimization. Feedback and real-world testing are appreciated.
 
-**Best for:** Systems with varying heating power or external disturbances
+PID (Proportional-Integral-Derivative) is the classic industrial control method. It sets the valve position from three terms:
 
-**How it works:** PID (Proportional-Integral-Derivative) is a classic control method used in industrial applications. It adjusts the valve position based on:
+- P (Proportional): how far you are from the target temperature
+- I (Integral): how long you have been away from it
+- D (Derivative): how fast the temperature is moving
 
-- **P (Proportional):** How far you are from target temperature
-- **I (Integral):** How long you've been away from target
-- **D (Derivative):** How fast the temperature is changing
+It tunes those three itself over time.
 
-The algorithm automatically tunes these parameters over time for optimal performance.
+PID reacts fast and handles disturbances well, which is what makes it a good fit for a room with sun through the windows, draughts or a heat source whose output varies. Early on it can be aggressive and oscillate a little while it tunes, and getting the most out of it means understanding roughly what the three parameters do.
 
-**Pros:**
+Pick it when your heating power varies, when outside influences keep moving the room temperature, and when you want a responsive controller and are comfortable with the parameters.
 
-- Proven industrial control method
-- Handles disturbances well (e.g., opening windows, sun through windows)
-- Self-tuning capability
-- Fast response to temperature changes
-- Good for varying heating conditions
+#### Auto-tuning and manual tuning
 
-**Cons:**
+Auto-tuning is on by default.
 
-- PID can be aggressive initially
-- May oscillate slightly during self-tuning
-- More technical - understanding the parameters helps
-
-**When to use:**
-
-- Your heating system power varies
-- You have external factors affecting room temperature (sun, drafts, etc.)
-- You want responsive temperature control
-- You have some technical knowledge
-
-#### PID Auto-Tuning and Manual Tuning
-
-The PID Controller includes an **auto-tuning feature** that is enabled by default. Here's what you need to know:
-
-**Auto-Tuning Timeline:**
+**Timeline:**
 
 - **Initial period (Days 1-3):** The controller starts with default values (Kp=20, Ki=0.02, Kd=400) and begins learning your room's behavior. You may notice slight temperature oscillations as it adjusts.
 
@@ -170,7 +97,7 @@ The PID Controller includes an **auto-tuning feature** that is enabled by defaul
 
 - **Settled phase (Week 2+):** After about 1-2 weeks, the parameters should stabilize and provide smooth temperature control with minimal overshooting.
 
-**What to Expect:**
+**What to expect:**
 
 - Adjustments happen at least 5 minutes apart (300 seconds) to avoid over-tuning
 - Parameters are constrained to safe ranges:
@@ -179,7 +106,7 @@ The PID Controller includes an **auto-tuning feature** that is enabled by defaul
   - Kd: 100-10,000
 - Auto-tuning is conservative - it makes small changes and learns gradually
 
-**Manual Tuning (Advanced Users):**
+**Manual tuning:**
 
 If you want to tune PID parameters manually or understand what the auto-tuning is doing:
 
@@ -198,7 +125,7 @@ If you want to tune PID parameters manually or understand what the auto-tuning i
    - Too low: Overshoot, slow damping
    - Default: 400
 
-**Monitoring Auto-Tuning:**
+**Monitoring the learned values:**
 
 You can monitor the learned PID values in Home Assistant:
 
@@ -206,15 +133,15 @@ You can monitor the learned PID values in Home Assistant:
 2. Find your Better Thermostat entity
 3. Look for attributes containing PID debug info showing current Kp, Ki, Kd values
 
-**Tips for Best PID Performance:**
+**Getting the best out of PID:**
 
-- **Be patient:** Give auto-tuning at least 1-2 weeks to fully settle
-- **Stable conditions:** Auto-tuning works best when you maintain consistent target temperatures
-- **Avoid manual interference:** During the learning phase, avoid frequently changing target temperatures
-- **Temperature sensor placement:** Ensure your external sensor is well-placed (away from heat sources, drafts)
-- **Direct valve control:** PID works best with devices that support direct valve control (see [Direct Valve Control](#direct-valve-control) section)
+- Give auto-tuning one to two weeks to settle
+- Keep target temperatures consistent; auto-tuning reads a moving target as a disturbance
+- Avoid changing the target often during the learning phase
+- Place the external sensor away from heat sources and draughts
+- Prefer a device with direct valve control (see [Direct valve control](#direct-valve-control))
 
-**Disabling Auto-Tuning:**
+**Turning auto-tuning off:**
 
 While not recommended for most users, auto-tuning can be disabled through the advanced configuration if you prefer fixed PID parameters. This is only useful if you have specific PID values you want to maintain.
 
@@ -222,33 +149,15 @@ While not recommended for most users, auto-tuning can be disabled through the ad
 
 ### TPI Controller
 
-**Best for:** Simple, consistent heating patterns
+TPI (Time Proportional Integral) turns the distance from your target into a duty cycle: what share of the time the valve should be open. At 60 % demand it might hold the valve fully open for six minutes, then closed for four.
 
-**How it works:** TPI (Time Proportional Integral) calculates heating duty cycles based on how far your current temperature is from your target. It determines what percentage of time the valve should be open. For example, if you need 60% heating, it might open the valve fully for 6 minutes, then close for 4 minutes.
+The model is easy to follow and suits a radiator with real thermal inertia, where a slow on/off rhythm is closer to how the heat actually arrives. It does less than MPC or PID, and it adapts less readily when conditions change.
 
-**Pros:**
-
-- Simple and effective
-- Good for consistent heating patterns
-- Easy to understand
-- Works well with radiators that have thermal inertia
-
-**Cons:**
-
-- Less sophisticated than MPC or PID
-- May not adapt to changing conditions as well
-- Simpler algorithm with fewer optimizations
-
-**When to use:**
-
-- You want simple, predictable behavior
-- Your heating system is consistent
-- You don't need advanced features
-- You're looking for a straightforward alternative to Normal mode
+Pick it when your heating system is consistent and you want predictable behaviour without the machinery of the learning modes.
 
 ---
 
-## Comparison Table
+## Comparison
 
 | Feature | Normal | Aggressive | AI Time Based | MPC Predictive | PID Controller | TPI Controller |
 | --------- | -------- | ------------ | --------------- | ---------------- | ---------------- | ---------------- |
@@ -259,16 +168,15 @@ While not recommended for most users, auto-tuning can be disabled through the ad
 | **Response Speed** | Medium | Fast | Medium | Measured | Fast | Medium |
 | **Adaptation** | None | None | Good | Excellent | Good | None |
 | **Direct Valve Benefit** | Low | Low | Medium | **High** | **High** | Medium |
-| **Status** | Stable | Stable | Stable | **Tested & Stable** | **Beta** | Stable |
+| **Status** | Stable | Stable | Stable | Stable | Beta | Stable |
 | **Best For** | Simple setups | Fast heating | Most users | Optimization | Variable systems | Simple control |
 
 **Notes:**
 
-- "Direct Valve Benefit" indicates how much the algorithm benefits from direct valve control (see [Direct Valve Control](#direct-valve-control) section below)
-- **MPC Predictive** is stable and production-ready
+- "Direct Valve Benefit" indicates how much the algorithm gains from direct valve control (see [Direct valve control](#direct-valve-control) below)
 - **PID Controller** is in beta and may require further algorithm fine-tuning
 
-## Advanced: How the Algorithms Work Together with Calibration Types
+## How algorithms and calibration types combine
 
 The **Calibration Mode** (algorithm) works together with the **Calibration Type**:
 
@@ -278,11 +186,11 @@ The **Calibration Mode** (algorithm) works together with the **Calibration Type*
 
 Not all TRVs support offset-based calibration. Better Thermostat will automatically detect your TRV's capabilities and offer appropriate options.
 
-## Direct Valve Control
+## Direct valve control
 
-Some TRV devices support **direct valve control**, where Better Thermostat can directly set the valve opening percentage (0-100%) instead of only adjusting target temperatures or offsets. This provides more precise control and is particularly beneficial with advanced algorithms.
+Some TRV devices support **direct valve control**, where Better Thermostat can directly set the valve opening percentage (0-100%) instead of only adjusting target temperatures or offsets. That gives the algorithms finer control, which matters most for MPC and PID.
 
-### What is Direct Valve Control?
+### What direct valve control is
 
 With direct valve control, Better Thermostat can:
 
@@ -291,7 +199,7 @@ With direct valve control, Better Thermostat can:
 - Achieve more precise and responsive heating control
 - Better implement advanced algorithms like MPC and PID
 
-### Which Devices Support It?
+### Devices that support it
 
 Direct valve control is available for TRVs that expose valve position as a controllable entity, including:
 
@@ -301,7 +209,7 @@ Direct valve control is available for TRVs that expose valve position as a contr
 
 Better Thermostat automatically detects if your TRV supports direct valve control.
 
-### How Algorithms Use Direct Valve Control
+### How the algorithms use it
 
 When direct valve control is available:
 
@@ -313,7 +221,7 @@ When direct valve control is available:
 
 - **AI Time Based, Normal, Aggressive**: These algorithms will still work but convert their output to valve positions when direct control is available.
 
-### Without Direct Valve Control
+### Without direct valve control
 
 If your TRV doesn't support direct valve control, Better Thermostat uses **setpoint manipulation**:
 
@@ -323,7 +231,7 @@ If your TRV doesn't support direct valve control, Better Thermostat uses **setpo
 
 This still works well but gives the TRV's internal algorithm more influence over the final valve position.
 
-### Checking If You Have Direct Valve Control
+### Checking whether you have it
 
 1. Go to your Better Thermostat device in Home Assistant
 2. Check the device attributes for entries like:
@@ -336,19 +244,15 @@ For MQTT/Zigbee2MQTT users, you can also check if your TRV exposes entities like
 - `number.your_trv_valve_position`
 - `number.your_trv_valve_opening_degree`
 
-### Benefits of Direct Valve Control
+### What it buys you
 
-✅ **More precise control** - Algorithms can set exact heating power
-✅ **Faster response** - No waiting for TRV's internal logic
-✅ **Better learning** - Algorithms can better understand room behavior
-✅ **Reduced overshooting** - Finer control over heating intensity
-✅ **Algorithm effectiveness** - MPC and PID work best with direct control
+The algorithm sets heating power exactly rather than asking the TRV's own logic for it, so the response arrives without a detour and the room's reaction is a cleaner signal to learn from. Finer control over heating intensity also means less overshoot. MPC and PID are the two modes that gain the most.
 
-### Recommendation
+### If you are buying new TRVs
 
 If you're purchasing new TRVs and want the best performance from Better Thermostat's advanced algorithms (especially MPC Predictive or PID Controller), consider devices that support direct valve control through Zigbee2MQTT or similar integrations.
 
-## Tips for Best Results
+## Getting good results
 
 1. **Give it time:** Algorithms with learning need time to learn your room:
    - **MPC Predictive**: 1 day for fine-tuned performance
@@ -390,14 +294,14 @@ If you're purchasing new TRVs and want the best performance from Better Thermost
 - Verify TRV is working correctly
 - Try a different algorithm
 
-## Technical Details
+## Technical details
 
 For developers and advanced users who want to understand the implementation details, see:
 
 - [Hydraulic Balance Design Document](../../hydraulic_balance_design.md) - Deep technical documentation
 - Source code in `custom_components/better_thermostat/utils/calibration/` directory
 
-## Need More Help?
+## Further reading
 
 If you're still unsure which algorithm to use or experiencing issues:
 

--- a/docs/Configuration/algorithms.md
+++ b/docs/Configuration/algorithms.md
@@ -14,7 +14,7 @@ Start here if you are unsure:
 | --- | --- |
 | Setting up for the first time | AI Time Based (default) |
 | Room heats too slowly | Aggressive |
-| Temperature overshoots often | MPC Predictive |
+| Temperature often overshoots | MPC Predictive |
 | You want fine control and know PID tuning | PID Controller |
 | You want something simple | Normal or TPI Controller |
 
@@ -58,7 +58,7 @@ MPC (Model Predictive Control) predicts how your room temperature will change ov
 - Temperature trends
 - Learned thermal properties of your room (how fast it heats and cools)
 
-From that prediction it picks the valve opening that reaches your target smoothly instead of driving hard and correcting afterwards, and it keeps updating the model as the room behaves.
+From that prediction it picks the valve opening that reaches your target smoothly instead of driving hard and correcting afterward, and it keeps updating the model as the room behaves.
 
 Of all the modes it is the best at avoiding overshoot and the most economical with energy. It is also the most complex, and it reacts deliberately rather than quickly, which can read as sluggish at first. Give it about a day of operation before judging it.
 
@@ -246,7 +246,7 @@ For MQTT/Zigbee2MQTT users, you can also check if your TRV exposes entities like
 
 ### What it buys you
 
-The algorithm sets heating power exactly rather than asking the TRV's own logic for it, so the response arrives without a detour and the room's reaction is a cleaner signal to learn from. Finer control over heating intensity also means less overshoot. MPC and PID are the two modes that gain the most.
+The algorithm sets the valve opening itself rather than asking the TRV's own logic for it, so the response arrives without a detour and the room's reaction is a cleaner signal to learn from. Valve position is not heat output — flow temperature and the valve's own authority still sit in between — but it is the finest handle Better Thermostat can get, and a finer handle leaves less room for overshoot. MPC and PID gain the most from it; every mode runs without it.
 
 ### If you are buying new TRVs
 

--- a/docs/Configuration/algorithms.md
+++ b/docs/Configuration/algorithms.md
@@ -52,11 +52,12 @@ Once settled it balances comfort against energy use, keeps overshoot down and co
 
 ### MPC Predictive
 
-MPC (Model Predictive Control) predicts how your room temperature will change over the next hour, from three inputs:
+MPC (Model Predictive Control) predicts how your room temperature will change over the next hour. It reads several inputs, among them:
 
-- Current valve position
-- Temperature trends
+- Room temperature, its trend and your target
 - Learned thermal properties of your room (how fast it heats and cools)
+- Outdoor temperature, daylight and solar intensity
+- Window state, and the valve opening it last asked for
 
 From that prediction it picks the correction that reaches your target smoothly instead of driving hard and correcting afterward, and it keeps updating the model as the room behaves. With direct valve control that correction is a valve opening; without it, the correction reaches the valve through the setpoint the TRV sees.
 

--- a/docs/Configuration/configuration.md
+++ b/docs/Configuration/configuration.md
@@ -30,7 +30,7 @@ or click on the button below:
 
 **Window Sensor** This is an optional field. If you have a window sensor you can use it to turn off the thermostat if the window is open and turn it on again when the window is closed. If you have more than one window in a room, you can also select window groups (see the GitHub page for more info).
 
-### Example Window/Door - Sensor config
+### Example window/door sensor config
 
 ```yaml
 group:
@@ -101,11 +101,11 @@ Better Thermostat offers several algorithms to control your heating:
 
 **Quick guide:**
 
-- First-time user? → Start with **AI Time Based** (default)
-- Room heats slowly? → Try **Aggressive**
-- Temperature overshoots? → Try **MPC Predictive**
-- Want fine control? → Try **PID Controller**
-- **Using HomeMatic IP/CCU?** → Offset-based calibration now supports SELECT entities automatically
+- Start with AI Time Based, the default
+- Switch to Aggressive if the room heats slowly
+- Switch to MPC Predictive if the temperature overshoots
+- Switch to PID Controller if you want fine control
+- On HomeMatic IP/CCU, offset-based calibration handles SELECT entities automatically
 
 **Overheating protection** This should only be checked if you have any problems with strong overheating.
 

--- a/docs/deep-explanations/central-heating-thermostat.md
+++ b/docs/deep-explanations/central-heating-thermostat.md
@@ -38,6 +38,8 @@ actions:
 
 Swap the two temperatures for whatever your central thermostat treats as "run" and "stand down".
 
+This only works while the central thermostat is in a heating mode. `climate.set_temperature` leaves the current mode alone, so a thermostat sitting at `off` takes the new setpoint and still does not fire the boiler. Either leave it in `heat` permanently and let the setpoint do the switching, as above, or drive the mode as well with a separate `climate.set_hvac_mode` action ahead of the setpoint — not through `hvac_mode` inside `set_temperature`, which many integrations ignore.
+
 The start trigger covers the restart. A state trigger only fires on a change it is listening for, and there is no guarantee the automation is attached by the time the room entities come back, so without it the central thermostat can sit on its pre-restart target until the next room transition.
 
 ### One attribute to stay away from

--- a/docs/deep-explanations/central-heating-thermostat.md
+++ b/docs/deep-explanations/central-heating-thermostat.md
@@ -1,0 +1,55 @@
+---
+title: A central thermostat alongside TRVs
+description: How Better Thermostat fits a system that has both a boiler thermostat and radiator valves.
+---
+
+Better Thermostat has no concept of a boiler. It controls TRVs, one instance per room, and it never decides whether the heat source runs. If your system has a central thermostat as well, that thermostat stays outside Better Thermostat and you drive it yourself.
+
+This page exists because the question keeps coming back and the answer was never written down.
+
+## The shape that works
+
+Give each room its own Better Thermostat instance with that room's TRVs and its temperature sensor, and leave the central thermostat out of every one of them. Keep the central thermostat as its own climate entity, and drive it from an automation that watches the rooms.
+
+## The signal to drive it with
+
+Use `hvac_action` on the Better Thermostat entities. It reports `heating` while a room wants heat and `idle` once the room is satisfied, which is exactly the aggregate a boiler needs.
+
+```yaml
+triggers:
+  - trigger: state
+    entity_id:
+      - climate.living_room
+      - climate.bedroom
+    attribute: hvac_action
+actions:
+  - action: climate.set_temperature
+    target:
+      entity_id: climate.central_thermostat
+    data:
+      temperature: >
+        {{ 21 if expand('climate.living_room', 'climate.bedroom')
+             | selectattr('attributes.hvac_action', 'eq', 'heating')
+             | list | count > 0
+           else 15 }}
+```
+
+Swap the two temperatures for whatever your central thermostat treats as "run" and "stand down".
+
+### One attribute to stay away from
+
+`call_for_heat` looks like the right signal and is not. It is the weather-based shutdown flag: it says the outdoor temperature is below the cut-off, not that this room wants heat. It is identical across every room served by the same weather entity.
+
+## Why the central thermostat cannot be left alone
+
+Leaving the boiler thermostat on its own schedule produces a failure that is easy to misread as a Better Thermostat problem.
+
+While the central thermostat is satisfied, no flow reaches the radiators. The rooms keep missing their targets, so Better Thermostat opens their valves further, which is the correct response to a room that will not warm up. When the central thermostat calls for heat again, every valve is wide open and the rooms overshoot together. The symptom shows up as overshoot; the cause is the ceiling above the valves.
+
+Wiring the central thermostat to the rooms removes the mismatch, because the boiler runs when a room asks and stands down when none does.
+
+## A note on flow temperature
+
+Better Thermostat does not modulate flow temperature either, and a flow-temperature loop is a second controller with its own time constant. Keep it much slower than the room loop: every change in flow temperature is a disturbance to every room at once, and a fast outer loop will fight the inner ones into an oscillation. Weather compensation from outdoor temperature, corrected slowly, is the usual well-behaved version.
+
+For what Better Thermostat does contribute to distribution across rooms, see [Hydraulic balance](/deep-explanations/hydraulic-balance/).

--- a/docs/deep-explanations/central-heating-thermostat.md
+++ b/docs/deep-explanations/central-heating-thermostat.md
@@ -22,6 +22,8 @@ triggers:
       - climate.living_room
       - climate.bedroom
     attribute: hvac_action
+  - trigger: homeassistant
+    event: start
 actions:
   - action: climate.set_temperature
     target:
@@ -36,6 +38,8 @@ actions:
 
 Swap the two temperatures for whatever your central thermostat treats as "run" and "stand down".
 
+The start trigger covers the restart. A state trigger only fires on a change it is listening for, and there is no guarantee the automation is attached by the time the room entities come back, so without it the central thermostat can sit on its pre-restart target until the next room transition.
+
 ### One attribute to stay away from
 
 `call_for_heat` looks like the right signal and is not. It is the weather-based shutdown flag: it says the outdoor temperature is below the cut-off, not that this room wants heat. It is identical across every room served by the same weather entity.
@@ -44,9 +48,9 @@ Swap the two temperatures for whatever your central thermostat treats as "run" a
 
 Leaving the boiler thermostat on its own schedule produces a failure that is easy to misread as a Better Thermostat problem.
 
-While the central thermostat is satisfied, no flow reaches the radiators. The rooms keep missing their targets, so Better Thermostat opens their valves further, which is the correct response to a room that will not warm up. When the central thermostat calls for heat again, every valve is wide open and the rooms overshoot together. The symptom shows up as overshoot; the cause is the ceiling above the valves.
+While the central thermostat is satisfied, no flow reaches the radiators. The rooms keep missing their targets, so Better Thermostat opens their valves further, which is the correct response to a room that will not warm up. When the central thermostat calls for heat again, those valves are open wider than the rooms now need, and the ones that opened furthest overshoot. The symptom shows up as overshoot; the cause is the ceiling above the valves.
 
-Wiring the central thermostat to the rooms removes the mismatch, because the boiler runs when a room asks and stands down when none does.
+Wiring the central thermostat to the rooms removes that ceiling, because the boiler runs when a room asks and stands down when none does.
 
 ## A note on flow temperature
 

--- a/docs/faq/common-questions.md
+++ b/docs/faq/common-questions.md
@@ -15,7 +15,7 @@ Local calibration support depends on adapter support and TRV capabilities. Curre
 
 For device-level details, see [Working devices](/working-devices/compatibility/).
 
-## Local calibration vs target temperature calibration — what is the difference?
+## Local calibration vs target temperature calibration
 
 - **Local calibration (offset based)**: BT adjusts TRV offset so TRV reading matches room sensor.
 - **Target temperature based**: BT adjusts requested target temperature to compensate internally.

--- a/docs/optimal-settings/algorithm-selection.md
+++ b/docs/optimal-settings/algorithm-selection.md
@@ -8,7 +8,7 @@ description: Pick the right control algorithm for your room behavior.
 - AI Time Based: the first choice for most homes.
 - Normal: stable and simple fallback.
 - Aggressive: faster warm-up, at the price of more overshoot.
-- MPC Predictive: lowest overshoot and lowest energy use.
+- MPC Predictive: aims at a steady arrival rather than a fast one.
 - PID Controller: responsive control with auto-tuning.
 - TPI Controller: simple proportional-time behaviour.
 

--- a/docs/optimal-settings/algorithm-selection.md
+++ b/docs/optimal-settings/algorithm-selection.md
@@ -5,12 +5,12 @@ description: Pick the right control algorithm for your room behavior.
 
 ## Quick decision guide
 
-- **AI Time Based**: Best first choice for most homes.
-- **Normal**: Stable and simple fallback.
-- **Aggressive**: Faster warm-up, potentially more overshoot.
-- **MPC Predictive**: Best efficiency and overshoot prevention.
-- **PID Controller**: Advanced control with auto-tuning.
-- **TPI Controller**: Simple proportional-time behavior.
+- AI Time Based: the first choice for most homes.
+- Normal: stable and simple fallback.
+- Aggressive: faster warm-up, at the price of more overshoot.
+- MPC Predictive: lowest overshoot and lowest energy use.
+- PID Controller: responsive control with auto-tuning.
+- TPI Controller: simple proportional-time behaviour.
 
 ## Decision matrix
 
@@ -24,6 +24,6 @@ description: Pick the right control algorithm for your room behavior.
 
 ## Advanced note
 
-MPC and PID benefit strongly from direct valve control capable devices.
+MPC and PID both gain a lot from a device that supports direct valve control.
 
 For deeper technical details of balancing behavior and control signals, see [Hydraulic balance](/deep-explanations/hydraulic-balance/).

--- a/docs/optimal-settings/recommended-settings.md
+++ b/docs/optimal-settings/recommended-settings.md
@@ -13,20 +13,14 @@ Use this profile as your starting point for each room.
 - **Window delay**: 2-5 minutes
 - **Overheating protection**: Off by default; enable only if needed
 
-## When to change this profile
+## When to change it
 
-- Room heats very slowly → switch to **Aggressive**.
-- Room frequently overshoots target → switch to **MPC Predictive**.
-- Room has strong disturbances (sun, drafts, doors) → try **PID**.
+Switch to Aggressive if the room heats very slowly, to MPC Predictive if it overshoots the target regularly, and to PID if it faces strong disturbances such as sun, draughts or an often-opened door.
 
-## Sensor placement tips
+## Sensor placement
 
-- Place room sensor away from radiator and direct sun.
-- Avoid drafts and exterior doors.
-- Keep sensor position stable for at least a few days while learning.
+Put the room sensor away from the radiator and out of direct sun, clear of draughts and exterior doors. Then leave it where it is for a few days: the learning modes treat a moved sensor as a change in the room.
 
-## Expectations after setup
+## What to expect
 
-- AI Time Based needs a short learning phase.
-- MPC and PID perform best with clean, regular sensor updates.
-- Avoid changing multiple tuning values at once.
+AI Time Based needs a short learning phase before its results settle. MPC and PID both depend on clean, regular sensor updates, so an infrequently reporting sensor costs them more than it costs the simpler modes. Change one tuning value at a time, or you will not know which one did what.

--- a/docs/setup/configuration-walkthrough.md
+++ b/docs/setup/configuration-walkthrough.md
@@ -24,7 +24,7 @@ This page explains the two setup screens in plain language and gives practical d
 - **Name**: A friendly name for this room's thermostat (e.g., "Living Room Heating").
 - **The real thermostat**: Select the smart radiator valves or thermostats in this room.
 - **The cooling device (optional)**: If you have an AC or cooler, select it here to control it alongside your heating.
-- **Temperature sensor**: Your separate room temperature sensor. This is crucial for accurate heating!
+- **Temperature sensor**: Your separate room temperature sensor. Accurate control depends on this one.
 - **Humidity sensor**: Currently just displays the humidity on your dashboard.
 - **If you have an outdoor sensor, you can use it to get the outdoor temperature**: Select your outdoor sensor to let the system know when it's warm outside.
 - **Window sensor**: Select your window sensor so the heating pauses automatically when you open a window.
@@ -92,7 +92,7 @@ Use [Algorithm selection](/optimal-settings/algorithm-selection/) for decision h
 
 ### Other important toggles
 
-- **Overheating protection?**: Turn this on if your room keeps getting too hot even after reaching the target temperature (often happens if radiators stay hot for a long time).
+- **Overheating protection**: Turn this on if your room keeps getting too hot even after reaching the target temperature (often happens if radiators stay hot for a long time).
 - **If your TRV can't handle the off mode, you can enable this to use target temperature 5°C instead**: Some devices don't have a proper "Off" switch. This sets them to 5°C instead to keep them off safely.
 - **If the auto means heat for your TRV and you want to swap it**: Fixes a quirk with some specific thermostat brands where the modes are mixed up in Home Assistant.
 - **If your thermostat has no own maintenance mode, you can use this one**: Adds a maintenance mode (like opening the valve fully to prevent it from getting stuck in summer) if your device lacks one.

--- a/docs/setup/configurator.mdx
+++ b/docs/setup/configurator.mdx
@@ -7,9 +7,7 @@ description: Step-by-step wizard to find the best Better Thermostat settings for
 
 import { BtConfigurator } from '../../website/src/components/Configurator.ts';
 
-Welcome to the **Better Thermostat Configurator**. 
-
-Every room is different. A small, well-insulated bathroom needs different heating settings than a large, drafty living room. This interactive guide will ask you a few simple questions about your room and recommend the optimal settings for your Better Thermostat configuration.
+A small, well-insulated bathroom needs different heating settings than a large, draughty living room. Answer a few questions about the room below and the configurator suggests settings to start from.
 
 <BtConfigurator client:load></BtConfigurator>
 
@@ -21,4 +19,4 @@ Once you have your recommended settings:
 3. Click on **Configure** for the specific room/thermostat.
 4. Apply the recommended **Calibration Mode**, **Tolerance**, and **Window Delay**.
 
-If you want to understand more about why these settings are recommended, check out our [Algorithm Selection](/optimal-settings/algorithm-selection/) and [Hydraulic Balance](/deep-explanations/hydraulic-balance/) guides.
+For the reasoning behind the suggestions, see [Algorithm selection](/optimal-settings/algorithm-selection/) and [Hydraulic balance](/deep-explanations/hydraulic-balance/).

--- a/docs/setup/getting-started.md
+++ b/docs/setup/getting-started.md
@@ -5,7 +5,7 @@ sidebar:
 description: Install Better Thermostat and create your first room in a few minutes.
 ---
 
-Welcome to Better Thermostat! Let's get your smart heating set up in just a few minutes.
+Installing Better Thermostat and setting up your first room takes a few minutes.
 
 ## 1) Install the integration
 
@@ -28,14 +28,14 @@ Or click this button to start directly:
 Before setting up a room, make sure you have these devices ready in Home Assistant:
 
 - **A smart radiator valve or thermostat** (required)
-- **A separate room temperature sensor** (highly recommended! The sensor on the radiator is often inaccurate because it's too close to the heat source)
+- **A separate room temperature sensor** (strongly recommended: the sensor inside the radiator valve sits too close to the heat source to read the room)
 - *Optional:* A window sensor (to automatically pause heating when you air out the room)
 - *Optional:* A weather integration or outdoor temperature sensor (to stop heating when it's warm outside)
 
 ## 4) Follow the configuration walkthrough
 
-Ready to set up your first room? Follow our simple, step-by-step [Configuration walkthrough](/setup/configuration-walkthrough/) to understand all the options.
+The [Configuration walkthrough](/setup/configuration-walkthrough/) goes through every option in the setup form.
 
 ## 5) Apply recommended defaults
 
-Not sure which settings to choose? Start with our [Recommended settings](/optimal-settings/recommended-settings/) for a setup that works great for most homes.
+If you are unsure what to pick, start from [Recommended settings](/optimal-settings/recommended-settings/) and adjust from there.

--- a/docs/setup/getting-started.md
+++ b/docs/setup/getting-started.md
@@ -28,7 +28,7 @@ Or click this button to start directly:
 Before setting up a room, make sure you have these devices ready in Home Assistant:
 
 - **A smart radiator valve or thermostat** (required)
-- **A separate room temperature sensor** (strongly recommended: the sensor inside the radiator valve sits too close to the heat source to read the room)
+- **A separate room temperature sensor** (required: the sensor inside the radiator valve sits too close to the heat source to read the room, and the setup form will not let you finish without one)
 - *Optional:* A window sensor (to automatically pause heating when you air out the room)
 - *Optional:* A weather integration or outdoor temperature sensor (to stop heating when it's warm outside)
 

--- a/docs/setup/presets.md
+++ b/docs/setup/presets.md
@@ -1,0 +1,52 @@
+---
+title: Presets
+description: What each Better Thermostat preset does, what it defaults to and how to change it.
+---
+
+A preset is a named target temperature. Switching a thermostat to one applies that preset's temperature and remembers the target you had; switching back to `none` puts the old target back. No preset name carries a schedule, a timer or any other logic behind it, so `away` and `sleep` differ only in the number attached to them.
+
+## The shipped defaults
+
+| Preset | Default |
+| --- | --- |
+| Away | 16 °C |
+| Sleep | 18 °C |
+| Eco | 19 °C |
+| Home | 20 °C |
+| Comfort | 21 °C |
+| Activity | 22 °C |
+| Boost | 24 °C |
+
+These are starting values, not fixed meanings. Set Away to 12 °C and Away becomes a 12 °C preset.
+
+## Choosing which presets appear
+
+Presets are opt-in per thermostat. Open **Settings → Devices & Services → Better Thermostat → Configure** and tick the ones you want under **Enabled Presets**. A new configuration starts with Eco alone.
+
+Home Assistant validates the preset name before Better Thermostat sees it, so calling `climate.set_preset_mode` with a preset you have not enabled fails with `Preset mode <name> is not valid` and leaves the thermostat untouched.
+
+## Changing a preset temperature
+
+Every enabled preset gets its own number entity in the *Configuration* section of the Better Thermostat device, named after the preset: an enabled Eco preset gives you an `Eco` number, typically `number.<your_thermostat>_eco`. Write to it and the preset applies that temperature from then on. Writing it while its preset is already active retargets the thermostat straight away.
+
+The value survives a restart, and it is clamped to the thermostat's own minimum and maximum, so a preset can never ask for a temperature the device cannot reach.
+
+With a cooler configured, each preset has two numbers instead of one: `<Preset> Min` carries the heating target and `<Preset> Max` the cooling target.
+
+## Saving and restoring
+
+The save happens on the way *into* a preset, and only from `none`:
+
+- From `none` into any preset, the current target is stored and the preset temperature applied.
+- Between two presets, nothing is stored again, so the value kept is still the target you had before the first preset.
+- Back to `none`, the stored target is restored and forgotten.
+
+The stored value is published as the `preset_temperature` state attribute and read back at startup, so a restart in the middle of an away period does not lose your normal target.
+
+## Boost is the one exception
+
+Every other preset is only a temperature. Boost also changes how the valve is driven, but only where Better Thermostat can drive it directly: with calibration type *Direct Valve Based*, Boost holds the valve at its *Valve Max Opening* (100 % unless you have capped that TRV) for as long as the room is below target, rather than modulating towards it. On the other calibration types Boost is its temperature and nothing more.
+
+## Coming from the old save and restore actions
+
+The three Better Thermostat actions that set and restored a temporary target were removed in 1.8.0, and the mechanism above replaces them. [Schedule and night mode](/deep-explanations/schedule-and-night-mode/) lists each retired action next to what to call instead.

--- a/docs/setup/presets.md
+++ b/docs/setup/presets.md
@@ -3,7 +3,7 @@ title: Presets
 description: What each Better Thermostat preset does, what it defaults to and how to change it.
 ---
 
-A preset is a named target temperature. Switching a thermostat to one applies that preset's temperature and remembers the target you had; switching back to `none` puts the old target back. No preset name carries a schedule, a timer or any other logic behind it, so `away` and `sleep` differ only in the number attached to them.
+A preset is a named target temperature. Switching from `none` into a preset applies that preset's temperature and remembers the target you had; switching back to `none` puts that target back. No preset name carries a schedule, a timer or any other logic behind it, so `away` and `sleep` differ only in the number attached to them.
 
 ## The shipped defaults
 
@@ -17,7 +17,7 @@ A preset is a named target temperature. Switching a thermostat to one applies th
 | Activity | 22 °C |
 | Boost | 24 °C |
 
-These are starting values, not fixed meanings. Set Away to 12 °C and Away becomes a 12 °C preset.
+These are starting values, not fixed meanings. Set Away to 12 °C and Away becomes a 12 °C preset, as long as 12 °C is inside the thermostat's own range.
 
 ## Choosing which presets appear
 
@@ -29,7 +29,7 @@ Home Assistant validates the preset name before Better Thermostat sees it, so ca
 
 Every enabled preset gets its own number entity in the *Configuration* section of the Better Thermostat device, named after the preset: an enabled Eco preset gives you an `Eco` number, typically `number.<your_thermostat>_eco`. Write to it and the preset applies that temperature from then on. Writing it while its preset is already active retargets the thermostat straight away.
 
-The value survives a restart, and it is clamped to the thermostat's own minimum and maximum, so a preset can never ask for a temperature the device cannot reach.
+The value survives a restart. Home Assistant refuses a write outside the thermostat's own minimum and maximum, and activating a preset clamps the target into that range, so a preset can never ask for a temperature the device cannot reach.
 
 With a cooler configured, each preset has two numbers instead of one: `<Preset> Min` carries the heating target and `<Preset> Max` the cooling target.
 

--- a/docs/setup/presets.md
+++ b/docs/setup/presets.md
@@ -3,7 +3,7 @@ title: Presets
 description: What each Better Thermostat preset does, what it defaults to and how to change it.
 ---
 
-A preset is a named target temperature. Switching from `none` into a preset applies that preset's temperature and remembers the target you had; switching back to `none` puts that target back. No preset name carries a schedule, a timer or any other logic behind it, so `away` and `sleep` differ only in the number attached to them.
+A preset is a named target temperature. Switching from `none` into a preset applies that preset's temperature and remembers the target you had; switching back to `none` puts that target back. No preset name carries a schedule or a timer behind it, so `away` and `sleep` differ only in the number attached to them. Boost is the one preset that does more than carry a temperature, and only on one calibration type; see [Boost is the one exception](#boost-is-the-one-exception).
 
 ## The shipped defaults
 

--- a/docs/working-devices/recommended-devices.md
+++ b/docs/working-devices/recommended-devices.md
@@ -68,7 +68,7 @@ A window sensor lets Better Thermostat pause the heating as soon as a window ope
 
 ## Integrations
 
-For these devices we recommend **Zigbee2MQTT (Z2M)**. It exposes the local-calibration and valve-position entities Better Thermostat writes to; ZHA and deCONZ do not always expose them, and without them the calibration falls back to the setpoint.
+For the Zigbee TRVs above we recommend **Zigbee2MQTT (Z2M)**: it exposes the local-calibration and valve-position entities Better Thermostat writes to, where ZHA and deCONZ do not always expose them. Which of the two exists depends on the TRV as much as on the integration. Where neither does, the setup form preselects the **Target Temperature Based** calibration type and Better Thermostat steers the device through its setpoint instead. Tado is the exception in the list above: it runs on its own native integration.
 
 If you are looking for a good Zigbee coordinator, the [SONOFF Zigbee 3.0 USB Dongle Plus](https://amzn.to/4rt9aWt) is a popular choice that works well with Zigbee2MQTT and supports a wide range of devices. If you also want to support Home Assistant itself, consider the [ZBT-2](https://www.home-assistant.io/connect/zbt-2/): it costs a little more and Home Assistant maintains it as a first-party Zigbee coordinator.
 

--- a/docs/working-devices/recommended-devices.md
+++ b/docs/working-devices/recommended-devices.md
@@ -3,80 +3,80 @@ title: Recommended Devices
 description: The best TRVs and sensors to use with Better Thermostat.
 ---
 
-When choosing a Smart Radiator Valve (TRV) or temperature sensor for Better Thermostat, some devices perform significantly better than others due to their hardware capabilities and how they integrate with Home Assistant.
+When choosing a Smart Radiator Valve (TRV) or temperature sensor for Better Thermostat, hardware capabilities and integration quality differ enough to change how well Better Thermostat can control them.
 
-## What makes a TRV "Good" for Better Thermostat?
+## What makes a TRV a good fit
 
 The best TRVs for Better Thermostat have the following features:
 1. **Local Temperature Calibration**: Allows Better Thermostat to send an offset to the TRV, making the TRV's internal logic work with your external room sensor.
-2. **Direct Valve Control**: Allows Better Thermostat to directly set the valve opening percentage (e.g., 0-100%). This is **highly recommended** for advanced algorithms like MPC Predictive and PID Controller to work optimally.
+2. **Direct Valve Control**: Allows Better Thermostat to directly set the valve opening percentage (e.g., 0-100%). MPC Predictive and PID Controller need this to work at their best.
 3. **Fast Reporting**: Sends temperature and state updates frequently without aggressive battery-saving sleep modes that delay commands.
 
-## Top Recommended TRVs
+## Recommended TRVs
 
-Based on community feedback and integration capabilities, here are some of the most recommended TRVs:
+Based on community feedback and what the integrations expose:
 
 ### 1. Sonoff TRVZB
-- **Why it's great**: Excellent Zigbee2MQTT support, fast response times, and reliable local temperature calibration. It also has specific model fixes built into Better Thermostat to ensure smooth operation.
-- **Best Algorithm**: AI Time Based or Aggressive or MPC.
+- Good Zigbee2MQTT support, fast response times and reliable local temperature calibration. It also has specific model fixes built into Better Thermostat to ensure smooth operation.
+- Suggested algorithm: AI Time Based or Aggressive or MPC.
 
 ### 2. Eurotronic Spirit Zigbee (SPZB0001)
-- **Why it's great**: One of the few TRVs that reliably supports **Direct Valve Control**. This makes it the absolute best choice if you want to use the advanced **MPC Predictive** or **PID Controller** algorithms.
-- **Best Algorithm**: MPC Predictive or PID Controller.
+- One of the few TRVs that reliably supports **Direct Valve Control**. That makes it the strongest option if you want to run MPC Predictive or PID Controller.
+- Suggested algorithm: MPC Predictive or PID Controller.
 
 ### 3. Moes / Tuya TS0601 Series
-- **Why it's great**: Very affordable and widely available. Better Thermostat includes extensive model fixes for these devices to correct their often-quirky default behaviors and make them reliable.
-- **Best Algorithm**: AI Time Based or MPC.
+- Very affordable and widely available. Better Thermostat includes extensive model fixes for these devices to correct their often-quirky default behaviors and make them reliable.
+- Suggested algorithm: AI Time Based or MPC.
 
 ### 4. Tado Smart Radiator Thermostats
-- **Why it's great**: Premium build quality and excellent native integration support for local calibration.
-- **Best Algorithm**: AI Time Based.
+- Solid build quality and native integration support for local calibration.
+- Suggested algorithm: AI Time Based.
 
-## Recommended External Sensors
+## External sensors
 
 Better Thermostat relies heavily on accurate room temperature readings. The internal sensor of a TRV is too close to the radiator to be accurate. **You must use an external room sensor for the best experience.**
 
-### What makes a good external sensor?
+### What makes a good external sensor
 - **Frequent Updates**: The sensor should report temperature changes of 0.1°C or 0.2°C immediately.
 - **Placement**: Place it at eye level, away from direct sunlight, drafts, and the radiator itself.
 
-### Top Picks:
+### Suggestions
 - **Aqara Temperature and Humidity Sensor**: Affordable, reliable, and updates frequently enough for most rooms.
 - **Xiaomi Mijia Bluetooth/Zigbee Sensors**: Very accurate and easy to place anywhere.
-- **Shelly Temperature Sensor**: Excellent battery life and precision.
+- **Shelly Temperature Sensor**: long battery life and good precision.
 
-## Recommended Window/Door Sensors
+## Window and door sensors
 
-Window sensors are crucial for Better Thermostat to quickly turn off the heating when a window is opened, saving energy and preventing the TRV from trying to heat the outside.
+A window sensor lets Better Thermostat pause the heating as soon as a window opens, instead of letting the TRV heat the outside.
 
-### What makes a good window sensor?
+### What makes a good window sensor
 - **Instant Reporting**: The sensor must report its state change (open/closed) immediately without delay.
 - **Reliability**: It shouldn't drop off the network or miss state changes.
 
-### Top Picks:
-- **Aqara Door and Window Sensor**: Extremely reliable, instant reporting, and very small form factor.
+### Suggestions
+- **Aqara Door and Window Sensor**: reliable, reports instantly, small.
 - **Sonoff SNZB-04**: Affordable, uses standard Zigbee, and reports instantly.
-- **Shelly Door/Window 2**: Great Wi-Fi option if you don't have a Zigbee network, includes tilt and temperature sensors.
+- **Shelly Door/Window 2**: a Wi-Fi option if you have no Zigbee network; includes tilt and temperature sensors.
 
-## Recommended Integrations
+## Integrations
 
-To get the most out of these devices, we highly recommend using **Zigbee2MQTT (Z2M)**. It provides the most granular control over TRV entities, exposing calibration and valve control entities that other integrations (like ZHA or deCONZ) sometimes hide or don't support fully.
+For these devices we recommend **Zigbee2MQTT (Z2M)**. It provides the most granular control over TRV entities, exposing calibration and valve control entities that other integrations (like ZHA or deCONZ) sometimes hide or don't support fully.
 
 if you looking for a good Zigbee coordinator, the [SONOFF Zigbee 3.0 USB Dongle Plus](https://amzn.to/4rt9aWt) is a popular choice that works well with Zigbee2MQTT and supports a wide range of devices. But, if you want to support even HomeAssistant itself, you better get the [ZBT-2](https://www.home-assistant.io/connect/zbt-2/) its a bit more expensive but it has better performance and reliability, and it's also supported by HomeAssistant itself as a native Zigbee coordinator.
 
-## Tested and Good Setups
+## Tested setups
 
-Here are some examples of complete setups that have been tested and proven to work very well together.
+Complete setups that people run successfully.
 
 ### Setup 1: The "SEA801/SEA802" Setup
-This is a highly reliable and affordable setup using popular Zigbee devices.
+An affordable setup built from widely available Zigbee devices.
 
 - **TRV**: SEA801-Zigbee / SEA802-Zigbee (TS0601) [Buying Link](https://amzn.to/4aDFMW3)
 - **Room Sensor**: Aqara Temperature and Humidity Sensor (WSDCGQ11LM / lumi.weather) [Buying Link](https://amzn.to/40jCClw)
 - **Window Sensor**: Aqara Door and Window Sensor (MCCGQ11LM / lumi.sensor_magnet.aq2) [Buying Link](https://amzn.to/4cB4zwz)
 - **Weather Integration**: Meteorologisk institutt (Met.no)
 
-**Recommended Configuration:**
+**Configuration:**
 - **Algorithm**: MPC Predictive or AI Time Based
 - **Calibration Type**: Local Calibration (Default)
 - **Important Note for Large Temperature Gaps**: The SEA801/SEA802 TRVs only allow a small offset calibration via Zigbee2MQTT. If you have a room with a **large temperature difference** between the radiator and the room sensor, the standard local offset calibration won't be enough. In this specific case, you need to switch the Calibration Type to **Target Temperature Based**. This bypasses the TRV's offset limit and directly manipulates the target temperature to achieve the desired room temperature.
@@ -97,7 +97,7 @@ This setup uses the powerful Eurotronic Spirit TRV, which supports both local of
 - **Window Sensor**: Aqara Door and Window Sensor (MCCGQ11LM / lumi.sensor_magnet.aq2) [Buying Link](https://amzn.to/4cB4zwz)
 - **Weather Integration**: Meteorologisk institutt (Met.no)
 
-**Recommended Configuration:**
+**Configuration:**
 - **Algorithm**: AI Time Based or Aggressive
 - **Calibration Type**: Local Calibration or Valve Control (both work well)
 

--- a/docs/working-devices/recommended-devices.md
+++ b/docs/working-devices/recommended-devices.md
@@ -19,17 +19,17 @@ Based on community feedback and what the integrations expose:
 ### 1. Sonoff TRVZB
 
 - Good Zigbee2MQTT support, fast response times and reliable local temperature calibration. It also has specific model fixes built into Better Thermostat to ensure smooth operation.
-- Suggested algorithm: AI Time Based or Aggressive or MPC.
+- Suggested algorithms: AI Time Based, Aggressive or MPC Predictive.
 
 ### 2. Eurotronic Spirit Zigbee (SPZB0001)
 
 - One of the few TRVs that reliably supports **Direct Valve Control**, which is the capability MPC Predictive and PID Controller gain the most from.
-- Suggested algorithm: MPC Predictive or PID Controller.
+- Suggested algorithms: MPC Predictive or PID Controller.
 
 ### 3. Moes / Tuya TS0601 Series
 
 - Very affordable and widely available. Better Thermostat includes extensive model fixes for these devices to correct their often-quirky default behaviors and make them reliable.
-- Suggested algorithm: AI Time Based or MPC.
+- Suggested algorithms: AI Time Based or MPC Predictive.
 
 ### 4. Tado Smart Radiator Thermostats
 

--- a/docs/working-devices/recommended-devices.md
+++ b/docs/working-devices/recommended-devices.md
@@ -17,18 +17,22 @@ The best TRVs for Better Thermostat have the following features:
 Based on community feedback and what the integrations expose:
 
 ### 1. Sonoff TRVZB
+
 - Good Zigbee2MQTT support, fast response times and reliable local temperature calibration. It also has specific model fixes built into Better Thermostat to ensure smooth operation.
 - Suggested algorithm: AI Time Based or Aggressive or MPC.
 
 ### 2. Eurotronic Spirit Zigbee (SPZB0001)
-- One of the few TRVs that reliably supports **Direct Valve Control**. That makes it the strongest option if you want to run MPC Predictive or PID Controller.
+
+- One of the few TRVs that reliably supports **Direct Valve Control**, which is the capability MPC Predictive and PID Controller gain the most from.
 - Suggested algorithm: MPC Predictive or PID Controller.
 
 ### 3. Moes / Tuya TS0601 Series
+
 - Very affordable and widely available. Better Thermostat includes extensive model fixes for these devices to correct their often-quirky default behaviors and make them reliable.
 - Suggested algorithm: AI Time Based or MPC.
 
 ### 4. Tado Smart Radiator Thermostats
+
 - Solid build quality and native integration support for local calibration.
 - Suggested algorithm: AI Time Based.
 
@@ -37,10 +41,12 @@ Based on community feedback and what the integrations expose:
 Better Thermostat relies heavily on accurate room temperature readings. The internal sensor of a TRV is too close to the radiator to be accurate. **You must use an external room sensor for the best experience.**
 
 ### What makes a good external sensor
+
 - **Frequent Updates**: The sensor should report temperature changes of 0.1°C or 0.2°C immediately.
 - **Placement**: Place it at eye level, away from direct sunlight, drafts, and the radiator itself.
 
 ### Suggestions
+
 - **Aqara Temperature and Humidity Sensor**: Affordable, reliable, and updates frequently enough for most rooms.
 - **Xiaomi Mijia Bluetooth/Zigbee Sensors**: Very accurate and easy to place anywhere.
 - **Shelly Temperature Sensor**: long battery life and good precision.
@@ -50,25 +56,28 @@ Better Thermostat relies heavily on accurate room temperature readings. The inte
 A window sensor lets Better Thermostat pause the heating as soon as a window opens, instead of letting the TRV heat the outside.
 
 ### What makes a good window sensor
+
 - **Instant Reporting**: The sensor must report its state change (open/closed) immediately without delay.
 - **Reliability**: It shouldn't drop off the network or miss state changes.
 
 ### Suggestions
+
 - **Aqara Door and Window Sensor**: reliable, reports instantly, small.
 - **Sonoff SNZB-04**: Affordable, uses standard Zigbee, and reports instantly.
 - **Shelly Door/Window 2**: a Wi-Fi option if you have no Zigbee network; includes tilt and temperature sensors.
 
 ## Integrations
 
-For these devices we recommend **Zigbee2MQTT (Z2M)**. It provides the most granular control over TRV entities, exposing calibration and valve control entities that other integrations (like ZHA or deCONZ) sometimes hide or don't support fully.
+For these devices we recommend **Zigbee2MQTT (Z2M)**. It exposes the local-calibration and valve-position entities Better Thermostat writes to; ZHA and deCONZ do not always expose them, and without them the calibration falls back to the setpoint.
 
-If you are looking for a good Zigbee coordinator, the [SONOFF Zigbee 3.0 USB Dongle Plus](https://amzn.to/4rt9aWt) is a popular choice that works well with Zigbee2MQTT and supports a wide range of devices. If you also want to support Home Assistant itself, consider the [ZBT-2](https://www.home-assistant.io/connect/zbt-2/): it is a bit more expensive, but it performs better, is more reliable, and Home Assistant supports it as a native Zigbee coordinator.
+If you are looking for a good Zigbee coordinator, the [SONOFF Zigbee 3.0 USB Dongle Plus](https://amzn.to/4rt9aWt) is a popular choice that works well with Zigbee2MQTT and supports a wide range of devices. If you also want to support Home Assistant itself, consider the [ZBT-2](https://www.home-assistant.io/connect/zbt-2/): it costs a little more and Home Assistant maintains it as a first-party Zigbee coordinator.
 
 ## Tested setups
 
 Complete setups that people run successfully.
 
 ### Setup 1: The "SEA801/SEA802" Setup
+
 An affordable setup built from widely available Zigbee devices.
 
 - **TRV**: SEA801-Zigbee / SEA802-Zigbee (TS0601) [Buying Link](https://amzn.to/4aDFMW3)
@@ -90,6 +99,7 @@ An affordable setup built from widely available Zigbee devices.
 - Does not support direct valve control
 
 ### Setup 2: The "Eurotronic Spirit" Setup
+
 This setup uses the powerful Eurotronic Spirit TRV, which supports both local offset and direct valve control.
 
 - **TRV**: Eurotronic Spirit Zigbee (SPZB0001) [Buying Link](https://amzn.to/40mKByg)

--- a/docs/working-devices/recommended-devices.md
+++ b/docs/working-devices/recommended-devices.md
@@ -9,7 +9,7 @@ When choosing a Smart Radiator Valve (TRV) or temperature sensor for Better Ther
 
 The best TRVs for Better Thermostat have the following features:
 1. **Local Temperature Calibration**: Allows Better Thermostat to send an offset to the TRV, making the TRV's internal logic work with your external room sensor.
-2. **Direct Valve Control**: Allows Better Thermostat to directly set the valve opening percentage (e.g., 0-100%). Every algorithm runs without it, but MPC Predictive and PID Controller gain the most from it.
+2. **Direct Valve Control**: Allows Better Thermostat to directly set the valve opening percentage (e.g., 0-100%). Every algorithm runs without it; with it, the algorithm's decision reaches the valve without the TRV's own controller in between.
 3. **Fast Reporting**: Sends temperature and state updates frequently without aggressive battery-saving sleep modes that delay commands.
 
 ## Recommended TRVs
@@ -23,7 +23,7 @@ Based on community feedback and what the integrations expose:
 
 ### 2. Eurotronic Spirit Zigbee (SPZB0001)
 
-- One of the few TRVs that reliably supports **Direct Valve Control**, which is the capability MPC Predictive and PID Controller gain the most from.
+- One of the few TRVs that reliably supports **Direct Valve Control**, so Better Thermostat's decision reaches the valve without the TRV's own controller in between.
 - Suggested algorithms: MPC Predictive or PID Controller.
 
 ### 3. Moes / Tuya TS0601 Series

--- a/docs/working-devices/recommended-devices.md
+++ b/docs/working-devices/recommended-devices.md
@@ -9,7 +9,7 @@ When choosing a Smart Radiator Valve (TRV) or temperature sensor for Better Ther
 
 The best TRVs for Better Thermostat have the following features:
 1. **Local Temperature Calibration**: Allows Better Thermostat to send an offset to the TRV, making the TRV's internal logic work with your external room sensor.
-2. **Direct Valve Control**: Allows Better Thermostat to directly set the valve opening percentage (e.g., 0-100%). MPC Predictive and PID Controller need this to work at their best.
+2. **Direct Valve Control**: Allows Better Thermostat to directly set the valve opening percentage (e.g., 0-100%). Every algorithm runs without it, but MPC Predictive and PID Controller gain the most from it.
 3. **Fast Reporting**: Sends temperature and state updates frequently without aggressive battery-saving sleep modes that delay commands.
 
 ## Recommended TRVs
@@ -62,7 +62,7 @@ A window sensor lets Better Thermostat pause the heating as soon as a window ope
 
 For these devices we recommend **Zigbee2MQTT (Z2M)**. It provides the most granular control over TRV entities, exposing calibration and valve control entities that other integrations (like ZHA or deCONZ) sometimes hide or don't support fully.
 
-if you looking for a good Zigbee coordinator, the [SONOFF Zigbee 3.0 USB Dongle Plus](https://amzn.to/4rt9aWt) is a popular choice that works well with Zigbee2MQTT and supports a wide range of devices. But, if you want to support even HomeAssistant itself, you better get the [ZBT-2](https://www.home-assistant.io/connect/zbt-2/) its a bit more expensive but it has better performance and reliability, and it's also supported by HomeAssistant itself as a native Zigbee coordinator.
+If you are looking for a good Zigbee coordinator, the [SONOFF Zigbee 3.0 USB Dongle Plus](https://amzn.to/4rt9aWt) is a popular choice that works well with Zigbee2MQTT and supports a wide range of devices. If you also want to support Home Assistant itself, consider the [ZBT-2](https://www.home-assistant.io/connect/zbt-2/): it is a bit more expensive, but it performs better, is more reliable, and Home Assistant supports it as a native Zigbee coordinator.
 
 ## Tested setups
 


### PR DESCRIPTION
Closes #2206.

Two pages, both for questions users asked in discussions this summer.

## `docs/setup/presets.md`

#2196 covers presets for the scheduling case, which is its job. A reader arriving from the config flow still had nowhere to look up what the names mean. This page carries the reference material: the shipped defaults per preset, that presets are opt-in and a fresh configuration starts with Eco alone, which number entity carries which temperature (and the `Min`/`Max` pair when a cooler is configured), and that the value is clamped to the device range and survives a restart.

It also spells out the save and restore rule, including the part that surprises people: the save happens only on the way in from `none`, so hopping between two presets does not overwrite the target you started from.

Boost gets its own section, because it is the only preset that is more than a temperature: with `Direct Valve Based` calibration it holds the valve at its Valve Max Opening while the room is below target.

Asked in #2031.

## `docs/deep-explanations/central-heating-thermostat.md`

Better Thermostat has no concept of a boiler. That is a defensible scope decision the docs never stated, so users with a combi boiler plus TRVs went hunting for a setting that does not exist.

The page gives the per-room shape, an automation that drives the central thermostat from the rooms' `hvac_action`, and a warning against `call_for_heat`, which reads like the right signal and is actually the weather shutdown flag. It also explains the failure that gets misread as a Better Thermostat bug: while the central thermostat is satisfied no flow reaches the radiators, BT opens valves further because the rooms will not warm, and everything overshoots together when flow returns.

Asked in #2032, which links two older discussions (#744, #940) that ended without a documented outcome.

## Notes

Neither page sets an explicit `slug`, matching the other files in those two directories, so both are picked up by the existing autogenerated sidebar sections and `website/astro.config.mjs` needs no change.

The retired action names appear in neither page. `test_docs_service_references.py` allows them in the migration guide alone, and both pages link there instead of repeating them.

## Second commit: cleaning the existing pages

An audit of the whole tree (22 files, 13.6k words) with the avoid-ai-writing rules turned up **no Tier 1 vocabulary at all**. No `delve`, `robust`, `comprehensive`, `seamless`, `leverage`, `holistic`, no inflated formality. The signature was entirely structural, and concentrated in four files.

`Configuration/algorithms.md` was the worst of it. Seven algorithm sections repeated the same five bolded labels (`**Best for:**` / `**How it works:**` / `**Pros:**` / `**Cons:**` / `**When to use:**`), the chooser at the top was five rhetorical questions in a row, and a dozen headings ran in Title Case. Each algorithm now reads as prose that names the trade it makes, the chooser is a table, and bold went from 4.6 % of the page to 2.4 %.

`configuration.md` carried a copy of the same rhetorical-question block. `recommended-devices.md` had a per-device `**Why it's great**` / `**Best Algorithm**` template plus the superlatives that come with that shape. `getting-started.md` opened with "Welcome to Better Thermostat! Let's get your smart heating set up" and used two rhetorical questions as section transitions. `recommended-settings.md` was four sections of nothing but bullets; the two that carried claims rather than list items are now prose.

Deliberately left alone, and relevant to the review:

- Bold on UI field names in the configuration walkthrough and on device names in the device list. A label is the right form there, so the density stays above the guideline on purpose.
- Em dashes inside FAQ definitions, where the dash is doing punctuation work rather than splicing a sentence.
- The internals design documents. They audit clean on vocabulary, transitions, headings and bold. Their em-dash rate is high (roughly 17 per 1,000 words against a guideline of 1), but converting 95 of them mechanically would reflow prose that reads well and is dense with meaning, which is the over-polishing the rules themselves warn against. Only the seven em-dash *headings* in the region docs changed, to colons.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for integrating room TRVs with an independent central boiler thermostat.
  - Documented presets, default configurations, temperature validation, saved settings, and Boost behavior.
  - Reorganized calibration algorithm guidance with clearer comparisons, recommendations, learning expectations, and tuning advice.
  - Clarified sensor placement, direct valve control, heating requirements, and configuration walkthroughs.
  - Improved setup, FAQ, device recommendation, and optimal-settings documentation with shorter, clearer guidance and updated terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->