### PR TITLE
test(integration): parametrize the harness over real device forms

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,8 +7,8 @@ exercised end to end.
 
 The simulated devices are built from the profiles in ``device_profiles``:
 ``fake_trv`` and ``device_role`` are parametrized indirectly to move the
-whole harness onto another device form, and ``make_entry`` derives the
-matching config entry from the same profile.
+whole harness onto another device form, and every test names the devices its
+config entry is built for, so an axis cannot be flattened by accident.
 """
 
 import asyncio
@@ -51,14 +51,14 @@ from homeassistant.util.unit_conversion import TemperatureConverter
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from .device_profiles import (
-    COOLER_ID,
     GENERIC_HEAT_TRV,
     HEAT_ONLY,
     OFFSET_NUMBER_ID,
-    TRV_ID,
+    VALVE_NUMBER_ID,
     DeviceProfile,
     OffsetChannel,
     RoleScenario,
+    ValveChannel,
 )
 
 DOMAIN = "better_thermostat"
@@ -73,32 +73,15 @@ BT_ENTITY = "climate.bt_test"
 DEVICE_INTEGRATION = "test"
 DEVICE_IDENTIFIERS = {(DEVICE_INTEGRATION, "fake_device")}
 
-# What the test modules import from the harness. The entity ids and the
-# profile types are re-exported so a test needs one import, not two.
-__all__ = [
-    "BT_ENTITY",
-    "COOLER_ID",
-    "DEVICE_INTEGRATION",
-    "DOMAIN",
-    "OFFSET_NUMBER_ID",
-    "SENSOR_ID",
-    "TRV_ID",
-    "WINDOW_ID",
-    "DeviceProfile",
-    "OffsetChannel",
-    "RoleScenario",
-    "SimulatedClimate",
-    "SimulatedOffsetNumber",
-    "assert_on_device_grid",
-    "assert_profile_adopted",
-    "build_devices",
-    "make_entry",
-    "profile_id",
-    "set_room_sensor",
-    "setup_entry",
-    "wait_for",
-    "wait_for_startup",
-]
+# Production pacing constants a test patches to run a control cycle without
+# waiting out wall-clock time. They live here because a rename in production
+# has to break every patch site at once, not one of them.
+WRITE_BUDGET = (
+    "custom_components.better_thermostat.utils.controlling.MIN_WRITE_INTERVAL_S"
+)
+COOLER_RESEND = (
+    "custom_components.better_thermostat.utils.controlling.COOLER_RESEND_INTERVAL_S"
+)
 
 
 @pytest.fixture(autouse=True)
@@ -135,42 +118,24 @@ def _compressed_sleeps():
         yield
 
 
-@dataclass
-class _ActiveDevices:
-    """The devices a bare ``make_entry()`` builds its entry for.
-
-    A test that parametrizes its fixture and then calls ``make_entry()``
-    without arguments would otherwise get an entry for the default device,
-    which silently flattens the axis it parametrized. ``build_devices`` and
-    ``device_role`` point this holder at the devices they registered;
-    ``_reset_active_devices`` bounds it to one test.
-    """
-
-    profile: DeviceProfile = GENERIC_HEAT_TRV
-    cooler_entity_id: str | None = None
-
-
-_ACTIVE = _ActiveDevices()
-
-
-@pytest.fixture(autouse=True)
-def _reset_active_devices():
-    """Point the ambient device state back at the default profile."""
-    _ACTIVE.profile = GENERIC_HEAT_TRV
-    _ACTIVE.cooler_entity_id = None
-
-
 class SimulatedClimate(ClimateEntity):
     """A simulated climate device, built from a device profile.
 
     Commands arrive through the real climate services and are confirmed
     into the entity state, like a device that applies every write. The
     recorded calls are the assertion surface. Nothing here rejects a
-    command: a device only refuses what Home Assistant's own validation
-    refuses on the strength of the published capabilities.
+    command outright: a device only refuses what Home Assistant's own
+    validation refuses on the strength of the published capabilities.
 
-    ``offset_number`` is the calibration entity of a device whose offset
-    channel is a number entity, and ``None`` for every other device.
+    What it can do is lose one: with ``drop_next_setpoint_write`` set, a
+    command is recorded and then swallowed, which is how a channel is
+    driven into the divergence the write gate and the reconciler exist to
+    resolve. The calibration and valve numbers carry the same switch under
+    the name ``drop_next_write``.
+
+    ``offset_number`` and ``valve_number`` are the calibration and valve
+    entities of a device that exposes those channels, and ``None`` for a
+    device that does not.
     """
 
     _attr_should_poll = False
@@ -179,6 +144,7 @@ class SimulatedClimate(ClimateEntity):
         """Publish the profile's capabilities and open the assertion surface."""
         self.profile = profile
         self.offset_number: SimulatedOffsetNumber | None = None
+        self.valve_number: SimulatedValveNumber | None = None
         self._attr_name = profile.entity_name
         self._attr_temperature_unit = profile.temperature_unit
         self._attr_hvac_modes = list(profile.hvac_modes)
@@ -189,6 +155,8 @@ class SimulatedClimate(ClimateEntity):
         self._attr_hvac_mode = profile.hvac_mode
         self._attr_current_temperature = profile.current_temperature
         self._attr_target_temperature = profile.target_temperature
+        self._attr_target_temperature_low = profile.target_temperature_low
+        self._attr_target_temperature_high = profile.target_temperature_high
         if profile.precision is not None:
             self._attr_precision = profile.precision
         if profile.has_device_registry_entry:
@@ -200,8 +168,6 @@ class SimulatedClimate(ClimateEntity):
             self._attr_extra_state_attributes = {"offset_celsius": 0.0}
         self.set_temperature_calls: list[float | dict[str, float]] = []
         self.set_hvac_mode_calls: list[str] = []
-        # Radio loss simulation: the next setpoint write is recorded but
-        # neither applied nor confirmed.
         self.drop_next_setpoint_write = False
 
     async def async_set_temperature(self, **kwargs) -> None:
@@ -240,37 +206,85 @@ class SimulatedClimate(ClimateEntity):
         self.async_write_ha_state()
 
 
-class SimulatedOffsetNumber(NumberEntity):
-    """The calibration number a device exposes next to its climate entity.
+class _SimulatedNumber(NumberEntity):
+    """A number entity on the same device as a simulated climate entity.
 
-    It sits on the same device as the climate entity and carries the
-    translation key calibration discovery looks for. It publishes no device
-    class on purpose: a temperature device class would make Home Assistant
-    convert the native value, so a read back would not be what was written.
+    Sitting on that device is what makes it discoverable: Better Thermostat
+    finds the calibration and valve channels by walking the entity registry
+    from the device the climate entity belongs to. Like the climate entity it
+    confirms every write into its state and can be told to lose one.
+
+    It publishes no device class on purpose: a temperature device class would
+    make Home Assistant convert the native value, so a read back would not be
+    what was written.
     """
 
     _attr_should_poll = False
+    _attr_mode = NumberMode.BOX
+
+    def __init__(self, profile: DeviceProfile, suffix: str):
+        """Attach the entity to the profile's device."""
+        self._attr_unique_id = f"{_object_id(profile.entity_id)}_{suffix}"
+        self._attr_device_info = DeviceInfo(identifiers=DEVICE_IDENTIFIERS)
+        self.set_value_calls: list[float] = []
+        self.drop_next_write = False
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Apply and confirm a write, unless this one is to be lost."""
+        self.set_value_calls.append(value)
+        if self.drop_next_write:
+            self.drop_next_write = False
+            return
+        self._attr_native_value = value
+        self.async_write_ha_state()
+
+
+class SimulatedOffsetNumber(_SimulatedNumber):
+    """The calibration number a device exposes next to its climate entity."""
+
     _attr_name = "local temperature calibration"
     _attr_translation_key = "local_temperature_calibration"
     _attr_native_min_value = -12.0
     _attr_native_max_value = 12.0
     _attr_native_step = 0.5
-    _attr_mode = NumberMode.BOX
 
     def __init__(self, profile: DeviceProfile):
-        """Attach the calibration entity to the profile's device."""
-        self._attr_unique_id = (
-            f"{_object_id(profile.entity_id)}_local_temperature_calibration"
-        )
-        self._attr_device_info = DeviceInfo(identifiers=DEVICE_IDENTIFIERS)
+        """Start the device out uncalibrated."""
+        super().__init__(profile, "local_temperature_calibration")
         self._attr_native_value = 0.0
-        self.set_value_calls: list[float] = []
 
-    async def async_set_native_value(self, value: float) -> None:
-        """Apply and confirm an offset write."""
-        self.set_value_calls.append(value)
-        self._attr_native_value = value
-        self.async_write_ha_state()
+
+class SimulatedValveNumber(_SimulatedNumber):
+    """The valve position a device exposes next to its climate entity."""
+
+    _attr_name = "valve position"
+    _attr_translation_key = "valve_position"
+    _attr_native_min_value = 0.0
+    _attr_native_max_value = 100.0
+    _attr_native_step = 1.0
+
+    def __init__(self, profile: DeviceProfile):
+        """Start the device out with a closed valve."""
+        super().__init__(profile, "valve_position")
+        self._attr_native_value = 0.0
+
+
+@dataclass(frozen=True)
+class WiredRoom:
+    """The devices one role scenario wired, and the scenario that named them."""
+
+    scenario: RoleScenario
+    entities: list[SimulatedClimate]
+
+    @property
+    def thermostat(self) -> SimulatedClimate:
+        """The device the entry drives as its thermostat."""
+        return self.entities[0]
+
+    @property
+    def cooler(self) -> SimulatedClimate:
+        """The device that cools: a separate one, or the thermostat itself."""
+        return self.entities[-1]
 
 
 def _object_id(entity_id: str) -> str:
@@ -281,9 +295,8 @@ def _object_id(entity_id: str) -> str:
 async def build_devices(hass, *profiles: DeviceProfile) -> list[SimulatedClimate]:
     """Register one simulated device per profile and return the entities.
 
-    The first profile becomes the ambient one a bare ``make_entry()`` builds
-    its entry for. Profiles must agree on ``has_device_registry_entry``: the
-    two registration routes are mutually exclusive.
+    Profiles must agree on ``has_device_registry_entry``: the two
+    registration routes are mutually exclusive.
     """
     if not profiles:
         raise ValueError("build_devices needs at least one profile")
@@ -292,8 +305,8 @@ async def build_devices(hass, *profiles: DeviceProfile) -> list[SimulatedClimate
         raise ValueError("profiles must agree on has_device_registry_entry")
     if sum(p.offset_channel is OffsetChannel.NUMBER_ENTITY for p in profiles) > 1:
         raise ValueError("only one device may carry a calibration number entity")
-
-    _ACTIVE.profile = profiles[0]
+    if sum(p.valve_channel is ValveChannel.NUMBER_ENTITY for p in profiles) > 1:
+        raise ValueError("only one device may carry a valve number entity")
 
     # The system unit is captured into the entity at entry setup and is the
     # fallback behind every unit resolution, so it has to be in place before
@@ -310,10 +323,15 @@ async def build_devices(hass, *profiles: DeviceProfile) -> list[SimulatedClimate
         # registered under an id derived from the device name.
         entity.entity_id = profile.entity_id
         if profile.offset_channel is OffsetChannel.NUMBER_ENTITY:
-            number = SimulatedOffsetNumber(profile)
-            number.entity_id = OFFSET_NUMBER_ID
-            entity.offset_number = number
-            numbers.append(number)
+            offset = SimulatedOffsetNumber(profile)
+            offset.entity_id = OFFSET_NUMBER_ID
+            entity.offset_number = offset
+            numbers.append(offset)
+        if profile.valve_channel is ValveChannel.NUMBER_ENTITY:
+            valve = SimulatedValveNumber(profile)
+            valve.entity_id = VALVE_NUMBER_ID
+            entity.valve_number = valve
+            numbers.append(valve)
         entities.append(entity)
 
     if with_device:
@@ -369,11 +387,12 @@ async def _add_devices_from_config_entry(hass, entities, numbers) -> None:
 
 
 @pytest.fixture
-async def fake_trv(hass, request, _reset_active_devices):
+async def fake_trv(hass, request):
     """Register a fake TRV with the real climate component.
 
     Parametrize indirectly with a ``DeviceProfile`` to move the test onto
-    another device form.
+    another device form; the profile is on the returned entity, so the test
+    builds its entry for the device it was given.
     """
     profile = getattr(request, "param", GENERIC_HEAT_TRV)
     (entity,) = await build_devices(hass, profile)
@@ -381,39 +400,36 @@ async def fake_trv(hass, request, _reset_active_devices):
 
 
 @pytest.fixture
-async def device_role(hass, request, _reset_active_devices):
-    """Register the devices of a role scenario and wire the entry to them.
+async def device_role(hass, request) -> WiredRoom:
+    """Register the devices of a role scenario.
 
-    Parametrize indirectly with a ``RoleScenario``. The returned entities are
-    the thermostat first, then a separate cooler if the scenario has one; a
+    Parametrize indirectly with a ``RoleScenario``. The entities are the
+    thermostat first, then a separate cooler if the scenario has one; a
     dual-role device yields a single entity that the entry names twice.
     """
     scenario: RoleScenario = getattr(request, "param", HEAT_ONLY)
     profiles = [scenario.trv]
     if scenario.cooler is not None:
         profiles.append(scenario.cooler)
-    entities = await build_devices(hass, *profiles)
-    _ACTIVE.cooler_entity_id = scenario.cooler_entity_id
-    return entities
+    return WiredRoom(scenario, await build_devices(hass, *profiles))
 
 
 def make_entry(
+    devices: DeviceProfile | RoleScenario,
     *,
-    profile: DeviceProfile | None = None,
     with_window: bool = False,
     name: str = "BT Test",
-    cooler: str | None = None,
     heat_auto_swapped: bool = False,
 ) -> MockConfigEntry:
-    """Build a config entry matching the current entry schema.
+    """Build a config entry for ``devices``, matching the current entry schema.
 
-    ``profile`` and ``cooler`` default to the devices most recently built,
-    so a test that parametrizes its fixture gets the matching entry without
-    naming the device twice.
+    ``devices`` is the profile of the single device the entry controls, or
+    the role scenario that says which devices it wires to which channel.
     """
-    profile = profile or _ACTIVE.profile
-    if cooler is None:
-        cooler = _ACTIVE.cooler_entity_id
+    if isinstance(devices, RoleScenario):
+        profile, cooler = devices.trv, devices.cooler_entity_id
+    else:
+        profile, cooler = devices, None
     data = {
         "name": name,
         "thermostat": [
@@ -423,7 +439,7 @@ def make_entry(
                 "model": "Generic",
                 "advanced": {
                     "calibration": profile.calibration,
-                    "calibration_mode": "default",
+                    "calibration_mode": profile.calibration_mode,
                     "no_off_system_mode": False,
                     "heat_auto_swapped": heat_auto_swapped,
                 },
@@ -488,6 +504,17 @@ def set_room_sensor(hass, value, unit=UnitOfTemperature.CELSIUS) -> None:
     hass.states.async_set(SENSOR_ID, str(value), {"unit_of_measurement": unit})
 
 
+def cooling_setpoint(call: float | dict[str, float]) -> float:
+    """Return the cooling setpoint a recorded setpoint write carries.
+
+    A cooler that publishes a band takes its cooling setpoint as the upper
+    bound of that band; one that publishes a single setpoint takes it plain.
+    """
+    if isinstance(call, dict):
+        return call[ATTR_TARGET_TEMP_HIGH]
+    return call
+
+
 def assert_on_device_grid(value: float, profile: DeviceProfile) -> None:
     """Fail unless ``value`` is a multiple of the device's setpoint step.
 
@@ -520,6 +547,14 @@ def assert_profile_adopted(bt, profile: DeviceProfile) -> None:
         _celsius(profile.max_temp, profile.temperature_unit), abs=1e-2
     )
     assert trv.capabilities().supports_off_mode is (HVACMode.OFF in profile.hvac_modes)
+    assert trv.capabilities().supports_offset_write is (
+        profile.offset_channel is not OffsetChannel.NONE
+    )
+    # The discovered valve surface, not the capability: every model carries a
+    # quirk-driven valve override, so the capability is true for devices that
+    # publish no valve entity at all.
+    valve_entity = bool(trv.valve_position_entity and trv.valve_position_writable)
+    assert valve_entity is (profile.valve_channel is ValveChannel.NUMBER_ENTITY)
 
 
 def _celsius(value: float, unit: UnitOfTemperature) -> float:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,14 +4,24 @@ The unit suite mocks the entity; everything here sets up a real config
 entry against a real (simulated) climate entity so the wiring across
 the layers — entity lifecycle, queues, kernel, adapters, services — is
 exercised end to end.
+
+The simulated devices are built from the profiles in ``device_profiles``:
+``fake_trv`` and ``device_role`` are parametrized indirectly to move the
+whole harness onto another device form, and ``make_entry`` derives the
+matching config entry from the same profile.
 """
 
 import asyncio
+from dataclasses import dataclass
 from unittest.mock import patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
+    MockModule,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
     setup_test_component_platform,
 )
 
@@ -22,18 +32,73 @@ from pytest_homeassistant_custom_component.common import (
 import custom_components.better_thermostat  # noqa: F401  isort: skip
 
 from homeassistant.components.climate import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
     DOMAIN as CLIMATE_DOMAIN,
     ClimateEntity,
-    ClimateEntityFeature,
     HVACMode,
 )
+from homeassistant.components.number import (
+    DOMAIN as NUMBER_DOMAIN,
+    NumberEntity,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.setup import async_setup_component
+from homeassistant.util.unit_conversion import TemperatureConverter
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+from .device_profiles import (
+    COOLER_ID,
+    GENERIC_HEAT_TRV,
+    HEAT_ONLY,
+    OFFSET_NUMBER_ID,
+    TRV_ID,
+    DeviceProfile,
+    OffsetChannel,
+    RoleScenario,
+)
 
 DOMAIN = "better_thermostat"
-TRV_ID = "climate.fake_trv"
 SENSOR_ID = "sensor.room_temperature"
 WINDOW_ID = "binary_sensor.window"
+
+# The entity every test drives, derived from the default entry title.
+BT_ENTITY = "climate.bt_test"
+
+# The integration the simulated devices belong to when they need a device
+# registry entry, and the device all of them share.
+DEVICE_INTEGRATION = "test"
+DEVICE_IDENTIFIERS = {(DEVICE_INTEGRATION, "fake_device")}
+
+# What the test modules import from the harness. The entity ids and the
+# profile types are re-exported so a test needs one import, not two.
+__all__ = [
+    "BT_ENTITY",
+    "COOLER_ID",
+    "DEVICE_INTEGRATION",
+    "DOMAIN",
+    "OFFSET_NUMBER_ID",
+    "SENSOR_ID",
+    "TRV_ID",
+    "WINDOW_ID",
+    "DeviceProfile",
+    "OffsetChannel",
+    "RoleScenario",
+    "SimulatedClimate",
+    "SimulatedOffsetNumber",
+    "assert_on_device_grid",
+    "assert_profile_adopted",
+    "build_devices",
+    "make_entry",
+    "profile_id",
+    "set_room_sensor",
+    "setup_entry",
+    "wait_for",
+    "wait_for_startup",
+]
 
 
 @pytest.fixture(autouse=True)
@@ -70,33 +135,70 @@ def _compressed_sleeps():
         yield
 
 
-class FakeTrvEntity(ClimateEntity):
-    """A well-behaved simulated TRV as a real climate entity.
+@dataclass
+class _ActiveDevices:
+    """The devices a bare ``make_entry()`` builds its entry for.
+
+    A test that parametrizes its fixture and then calls ``make_entry()``
+    without arguments would otherwise get an entry for the default device,
+    which silently flattens the axis it parametrized. ``build_devices`` and
+    ``device_role`` point this holder at the devices they registered;
+    ``_reset_active_devices`` bounds it to one test.
+    """
+
+    profile: DeviceProfile = GENERIC_HEAT_TRV
+    cooler_entity_id: str | None = None
+
+
+_ACTIVE = _ActiveDevices()
+
+
+@pytest.fixture(autouse=True)
+def _reset_active_devices():
+    """Point the ambient device state back at the default profile."""
+    _ACTIVE.profile = GENERIC_HEAT_TRV
+    _ACTIVE.cooler_entity_id = None
+
+
+class SimulatedClimate(ClimateEntity):
+    """A simulated climate device, built from a device profile.
 
     Commands arrive through the real climate services and are confirmed
     into the entity state, like a device that applies every write. The
-    recorded calls are the assertion surface.
+    recorded calls are the assertion surface. Nothing here rejects a
+    command: a device only refuses what Home Assistant's own validation
+    refuses on the strength of the published capabilities.
+
+    ``offset_number`` is the calibration entity of a device whose offset
+    channel is a number entity, and ``None`` for every other device.
     """
 
-    _attr_name = "fake trv"
     _attr_should_poll = False
-    _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
-    _attr_supported_features = (
-        ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.TURN_OFF
-        | ClimateEntityFeature.TURN_ON
-    )
-    _attr_min_temp = 5.0
-    _attr_max_temp = 30.0
-    _attr_target_temperature_step = 0.5
 
-    def __init__(self):
-        """Initialize device state and the recorded-write assertion surface."""
-        self._attr_hvac_mode = HVACMode.HEAT
-        self._attr_current_temperature = 19.5
-        self._attr_target_temperature = 20.0
-        self.set_temperature_calls: list[float] = []
+    def __init__(self, profile: DeviceProfile):
+        """Publish the profile's capabilities and open the assertion surface."""
+        self.profile = profile
+        self.offset_number: SimulatedOffsetNumber | None = None
+        self._attr_name = profile.entity_name
+        self._attr_temperature_unit = profile.temperature_unit
+        self._attr_hvac_modes = list(profile.hvac_modes)
+        self._attr_supported_features = profile.supported_features
+        self._attr_min_temp = profile.min_temp
+        self._attr_max_temp = profile.max_temp
+        self._attr_target_temperature_step = profile.target_temperature_step
+        self._attr_hvac_mode = profile.hvac_mode
+        self._attr_current_temperature = profile.current_temperature
+        self._attr_target_temperature = profile.target_temperature
+        if profile.precision is not None:
+            self._attr_precision = profile.precision
+        if profile.has_device_registry_entry:
+            self._attr_unique_id = f"{_object_id(profile.entity_id)}_climate"
+            self._attr_device_info = DeviceInfo(identifiers=DEVICE_IDENTIFIERS)
+        if profile.offset_channel is OffsetChannel.ECOSYSTEM_SERVICE:
+            # The ecosystem adapter reads the current offset off the climate
+            # entity itself instead of a separate calibration entity.
+            self._attr_extra_state_attributes = {"offset_celsius": 0.0}
+        self.set_temperature_calls: list[float | dict[str, float]] = []
         self.set_hvac_mode_calls: list[str] = []
         # Radio loss simulation: the next setpoint write is recorded but
         # neither applied nor confirmed.
@@ -107,9 +209,23 @@ class FakeTrvEntity(ClimateEntity):
 
         The write is always recorded; with ``drop_next_setpoint_write``
         set it is then swallowed instead of applied, simulating a device
-        that lost the command over the radio.
+        that lost the command over the radio. A ranged write is recorded
+        as a dict of both bounds.
         """
-        temperature = kwargs[ATTR_TEMPERATURE]
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            low = kwargs.get(ATTR_TARGET_TEMP_LOW)
+            high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
+            self.set_temperature_calls.append(
+                {ATTR_TARGET_TEMP_LOW: low, ATTR_TARGET_TEMP_HIGH: high}
+            )
+            if self.drop_next_setpoint_write:
+                self.drop_next_setpoint_write = False
+                return
+            self._attr_target_temperature_low = low
+            self._attr_target_temperature_high = high
+            self.async_write_ha_state()
+            return
         self.set_temperature_calls.append(temperature)
         if self.drop_next_setpoint_write:
             self.drop_next_setpoint_write = False
@@ -124,41 +240,203 @@ class FakeTrvEntity(ClimateEntity):
         self.async_write_ha_state()
 
 
-@pytest.fixture
-async def fake_trv(hass):
-    """Register a fake TRV with the real climate component."""
-    entity = FakeTrvEntity()
-    setup_test_component_platform(hass, CLIMATE_DOMAIN, [entity])
+class SimulatedOffsetNumber(NumberEntity):
+    """The calibration number a device exposes next to its climate entity.
+
+    It sits on the same device as the climate entity and carries the
+    translation key calibration discovery looks for. It publishes no device
+    class on purpose: a temperature device class would make Home Assistant
+    convert the native value, so a read back would not be what was written.
+    """
+
+    _attr_should_poll = False
+    _attr_name = "local temperature calibration"
+    _attr_translation_key = "local_temperature_calibration"
+    _attr_native_min_value = -12.0
+    _attr_native_max_value = 12.0
+    _attr_native_step = 0.5
+    _attr_mode = NumberMode.BOX
+
+    def __init__(self, profile: DeviceProfile):
+        """Attach the calibration entity to the profile's device."""
+        self._attr_unique_id = (
+            f"{_object_id(profile.entity_id)}_local_temperature_calibration"
+        )
+        self._attr_device_info = DeviceInfo(identifiers=DEVICE_IDENTIFIERS)
+        self._attr_native_value = 0.0
+        self.set_value_calls: list[float] = []
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Apply and confirm an offset write."""
+        self.set_value_calls.append(value)
+        self._attr_native_value = value
+        self.async_write_ha_state()
+
+
+def _object_id(entity_id: str) -> str:
+    """Return the object id half of ``entity_id``."""
+    return entity_id.split(".", 1)[1]
+
+
+async def build_devices(hass, *profiles: DeviceProfile) -> list[SimulatedClimate]:
+    """Register one simulated device per profile and return the entities.
+
+    The first profile becomes the ambient one a bare ``make_entry()`` builds
+    its entry for. Profiles must agree on ``has_device_registry_entry``: the
+    two registration routes are mutually exclusive.
+    """
+    if not profiles:
+        raise ValueError("build_devices needs at least one profile")
+    with_device = profiles[0].has_device_registry_entry
+    if any(p.has_device_registry_entry is not with_device for p in profiles):
+        raise ValueError("profiles must agree on has_device_registry_entry")
+    if sum(p.offset_channel is OffsetChannel.NUMBER_ENTITY for p in profiles) > 1:
+        raise ValueError("only one device may carry a calibration number entity")
+
+    _ACTIVE.profile = profiles[0]
+
+    # The system unit is captured into the entity at entry setup and is the
+    # fallback behind every unit resolution, so it has to be in place before
+    # the devices exist — a device unit alone changes nothing Better
+    # Thermostat can observe, because a climate entity publishes no unit.
+    if profiles[0].temperature_unit is UnitOfTemperature.FAHRENHEIT:
+        hass.config.units = US_CUSTOMARY_SYSTEM
+
+    entities = []
+    numbers = []
+    for profile in profiles:
+        entity = SimulatedClimate(profile)
+        # Pinned before adding: without it a device-backed entity is
+        # registered under an id derived from the device name.
+        entity.entity_id = profile.entity_id
+        if profile.offset_channel is OffsetChannel.NUMBER_ENTITY:
+            number = SimulatedOffsetNumber(profile)
+            number.entity_id = OFFSET_NUMBER_ID
+            entity.offset_number = number
+            numbers.append(number)
+        entities.append(entity)
+
+    if with_device:
+        await _add_devices_from_config_entry(hass, entities, numbers)
+    else:
+        await _add_devices_from_yaml(hass, entities)
+
+    await hass.async_block_till_done()
+    for entity in entities:
+        assert hass.states.get(entity.entity_id) is not None
+    for number in numbers:
+        assert hass.states.get(number.entity_id) is not None
+    return entities
+
+
+async def _add_devices_from_yaml(hass, entities) -> None:
+    """Add the entities through a YAML platform: no registry row, no device."""
+    setup_test_component_platform(hass, CLIMATE_DOMAIN, entities)
     assert await async_setup_component(
         hass, CLIMATE_DOMAIN, {CLIMATE_DOMAIN: {"platform": "test"}}
     )
-    await hass.async_block_till_done()
-    assert hass.states.get(TRV_ID) is not None
+
+
+async def _add_devices_from_config_entry(hass, entities, numbers) -> None:
+    """Add the entities through a config entry, so they get a device.
+
+    Every line is load-bearing: without the mocked config flow platform the
+    setup fails with "Platform test.config_flow not found", and without the
+    mocked flow handler with "Flow handler not found".
+    """
+    platforms = [CLIMATE_DOMAIN] + ([NUMBER_DOMAIN] if numbers else [])
+
+    async def async_setup_entry(hass, entry):
+        await hass.config_entries.async_forward_entry_setups(entry, platforms)
+        return True
+
+    mock_integration(
+        hass, MockModule(DEVICE_INTEGRATION, async_setup_entry=async_setup_entry)
+    )
+    mock_platform(hass, f"{DEVICE_INTEGRATION}.config_flow", None)
+    setup_test_component_platform(
+        hass, CLIMATE_DOMAIN, entities, from_config_entry=True
+    )
+    if numbers:
+        setup_test_component_platform(
+            hass, NUMBER_DOMAIN, numbers, from_config_entry=True
+        )
+    device_entry = MockConfigEntry(domain=DEVICE_INTEGRATION)
+    device_entry.add_to_hass(hass)
+    with mock_config_flow(DEVICE_INTEGRATION, ConfigFlow):
+        assert await hass.config_entries.async_setup(device_entry.entry_id)
+        await hass.async_block_till_done()
+
+
+@pytest.fixture
+async def fake_trv(hass, request, _reset_active_devices):
+    """Register a fake TRV with the real climate component.
+
+    Parametrize indirectly with a ``DeviceProfile`` to move the test onto
+    another device form.
+    """
+    profile = getattr(request, "param", GENERIC_HEAT_TRV)
+    (entity,) = await build_devices(hass, profile)
     return entity
 
 
-def make_entry(*, with_window=False, name="BT Test") -> MockConfigEntry:
-    """Build a config entry matching the current entry schema."""
+@pytest.fixture
+async def device_role(hass, request, _reset_active_devices):
+    """Register the devices of a role scenario and wire the entry to them.
+
+    Parametrize indirectly with a ``RoleScenario``. The returned entities are
+    the thermostat first, then a separate cooler if the scenario has one; a
+    dual-role device yields a single entity that the entry names twice.
+    """
+    scenario: RoleScenario = getattr(request, "param", HEAT_ONLY)
+    profiles = [scenario.trv]
+    if scenario.cooler is not None:
+        profiles.append(scenario.cooler)
+    entities = await build_devices(hass, *profiles)
+    _ACTIVE.cooler_entity_id = scenario.cooler_entity_id
+    return entities
+
+
+def make_entry(
+    *,
+    profile: DeviceProfile | None = None,
+    with_window: bool = False,
+    name: str = "BT Test",
+    cooler: str | None = None,
+    heat_auto_swapped: bool = False,
+) -> MockConfigEntry:
+    """Build a config entry matching the current entry schema.
+
+    ``profile`` and ``cooler`` default to the devices most recently built,
+    so a test that parametrizes its fixture gets the matching entry without
+    naming the device twice.
+    """
+    profile = profile or _ACTIVE.profile
+    if cooler is None:
+        cooler = _ACTIVE.cooler_entity_id
     data = {
         "name": name,
         "thermostat": [
             {
-                "trv": TRV_ID,
-                "integration": "generic_thermostat",
+                "trv": profile.entity_id,
+                "integration": profile.integration,
                 "model": "Generic",
                 "advanced": {
-                    "calibration": "target_temp_based",
+                    "calibration": profile.calibration,
                     "calibration_mode": "default",
                     "no_off_system_mode": False,
+                    "heat_auto_swapped": heat_auto_swapped,
                 },
             }
         ],
         "temperature_sensor": SENSOR_ID,
         "model": "Generic",
-        "target_temp_step": "0.5",
+        "target_temp_step": profile.configured_target_temp_step,
         "tolerance": 0.3,
         "off_temperature": 5,
     }
+    if cooler is not None:
+        data["cooler"] = cooler
     if with_window:
         data["window_sensors"] = WINDOW_ID
         data["window_off_delay"] = 0
@@ -198,3 +476,64 @@ async def wait_for_startup(hass, entry):
         lambda: not bt.startup_running and bt._async_unsub_state_changed is not None,
     )
     return bt
+
+
+def profile_id(spec) -> str:
+    """Name a parametrized case after the device form or wiring it drives."""
+    return spec.name
+
+
+def set_room_sensor(hass, value, unit=UnitOfTemperature.CELSIUS) -> None:
+    """Publish an external room temperature reading in ``unit``."""
+    hass.states.async_set(SENSOR_ID, str(value), {"unit_of_measurement": unit})
+
+
+def assert_on_device_grid(value: float, profile: DeviceProfile) -> None:
+    """Fail unless ``value`` is a multiple of the device's setpoint step.
+
+    A device only accepts setpoints on the grid it published, so every value
+    that leaves the integration has to be zero-anchored on that grid — which
+    is a different number per device form. ``value`` is in the device's own
+    unit, like the step it is checked against.
+    """
+    step = profile.target_temperature_step
+    assert value == pytest.approx(round(value / step) * step, abs=1e-6)
+
+
+def assert_profile_adopted(bt, profile: DeviceProfile) -> None:
+    """Fail if Better Thermostat did not read this device's capabilities.
+
+    The guard that keeps a parametrized axis honest: a device whose state
+    arrived too late is read as a device without capabilities, and every
+    assertion downstream then measures that one case instead of the profile.
+    """
+    trv = bt.real_trvs[profile.entity_id]
+    assert trv.hvac_modes == list(profile.hvac_modes)
+    assert trv.target_temp_step == pytest.approx(
+        _celsius_step(profile.target_temperature_step, profile.temperature_unit),
+        abs=1e-3,
+    )
+    assert trv.min_temp == pytest.approx(
+        _celsius(profile.min_temp, profile.temperature_unit), abs=1e-2
+    )
+    assert trv.max_temp == pytest.approx(
+        _celsius(profile.max_temp, profile.temperature_unit), abs=1e-2
+    )
+    assert trv.capabilities().supports_off_mode is (HVACMode.OFF in profile.hvac_modes)
+
+
+def _celsius(value: float, unit: UnitOfTemperature) -> float:
+    """Convert a temperature reading from the device's unit to Celsius."""
+    return TemperatureConverter.convert(value, unit, UnitOfTemperature.CELSIUS)
+
+
+def _celsius_step(value: float, unit: UnitOfTemperature) -> float:
+    """Convert a step from the device's unit to Celsius.
+
+    A step is a difference, so a Fahrenheit step is scaled instead of run
+    through the absolute conversion, which is the rule the integration
+    applies to a reported step.
+    """
+    if unit is UnitOfTemperature.FAHRENHEIT:
+        return round(value * 5.0 / 9.0, 4)
+    return value

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -296,23 +296,37 @@ async def build_devices(hass, *profiles: DeviceProfile) -> list[SimulatedClimate
     """Register one simulated device per profile and return the entities.
 
     Profiles must agree on ``has_device_registry_entry``: the two
-    registration routes are mutually exclusive.
+    registration routes are mutually exclusive. They must agree on
+    ``temperature_unit`` too, because the unit is a property of the
+    Home Assistant instance the devices share, not of one device.
     """
     if not profiles:
         raise ValueError("build_devices needs at least one profile")
     with_device = profiles[0].has_device_registry_entry
     if any(p.has_device_registry_entry is not with_device for p in profiles):
         raise ValueError("profiles must agree on has_device_registry_entry")
+    unit = profiles[0].temperature_unit
+    if any(p.temperature_unit is not unit for p in profiles):
+        raise ValueError("profiles must agree on temperature_unit")
     if sum(p.offset_channel is OffsetChannel.NUMBER_ENTITY for p in profiles) > 1:
         raise ValueError("only one device may carry a calibration number entity")
     if sum(p.valve_channel is ValveChannel.NUMBER_ENTITY for p in profiles) > 1:
         raise ValueError("only one device may carry a valve number entity")
+    # A number entity is discovered through the device registry entry and is
+    # registered along the config-entry route only, so the combination below
+    # would build a device whose channel is silently absent.
+    if not with_device and any(
+        p.offset_channel is OffsetChannel.NUMBER_ENTITY
+        or p.valve_channel is ValveChannel.NUMBER_ENTITY
+        for p in profiles
+    ):
+        raise ValueError("a number channel needs has_device_registry_entry=True")
 
     # The system unit is captured into the entity at entry setup and is the
     # fallback behind every unit resolution, so it has to be in place before
     # the devices exist — a device unit alone changes nothing Better
     # Thermostat can observe, because a climate entity publishes no unit.
-    if profiles[0].temperature_unit is UnitOfTemperature.FAHRENHEIT:
+    if unit is UnitOfTemperature.FAHRENHEIT:
         hass.config.units = US_CUSTOMARY_SYSTEM
 
     entities = []
@@ -524,7 +538,22 @@ def assert_on_device_grid(value: float, profile: DeviceProfile) -> None:
     unit, like the step it is checked against.
     """
     step = profile.target_temperature_step
+    assert step > 0, f"{profile.name} publishes no setpoint grid to check against"
     assert value == pytest.approx(round(value / step) * step, abs=1e-6)
+
+
+def assert_write_is(value: float, expected: float, profile: DeviceProfile) -> None:
+    """Fail unless ``value`` is ``expected`` as this device can express it.
+
+    Both are in the device's own unit. ``assert_on_device_grid`` alone
+    accepts any point on the grid, so it also passes for a write that
+    carries an entirely different temperature; this pins the value as
+    well, within the half step the grid costs, and without assuming
+    which way the integration breaks a tie.
+    """
+    assert_on_device_grid(value, profile)
+    half_step = profile.target_temperature_step / 2 + 1e-6
+    assert value == pytest.approx(expected, abs=half_step)
 
 
 def assert_profile_adopted(bt, profile: DeviceProfile) -> None:

--- a/tests/integration/device_profiles.py
+++ b/tests/integration/device_profiles.py
@@ -1,0 +1,202 @@
+"""Device forms the integration harness can be parametrized over.
+
+Pure data: a profile names one real-world device shape together with the
+Better Thermostat configuration that belongs to it, because the two are
+inseparable — a Zigbee2MQTT head *is* the mqtt integration plus local
+calibration, and pairing one with the other integration describes a device
+that does not exist. ``conftest.py`` turns a profile into live entities.
+"""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from homeassistant.components.climate import ClimateEntityFeature, HVACMode
+from homeassistant.const import UnitOfTemperature
+
+TRV_ID = "climate.fake_trv"
+COOLER_ID = "climate.fake_cooler"
+OFFSET_NUMBER_ID = "number.fake_trv_calibration"
+
+_SETPOINT_FEATURES = (
+    ClimateEntityFeature.TARGET_TEMPERATURE
+    | ClimateEntityFeature.TURN_OFF
+    | ClimateEntityFeature.TURN_ON
+)
+
+
+class OffsetChannel(StrEnum):
+    """How a device takes a calibration offset."""
+
+    NONE = "none"
+    NUMBER_ENTITY = "number_entity"
+    ECOSYSTEM_SERVICE = "ecosystem_service"
+
+
+@dataclass(frozen=True)
+class DeviceProfile:
+    """A simulated climate device, as Better Thermostat is configured for it.
+
+    Every temperature-shaped field is expressed in the device's own unit,
+    which is what a real device reports and what the climate entity
+    attributes mean.
+
+    ``configured_target_temp_step`` is the config entry's step string, where
+    ``"0.0"`` means "not configured". A configured step overrides the device's
+    own grid for every child, so a profile that varies the device step keeps
+    this at ``"0.0"``.
+    """
+
+    name: str
+    entity_id: str = TRV_ID
+    entity_name: str = "fake trv"
+    hvac_modes: tuple[HVACMode, ...] = (HVACMode.HEAT, HVACMode.OFF)
+    hvac_mode: HVACMode = HVACMode.HEAT
+    min_temp: float = 5.0
+    max_temp: float = 30.0
+    current_temperature: float = 19.5
+    target_temperature: float = 20.0
+    target_temperature_step: float = 0.5
+    temperature_unit: UnitOfTemperature = UnitOfTemperature.CELSIUS
+    supported_features: ClimateEntityFeature = _SETPOINT_FEATURES
+    precision: float | None = None
+    integration: str = "generic_thermostat"
+    calibration: str = "target_temp_based"
+    configured_target_temp_step: str = "0.0"
+    offset_channel: OffsetChannel = OffsetChannel.NONE
+    has_device_registry_entry: bool = False
+
+
+@dataclass(frozen=True)
+class RoleScenario:
+    """How Better Thermostat is wired to one or two devices.
+
+    ``cooler_entity_id`` is the entry's cooler key. It is not always
+    ``cooler.entity_id``: a dual-role device is a single entity wired as
+    thermostat and as cooler at the same time.
+    """
+
+    name: str
+    trv: DeviceProfile
+    cooler: DeviceProfile | None
+    cooler_entity_id: str | None
+
+
+GENERIC_HEAT_TRV = DeviceProfile(
+    name="generic_heat_trv", configured_target_temp_step="0.5"
+)
+"""The common half-degree Celsius radiator head with heat and off."""
+
+AUTO_COOL_AC = DeviceProfile(
+    name="auto_cool_ac",
+    hvac_modes=(HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF),
+    hvac_mode=HVACMode.AUTO,
+)
+"""An air conditioner head that offers auto and cool, but no heat."""
+
+AUTO_ONLY_TRV = DeviceProfile(
+    name="auto_only_trv",
+    hvac_modes=(HVACMode.AUTO, HVACMode.OFF),
+    hvac_mode=HVACMode.AUTO,
+)
+"""A radiator head whose heating mode is called auto."""
+
+HEAT_COOL_TRV = DeviceProfile(
+    name="heat_cool_trv",
+    hvac_modes=(HVACMode.HEAT_COOL, HVACMode.OFF),
+    hvac_mode=HVACMode.HEAT_COOL,
+)
+"""A radiator head that exposes heat_cool where others expose heat."""
+
+INTEGER_GRID_TRV = DeviceProfile(name="integer_grid_trv", target_temperature_step=1.0)
+"""A wall thermostat with a whole-degree setpoint grid."""
+
+FAHRENHEIT_TRV = DeviceProfile(
+    name="fahrenheit_trv",
+    min_temp=41.0,
+    max_temp=86.0,
+    current_temperature=67.1,
+    target_temperature=68.0,
+    target_temperature_step=1.0,
+    temperature_unit=UnitOfTemperature.FAHRENHEIT,
+    precision=0.1,
+)
+"""A device on a Fahrenheit system, reporting whole degrees Fahrenheit.
+
+``precision`` is pinned to a tenth because a climate entity on a Fahrenheit
+system otherwise rounds every published temperature to a whole degree, which
+is a third of a degree Celsius of drift on top of the value under test.
+"""
+
+MQTT_OFFSET_TRV = DeviceProfile(
+    name="mqtt_offset_trv",
+    current_temperature=19.0,
+    integration="mqtt",
+    calibration="local_calibration_based",
+    offset_channel=OffsetChannel.NUMBER_ENTITY,
+    has_device_registry_entry=True,
+)
+"""A Zigbee2MQTT head whose calibration is a number entity on its device.
+
+The registry entry is a precondition, not a decoration: calibration entity
+discovery walks the entity registry from the device the head belongs to, so a
+device-less entity has no calibration channel at all.
+"""
+
+TADO_OFFSET_TRV = DeviceProfile(
+    name="tado_offset_trv",
+    current_temperature=19.0,
+    integration="tado",
+    calibration="local_calibration_based",
+    offset_channel=OffsetChannel.ECOSYSTEM_SERVICE,
+)
+"""A head whose calibration is an ecosystem service call, not an entity."""
+
+ROOM_AC_COOLER = DeviceProfile(
+    name="room_ac_cooler",
+    entity_id=COOLER_ID,
+    entity_name="fake cooler",
+    hvac_modes=(HVACMode.COOL, HVACMode.OFF),
+    hvac_mode=HVACMode.OFF,
+    min_temp=16.0,
+    max_temp=30.0,
+    current_temperature=22.0,
+    target_temperature=24.0,
+)
+"""The cooling partner of a heated room, with a narrower range than the head."""
+
+DUAL_ROLE_AC = DeviceProfile(
+    name="dual_role_ac",
+    hvac_modes=(HVACMode.HEAT, HVACMode.COOL, HVACMode.OFF),
+    hvac_mode=HVACMode.HEAT,
+    current_temperature=22.0,
+)
+"""One entity that heats and cools, wired as thermostat and as cooler."""
+
+HEAT_ONLY = RoleScenario(
+    name="heat_only", trv=GENERIC_HEAT_TRV, cooler=None, cooler_entity_id=None
+)
+
+SEPARATE_COOLER = RoleScenario(
+    name="separate_cooler",
+    trv=GENERIC_HEAT_TRV,
+    cooler=ROOM_AC_COOLER,
+    cooler_entity_id=COOLER_ID,
+)
+
+DUAL_ROLE = RoleScenario(
+    name="dual_role", trv=DUAL_ROLE_AC, cooler=None, cooler_entity_id=TRV_ID
+)
+
+SINGLE_ROLE_PROFILES = (
+    GENERIC_HEAT_TRV,
+    AUTO_COOL_AC,
+    AUTO_ONLY_TRV,
+    HEAT_COOL_TRV,
+    INTEGER_GRID_TRV,
+    FAHRENHEIT_TRV,
+    MQTT_OFFSET_TRV,
+    TADO_OFFSET_TRV,
+)
+"""Every profile a test can drive as the single controlled device."""
+
+ROLE_SCENARIOS = (HEAT_ONLY, SEPARATE_COOLER, DUAL_ROLE)

--- a/tests/integration/device_profiles.py
+++ b/tests/integration/device_profiles.py
@@ -4,7 +4,10 @@ Pure data: a profile names one real-world device shape together with the
 Better Thermostat configuration that belongs to it, because the two are
 inseparable — a Zigbee2MQTT head *is* the mqtt integration plus local
 calibration, and pairing one with the other integration describes a device
-that does not exist. ``conftest.py`` turns a profile into live entities.
+that does not exist. Every profile therefore states its integration, its
+calibration strategy and whether its entity carries a device registry entry,
+so the table reads as a list of devices instead of a list of overrides.
+``conftest.py`` turns a profile into live entities.
 """
 
 from dataclasses import dataclass
@@ -14,11 +17,19 @@ from homeassistant.components.climate import ClimateEntityFeature, HVACMode
 from homeassistant.const import UnitOfTemperature
 
 TRV_ID = "climate.fake_trv"
+SPARE_TRV_ID = "climate.spare_trv"
 COOLER_ID = "climate.fake_cooler"
 OFFSET_NUMBER_ID = "number.fake_trv_calibration"
+VALVE_NUMBER_ID = "number.fake_trv_valve_position"
 
 _SETPOINT_FEATURES = (
     ClimateEntityFeature.TARGET_TEMPERATURE
+    | ClimateEntityFeature.TURN_OFF
+    | ClimateEntityFeature.TURN_ON
+)
+
+_RANGE_FEATURES = (
+    ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
     | ClimateEntityFeature.TURN_OFF
     | ClimateEntityFeature.TURN_ON
 )
@@ -32,13 +43,25 @@ class OffsetChannel(StrEnum):
     ECOSYSTEM_SERVICE = "ecosystem_service"
 
 
-@dataclass(frozen=True)
+class ValveChannel(StrEnum):
+    """How a device takes a valve position."""
+
+    NONE = "none"
+    NUMBER_ENTITY = "number_entity"
+
+
+@dataclass(frozen=True, kw_only=True)
 class DeviceProfile:
     """A simulated climate device, as Better Thermostat is configured for it.
 
     Every temperature-shaped field is expressed in the device's own unit,
     which is what a real device reports and what the climate entity
     attributes mean.
+
+    ``integration``, ``calibration`` and ``has_device_registry_entry`` carry
+    no defaults on purpose: they decide which adapter runs and which
+    discovery channels exist, so a profile that left them implicit would
+    describe a different device than its docstring claims.
 
     ``configured_target_temp_step`` is the config entry's step string, where
     ``"0.0"`` means "not configured". A configured step overrides the device's
@@ -47,6 +70,9 @@ class DeviceProfile:
     """
 
     name: str
+    integration: str
+    calibration: str
+    has_device_registry_entry: bool
     entity_id: str = TRV_ID
     entity_name: str = "fake trv"
     hvac_modes: tuple[HVACMode, ...] = (HVACMode.HEAT, HVACMode.OFF)
@@ -54,16 +80,17 @@ class DeviceProfile:
     min_temp: float = 5.0
     max_temp: float = 30.0
     current_temperature: float = 19.5
-    target_temperature: float = 20.0
+    target_temperature: float | None = 20.0
+    target_temperature_low: float | None = None
+    target_temperature_high: float | None = None
     target_temperature_step: float = 0.5
     temperature_unit: UnitOfTemperature = UnitOfTemperature.CELSIUS
     supported_features: ClimateEntityFeature = _SETPOINT_FEATURES
     precision: float | None = None
-    integration: str = "generic_thermostat"
-    calibration: str = "target_temp_based"
+    calibration_mode: str = "default"
     configured_target_temp_step: str = "0.0"
     offset_channel: OffsetChannel = OffsetChannel.NONE
-    has_device_registry_entry: bool = False
+    valve_channel: ValveChannel = ValveChannel.NONE
 
 
 @dataclass(frozen=True)
@@ -82,36 +109,86 @@ class RoleScenario:
 
 
 GENERIC_HEAT_TRV = DeviceProfile(
-    name="generic_heat_trv", configured_target_temp_step="0.5"
+    name="generic_heat_trv",
+    integration="generic_thermostat",
+    calibration="target_temp_based",
+    has_device_registry_entry=False,
+    configured_target_temp_step="0.5",
 )
-"""The common half-degree Celsius radiator head with heat and off."""
+"""A device-less climate helper offering heat and off on half degrees Celsius.
+
+The plainest form Better Thermostat sits in front of: no device registry
+entry, so no calibration or valve channel can be discovered for it, and the
+setpoint is the only thing that can be written.
+"""
+
+SPARE_HEAT_TRV = DeviceProfile(
+    name="spare_heat_trv",
+    integration="generic_thermostat",
+    calibration="target_temp_based",
+    has_device_registry_entry=False,
+    entity_id=SPARE_TRV_ID,
+    entity_name="spare trv",
+    configured_target_temp_step="0.5",
+)
+"""A second device-less helper, for a room whose thermostat is swapped.
+
+Identical in shape to ``GENERIC_HEAT_TRV`` and different only in identity:
+what it is for is being a device the config entry has never seen.
+"""
 
 AUTO_COOL_AC = DeviceProfile(
     name="auto_cool_ac",
+    integration="generic_thermostat",
+    calibration="target_temp_based",
+    has_device_registry_entry=False,
     hvac_modes=(HVACMode.AUTO, HVACMode.COOL, HVACMode.OFF),
     hvac_mode=HVACMode.AUTO,
 )
-"""An air conditioner head that offers auto and cool, but no heat."""
+"""A cooling-first device: it offers auto and cool, and no heating mode."""
 
 AUTO_ONLY_TRV = DeviceProfile(
     name="auto_only_trv",
+    integration="generic_thermostat",
+    calibration="target_temp_based",
+    has_device_registry_entry=False,
     hvac_modes=(HVACMode.AUTO, HVACMode.OFF),
     hvac_mode=HVACMode.AUTO,
 )
-"""A radiator head whose heating mode is called auto."""
+"""A device whose only mode besides off is auto.
+
+Nothing in the mode list says heat, and whether auto means heating is a
+question the device does not answer — only the entry's swap option does.
+"""
 
 HEAT_COOL_TRV = DeviceProfile(
     name="heat_cool_trv",
+    integration="generic_thermostat",
+    calibration="target_temp_based",
+    has_device_registry_entry=False,
     hvac_modes=(HVACMode.HEAT_COOL, HVACMode.OFF),
     hvac_mode=HVACMode.HEAT_COOL,
 )
-"""A radiator head that exposes heat_cool where others expose heat."""
+"""A device that names its one active mode heat_cool.
 
-INTEGER_GRID_TRV = DeviceProfile(name="integer_grid_trv", target_temperature_step=1.0)
+A single setpoint drives both directions, so the device offers one mode for
+both and expects that name on the wire whenever it is to run at all.
+"""
+
+INTEGER_GRID_TRV = DeviceProfile(
+    name="integer_grid_trv",
+    integration="generic_thermostat",
+    calibration="target_temp_based",
+    has_device_registry_entry=False,
+    target_temperature_step=1.0,
+)
 """A wall thermostat with a whole-degree setpoint grid."""
 
 FAHRENHEIT_TRV = DeviceProfile(
     name="fahrenheit_trv",
+    integration="generic_thermostat",
+    calibration="target_temp_based",
+    has_device_registry_entry=False,
     min_temp=41.0,
     max_temp=86.0,
     current_temperature=67.1,
@@ -122,6 +199,10 @@ FAHRENHEIT_TRV = DeviceProfile(
 )
 """A device on a Fahrenheit system, reporting whole degrees Fahrenheit.
 
+Building this profile also puts the whole Home Assistant instance on the US
+customary unit system: a climate entity publishes no unit of its own, so the
+system unit is the only thing Better Thermostat can read a device unit from.
+
 ``precision`` is pinned to a tenth because a climate entity on a Fahrenheit
 system otherwise rounds every published temperature to a whole degree, which
 is a third of a degree Celsius of drift on top of the value under test.
@@ -129,11 +210,11 @@ is a third of a degree Celsius of drift on top of the value under test.
 
 MQTT_OFFSET_TRV = DeviceProfile(
     name="mqtt_offset_trv",
-    current_temperature=19.0,
     integration="mqtt",
     calibration="local_calibration_based",
-    offset_channel=OffsetChannel.NUMBER_ENTITY,
     has_device_registry_entry=True,
+    current_temperature=19.0,
+    offset_channel=OffsetChannel.NUMBER_ENTITY,
 )
 """A Zigbee2MQTT head whose calibration is a number entity on its device.
 
@@ -144,15 +225,35 @@ device-less entity has no calibration channel at all.
 
 TADO_OFFSET_TRV = DeviceProfile(
     name="tado_offset_trv",
-    current_temperature=19.0,
     integration="tado",
     calibration="local_calibration_based",
+    has_device_registry_entry=False,
+    current_temperature=19.0,
     offset_channel=OffsetChannel.ECOSYSTEM_SERVICE,
 )
 """A head whose calibration is an ecosystem service call, not an entity."""
 
+VALVE_TRV = DeviceProfile(
+    name="valve_trv",
+    integration="mqtt",
+    calibration="direct_valve_based",
+    calibration_mode="heating_power_calibration",
+    has_device_registry_entry=True,
+    current_temperature=19.0,
+    valve_channel=ValveChannel.NUMBER_ENTITY,
+)
+"""A Zigbee2MQTT head driven by its valve rather than by its setpoint.
+
+The valve number sits on the same device as the climate entity, which is
+what makes it discoverable and writable; direct valve control is the one
+calibration strategy that puts a percentage on the wire at all.
+"""
+
 ROOM_AC_COOLER = DeviceProfile(
     name="room_ac_cooler",
+    integration="generic_thermostat",
+    calibration="target_temp_based",
+    has_device_registry_entry=False,
     entity_id=COOLER_ID,
     entity_name="fake cooler",
     hvac_modes=(HVACMode.COOL, HVACMode.OFF),
@@ -164,8 +265,34 @@ ROOM_AC_COOLER = DeviceProfile(
 )
 """The cooling partner of a heated room, with a narrower range than the head."""
 
+RANGED_AC_COOLER = DeviceProfile(
+    name="ranged_ac_cooler",
+    integration="generic_thermostat",
+    calibration="target_temp_based",
+    has_device_registry_entry=False,
+    entity_id=COOLER_ID,
+    entity_name="fake cooler",
+    hvac_modes=(HVACMode.COOL, HVACMode.OFF),
+    hvac_mode=HVACMode.OFF,
+    min_temp=16.0,
+    max_temp=30.0,
+    current_temperature=22.0,
+    target_temperature=None,
+    target_temperature_low=20.0,
+    target_temperature_high=24.0,
+    supported_features=_RANGE_FEATURES,
+)
+"""A cooler that publishes a band instead of a setpoint.
+
+It advertises only the range feature, so it rejects a plain ``temperature``
+payload; the cooling setpoint has to arrive as the upper bound of a band.
+"""
+
 DUAL_ROLE_AC = DeviceProfile(
     name="dual_role_ac",
+    integration="generic_thermostat",
+    calibration="target_temp_based",
+    has_device_registry_entry=False,
     hvac_modes=(HVACMode.HEAT, HVACMode.COOL, HVACMode.OFF),
     hvac_mode=HVACMode.HEAT,
     current_temperature=22.0,
@@ -183,6 +310,13 @@ SEPARATE_COOLER = RoleScenario(
     cooler_entity_id=COOLER_ID,
 )
 
+RANGED_COOLER = RoleScenario(
+    name="ranged_cooler",
+    trv=GENERIC_HEAT_TRV,
+    cooler=RANGED_AC_COOLER,
+    cooler_entity_id=COOLER_ID,
+)
+
 DUAL_ROLE = RoleScenario(
     name="dual_role", trv=DUAL_ROLE_AC, cooler=None, cooler_entity_id=TRV_ID
 )
@@ -196,7 +330,8 @@ SINGLE_ROLE_PROFILES = (
     FAHRENHEIT_TRV,
     MQTT_OFFSET_TRV,
     TADO_OFFSET_TRV,
+    VALVE_TRV,
 )
 """Every profile a test can drive as the single controlled device."""
 
-ROLE_SCENARIOS = (HEAT_ONLY, SEPARATE_COOLER, DUAL_ROLE)
+ROLE_SCENARIOS = (HEAT_ONLY, SEPARATE_COOLER, RANGED_COOLER, DUAL_ROLE)

--- a/tests/integration/test_device_matrix.py
+++ b/tests/integration/test_device_matrix.py
@@ -2,25 +2,35 @@
 
 The lifecycle tests drive one device from entry to write. These drive the
 axes real devices differ on — the mode vocabulary, the setpoint grid, the
-temperature unit, the calibration channel and the role a device plays — and
-assert on what arrives at the simulated device rather than on what Better
-Thermostat believes it sent.
+temperature unit, the calibration and valve channels, the device registry
+entry and the role a device plays — and assert on what arrives at the
+simulated device rather than on what Better Thermostat believes it sent.
 """
 
 from dataclasses import replace
 from unittest.mock import patch
 
-from homeassistant.components.climate import HVACMode
-from homeassistant.const import UnitOfTemperature
+from homeassistant.components.climate import (
+    DOMAIN as CLIMATE_DOMAIN,
+    SERVICE_SET_HVAC_MODE,
+    ClimateEntityFeature,
+    HVACMode,
+)
+from homeassistant.const import EVENT_CALL_SERVICE, UnitOfTemperature
 import pytest
-from pytest_homeassistant_custom_component.common import async_mock_service
+from pytest_homeassistant_custom_component.common import (
+    async_capture_events,
+    async_mock_service,
+)
 
 from .conftest import (
     BT_ENTITY,
-    OFFSET_NUMBER_ID,
-    TRV_ID,
+    COOLER_RESEND,
+    WRITE_BUDGET,
     assert_on_device_grid,
     assert_profile_adopted,
+    build_devices,
+    cooling_setpoint,
     make_entry,
     profile_id,
     set_room_sensor,
@@ -37,23 +47,18 @@ from .device_profiles import (
     HEAT_COOL_TRV,
     INTEGER_GRID_TRV,
     MQTT_OFFSET_TRV,
+    OFFSET_NUMBER_ID,
+    RANGED_COOLER,
     SEPARATE_COOLER,
     SINGLE_ROLE_PROFILES,
+    SPARE_HEAT_TRV,
+    SPARE_TRV_ID,
     TADO_OFFSET_TRV,
+    TRV_ID,
+    VALVE_NUMBER_ID,
+    VALVE_TRV,
     DeviceProfile,
 )
-
-_WRITE_BUDGET = (
-    "custom_components.better_thermostat.utils.controlling.MIN_WRITE_INTERVAL_S"
-)
-_COOLER_RESEND = (
-    "custom_components.better_thermostat.utils.controlling.COOLER_RESEND_INTERVAL_S"
-)
-
-# A mode the device does not offer is dropped before the write, so the wait
-# for a mode write that is never sent can only run out. It is bounded tightly
-# rather than holding the suite for the full timeout.
-_DECLINED_WRITE_TIMEOUT_S = 3.0
 
 _DUAL_ROLE_TRV_WRITE_LANDS_LAST = (
     "one entity configured as both thermostat and cooler receives cool from the "
@@ -74,6 +79,23 @@ def _switched_off(profile: DeviceProfile) -> DeviceProfile:
     return replace(profile, hvac_mode=HVACMode.OFF)
 
 
+def _mode_commands(events, entity_id: str) -> list[str]:
+    """The hvac modes dispatched at ``entity_id``, whatever became of them.
+
+    Read off the bus rather than off the device, because Home Assistant
+    rejects a mode the entity does not offer before the entity ever sees it:
+    a command that was never sent and one that was sent and refused are
+    indistinguishable at the device.
+    """
+    return [
+        event.data["service_data"]["hvac_mode"]
+        for event in events
+        if event.data["domain"] == CLIMATE_DOMAIN
+        and event.data["service"] == SERVICE_SET_HVAC_MODE
+        and event.data["service_data"].get("entity_id") == entity_id
+    ]
+
+
 @pytest.mark.parametrize(
     "fake_trv", SINGLE_ROLE_PROFILES, indirect=True, ids=profile_id
 )
@@ -86,7 +108,7 @@ async def test_startup_adopts_the_device_capabilities(hass, fake_trv):
     """
     profile = fake_trv.profile
     set_room_sensor(hass, profile.current_temperature, profile.temperature_unit)
-    entry = make_entry()
+    entry = make_entry(profile)
     await setup_entry(hass, entry)
     bt = await wait_for_startup(hass, entry)
 
@@ -119,7 +141,7 @@ async def test_mode_write_reaches_a_device_that_offers_the_mode(
     """
     profile = fake_trv.profile
     set_room_sensor(hass, 18.0)
-    entry = make_entry(heat_auto_swapped=heat_auto_swapped)
+    entry = make_entry(profile, heat_auto_swapped=heat_auto_swapped)
     await setup_entry(hass, entry)
     bt = await wait_for_startup(hass, entry)
     assert_profile_adopted(bt, profile)
@@ -159,9 +181,9 @@ async def test_device_without_an_offered_heating_mode_keeps_its_mode(
     Better Thermostat will not guess which of a device's modes heats: on a
     head that offers auto but no heat, auto may mean heating, and on an air
     conditioner offering the same list it means automatic heat/cool. So no
-    mode is written at all, the device keeps the mode it had, and the user
-    is pointed at the swap option that would resolve the ambiguity. The
-    setpoint is unaffected by any of that and still arrives.
+    mode command is dispatched at all, the device keeps the mode it had, and
+    the user is pointed at the swap option that would resolve the ambiguity.
+    The setpoint is unaffected by any of that and still arrives.
 
     The counterpart is the swapped parametrization of the mode-write test
     above: the same two devices do receive their heating mode once the entry
@@ -169,11 +191,12 @@ async def test_device_without_an_offered_heating_mode_keeps_its_mode(
     """
     profile = fake_trv.profile
     set_room_sensor(hass, 18.0)
-    entry = make_entry()
+    entry = make_entry(profile)
     await setup_entry(hass, entry)
     bt = await wait_for_startup(hass, entry)
     assert_profile_adopted(bt, profile)
     fake_trv.set_hvac_mode_calls.clear()
+    dispatched = async_capture_events(hass, EVENT_CALL_SERVICE)
 
     await hass.services.async_call(
         "climate",
@@ -187,12 +210,12 @@ async def test_device_without_an_offered_heating_mode_keeps_its_mode(
         {"entity_id": BT_ENTITY, "temperature": 22.0},
         blocking=True,
     )
+    # The setpoint arriving is the same control cycle that decided against
+    # the mode, so by now the mode decision has been taken.
     assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
 
-    # No mode write is attempted, so the device stays where it was.
-    assert not await wait_for(
-        hass, lambda: fake_trv.set_hvac_mode_calls, timeout_s=_DECLINED_WRITE_TIMEOUT_S
-    )
+    assert _mode_commands(dispatched, TRV_ID) == []
+    assert fake_trv.set_hvac_mode_calls == []
     assert hass.states.get(TRV_ID).state == HVACMode.OFF
     assert_on_device_grid(fake_trv.set_temperature_calls[-1], profile)
 
@@ -225,13 +248,13 @@ async def test_setpoint_rounds_to_the_device_grid(hass, fake_trv, expected_setpo
     the next full degree instead of a setpoint it is already sitting at.
     """
     set_room_sensor(hass, fake_trv.profile.current_temperature)
-    entry = make_entry()
+    entry = make_entry(fake_trv.profile)
     await setup_entry(hass, entry)
     bt = await wait_for_startup(hass, entry)
     assert_profile_adopted(bt, fake_trv.profile)
     assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
 
-    with patch(_WRITE_BUDGET, 0.0):
+    with patch(WRITE_BUDGET, 0.0):
         baseline = len(fake_trv.set_temperature_calls)
         await hass.services.async_call(
             "climate",
@@ -258,7 +281,7 @@ async def test_fahrenheit_device_is_read_and_written_in_its_own_unit(hass, fake_
     """
     profile = fake_trv.profile
     set_room_sensor(hass, 64.4, UnitOfTemperature.FAHRENHEIT)
-    entry = make_entry()
+    entry = make_entry(profile)
     await setup_entry(hass, entry)
     bt = await wait_for_startup(hass, entry)
     assert_profile_adopted(bt, profile)
@@ -284,7 +307,7 @@ async def test_offset_reaches_the_calibration_number_entity(hass, fake_trv):
     room = 21.0
     expected_offset = room - fake_trv.profile.current_temperature
     set_room_sensor(hass, room)
-    entry = make_entry()
+    entry = make_entry(fake_trv.profile)
     await setup_entry(hass, entry)
     bt = await wait_for_startup(hass, entry)
     assert_profile_adopted(bt, fake_trv.profile)
@@ -305,6 +328,51 @@ async def test_offset_reaches_the_calibration_number_entity(hass, fake_trv):
     assert bt.real_trvs[TRV_ID].last_calibration == pytest.approx(expected_offset)
 
 
+@pytest.mark.parametrize("fake_trv", [MQTT_OFFSET_TRV], indirect=True, ids=profile_id)
+async def test_an_unanswered_offset_reopens_the_calibration_gate(hass, fake_trv):
+    """A device that never confirms an offset is given up on, not waited on.
+
+    The calibration channel writes under a gate that shuts the moment a
+    command goes out and only reopens once the device is seen holding it. A
+    head that swallows the command silently — the write is on the wire, the
+    value never lands — would hold that gate shut for the lifetime of the
+    entity and the offset would never be written again, however far the room
+    drifted. So a command the device never answers is abandoned instead of
+    waited on, and the device is left visibly diverged from what it was
+    commanded, which is the state the reconciler acts on.
+    """
+    set_room_sensor(hass, 21.0)
+    entry = make_entry(fake_trv.profile)
+    await setup_entry(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+    assert_profile_adopted(bt, fake_trv.profile)
+    trv = bt.real_trvs[TRV_ID]
+    offset_number = fake_trv.offset_number
+    assert await wait_for(hass, lambda: offset_number.set_value_calls)
+
+    with patch(WRITE_BUDGET, 0.0):
+        # The device swallows the offset the warmer room calls for.
+        offset_number.drop_next_write = True
+        baseline = len(offset_number.set_value_calls)
+        set_room_sensor(hass, 23.0)
+        assert await wait_for(
+            hass, lambda: len(offset_number.set_value_calls) > baseline
+        )
+
+        # The command went out and the device kept the value it had.
+        lost = offset_number.set_value_calls[-1]
+        assert trv.last_calibration == pytest.approx(lost)
+        assert float(hass.states.get(OFFSET_NUMBER_ID).state) != pytest.approx(lost)
+
+        # It is abandoned rather than waited on forever.
+        assert await wait_for(hass, lambda: trv.calibration_received)
+
+    # Better Thermostat still holds a command the device never took, so the
+    # divergence the reconciler compares against is a real one.
+    reported = float(hass.states.get(OFFSET_NUMBER_ID).state)
+    assert trv.last_calibration != pytest.approx(reported)
+
+
 @pytest.mark.parametrize("fake_trv", [TADO_OFFSET_TRV], indirect=True, ids=profile_id)
 async def test_offset_reaches_the_ecosystem_service(hass, fake_trv):
     """A device without a calibration entity is corrected by a service call."""
@@ -312,7 +380,7 @@ async def test_offset_reaches_the_ecosystem_service(hass, fake_trv):
     room = 21.0
     expected_offset = room - fake_trv.profile.current_temperature
     set_room_sensor(hass, room)
-    entry = make_entry()
+    entry = make_entry(fake_trv.profile)
     await setup_entry(hass, entry)
     bt = await wait_for_startup(hass, entry)
     assert_profile_adopted(bt, fake_trv.profile)
@@ -323,10 +391,77 @@ async def test_offset_reaches_the_ecosystem_service(hass, fake_trv):
     assert payload["offset"] == pytest.approx(expected_offset)
 
 
+@pytest.mark.parametrize("fake_trv", [VALVE_TRV], indirect=True, ids=profile_id)
+async def test_valve_percentage_reaches_the_valve_number_entity(hass, fake_trv):
+    """A valve-driven device is controlled by percentage, not by setpoint.
+
+    The percentage follows the demand rather than the target: a room that is
+    already warm enough leaves the valve shut, and a room calling for heat
+    opens it. Both ends arrive at the number entity on the device.
+    """
+    set_room_sensor(hass, 21.0)
+    entry = make_entry(fake_trv.profile)
+    await setup_entry(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+    assert_profile_adopted(bt, fake_trv.profile)
+
+    valve_number = fake_trv.valve_number
+    assert await wait_for(hass, lambda: valve_number.set_value_calls)
+    assert valve_number.set_value_calls[-1] == pytest.approx(0.0)
+
+    with patch(WRITE_BUDGET, 0.0):
+        await hass.services.async_call(
+            "climate",
+            "set_temperature",
+            {"entity_id": BT_ENTITY, "temperature": 24.0},
+            blocking=True,
+        )
+        assert await wait_for(
+            hass, lambda: any(value > 0 for value in valve_number.set_value_calls)
+        )
+
+    opened = valve_number.set_value_calls[-1]
+    assert 0.0 < opened <= 100.0
+    assert float(hass.states.get(VALVE_NUMBER_ID).state) == pytest.approx(opened)
+    assert bt.real_trvs[TRV_ID].last_valve_percent == pytest.approx(opened)
+
+
+async def test_options_flow_swaps_the_thermostat_to_a_device_less_entity(hass):
+    """The configured thermostat can be swapped for an entity without a device.
+
+    A device-less climate entity resolves to no manufacturer and no model, so
+    the options flow has to fall back to the model it carries itself. It is
+    the one path where the flow — not the climate entity — is the object model
+    resolution is asked about, and the swap is what puts a TRV on it that the
+    entry has never seen.
+    """
+    await build_devices(hass, GENERIC_HEAT_TRV, SPARE_HEAT_TRV)
+    set_room_sensor(hass, 18.0)
+    entry = make_entry(GENERIC_HEAT_TRV)
+    await setup_entry(hass, entry)
+    await wait_for_startup(hass, entry)
+
+    flow = await hass.config_entries.options.async_init(entry.entry_id)
+    assert flow["step_id"] == "user"
+
+    swapped = await hass.config_entries.options.async_configure(
+        flow["flow_id"],
+        {
+            "name": entry.data["name"],
+            "thermostat": [SPARE_TRV_ID],
+            "temperature_sensor": entry.data["temperature_sensor"],
+        },
+    )
+
+    assert swapped["step_id"] == "advanced"
+    assert swapped["description_placeholders"]["trv"] == SPARE_TRV_ID
+
+
 @pytest.mark.parametrize(
     "device_role",
     [
         pytest.param(SEPARATE_COOLER, id="separate_cooler"),
+        pytest.param(RANGED_COOLER, id="ranged_cooler"),
         pytest.param(
             DUAL_ROLE,
             id="dual_role",
@@ -344,14 +479,14 @@ async def test_cooling_demand_reaches_the_cooler(hass, device_role):
     and the resend interval paces the cooler channel, and the demand appears
     within the window of both.
     """
-    thermostat, cooler = device_role[0], device_role[-1]
+    cooler = device_role.cooler
     set_room_sensor(hass, 27.0)
-    entry = make_entry()
+    entry = make_entry(device_role.scenario)
     await setup_entry(hass, entry)
     bt = await wait_for_startup(hass, entry)
-    assert_profile_adopted(bt, thermostat.profile)
+    assert_profile_adopted(bt, device_role.scenario.trv)
 
-    with patch(_WRITE_BUDGET, 0.0), patch(_COOLER_RESEND, 0.0):
+    with patch(WRITE_BUDGET, 0.0), patch(COOLER_RESEND, 0.0):
         await hass.services.async_call(
             "climate",
             "set_temperature",
@@ -362,4 +497,13 @@ async def test_cooling_demand_reaches_the_cooler(hass, device_role):
         assert await wait_for(hass, lambda: cooler.set_temperature_calls)
 
     assert hass.states.get(cooler.entity_id).state == HVACMode.COOL
-    assert cooler.set_temperature_calls[-1] == pytest.approx(23.0)
+    written = cooler.set_temperature_calls[-1]
+    assert cooling_setpoint(written) == pytest.approx(23.0)
+
+    # The payload follows what the device accepts: a cooler that publishes
+    # only a band rejects a plain setpoint outright, so the cooling target
+    # has to arrive as the upper bound of one.
+    takes_a_setpoint = bool(
+        cooler.profile.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
+    )
+    assert isinstance(written, dict) is not takes_a_setpoint

--- a/tests/integration/test_device_matrix.py
+++ b/tests/integration/test_device_matrix.py
@@ -1,0 +1,365 @@
+"""End-to-end tests across the device forms the integration is used with.
+
+The lifecycle tests drive one device from entry to write. These drive the
+axes real devices differ on — the mode vocabulary, the setpoint grid, the
+temperature unit, the calibration channel and the role a device plays — and
+assert on what arrives at the simulated device rather than on what Better
+Thermostat believes it sent.
+"""
+
+from dataclasses import replace
+from unittest.mock import patch
+
+from homeassistant.components.climate import HVACMode
+from homeassistant.const import UnitOfTemperature
+import pytest
+from pytest_homeassistant_custom_component.common import async_mock_service
+
+from .conftest import (
+    BT_ENTITY,
+    OFFSET_NUMBER_ID,
+    TRV_ID,
+    assert_on_device_grid,
+    assert_profile_adopted,
+    make_entry,
+    profile_id,
+    set_room_sensor,
+    setup_entry,
+    wait_for,
+    wait_for_startup,
+)
+from .device_profiles import (
+    AUTO_COOL_AC,
+    AUTO_ONLY_TRV,
+    DUAL_ROLE,
+    FAHRENHEIT_TRV,
+    GENERIC_HEAT_TRV,
+    HEAT_COOL_TRV,
+    INTEGER_GRID_TRV,
+    MQTT_OFFSET_TRV,
+    SEPARATE_COOLER,
+    SINGLE_ROLE_PROFILES,
+    TADO_OFFSET_TRV,
+    DeviceProfile,
+)
+
+_WRITE_BUDGET = (
+    "custom_components.better_thermostat.utils.controlling.MIN_WRITE_INTERVAL_S"
+)
+_COOLER_RESEND = (
+    "custom_components.better_thermostat.utils.controlling.COOLER_RESEND_INTERVAL_S"
+)
+
+# A mode the device does not offer is dropped before the write, so the wait
+# for a mode write that is never sent can only run out. It is bounded tightly
+# rather than holding the suite for the full timeout.
+_DECLINED_WRITE_TIMEOUT_S = 3.0
+
+_DUAL_ROLE_TRV_WRITE_LANDS_LAST = (
+    "one entity configured as both thermostat and cooler receives cool from the "
+    "cooler channel and heat from the TRV channel in the same control cycle; the "
+    "TRV write lands last, so the device is left in heat at the calibrated heat "
+    "setpoint while the entity reports cooling"
+)
+
+
+def _switched_off(profile: DeviceProfile) -> DeviceProfile:
+    """Return the profile with the device sitting in off.
+
+    A device already in the mode Better Thermostat wants receives no mode
+    write at all, so on a device that was never commanded the absence of a
+    write proves nothing. Starting from off makes the write the only way the
+    device can reach its heating mode.
+    """
+    return replace(profile, hvac_mode=HVACMode.OFF)
+
+
+@pytest.mark.parametrize(
+    "fake_trv", SINGLE_ROLE_PROFILES, indirect=True, ids=profile_id
+)
+async def test_startup_adopts_the_device_capabilities(hass, fake_trv):
+    """Startup reads back every capability the device publishes.
+
+    The guard under every other row of the matrix: an axis whose values
+    never reach the integration is an axis that proves nothing, and a
+    device read too late looks like a device without capabilities.
+    """
+    profile = fake_trv.profile
+    set_room_sensor(hass, profile.current_temperature, profile.temperature_unit)
+    entry = make_entry()
+    await setup_entry(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+
+    assert_profile_adopted(bt, profile)
+
+
+@pytest.mark.parametrize(
+    ("fake_trv", "heat_auto_swapped"),
+    [
+        pytest.param(_switched_off(GENERIC_HEAT_TRV), False, id="generic_heat_trv"),
+        pytest.param(_switched_off(HEAT_COOL_TRV), False, id="heat_cool_trv"),
+        pytest.param(
+            _switched_off(AUTO_COOL_AC), True, id="auto_cool_ac-heat_auto_swapped"
+        ),
+        pytest.param(
+            _switched_off(AUTO_ONLY_TRV), True, id="auto_only_trv-heat_auto_swapped"
+        ),
+    ],
+    indirect=["fake_trv"],
+)
+async def test_mode_write_reaches_a_device_that_offers_the_mode(
+    hass, fake_trv, heat_auto_swapped
+):
+    """Switching the thermostat on writes a mode the device offers.
+
+    Every device names its heating mode differently: plain heat, heat_cool,
+    or the auto that the swap option declares to mean heat. Whichever it is,
+    the device has to end up in it, so the observables are the write that
+    arrived and the mode the device is left in.
+    """
+    profile = fake_trv.profile
+    set_room_sensor(hass, 18.0)
+    entry = make_entry(heat_auto_swapped=heat_auto_swapped)
+    await setup_entry(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+    assert_profile_adopted(bt, profile)
+    fake_trv.set_hvac_mode_calls.clear()
+
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": BT_ENTITY, "hvac_mode": "heat"},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": BT_ENTITY, "temperature": 22.0},
+        blocking=True,
+    )
+
+    assert await wait_for(hass, lambda: fake_trv.set_hvac_mode_calls)
+    written = fake_trv.set_hvac_mode_calls[-1]
+    assert written in profile.hvac_modes
+    assert written != HVACMode.OFF
+    assert hass.states.get(TRV_ID).state == written
+
+
+@pytest.mark.parametrize(
+    "fake_trv",
+    [_switched_off(AUTO_COOL_AC), _switched_off(AUTO_ONLY_TRV)],
+    indirect=True,
+    ids=["auto_cool_ac", "auto_only_trv"],
+)
+async def test_device_without_an_offered_heating_mode_keeps_its_mode(
+    hass, fake_trv, caplog
+):
+    """A device offering no heating mode is left alone and told about.
+
+    Better Thermostat will not guess which of a device's modes heats: on a
+    head that offers auto but no heat, auto may mean heating, and on an air
+    conditioner offering the same list it means automatic heat/cool. So no
+    mode is written at all, the device keeps the mode it had, and the user
+    is pointed at the swap option that would resolve the ambiguity. The
+    setpoint is unaffected by any of that and still arrives.
+
+    The counterpart is the swapped parametrization of the mode-write test
+    above: the same two devices do receive their heating mode once the entry
+    declares what auto means.
+    """
+    profile = fake_trv.profile
+    set_room_sensor(hass, 18.0)
+    entry = make_entry()
+    await setup_entry(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+    assert_profile_adopted(bt, profile)
+    fake_trv.set_hvac_mode_calls.clear()
+
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": BT_ENTITY, "hvac_mode": "heat"},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": BT_ENTITY, "temperature": 22.0},
+        blocking=True,
+    )
+    assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
+
+    # No mode write is attempted, so the device stays where it was.
+    assert not await wait_for(
+        hass, lambda: fake_trv.set_hvac_mode_calls, timeout_s=_DECLINED_WRITE_TIMEOUT_S
+    )
+    assert hass.states.get(TRV_ID).state == HVACMode.OFF
+    assert_on_device_grid(fake_trv.set_temperature_calls[-1], profile)
+
+    # The device is not silently abandoned: the one thing that would make it
+    # controllable is named, once.
+    declined = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelname == "ERROR" and "does not offer HVAC mode" in record.message
+    ]
+    assert len(declined) == 1
+    assert TRV_ID in declined[0]
+    assert "heat auto swapped" in declined[0]
+
+
+@pytest.mark.parametrize(
+    ("fake_trv", "expected_setpoint"),
+    [
+        pytest.param(GENERIC_HEAT_TRV, 20.5, id="generic_heat_trv"),
+        pytest.param(INTEGER_GRID_TRV, 21.0, id="integer_grid_trv"),
+    ],
+    indirect=["fake_trv"],
+)
+async def test_setpoint_rounds_to_the_device_grid(hass, fake_trv, expected_setpoint):
+    """The setpoint arrives snapped to the grid the device publishes.
+
+    The room sensor reads what the device reads, so the calibration is a
+    no-op and the value under test is the target itself. A room demanding
+    heat rounds it up onto the grid, so the whole-degree device receives
+    the next full degree instead of a setpoint it is already sitting at.
+    """
+    set_room_sensor(hass, fake_trv.profile.current_temperature)
+    entry = make_entry()
+    await setup_entry(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+    assert_profile_adopted(bt, fake_trv.profile)
+    assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
+
+    with patch(_WRITE_BUDGET, 0.0):
+        baseline = len(fake_trv.set_temperature_calls)
+        await hass.services.async_call(
+            "climate",
+            "set_temperature",
+            {"entity_id": BT_ENTITY, "temperature": 20.5},
+            blocking=True,
+        )
+        assert await wait_for(
+            hass, lambda: len(fake_trv.set_temperature_calls) > baseline
+        )
+
+    assert fake_trv.set_temperature_calls[-1] == pytest.approx(expected_setpoint)
+
+
+@pytest.mark.parametrize("fake_trv", [FAHRENHEIT_TRV], indirect=True, ids=profile_id)
+async def test_fahrenheit_device_is_read_and_written_in_its_own_unit(hass, fake_trv):
+    """A device on a Fahrenheit system publishes and receives Fahrenheit.
+
+    The range and the reading are converted into Celsius on the way in and
+    the step is scaled as the difference it is; the setpoint is converted
+    back on the way out and lands on the device's own whole-degree grid. A
+    Celsius-sized number would sit far below the device's range, and a value
+    rounded before the conversion would sit off its grid.
+    """
+    profile = fake_trv.profile
+    set_room_sensor(hass, 64.4, UnitOfTemperature.FAHRENHEIT)
+    entry = make_entry()
+    await setup_entry(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+    assert_profile_adopted(bt, profile)
+
+    trv = bt.real_trvs[TRV_ID]
+    assert trv.min_temp == pytest.approx(5.0, abs=0.01)
+    assert trv.max_temp == pytest.approx(30.0, abs=0.01)
+    assert trv.target_temp_step == pytest.approx(0.5556, abs=1e-3)
+
+    assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
+    written = fake_trv.set_temperature_calls[-1]
+    assert profile.min_temp <= written <= profile.max_temp
+    assert_on_device_grid(written, profile)
+
+
+@pytest.mark.parametrize("fake_trv", [MQTT_OFFSET_TRV], indirect=True, ids=profile_id)
+async def test_offset_reaches_the_calibration_number_entity(hass, fake_trv):
+    """A device with a calibration number is corrected through that entity.
+
+    The channel only exists because the device carries a registry entry: the
+    calibration entity is found by walking the device the head belongs to.
+    """
+    room = 21.0
+    expected_offset = room - fake_trv.profile.current_temperature
+    set_room_sensor(hass, room)
+    entry = make_entry()
+    await setup_entry(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+    assert_profile_adopted(bt, fake_trv.profile)
+
+    # The calibration entity is zeroed once on startup, so the write under
+    # test is the last one, never the only one.
+    offset_number = fake_trv.offset_number
+    assert await wait_for(
+        hass,
+        lambda: (
+            offset_number.set_value_calls
+            and offset_number.set_value_calls[-1] == pytest.approx(expected_offset)
+        ),
+    ), offset_number.set_value_calls
+    assert float(hass.states.get(OFFSET_NUMBER_ID).state) == pytest.approx(
+        expected_offset
+    )
+    assert bt.real_trvs[TRV_ID].last_calibration == pytest.approx(expected_offset)
+
+
+@pytest.mark.parametrize("fake_trv", [TADO_OFFSET_TRV], indirect=True, ids=profile_id)
+async def test_offset_reaches_the_ecosystem_service(hass, fake_trv):
+    """A device without a calibration entity is corrected by a service call."""
+    offset_calls = async_mock_service(hass, "tado", "set_climate_temperature_offset")
+    room = 21.0
+    expected_offset = room - fake_trv.profile.current_temperature
+    set_room_sensor(hass, room)
+    entry = make_entry()
+    await setup_entry(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+    assert_profile_adopted(bt, fake_trv.profile)
+
+    assert await wait_for(hass, lambda: offset_calls)
+    payload = offset_calls[-1].data
+    assert payload["entity_id"] == TRV_ID
+    assert payload["offset"] == pytest.approx(expected_offset)
+
+
+@pytest.mark.parametrize(
+    "device_role",
+    [
+        pytest.param(SEPARATE_COOLER, id="separate_cooler"),
+        pytest.param(
+            DUAL_ROLE,
+            id="dual_role",
+            marks=pytest.mark.xfail(
+                strict=True, reason=_DUAL_ROLE_TRV_WRITE_LANDS_LAST
+            ),
+        ),
+    ],
+    indirect=True,
+)
+async def test_cooling_demand_reaches_the_cooler(hass, device_role):
+    """A room above the cooling target leaves the cooler cooling.
+
+    Both throttles are opened: the write budget paces the thermostat channel
+    and the resend interval paces the cooler channel, and the demand appears
+    within the window of both.
+    """
+    thermostat, cooler = device_role[0], device_role[-1]
+    set_room_sensor(hass, 27.0)
+    entry = make_entry()
+    await setup_entry(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+    assert_profile_adopted(bt, thermostat.profile)
+
+    with patch(_WRITE_BUDGET, 0.0), patch(_COOLER_RESEND, 0.0):
+        await hass.services.async_call(
+            "climate",
+            "set_temperature",
+            {"entity_id": BT_ENTITY, "target_temp_low": 19.0, "target_temp_high": 23.0},
+            blocking=True,
+        )
+        assert await wait_for(hass, lambda: "cool" in cooler.set_hvac_mode_calls)
+        assert await wait_for(hass, lambda: cooler.set_temperature_calls)
+
+    assert hass.states.get(cooler.entity_id).state == HVACMode.COOL
+    assert cooler.set_temperature_calls[-1] == pytest.approx(23.0)

--- a/tests/integration/test_entry_lifecycle.py
+++ b/tests/integration/test_entry_lifecycle.py
@@ -25,6 +25,7 @@ from .conftest import (
     WRITE_BUDGET,
     assert_on_device_grid,
     assert_profile_adopted,
+    assert_write_is,
     make_entry,
     profile_id,
     set_room_sensor,
@@ -118,7 +119,10 @@ async def test_restored_target_temperature_survives_a_restart(hass, fake_trv):
     assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
     state = hass.states.get(BT_ENTITY)
     assert state.attributes.get(ATTR_TEMPERATURE) == 23.5
-    assert_on_device_grid(fake_trv.set_temperature_calls[-1], fake_trv.profile)
+    # target_temp_based does not send the target itself: it sends the target
+    # corrected by how far the device's own reading sits from the room sensor.
+    corrected = 23.5 - 18.0 + fake_trv.profile.current_temperature
+    assert_write_is(fake_trv.set_temperature_calls[-1], corrected, fake_trv.profile)
 
 
 async def test_unload_and_reload_the_entry(hass, fake_trv):

--- a/tests/integration/test_entry_lifecycle.py
+++ b/tests/integration/test_entry_lifecycle.py
@@ -4,79 +4,120 @@ These tests exist because the unit suite mocks the entity: a control
 path that silently writes nothing keeps every unit test green. Here a
 real entry is set up against a simulated TRV and the assertions are the
 service calls that arrive at the device.
+
+The device form is an axis, not a constant: the fixtures are parametrized
+indirectly over the profiles in ``device_profiles`` and every expectation
+that depends on the device is derived from the profile it was built from.
 """
 
+from homeassistant.components.climate import HVACMode
 from homeassistant.components.climate.const import ATTR_HVAC_ACTION
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import State
 from homeassistant.helpers import entity_registry as er
+import pytest
 from pytest_homeassistant_custom_component.common import mock_restore_cache
 
 from .conftest import (
+    BT_ENTITY,
     DOMAIN,
-    SENSOR_ID,
     WINDOW_ID,
+    assert_on_device_grid,
+    assert_profile_adopted,
     make_entry,
+    profile_id,
+    set_room_sensor,
     setup_entry,
     wait_for,
     wait_for_startup,
 )
+from .device_profiles import (
+    DUAL_ROLE,
+    GENERIC_HEAT_TRV,
+    HEAT_COOL_TRV,
+    INTEGER_GRID_TRV,
+    ROLE_SCENARIOS,
+)
 
-BT_ENTITY = "climate.bt_test"
 
-
-def _room_sensor(hass, value="18.0"):
-    """Set the external room temperature sensor to ``value`` (°C)."""
-    hass.states.async_set(SENSOR_ID, value, {"unit_of_measurement": "°C"})
-
-
+@pytest.mark.parametrize(
+    "fake_trv",
+    [GENERIC_HEAT_TRV, HEAT_COOL_TRV, INTEGER_GRID_TRV],
+    indirect=True,
+    ids=profile_id,
+)
 async def test_setup_creates_the_entity_and_syncs_the_trv(hass, fake_trv):
-    """Startup ends with a real setpoint write at the device."""
-    _room_sensor(hass)
+    """Startup ends with a real setpoint write on the device's own grid."""
+    set_room_sensor(hass, 18.0)
     entry = make_entry()
     await setup_entry(hass, entry)
-    await wait_for_startup(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+    assert_profile_adopted(bt, fake_trv.profile)
 
     state = hass.states.get(BT_ENTITY)
     assert state is not None
     assert state.state == "heat"
 
-    # The initial sync wrote a setpoint through the climate service.
+    # The initial sync wrote a setpoint through the climate service, and it
+    # arrived inside the range and on the grid this device published.
     assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
     written = fake_trv.set_temperature_calls[-1]
-    assert 5.0 <= written <= 30.0
+    assert fake_trv.profile.min_temp <= written <= fake_trv.profile.max_temp
+    assert_on_device_grid(written, fake_trv.profile)
 
 
+@pytest.mark.parametrize(
+    "fake_trv", [GENERIC_HEAT_TRV, HEAT_COOL_TRV], indirect=True, ids=profile_id
+)
 async def test_window_open_turns_the_trv_off(hass, fake_trv):
-    """A window-open event reaches the device as an OFF command."""
-    _room_sensor(hass)
+    """A window-open event reaches the device as an OFF command.
+
+    Whichever mode a device calls heating, it keeps that mode while the
+    window is shut and receives the plain OFF it published when the window
+    opens — the remap applies to the heating mode, not to OFF.
+    """
+    set_room_sensor(hass, 18.0)
     hass.states.async_set(WINDOW_ID, "off")
     entry = make_entry(with_window=True)
     await setup_entry(hass, entry)
-    await wait_for_startup(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+    assert_profile_adopted(bt, fake_trv.profile)
     assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
+    assert hass.states.get(fake_trv.entity_id).state == fake_trv.profile.hvac_mode
 
     hass.states.async_set(WINDOW_ID, "on")
     assert await wait_for(hass, lambda: "off" in fake_trv.set_hvac_mode_calls)
 
+    assert fake_trv.set_hvac_mode_calls[-1] == HVACMode.OFF
+    assert hass.states.get(fake_trv.entity_id).state == HVACMode.OFF
     bt_state = hass.states.get(BT_ENTITY)
     assert bt_state.attributes.get("window_open") is True
 
 
+@pytest.mark.parametrize(
+    "fake_trv", [GENERIC_HEAT_TRV, INTEGER_GRID_TRV], indirect=True, ids=profile_id
+)
 async def test_restored_target_temperature_survives_a_restart(hass, fake_trv):
-    """The restored target temperature drives the first sync."""
+    """The restored target temperature drives the first sync.
+
+    The device grid constrains the write, not the target: a thermostat in
+    front of a whole-degree device keeps the half-degree target it restored
+    and rounds only what it sends.
+    """
     mock_restore_cache(
         hass,
         [State(BT_ENTITY, "heat", {ATTR_TEMPERATURE: 23.5, ATTR_HVAC_ACTION: "idle"})],
     )
-    _room_sensor(hass)
+    set_room_sensor(hass, 18.0)
     entry = make_entry()
     await setup_entry(hass, entry)
-    await wait_for_startup(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+    assert_profile_adopted(bt, fake_trv.profile)
 
     assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
     state = hass.states.get(BT_ENTITY)
     assert state.attributes.get(ATTR_TEMPERATURE) == 23.5
+    assert_on_device_grid(fake_trv.set_temperature_calls[-1], fake_trv.profile)
 
 
 async def test_unload_and_reload_the_entry(hass, fake_trv):
@@ -84,11 +125,13 @@ async def test_unload_and_reload_the_entry(hass, fake_trv):
 
     The entity runs several background tasks (control queue, window
     queue, keepalive) and many listeners — the classic leak class for
-    custom components lives exactly here.
+    custom components lives exactly here. Teardown is device-independent,
+    and two full entry setups make this the most expensive test in the
+    file, so it stays on the default device form.
     """
     from homeassistant.config_entries import ConfigEntryState
 
-    _room_sensor(hass)
+    set_room_sensor(hass, 18.0)
     entry = make_entry()
     await setup_entry(hass, entry)
     await wait_for_startup(hass, entry)
@@ -116,18 +159,46 @@ async def test_unload_and_reload_the_entry(hass, fake_trv):
     assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
 
 
-async def test_climate_entity_id_follows_device_name_after_rename(hass, fake_trv):
+@pytest.mark.parametrize(
+    ("device_role", "scenario"),
+    [(role, role) for role in ROLE_SCENARIOS],
+    indirect=["device_role"],
+    ids=[role.name for role in ROLE_SCENARIOS],
+)
+async def test_climate_entity_id_follows_device_name_after_rename(
+    hass, device_role, scenario
+):
     """Renaming the device renames the climate (and sensor) entity_id to match.
 
     HA's entity registry reuses the existing entry on reload (unique id ==
     config entry id), so without an explicit rename the entity_id is frozen
     at first creation while only the friendly name follows the device.
     Blueprints that reference ``climate.bt_<room>`` then miss the entity.
+
+    The rename runs over every wiring of the room — heat only, heat with a
+    separate cooler, and one entity in both roles — because the entity id is
+    rebuilt from the entry on every reload, whatever the entry controls.
     """
-    _room_sensor(hass)
+    set_room_sensor(hass, 18.0)
     entry = make_entry(name="Livingroom")
     await setup_entry(hass, entry)
-    await wait_for_startup(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+
+    # The entry controls exactly what the scenario wired: a room with a cooler
+    # trades plain heat for heat_cool, and a dual-role room points both
+    # channels at the one entity it built.
+    assert len(device_role) == (1 if scenario.cooler is None else 2)
+    assert entry.data.get("cooler") == scenario.cooler_entity_id
+    assert bt.cooler_entity_id == scenario.cooler_entity_id
+    assert list(bt.real_trvs) == [scenario.trv.entity_id]
+    assert (bt.cooler_entity_id in bt.real_trvs) is (scenario is DUAL_ROLE)
+    assert_profile_adopted(bt, scenario.trv)
+    if scenario.cooler_entity_id is None:
+        assert HVACMode.HEAT in bt.hvac_modes
+        assert HVACMode.HEAT_COOL not in bt.hvac_modes
+    else:
+        assert HVACMode.HEAT_COOL in bt.hvac_modes
+        assert HVACMode.HEAT not in bt.hvac_modes
 
     registry = er.async_get(hass)
     climate_key = ("climate", DOMAIN, entry.entry_id)
@@ -153,14 +224,19 @@ async def test_climate_entity_id_follows_device_name_after_rename(hass, fake_trv
     assert hass.states.get("climate.bt_livingroom") is not None
 
 
+@pytest.mark.parametrize(
+    "fake_trv", [GENERIC_HEAT_TRV, INTEGER_GRID_TRV], indirect=True, ids=profile_id
+)
 async def test_reconcile_tick_heals_a_lost_setpoint_write(hass, fake_trv):
     """A write the radio swallowed converges through the periodic tick.
 
     This pins the wiring: the five-minute interval is registered, the
     tick detects the commanded-vs-reported divergence, and the queued
-    control cycle re-sends through the real service. The write budget
-    is unit-tested elsewhere and zeroed here so the test does not have
-    to wait out real wall-clock spacing.
+    control cycle re-sends through the real service. The divergence is
+    measured against a tolerance of half a step, so the setpoint grid is
+    an axis of the detection itself. The write budget is unit-tested
+    elsewhere and zeroed here so the test does not have to wait out real
+    wall-clock spacing.
     """
     from datetime import timedelta
     from unittest.mock import patch
@@ -168,10 +244,11 @@ async def test_reconcile_tick_heals_a_lost_setpoint_write(hass, fake_trv):
     from homeassistant.util import dt as dt_util
     from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
-    _room_sensor(hass)
+    set_room_sensor(hass, 18.0)
     entry = make_entry()
     await setup_entry(hass, entry)
-    await wait_for_startup(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+    assert_profile_adopted(bt, fake_trv.profile)
     assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
 
     with patch(
@@ -192,6 +269,7 @@ async def test_reconcile_tick_heals_a_lost_setpoint_write(hass, fake_trv):
         )
         lost = fake_trv.set_temperature_calls[-1]
         assert lost != fake_trv._attr_target_temperature  # really lost
+        assert_on_device_grid(lost, fake_trv.profile)
 
         # The next reconcile tick detects the divergence and re-sends.
         resend_baseline = len(fake_trv.set_temperature_calls)

--- a/tests/integration/test_entry_lifecycle.py
+++ b/tests/integration/test_entry_lifecycle.py
@@ -22,6 +22,7 @@ from .conftest import (
     BT_ENTITY,
     DOMAIN,
     WINDOW_ID,
+    WRITE_BUDGET,
     assert_on_device_grid,
     assert_profile_adopted,
     make_entry,
@@ -49,7 +50,7 @@ from .device_profiles import (
 async def test_setup_creates_the_entity_and_syncs_the_trv(hass, fake_trv):
     """Startup ends with a real setpoint write on the device's own grid."""
     set_room_sensor(hass, 18.0)
-    entry = make_entry()
+    entry = make_entry(fake_trv.profile)
     await setup_entry(hass, entry)
     bt = await wait_for_startup(hass, entry)
     assert_profile_adopted(bt, fake_trv.profile)
@@ -78,7 +79,7 @@ async def test_window_open_turns_the_trv_off(hass, fake_trv):
     """
     set_room_sensor(hass, 18.0)
     hass.states.async_set(WINDOW_ID, "off")
-    entry = make_entry(with_window=True)
+    entry = make_entry(fake_trv.profile, with_window=True)
     await setup_entry(hass, entry)
     bt = await wait_for_startup(hass, entry)
     assert_profile_adopted(bt, fake_trv.profile)
@@ -109,7 +110,7 @@ async def test_restored_target_temperature_survives_a_restart(hass, fake_trv):
         [State(BT_ENTITY, "heat", {ATTR_TEMPERATURE: 23.5, ATTR_HVAC_ACTION: "idle"})],
     )
     set_room_sensor(hass, 18.0)
-    entry = make_entry()
+    entry = make_entry(fake_trv.profile)
     await setup_entry(hass, entry)
     bt = await wait_for_startup(hass, entry)
     assert_profile_adopted(bt, fake_trv.profile)
@@ -132,7 +133,7 @@ async def test_unload_and_reload_the_entry(hass, fake_trv):
     from homeassistant.config_entries import ConfigEntryState
 
     set_room_sensor(hass, 18.0)
-    entry = make_entry()
+    entry = make_entry(fake_trv.profile)
     await setup_entry(hass, entry)
     await wait_for_startup(hass, entry)
 
@@ -159,15 +160,37 @@ async def test_unload_and_reload_the_entry(hass, fake_trv):
     assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
 
 
-@pytest.mark.parametrize(
-    ("device_role", "scenario"),
-    [(role, role) for role in ROLE_SCENARIOS],
-    indirect=["device_role"],
-    ids=[role.name for role in ROLE_SCENARIOS],
-)
-async def test_climate_entity_id_follows_device_name_after_rename(
-    hass, device_role, scenario
-):
+@pytest.mark.parametrize("device_role", ROLE_SCENARIOS, indirect=True, ids=profile_id)
+async def test_the_role_scenario_decides_what_the_entry_controls(hass, device_role):
+    """The entry wires exactly the devices and channels its role names.
+
+    A room with a cooler trades plain heat for heat_cool, a heat-only room
+    keeps heat and never offers heat_cool, and a dual-role room points both
+    channels at the one entity it built — the same entity is the thermostat
+    and the cooler, which is the wiring the cooling path has to survive.
+    """
+    scenario = device_role.scenario
+    set_room_sensor(hass, 18.0)
+    entry = make_entry(scenario)
+    await setup_entry(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+
+    assert len(device_role.entities) == (1 if scenario.cooler is None else 2)
+    assert entry.data.get("cooler") == scenario.cooler_entity_id
+    assert bt.cooler_entity_id == scenario.cooler_entity_id
+    assert list(bt.real_trvs) == [scenario.trv.entity_id]
+    assert (bt.cooler_entity_id in bt.real_trvs) is (scenario is DUAL_ROLE)
+    assert_profile_adopted(bt, scenario.trv)
+    if scenario.cooler_entity_id is None:
+        assert HVACMode.HEAT in bt.hvac_modes
+        assert HVACMode.HEAT_COOL not in bt.hvac_modes
+    else:
+        assert HVACMode.HEAT_COOL in bt.hvac_modes
+        assert HVACMode.HEAT not in bt.hvac_modes
+
+
+@pytest.mark.parametrize("device_role", ROLE_SCENARIOS, indirect=True, ids=profile_id)
+async def test_climate_entity_id_follows_device_name_after_rename(hass, device_role):
     """Renaming the device renames the climate (and sensor) entity_id to match.
 
     HA's entity registry reuses the existing entry on reload (unique id ==
@@ -180,25 +203,9 @@ async def test_climate_entity_id_follows_device_name_after_rename(
     rebuilt from the entry on every reload, whatever the entry controls.
     """
     set_room_sensor(hass, 18.0)
-    entry = make_entry(name="Livingroom")
+    entry = make_entry(device_role.scenario, name="Livingroom")
     await setup_entry(hass, entry)
-    bt = await wait_for_startup(hass, entry)
-
-    # The entry controls exactly what the scenario wired: a room with a cooler
-    # trades plain heat for heat_cool, and a dual-role room points both
-    # channels at the one entity it built.
-    assert len(device_role) == (1 if scenario.cooler is None else 2)
-    assert entry.data.get("cooler") == scenario.cooler_entity_id
-    assert bt.cooler_entity_id == scenario.cooler_entity_id
-    assert list(bt.real_trvs) == [scenario.trv.entity_id]
-    assert (bt.cooler_entity_id in bt.real_trvs) is (scenario is DUAL_ROLE)
-    assert_profile_adopted(bt, scenario.trv)
-    if scenario.cooler_entity_id is None:
-        assert HVACMode.HEAT in bt.hvac_modes
-        assert HVACMode.HEAT_COOL not in bt.hvac_modes
-    else:
-        assert HVACMode.HEAT_COOL in bt.hvac_modes
-        assert HVACMode.HEAT not in bt.hvac_modes
+    await wait_for_startup(hass, entry)
 
     registry = er.async_get(hass)
     climate_key = ("climate", DOMAIN, entry.entry_id)
@@ -245,16 +252,13 @@ async def test_reconcile_tick_heals_a_lost_setpoint_write(hass, fake_trv):
     from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
     set_room_sensor(hass, 18.0)
-    entry = make_entry()
+    entry = make_entry(fake_trv.profile)
     await setup_entry(hass, entry)
     bt = await wait_for_startup(hass, entry)
     assert_profile_adopted(bt, fake_trv.profile)
     assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
 
-    with patch(
-        "custom_components.better_thermostat.utils.controlling.MIN_WRITE_INTERVAL_S",
-        0.0,
-    ):
+    with patch(WRITE_BUDGET, 0.0):
         # The device drops the write for the new target.
         fake_trv.drop_next_setpoint_write = True
         baseline_calls = len(fake_trv.set_temperature_calls)

--- a/tests/integration/test_preset_migration_contract.py
+++ b/tests/integration/test_preset_migration_contract.py
@@ -16,15 +16,22 @@ from pytest_homeassistant_custom_component.common import (
     mock_restore_cache,
 )
 
-from .conftest import DOMAIN, SENSOR_ID, make_entry, setup_entry, wait_for_startup
+from .conftest import (
+    BT_ENTITY,
+    DOMAIN,
+    make_entry,
+    set_room_sensor,
+    setup_entry,
+    wait_for_startup,
+)
+from .device_profiles import GENERIC_HEAT_TRV
 
-BT_ENTITY = "climate.bt_test"
 SLEEP_NUMBER = "number.bt_test_sleep"
 
 
 async def _setup(hass, presets=("sleep", "eco")):
-    hass.states.async_set(SENSOR_ID, "18.0", {"unit_of_measurement": "°C"})
-    data = dict(make_entry().data)
+    set_room_sensor(hass, 18.0)
+    data = dict(make_entry(GENERIC_HEAT_TRV).data)
     data["presets"] = list(presets)
     entry = MockConfigEntry(domain=DOMAIN, version=18, data=data, title=data["name"])
     await setup_entry(hass, entry)


### PR DESCRIPTION
The integration harness tested exactly one device form: Celsius, `[HEAT, OFF]`, half-degree
grid, no calibration channel, no valve channel, no cooler, and an entity without a device
registry entry. Every device-shaped defect reported recently lives outside that form, so the
end-to-end suite could not see any of them.

This replaces the hardcoded fake with a capability specification and runs the integration
tests across the forms real devices actually take.

## What the matrix covers

`tests/integration/device_profiles.py` holds pure data: ten `DeviceProfile` rows and four
role scenarios. Each row states its integration, its calibration strategy and whether its
entity carries a device registry entry, because those three decide which adapter runs and
which channels can be discovered at all.

| Axis | Forms |
|---|---|
| Mode vocabulary | `[HEAT,OFF]` · `[AUTO,COOL,OFF]` · `[HEAT_COOL,OFF]` · `[AUTO,OFF]`, both `heat_auto_swapped` polarities |
| Setpoint grid | half-degree · integer grid |
| Unit | Celsius · Fahrenheit |
| Calibration channel | none · number entity on the device · ecosystem service call |
| Valve channel | none · writable number |
| Device registry | without · with (a precondition of the number channel, not a free axis) |
| Role | heat only · separate cooler · cooler publishing a band · one entity in both roles |

`test_device_matrix.py` asserts per axis on what arrives at the simulated device.
`test_entry_lifecycle.py` runs its existing scenarios across the profiles, with the
expectations derived from the profile rather than hardcoded.

## Every axis is proven able to fail

A matrix that cannot go red is decoration. Each axis was verified by reverting the relevant
production change and confirming the new test fails behaviourally:

| Axis | Failure without the production code |
|---|---|
| Mode | `assert [<HVACMode.HEAT: 'heat'>] == []` |
| Calibration | the write-gate assertion times out |
| Device registry | `AttributeError: 'OptionsFlowHandler' object has no attribute 'model'` |
| Valve | `set_valve` returning `False` yields `assert []` |

The mode axis reads its evidence off the service bus rather than off the entity: Home
Assistant rejects an unoffered mode before the entity sees it, so a command that was never
sent and one that was sent and refused are indistinguishable at the device. An earlier
version of that test detected the defect only through a log message.

## The one expected failure

`test_cooling_demand_reaches_the_cooler[dual_role]` is `xfail(strict=True)`. One entity
configured as both thermostat and cooler receives `cool` from the cooler channel and `heat`
from the TRV channel in the same control cycle. The TRV write lands last, so the device is
left heating at the calibrated heat setpoint while the entity reports `cooling` — silently,
with no error. `separate_cooler` runs the identical body and passes, so the harness is not
the cause. The marker is strict: if the case starts passing, that is a change in the product
and should be read, not absorbed.

Worth deciding separately: the config flow accepts the same entity in both roles without any
validation. A guard there would make this case obsolete rather than fixed.

## Scope

Tests only — the production tree is untouched. Integration suite: 51 passed, 1 xfailed in
6.1 s. Full suite: 4563 passed, 1 xfailed. Order-independence checked across shuffled and
isolated runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded integration coverage across heating, cooling, calibration, valve control, temperature units, setpoint rounding, device capabilities, and role-based configurations.
  * Added scenarios for device registration paths, missing capabilities, dropped commands, reloads, renaming, and recovery.
  * Added validation for dual-role heating and cooling behavior, including cooling demand routing and unsupported mode handling.
  * Added coverage for device-less configuration changes and calibration reconciliation after unavailable or delayed commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->