### PR TITLE
test: spec the adapter-seam mocks against the contract they replace

### DIFF
--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -190,13 +190,13 @@ class TestControlTrvUnavailablePath:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -220,13 +220,13 @@ class TestControlTrvUnavailablePath:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -259,10 +259,10 @@ class TestControlTrvUnavailablePath:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -285,9 +285,11 @@ class TestControlTrvUnavailablePath:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_hvac_mode"]) as mock_set_hvac,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
-            patch(_PATCHES["set_valve"]) as mock_set_valve,
+            patch(_PATCHES["set_hvac_mode"], autospec=True) as mock_set_hvac,
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
+            patch(
+                _PATCHES["set_valve"], autospec=True, return_value=True
+            ) as mock_set_valve,
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             result = await control_trv(mock_self, "climate.trv1")
@@ -306,13 +308,13 @@ class TestControlTrvUnavailablePath:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -367,16 +369,16 @@ class TestControlTrvUnavailablePath:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["get_current_offset"], new=AsyncMock(return_value=0.0)),
-            patch(_PATCHES["set_offset"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["get_current_offset"], autospec=True, return_value=0.0),
+            patch(_PATCHES["set_offset"], autospec=True, return_value=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -415,16 +417,16 @@ class TestControlTrvUnavailablePath:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["get_current_offset"], new=AsyncMock(return_value=0.0)),
-            patch(_PATCHES["set_offset"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["get_current_offset"], autospec=True, return_value=0.0),
+            patch(_PATCHES["set_offset"], autospec=True, return_value=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -461,17 +463,19 @@ class TestControlTrvUnavailablePath:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
-            patch(_PATCHES["set_valve"]) as mock_set_valve,
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["set_valve"], autospec=True, return_value=True
+            ) as mock_set_valve,
+            patch(
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["get_current_offset"], new=AsyncMock(return_value=0.0)),
-            patch(_PATCHES["set_offset"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["get_current_offset"], autospec=True, return_value=0.0),
+            patch(_PATCHES["set_offset"], autospec=True, return_value=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -496,13 +500,13 @@ class TestControlTrvUnavailablePath:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -537,13 +541,13 @@ class TestControlTrvAvailablePath:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -578,13 +582,13 @@ class TestControlTrvAvailablePath:
 
         with (
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ) as mock_override_mode,
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_mode,
-            patch(_PATCHES["set_temperature"], new=AsyncMock()) as mock_set_temp,
+            patch(_PATCHES["set_hvac_mode"], autospec=True) as mock_set_mode,
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             await control_trv(mock_self, "climate.trv1")
@@ -622,13 +626,13 @@ class TestControlTrvAvailablePath:
 
         with (
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_mode,
-            patch(_PATCHES["set_temperature"], new=AsyncMock()) as mock_set_temp,
+            patch(_PATCHES["set_hvac_mode"], autospec=True) as mock_set_mode,
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             await control_trv(mock_self, "climate.trv1")
@@ -648,13 +652,13 @@ class TestControlTrvAvailablePath:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=True)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=True
             ) as mock_override,
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -688,13 +692,13 @@ class TestControlTrvAvailablePath:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ) as mock_override,
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -717,13 +721,13 @@ class TestControlTrvAvailablePath:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ) as mock_override,
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -787,15 +791,17 @@ class TestControlTrvAvailablePath:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_valve"]) as mock_set_valve,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["set_valve"], autospec=True, return_value=True
+            ) as mock_set_valve,
+            patch(
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -836,15 +842,17 @@ class TestControlTrvAvailablePath:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["get_current_offset"]) as mock_get_offset,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["get_current_offset"], autospec=True, return_value=0.0
+            ) as mock_get_offset,
+            patch(
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -881,15 +889,17 @@ class TestControlTrvAvailablePath:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["get_current_offset"]) as mock_get_offset,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["get_current_offset"], autospec=True, return_value=0.0
+            ) as mock_get_offset,
+            patch(
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -917,12 +927,14 @@ class TestControlTrvAvailablePath:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_hvac_mode"]) as mock_set_hvac,
-            patch(_PATCHES["override_set_hvac_mode"]) as mock_override,
+            patch(_PATCHES["set_hvac_mode"], autospec=True) as mock_set_hvac,
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
+            ) as mock_override,
+            patch(
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -955,12 +967,14 @@ class TestControlTrvAvailablePath:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_hvac_mode"]) as mock_set_hvac,
-            patch(_PATCHES["override_set_hvac_mode"]) as mock_override,
+            patch(_PATCHES["set_hvac_mode"], autospec=True) as mock_set_hvac,
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
+            ) as mock_override,
+            patch(
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -1019,16 +1033,16 @@ class TestControlTrvAvailablePath:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["set_valve"], side_effect=drop_trv_offline
+                _PATCHES["set_valve"], autospec=True, side_effect=drop_trv_offline
             ) as mock_set_valve,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ) as mock_override_hvac,
-            patch(_PATCHES["set_hvac_mode"]) as mock_set_hvac,
+            patch(_PATCHES["set_hvac_mode"], autospec=True) as mock_set_hvac,
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -1064,13 +1078,13 @@ class TestControlTrvAvailablePath:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -1095,12 +1109,14 @@ class TestControlTrvAvailablePath:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_hvac_mode"]) as mock_set_hvac,
-            patch(_PATCHES["override_set_hvac_mode"]) as mock_override,
+            patch(_PATCHES["set_hvac_mode"], autospec=True) as mock_set_hvac,
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
+            ) as mock_override,
+            patch(
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_temperature"], new=AsyncMock()),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -1133,14 +1149,14 @@ class TestControlTrvAvailablePath:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch(_PATCHES["set_hvac_mode"], autospec=True) as mock_set_hvac,
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -1177,14 +1193,14 @@ class TestControlTrvAvailablePath:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch(_PATCHES["set_hvac_mode"], autospec=True) as mock_set_hvac,
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -1214,14 +1230,14 @@ class TestControlTrvAvailablePath:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()) as mock_set_hvac,
+            patch(_PATCHES["set_hvac_mode"], autospec=True) as mock_set_hvac,
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -1254,15 +1270,16 @@ class TestControlTrvIgnoreFlagReset:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
             patch(
                 _PATCHES["set_temperature"],
-                new=AsyncMock(side_effect=RuntimeError("adapter failure")),
+                autospec=True,
+                side_effect=RuntimeError("adapter failure"),
             ),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
@@ -1292,13 +1309,17 @@ class TestControlTrvIgnoreFlagReset:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"], new=_blocking_set_temperature),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(
+                _PATCHES["set_temperature"],
+                autospec=True,
+                side_effect=_blocking_set_temperature,
+            ),
         ):
             mock_convert.return_value = {
                 "temperature": 21.0,
@@ -1337,13 +1358,17 @@ class TestControlTrvIgnoreFlagReset:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-            patch(_PATCHES["set_temperature"], new=_blocking_set_temperature),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(
+                _PATCHES["set_temperature"],
+                autospec=True,
+                side_effect=_blocking_set_temperature,
+            ),
         ):
             mock_convert.return_value = {
                 "temperature": 21.0,
@@ -1463,8 +1488,8 @@ class TestBoostModeSafetyOverride:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_valve"], side_effect=track_set_valve),
-            patch(_PATCHES["set_hvac_mode"]),
+            patch(_PATCHES["set_valve"], autospec=True, side_effect=track_set_valve),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
         ):
             mock_convert.return_value = {
                 "temperature": 20.0,
@@ -1511,15 +1536,17 @@ class TestBoostModeSafetyOverride:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"], new=AsyncMock()) as mock_set_temp,
-            patch(_PATCHES["set_valve"], new=AsyncMock()) as mock_set_valve,
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["set_valve"], autospec=True, return_value=True
+            ) as mock_set_valve,
+            patch(
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -1571,11 +1598,11 @@ class TestBoostModeSafetyOverride:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_valve"], side_effect=track_set_valve),
+            patch(_PATCHES["set_valve"], autospec=True, side_effect=track_set_valve),
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -1628,11 +1655,11 @@ class TestBoostModeSafetyOverride:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_valve"], side_effect=failing_set_valve),
+            patch(_PATCHES["set_valve"], autospec=True, side_effect=failing_set_valve),
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             mock_convert.return_value = {
@@ -1739,8 +1766,8 @@ class TestBoostModeSafetyOverride:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_valve"], side_effect=track_set_valve),
-            patch(_PATCHES["set_hvac_mode"]),
+            patch(_PATCHES["set_valve"], autospec=True, side_effect=track_set_valve),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
         ):
             mock_convert.return_value = {
                 "temperature": 20.0,
@@ -1892,17 +1919,21 @@ class TestRaceConditionLockCoverage:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_valve"]) as mock_set_valve,
-            patch(_PATCHES["set_hvac_mode"]) as mock_set_hvac_mode,
-            patch(_PATCHES["set_offset"]) as mock_set_offset,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["set_valve"], autospec=True, return_value=True
+            ) as mock_set_valve,
+            patch(_PATCHES["set_hvac_mode"], autospec=True) as mock_set_hvac_mode,
+            patch(
+                _PATCHES["set_offset"], autospec=True, return_value=True
+            ) as mock_set_offset,
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
+            patch(
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["get_current_offset"], new=AsyncMock(return_value=0.0)),
+            patch(_PATCHES["get_current_offset"], autospec=True, return_value=0.0),
         ):
             mock_convert.return_value = {
                 "temperature": 22.0,
@@ -2070,14 +2101,14 @@ class TestRaceConditionLockCoverage:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_temperature"]),
+            patch(_PATCHES["set_temperature"], autospec=True),
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["get_current_offset"], new=AsyncMock(return_value=0.0)),
+            patch(_PATCHES["get_current_offset"], autospec=True, return_value=0.0),
         ):
             mock_convert.return_value = {
                 "temperature": 22.0,
@@ -2166,17 +2197,21 @@ class TestRaceConditionLockCoverage:
 
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_valve"]) as mock_set_valve,
-            patch(_PATCHES["set_hvac_mode"]) as mock_set_hvac_mode,
-            patch(_PATCHES["set_offset"]) as mock_set_offset,
-            patch(_PATCHES["set_temperature"]) as mock_set_temp,
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["set_valve"], autospec=True, return_value=True
+            ) as mock_set_valve,
+            patch(_PATCHES["set_hvac_mode"], autospec=True) as mock_set_hvac_mode,
+            patch(
+                _PATCHES["set_offset"], autospec=True, return_value=True
+            ) as mock_set_offset,
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
+            patch(
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["get_current_offset"], new=AsyncMock(return_value=0.0)),
+            patch(_PATCHES["get_current_offset"], autospec=True, return_value=0.0),
         ):
             mock_convert.return_value = {
                 "temperature": 22.0,
@@ -2248,18 +2283,17 @@ class TestRaceConditionLockCoverage:
         with (
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
             patch(
                 _PATCHES["set_temperature"],
-                new=AsyncMock(
-                    side_effect=lambda *a, **k: set_temperature_calls.append(a)
-                ),
+                autospec=True,
+                side_effect=lambda *a, **k: set_temperature_calls.append(a),
             ),
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
-            patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
             patch("asyncio.sleep", new=AsyncMock(side_effect=record_lock_state)),
         ):
             mock_convert.return_value = {
@@ -2386,13 +2420,15 @@ class TestGroupedTrvCalibration:
 
         with (
             patch(
-                _PATCHES["get_current_offset"], new_callable=AsyncMock
+                _PATCHES["get_current_offset"], autospec=True, return_value=0.0
             ) as mock_get_offset,
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_offset"], new_callable=AsyncMock) as mock_set_offset,
-            patch(_PATCHES["set_temperature"], new_callable=AsyncMock),
-            patch(_PATCHES["set_hvac_mode"], new_callable=AsyncMock),
-            patch(_PATCHES["set_valve"], new_callable=AsyncMock),
+            patch(
+                _PATCHES["set_offset"], autospec=True, return_value=True
+            ) as mock_set_offset,
+            patch(_PATCHES["set_temperature"], autospec=True),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_valve"], autospec=True, return_value=True),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
             mock_get_offset.return_value = 2.0  # confirms last_calibration
@@ -2425,13 +2461,15 @@ class TestGroupedTrvCalibration:
 
         with (
             patch(
-                _PATCHES["get_current_offset"], new_callable=AsyncMock
+                _PATCHES["get_current_offset"], autospec=True, return_value=0.0
             ) as mock_get_offset,
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_offset"], new_callable=AsyncMock) as mock_set_offset,
-            patch(_PATCHES["set_temperature"], new_callable=AsyncMock),
-            patch(_PATCHES["set_hvac_mode"], new_callable=AsyncMock),
-            patch(_PATCHES["set_valve"], new_callable=AsyncMock),
+            patch(
+                _PATCHES["set_offset"], autospec=True, return_value=True
+            ) as mock_set_offset,
+            patch(_PATCHES["set_temperature"], autospec=True),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_valve"], autospec=True, return_value=True),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
             mock_get_offset.return_value = 2.0
@@ -2469,18 +2507,20 @@ class TestGroupedTrvCalibration:
 
         with (
             patch(
-                _PATCHES["get_current_offset"], new_callable=AsyncMock
+                _PATCHES["get_current_offset"], autospec=True, return_value=0.0
             ) as mock_get_offset,
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_offset"], new_callable=AsyncMock) as mock_set_offset,
-            patch(_PATCHES["set_temperature"], new_callable=AsyncMock) as mock_set_temp,
-            patch(_PATCHES["set_hvac_mode"], new_callable=AsyncMock),
-            patch(_PATCHES["set_valve"], new_callable=AsyncMock),
             patch(
-                _PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)
+                _PATCHES["set_offset"], autospec=True, return_value=True
+            ) as mock_set_offset,
+            patch(_PATCHES["set_temperature"], autospec=True) as mock_set_temp,
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_valve"], autospec=True, return_value=True),
+            patch(
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
             ),
             patch(
-                _PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
             ),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
@@ -2522,13 +2562,13 @@ class TestGroupedTrvCalibration:
 
         with (
             patch(
-                _PATCHES["get_current_offset"], new_callable=AsyncMock
+                _PATCHES["get_current_offset"], autospec=True, return_value=0.0
             ) as mock_get_offset,
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_offset"], new_callable=AsyncMock),
-            patch(_PATCHES["set_temperature"], new_callable=AsyncMock),
-            patch(_PATCHES["set_hvac_mode"], new_callable=AsyncMock),
-            patch(_PATCHES["set_valve"], new_callable=AsyncMock),
+            patch(_PATCHES["set_offset"], autospec=True, return_value=True),
+            patch(_PATCHES["set_temperature"], autospec=True),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_valve"], autospec=True, return_value=True),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
             mock_get_offset.return_value = reported
@@ -2557,13 +2597,13 @@ class TestGroupedTrvCalibration:
 
         with (
             patch(
-                _PATCHES["get_current_offset"], new_callable=AsyncMock
+                _PATCHES["get_current_offset"], autospec=True, return_value=0.0
             ) as mock_get_offset,
             patch(_PATCHES["convert_outbound_states"]) as mock_convert,
-            patch(_PATCHES["set_offset"], new_callable=AsyncMock),
-            patch(_PATCHES["set_temperature"], new_callable=AsyncMock),
-            patch(_PATCHES["set_hvac_mode"], new_callable=AsyncMock),
-            patch(_PATCHES["set_valve"], new_callable=AsyncMock),
+            patch(_PATCHES["set_offset"], autospec=True, return_value=True),
+            patch(_PATCHES["set_temperature"], autospec=True),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_valve"], autospec=True, return_value=True),
             patch("asyncio.sleep", new_callable=AsyncMock),
         ):
             mock_get_offset.return_value = 2.6
@@ -2633,14 +2673,14 @@ async def _run_offset_cycle(
     with (
         patch(_PATCHES["convert_outbound_states"]) as mock_convert,
         patch(
-            _PATCHES["get_current_offset"], new=AsyncMock(return_value=reported_offset)
+            _PATCHES["get_current_offset"], autospec=True, return_value=reported_offset
         ) as mock_get_offset,
-        patch(_PATCHES["set_offset"], new=set_offset),
-        patch(_PATCHES["set_temperature"], new=AsyncMock()),
-        patch(_PATCHES["set_hvac_mode"], new=AsyncMock()),
-        patch(_PATCHES["set_valve"], new=AsyncMock()),
-        patch(_PATCHES["override_set_hvac_mode"], new=AsyncMock(return_value=False)),
-        patch(_PATCHES["override_set_temperature"], new=AsyncMock(return_value=False)),
+        patch(_PATCHES["set_offset"], autospec=True, side_effect=set_offset),
+        patch(_PATCHES["set_temperature"], autospec=True),
+        patch(_PATCHES["set_hvac_mode"], autospec=True),
+        patch(_PATCHES["set_valve"], autospec=True, return_value=True),
+        patch(_PATCHES["override_set_hvac_mode"], autospec=True, return_value=False),
+        patch(_PATCHES["override_set_temperature"], autospec=True, return_value=False),
         patch("asyncio.sleep", new=AsyncMock()),
     ):
         mock_convert.return_value = {
@@ -2984,7 +3024,7 @@ class TestOffsetWriteGate:
         assert trv.calibration_received is False
         assert trv.calibration_write_generation == 2
 
-        with patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-2.0)):
+        with patch(f"{_CTRL}.get_current_offset", autospec=True, return_value=-2.0):
             assert await earlier_watchdog is True
 
         assert trv.calibration_received is False

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -2034,6 +2034,7 @@ class TestRaceConditionLockCoverage:
                 execution_log.append(f"set_valve_start_{args[1]}")
                 await asyncio.sleep(0.01)
                 execution_log.append(f"set_valve_end_{args[1]}")
+                return True
 
             async def delayed_set_hvac_mode(*args, **kwargs):
                 execution_log.append(f"set_hvac_mode_start_{args[1]}")
@@ -2044,6 +2045,7 @@ class TestRaceConditionLockCoverage:
                 execution_log.append(f"set_offset_start_{args[1]}")
                 await asyncio.sleep(0.01)
                 execution_log.append(f"set_offset_end_{args[1]}")
+                return True
 
             async def delayed_set_temp(*args, **kwargs):
                 execution_log.append(f"set_temp_start_{args[1]}")
@@ -2312,6 +2314,7 @@ class TestRaceConditionLockCoverage:
                 lock_state_during_operations.append(
                     ("set_valve", mock_self._temp_lock.locked())
                 )
+                return True
 
             async def check_lock_on_set_hvac_mode(*args, **kwargs):
                 lock_state_during_operations.append(
@@ -2322,6 +2325,7 @@ class TestRaceConditionLockCoverage:
                 lock_state_during_operations.append(
                     ("set_offset", mock_self._temp_lock.locked())
                 )
+                return True
 
             async def check_lock_on_set_temp(*args, **kwargs):
                 lock_state_during_operations.append(

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -1785,6 +1785,95 @@ class TestBoostModeSafetyOverride:
             assert set_valve_calls[1][2] == 0  # Safety reset: 0%
 
 
+class TestValveWriteResult:
+    """The valve channel acts on what the delegate answers.
+
+    A write the delegate refused still stamped the budget slot, so the
+    next cycle has to be requested explicitly. Without it the valve keeps
+    the position the device never took until an unrelated event triggers
+    control.
+    """
+
+    @staticmethod
+    def _boost_valve_self():
+        """Mock BetterThermostat whose boost drives a 100 % valve write."""
+        return _make_mock_self(
+            trv_state=HVACMode.HEAT,
+            trv_attrs={"temperature": 20.0},
+            preset_mode=PRESET_BOOST,
+            cur_temp=18.0,
+            bt_target_temp=22.0,
+            real_trvs={
+                "climate.trv1": _default_trv_config(
+                    advanced={
+                        "calibration_mode": CalibrationMode.MPC_CALIBRATION,
+                        "calibration": CalibrationType.DIRECT_VALVE_BASED,
+                        "no_off_system_mode": False,
+                    }
+                )
+            },
+        )
+
+    @staticmethod
+    async def _run_cycle(mock_self, valve_result):
+        """Run one control cycle with the delegate answering ``valve_result``.
+
+        Returns the valve mock and the names of the tasks the cycle
+        created.
+        """
+        captured = []
+        mock_self.task_manager.create_task = Mock(
+            side_effect=lambda coro, name=None: captured.append((coro, name)) or Mock()
+        )
+
+        with (
+            patch(_PATCHES["convert_outbound_states"]) as mock_convert,
+            patch(
+                _PATCHES["set_valve"], autospec=True, return_value=valve_result
+            ) as mock_set_valve,
+            patch(
+                _PATCHES["override_set_hvac_mode"], autospec=True, return_value=False
+            ),
+            patch(
+                _PATCHES["override_set_temperature"], autospec=True, return_value=False
+            ),
+            patch(_PATCHES["set_hvac_mode"], autospec=True),
+            patch(_PATCHES["set_temperature"], autospec=True),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            mock_convert.return_value = {
+                "temperature": 20.0,
+                "system_mode": HVACMode.HEAT,
+            }
+            await control_trv(mock_self, "climate.trv1")
+
+        for coro, _name in captured:
+            coro.close()
+        return mock_set_valve, [name for _coro, name in captured]
+
+    @pytest.mark.asyncio
+    async def test_a_refused_valve_write_schedules_a_retry_cycle(self):
+        """A delegate answering False leaves a follow-up cycle queued."""
+        mock_self = self._boost_valve_self()
+
+        mock_set_valve, task_names = await self._run_cycle(mock_self, False)
+
+        assert mock_set_valve.call_args[0][2] == 100
+        assert "bt_budget_retry_climate.trv1" in task_names
+        assert mock_self.real_trvs["climate.trv1"].budget_retry_pending is True
+
+    @pytest.mark.asyncio
+    async def test_an_accepted_valve_write_schedules_nothing(self):
+        """A delegate answering True needs no catch-up cycle."""
+        mock_self = self._boost_valve_self()
+
+        mock_set_valve, task_names = await self._run_cycle(mock_self, True)
+
+        assert mock_set_valve.call_args[0][2] == 100
+        assert "bt_budget_retry_climate.trv1" not in task_names
+        assert mock_self.real_trvs["climate.trv1"].budget_retry_pending is False
+
+
 # ---------------------------------------------------------------------------
 # Race condition / lock coverage (from test_race_condition_lock_coverage.py)
 # ---------------------------------------------------------------------------

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -686,7 +686,7 @@ class TestCheckCalibration:
 
         with (
             caplog.at_level(logging.WARNING, logger=_CTRL),
-            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-2.0)),
+            patch(f"{_CTRL}.get_current_offset", autospec=True, return_value=-2.0),
             sleep_patch,
         ):
             result = await check_calibration(mock_self, "climate.trv1")
@@ -703,7 +703,7 @@ class TestCheckCalibration:
         durations, sleep_patch = _sleep_recorder()
 
         with (
-            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-2.5)),
+            patch(f"{_CTRL}.get_current_offset", autospec=True, return_value=-2.5),
             sleep_patch,
         ):
             await check_calibration(mock_self, "climate.trv1")
@@ -722,7 +722,8 @@ class TestCheckCalibration:
             caplog.at_level(logging.WARNING, logger=_CTRL),
             patch(
                 f"{_CTRL}.get_current_offset",
-                new=AsyncMock(side_effect=lambda *_: reports.pop(0)),
+                autospec=True,
+                side_effect=lambda *_: reports.pop(0),
             ),
             sleep_patch,
         ):
@@ -745,7 +746,7 @@ class TestCheckCalibration:
 
         with (
             caplog.at_level(logging.WARNING, logger=_CTRL),
-            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-1.0)),
+            patch(f"{_CTRL}.get_current_offset", autospec=True, return_value=-1.0),
             sleep_patch,
         ):
             result = await check_calibration(mock_self, "climate.trv1")
@@ -765,7 +766,8 @@ class TestCheckCalibration:
             caplog.at_level(logging.WARNING, logger=_CTRL),
             patch(
                 f"{_CTRL}.get_current_offset",
-                new=AsyncMock(return_value="not-a-number"),
+                autospec=True,
+                return_value="not-a-number",
             ),
             sleep_patch,
         ):
@@ -783,7 +785,7 @@ class TestCheckCalibration:
         durations, sleep_patch = _sleep_recorder()
 
         with (
-            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-1.0)),
+            patch(f"{_CTRL}.get_current_offset", autospec=True, return_value=-1.0),
             sleep_patch,
         ):
             result = await check_calibration(mock_self, "climate.trv1")
@@ -799,7 +801,7 @@ class TestCheckCalibration:
         durations, sleep_patch = _sleep_recorder()
 
         with (
-            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-1.0)),
+            patch(f"{_CTRL}.get_current_offset", autospec=True, return_value=-1.0),
             sleep_patch,
         ):
             await check_calibration(mock_self, "climate.trv1")
@@ -831,7 +833,7 @@ class TestCheckCalibration:
         """A cancelled watchdog leaves the offset channel writable."""
         mock_self = self._mock_self()
 
-        with patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=0.0)):
+        with patch(f"{_CTRL}.get_current_offset", autospec=True, return_value=0.0):
             task = asyncio.create_task(check_calibration(mock_self, "climate.trv1"))
             await asyncio.sleep(0)
             await asyncio.sleep(0)
@@ -855,7 +857,7 @@ class TestCheckCalibrationGeneration:
 
         with (
             caplog.at_level(logging.WARNING, logger=_CTRL),
-            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-3.0)),
+            patch(f"{_CTRL}.get_current_offset", autospec=True, return_value=-3.0),
             sleep_patch,
         ):
             result = await check_calibration(mock_self, "climate.trv1", 1)
@@ -894,7 +896,7 @@ class TestCheckCalibrationGeneration:
         _, sleep_patch = _sleep_recorder()
 
         with (
-            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=-3.0)),
+            patch(f"{_CTRL}.get_current_offset", autospec=True, return_value=-3.0),
             sleep_patch,
         ):
             result = await check_calibration(mock_self, "climate.trv1", 2)

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -768,9 +768,10 @@ class TestInitializeTrvCurrentTemperature:
 
     async def _run(self, bt):
         with (
-            patch("custom_components.better_thermostat.climate.init", AsyncMock()),
+            patch("custom_components.better_thermostat.climate.init", autospec=True),
             patch(
-                "custom_components.better_thermostat.climate.initial_tweak", AsyncMock()
+                "custom_components.better_thermostat.climate.initial_tweak",
+                autospec=True,
             ),
             patch(
                 "custom_components.better_thermostat.climate.control_trv",

--- a/tests/unit/test_config_flow_options_model.py
+++ b/tests/unit/test_config_flow_options_model.py
@@ -105,7 +105,8 @@ async def test_options_flow_swap_to_generic_thermostat_resolves_generic_model():
         patch_dr,
         patch(
             "custom_components.better_thermostat.config_flow.load_adapter",
-            AsyncMock(return_value=_make_adapter()),
+            autospec=True,
+            return_value=_make_adapter(),
         ),
     ):
         result = await flow.async_step_user(_submission())
@@ -128,7 +129,8 @@ async def test_config_flow_swap_to_generic_thermostat_resolves_generic_model():
         patch_dr,
         patch(
             "custom_components.better_thermostat.config_flow.load_adapter",
-            AsyncMock(return_value=_make_adapter()),
+            autospec=True,
+            return_value=_make_adapter(),
         ),
     ):
         result = await flow.async_step_user(_submission())

--- a/tests/unit/test_mock_discipline.py
+++ b/tests/unit/test_mock_discipline.py
@@ -13,12 +13,12 @@ Independent hazards live at this seam, and they need different answers:
   ``return_value=`` given at the call, so a callback that falls off its
   end takes the stated answer back and hands the shell ``None``.
 
-Both halves are derived rather than listed: the seam comes from the
+Both halves are derived rather than listed. The seam comes from the
 production modules, so a new delegate or quirk function is covered the
-day it is written, and the patch spellings come from the module's own
-imports, so an alias or a ``patch.object`` cannot slip past. The one
-spelling this cannot read, ``patch.multiple``, is rejected outright
-instead of being passed over.
+day it is written. The patch spellings are matched on the dotted call
+itself and on the module's own import names, so neither an alias nor a
+``mock.patch.object`` can slip past. The one spelling this cannot read,
+``patch.multiple``, is rejected outright instead of being passed over.
 """
 
 from __future__ import annotations
@@ -75,6 +75,7 @@ class PatchSite(NamedTuple):
     keywords: dict[str, ast.expr]
     positional_new: bool
     async_defs: dict[str, list[ast.AsyncFunctionDef]]
+    scoped_async_defs: dict[tuple[int, str], list[ast.AsyncFunctionDef]]
     bound_name: str | None
     late_side_effects: dict[tuple[int, str], list[str]]
     scope: int
@@ -141,6 +142,17 @@ def _patch_aliases(tree: ast.Module) -> set[str]:
     return aliases
 
 
+def _names_patch(expression: str, aliases: set[str]) -> bool:
+    """Whether a dotted expression names ``unittest.mock.patch``.
+
+    Either it is one of the module's own names for it, or it ends in
+    ``.patch`` — which covers ``mock.patch``, ``unittest.mock.patch``
+    and any other spelling of the module, without the rule having to
+    resolve every import form.
+    """
+    return expression in aliases or expression.rpartition(".")[2] == "patch"
+
+
 def _patch_form(node: ast.Call, aliases: set[str]) -> str | None:
     """Which ``patch`` spelling a call uses, or ``None`` if it is not one.
 
@@ -148,15 +160,25 @@ def _patch_form(node: ast.Call, aliases: set[str]) -> str | None:
     where the target is the first argument. ``object`` covers
     ``patch.object(obj, "name")``, where it is the second. ``multiple``
     covers ``patch.multiple(obj, name=…)``, where the targets are the
-    keywords.
+    keywords. Each is recognised however the module reaches ``patch``,
+    so ``mock.patch.object`` counts the same as ``patch.object``.
     """
     func = node.func
     if isinstance(func, ast.Attribute):
-        owner = func.value.id if isinstance(func.value, ast.Name) else None
-        if func.attr in ("object", "multiple") and owner in aliases:
-            return func.attr
-        return "plain" if func.attr == "patch" else None
-    return "plain" if getattr(func, "id", None) in aliases else None
+        tail = func.attr
+    elif isinstance(func, ast.Name):
+        tail = func.id
+    else:
+        return None
+    # Cheap gate: every spelling ends in one of these, and unparsing the
+    # rest of a large test file's call nodes is not worth the certainty.
+    if tail not in ("patch", "object", "multiple") and tail not in aliases:
+        return None
+    source = ast.unparse(func)
+    head, _, last = source.rpartition(".")
+    if last in ("object", "multiple") and head and _names_patch(head, aliases):
+        return last
+    return "plain" if _names_patch(source, aliases) else None
 
 
 def _bound_names(tree: ast.Module) -> dict[int, str]:
@@ -240,9 +262,12 @@ def _iter_patch_sites() -> Iterator[PatchSite]:
         scopes = _scopes(tree)
         late = _late_side_effects(tree, scopes)
         async_defs: dict[str, list[ast.AsyncFunctionDef]] = {}
+        scoped_async_defs: dict[tuple[int, str], list[ast.AsyncFunctionDef]] = {}
         for node in ast.walk(tree):
             if isinstance(node, ast.AsyncFunctionDef):
                 async_defs.setdefault(node.name, []).append(node)
+                key = (scopes.get(id(node), 0), node.name)
+                scoped_async_defs.setdefault(key, []).append(node)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -265,6 +290,7 @@ def _iter_patch_sites() -> Iterator[PatchSite]:
                 keywords={kw.arg: kw.value for kw in node.keywords if kw.arg},
                 positional_new=len(node.args) > target_index + 1,
                 async_defs=async_defs,
+                scoped_async_defs=scoped_async_defs,
                 bound_name=bound.get(id(node)),
                 late_side_effects=late,
                 scope=scopes.get(id(node), 0),
@@ -353,7 +379,11 @@ def _late_side_effects_without_an_answer(site: PatchSite) -> list[str]:
         return []
     silent: list[str] = []
     for callback in site.late_side_effects.get((site.scope, site.bound_name), []):
-        definitions = site.async_defs.get(callback)
+        # The callback belonging to *this* test, not a same-named one from
+        # a neighbouring test that happens to answer.
+        definitions = site.scoped_async_defs.get(
+            (site.scope, callback)
+        ) or site.async_defs.get(callback)
         if definitions and not any(_returns_a_value(d) for d in definitions):
             silent.append(callback)
     return silent

--- a/tests/unit/test_mock_discipline.py
+++ b/tests/unit/test_mock_discipline.py
@@ -212,8 +212,10 @@ def _scopes(tree: ast.Module) -> dict[int, int]:
             owner[id(child)] = current
             descend(child, inner)
 
-    owner[id(tree)] = id(tree)
-    descend(tree, id(tree))
+    # Module scope is 0 rather than the tree's own id, so a lookup for a
+    # module-level definition needs no second handle on the tree.
+    owner[id(tree)] = 0
+    descend(tree, 0)
     return owner
 
 
@@ -379,11 +381,12 @@ def _late_side_effects_without_an_answer(site: PatchSite) -> list[str]:
         return []
     silent: list[str] = []
     for callback in site.late_side_effects.get((site.scope, site.bound_name), []):
-        # The callback belonging to *this* test, not a same-named one from
-        # a neighbouring test that happens to answer.
+        # The callback belonging to *this* test, or — when the test assigns
+        # one defined at module level — that one. Never the file-wide index:
+        # a same-named callback in a neighbouring test would answer for it.
         definitions = site.scoped_async_defs.get(
             (site.scope, callback)
-        ) or site.async_defs.get(callback)
+        ) or site.scoped_async_defs.get((0, callback))
         if definitions and not any(_returns_a_value(d) for d in definitions):
             silent.append(callback)
     return silent

--- a/tests/unit/test_mock_discipline.py
+++ b/tests/unit/test_mock_discipline.py
@@ -1,0 +1,229 @@
+"""The adapter seam is mocked under the contract it replaces.
+
+Two independent hazards live at this seam, and they need two different
+answers:
+
+* A ``patch()`` without ``autospec`` accepts any call signature, so a
+  shell call that drifts out of shape stays green. ``autospec=True``
+  makes the mock reject it.
+* An autospec mock still answers with a truthy mock. Where the shell
+  reads the answer — "the write went out" against "this device has no
+  such channel" — that turns a refused write into a completed one. Only
+  an explicit ``return_value`` or ``side_effect`` fixes it.
+
+The seam is derived from the production modules rather than listed here,
+so a new delegate or quirk function is covered the day it is written.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterator
+import inspect
+from pathlib import Path
+from types import ModuleType
+from typing import NamedTuple
+
+from custom_components.better_thermostat.adapters import delegate
+from custom_components.better_thermostat.model_fixes import default as default_quirk
+
+TESTS_ROOT = Path(__file__).resolve().parent.parent
+
+# Functions whose answer the shell branches on. A truthy mock here does
+# not merely blur a value, it selects the wrong path: the offset and
+# valve channels take an accepted write to mean a command is in flight,
+# and a quirk override reporting True suppresses the direct write that
+# would otherwise follow.
+ANSWER_IS_READ = frozenset(
+    {
+        "set_offset",
+        "set_valve",
+        "override_set_hvac_mode",
+        "override_set_temperature",
+        "override_set_valve",
+        "get_current_offset",
+    }
+)
+
+
+def _async_surface(module: ModuleType) -> set[str]:
+    """Public coroutine functions the module itself defines."""
+    return {
+        name
+        for name, obj in vars(module).items()
+        if not name.startswith("_")
+        and inspect.iscoroutinefunction(obj)
+        and getattr(obj, "__module__", None) == module.__name__
+    }
+
+
+SEAM = _async_surface(delegate) | _async_surface(default_quirk)
+
+
+class PatchSite(NamedTuple):
+    """One ``patch()`` call aimed at the adapter seam."""
+
+    path: Path
+    lineno: int
+    symbol: str
+    keywords: dict[str, ast.expr]
+    positional_new: bool
+    async_defs: dict[str, list[ast.AsyncFunctionDef]]
+
+    def __str__(self) -> str:
+        rel = self.path.relative_to(TESTS_ROOT.parent)
+        return f"{rel}:{self.lineno} patches {self.symbol}"
+
+
+def _dict_constants(tree: ast.Module) -> dict[tuple[str, str], str]:
+    """Module-level ``{"name": "target"}`` tables, keyed by (dict, key).
+
+    The controlling tests keep their patch targets in such a table and
+    subscript it at the call, so the target is not a literal there.
+    """
+    found: dict[tuple[str, str], str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Dict):
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        for key, value in zip(node.value.keys, node.value.values, strict=True):
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                found[(target.id, key.value)] = ast.unparse(value)
+    return found
+
+
+def _patch_target(arg: ast.expr, constants: dict[tuple[str, str], str]) -> str:
+    """Source form of a patch target, resolved through a lookup table."""
+    if isinstance(arg, ast.Constant):
+        return str(arg.value)
+    if (
+        isinstance(arg, ast.Subscript)
+        and isinstance(arg.value, ast.Name)
+        and isinstance(arg.slice, ast.Constant)
+        and isinstance(arg.slice.value, str)
+    ):
+        return constants.get((arg.value.id, arg.slice.value), ast.unparse(arg))
+    return ast.unparse(arg)
+
+
+def _patched_symbol(target: str) -> str:
+    """Last dotted segment of a target, past any f-string prefix."""
+    return target.rstrip("'\"").split(".")[-1].split("}")[-1]
+
+
+def _iter_patch_sites() -> Iterator[PatchSite]:
+    """Every ``patch()`` under tests/ that aims at the seam."""
+    for path in sorted(TESTS_ROOT.rglob("*.py")):
+        source = path.read_text()
+        if "patch(" not in source:
+            continue
+        tree = ast.parse(source)
+        constants = _dict_constants(tree)
+        async_defs: dict[str, list[ast.AsyncFunctionDef]] = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef):
+                async_defs.setdefault(node.name, []).append(node)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not node.args:
+                continue
+            func = node.func
+            name = (
+                func.attr
+                if isinstance(func, ast.Attribute)
+                else getattr(func, "id", None)
+            )
+            if name != "patch":
+                continue
+            symbol = _patched_symbol(_patch_target(node.args[0], constants))
+            if symbol not in SEAM:
+                continue
+            yield PatchSite(
+                path=path,
+                lineno=node.lineno,
+                symbol=symbol,
+                keywords={kw.arg: kw.value for kw in node.keywords if kw.arg},
+                positional_new=len(node.args) > 1,
+                async_defs=async_defs,
+            )
+
+
+def _substitute_enforces_the_signature(site: PatchSite) -> bool:
+    """Whether the replacement rejects a call of the wrong shape.
+
+    ``autospec=True`` does it by copying the signature. A hand-written
+    ``async def`` standing in for the function does it too — Python
+    itself binds the arguments — as long as it spells its parameters out
+    instead of swallowing them into ``*args``.
+    """
+    autospec = site.keywords.get("autospec")
+    if isinstance(autospec, ast.Constant) and autospec.value is True:
+        return True
+    new = site.keywords.get("new")
+    if not isinstance(new, ast.Name):
+        return False
+    definitions = site.async_defs.get(new.id)
+    if not definitions:
+        return False
+    return all(
+        d.args.vararg is None and d.args.kwarg is None and d.args.args
+        for d in definitions
+    )
+
+
+def _substitute_states_its_answer(site: PatchSite) -> bool:
+    """Whether the replacement answers something other than a mock."""
+    if {"return_value", "side_effect"} & site.keywords.keys():
+        return True
+    new = site.keywords.get("new")
+    return isinstance(new, ast.Name) and new.id in site.async_defs
+
+
+def test_the_seam_is_reachable_from_here():
+    """The derivation finds both halves of the seam and its patch sites.
+
+    A typo in a module path would empty ``SEAM`` and pass every other
+    test in this file without checking anything.
+    """
+    assert {"set_offset", "set_valve", "get_current_offset"} <= SEAM
+    assert {"override_set_hvac_mode", "override_set_temperature"} <= SEAM
+    assert len(list(_iter_patch_sites())) > 100
+
+
+def test_every_symbol_whose_answer_is_read_is_part_of_the_seam():
+    """The branching list names functions that still exist.
+
+    Renaming one in production would otherwise drop it out of the rule
+    silently instead of failing here.
+    """
+    assert ANSWER_IS_READ <= SEAM
+
+
+def test_no_seam_patch_leaves_the_signature_unchecked():
+    """Every stand-in rejects a call the real function would reject."""
+    offenders = [
+        f"{site} without autospec=True"
+        for site in _iter_patch_sites()
+        if site.positional_new or not _substitute_enforces_the_signature(site)
+    ]
+    assert not offenders, "unspecced patches of the adapter seam:\n" + "\n".join(
+        offenders
+    )
+
+
+def test_no_seam_patch_answers_with_a_bare_mock_where_the_shell_reads_it():
+    """Every stand-in the shell interrogates states its answer.
+
+    Without it the mock answers with a truthy mock, and the path taken
+    for "the write went out" also runs for a device that has no such
+    channel.
+    """
+    offenders = [
+        f"{site} without return_value= or side_effect="
+        for site in _iter_patch_sites()
+        if site.symbol in ANSWER_IS_READ and not _substitute_states_its_answer(site)
+    ]
+    assert not offenders, "adapter-seam patches with an unstated answer:\n" + "\n".join(
+        offenders
+    )

--- a/tests/unit/test_mock_discipline.py
+++ b/tests/unit/test_mock_discipline.py
@@ -1,7 +1,6 @@
 """The adapter seam is mocked under the contract it replaces.
 
-Two independent hazards live at this seam, and they need two different
-answers:
+Independent hazards live at this seam, and they need different answers:
 
 * A ``patch()`` without ``autospec`` accepts any call signature, so a
   shell call that drifts out of shape stays green. ``autospec=True``
@@ -10,9 +9,16 @@ answers:
   reads the answer — "the write went out" against "this device has no
   such channel" — that turns a refused write into a completed one. Only
   an explicit ``return_value`` or ``side_effect`` fixes it.
+* A ``side_effect`` assigned onto the mock afterwards wins over the
+  ``return_value=`` given at the call, so a callback that falls off its
+  end takes the stated answer back and hands the shell ``None``.
 
-The seam is derived from the production modules rather than listed here,
-so a new delegate or quirk function is covered the day it is written.
+Both halves are derived rather than listed: the seam comes from the
+production modules, so a new delegate or quirk function is covered the
+day it is written, and the patch spellings come from the module's own
+imports, so an alias or a ``patch.object`` cannot slip past. The one
+spelling this cannot read, ``patch.multiple``, is rejected outright
+instead of being passed over.
 """
 
 from __future__ import annotations
@@ -69,6 +75,9 @@ class PatchSite(NamedTuple):
     keywords: dict[str, ast.expr]
     positional_new: bool
     async_defs: dict[str, list[ast.AsyncFunctionDef]]
+    bound_name: str | None
+    late_side_effects: dict[tuple[int, str], list[str]]
+    scope: int
 
     def __str__(self) -> str:
         rel = self.path.relative_to(TESTS_ROOT.parent)
@@ -113,30 +122,140 @@ def _patched_symbol(target: str) -> str:
     return target.rstrip("'\"").split(".")[-1].split("}")[-1]
 
 
+def _patch_aliases(tree: ast.Module) -> set[str]:
+    """Names under which ``unittest.mock.patch`` is callable in a module.
+
+    A rule keyed on the spelling ``patch`` would step aside for
+    ``from unittest.mock import patch as mock_patch``, so the names are
+    read off the imports instead of assumed.
+    """
+    aliases = {"patch"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in (
+            "unittest.mock",
+            "mock",
+        ):
+            for imported in node.names:
+                if imported.name == "patch":
+                    aliases.add(imported.asname or imported.name)
+    return aliases
+
+
+def _patch_form(node: ast.Call, aliases: set[str]) -> str | None:
+    """Which ``patch`` spelling a call uses, or ``None`` if it is not one.
+
+    ``plain`` covers ``patch("a.b.c")`` and ``mock.patch("a.b.c")``,
+    where the target is the first argument. ``object`` covers
+    ``patch.object(obj, "name")``, where it is the second. ``multiple``
+    covers ``patch.multiple(obj, name=…)``, where the targets are the
+    keywords.
+    """
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        owner = func.value.id if isinstance(func.value, ast.Name) else None
+        if func.attr in ("object", "multiple") and owner in aliases:
+            return func.attr
+        return "plain" if func.attr == "patch" else None
+    return "plain" if getattr(func, "id", None) in aliases else None
+
+
+def _bound_names(tree: ast.Module) -> dict[int, str]:
+    """The ``as`` name of each ``with patch(…) as name`` call, by node id."""
+    bound: dict[int, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.With, ast.AsyncWith)):
+            continue
+        for item in node.items:
+            if isinstance(item.optional_vars, ast.Name):
+                bound[id(item.context_expr)] = item.optional_vars.id
+    return bound
+
+
+def _scopes(tree: ast.Module) -> dict[int, int]:
+    """Map every node to the ``id`` of the function that encloses it.
+
+    A module reuses one mock name across many tests, so a rule keyed on
+    the name alone would report every test in the file for one offending
+    assignment. The enclosing function is the scope that matters.
+    """
+    owner: dict[int, int] = {}
+
+    def descend(node: ast.AST, current: int) -> None:
+        for child in ast.iter_child_nodes(node):
+            inner = (
+                id(child)
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+                else current
+            )
+            owner[id(child)] = current
+            descend(child, inner)
+
+    owner[id(tree)] = id(tree)
+    descend(tree, id(tree))
+    return owner
+
+
+def _late_side_effects(
+    tree: ast.Module, scopes: dict[int, int]
+) -> dict[tuple[int, str], list[str]]:
+    """``mock.side_effect = callback`` assignments, by (scope, mock name).
+
+    An assignment made after the ``patch()`` call overrides whatever
+    ``return_value=`` the call declared, so a rule reading only the call
+    keywords would accept an answer the test then throws away. Every
+    callback assigned to a name is kept: checking only the last would
+    let the earlier ones through.
+    """
+    late: dict[tuple[int, str], list[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Name):
+            continue
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and target.attr == "side_effect"
+                and isinstance(target.value, ast.Name)
+            ):
+                key = (scopes.get(id(node), 0), target.value.id)
+                late.setdefault(key, []).append(node.value.id)
+    return late
+
+
 def _iter_patch_sites() -> Iterator[PatchSite]:
-    """Every ``patch()`` under tests/ that aims at the seam."""
+    """Every ``patch()`` or ``patch.object()`` under tests/ that aims at the seam.
+
+    ``patch.multiple`` is deliberately absent: its replacements are the
+    keyword values, so neither rule below can read them.
+    ``test_no_seam_patch_hides_in_an_unsupported_form`` rejects that
+    spelling outright rather than letting it pass unexamined.
+    """
     for path in sorted(TESTS_ROOT.rglob("*.py")):
         source = path.read_text()
-        if "patch(" not in source:
+        if "patch" not in source:
             continue
         tree = ast.parse(source)
+        aliases = _patch_aliases(tree)
         constants = _dict_constants(tree)
+        bound = _bound_names(tree)
+        scopes = _scopes(tree)
+        late = _late_side_effects(tree, scopes)
         async_defs: dict[str, list[ast.AsyncFunctionDef]] = {}
         for node in ast.walk(tree):
             if isinstance(node, ast.AsyncFunctionDef):
                 async_defs.setdefault(node.name, []).append(node)
         for node in ast.walk(tree):
-            if not isinstance(node, ast.Call) or not node.args:
+            if not isinstance(node, ast.Call):
                 continue
-            func = node.func
-            name = (
-                func.attr
-                if isinstance(func, ast.Attribute)
-                else getattr(func, "id", None)
-            )
-            if name != "patch":
+            form = _patch_form(node, aliases)
+            if form == "plain":
+                target_index = 0
+            elif form == "object":
+                target_index = 1
+            else:
                 continue
-            symbol = _patched_symbol(_patch_target(node.args[0], constants))
+            if len(node.args) <= target_index:
+                continue
+            symbol = _patched_symbol(_patch_target(node.args[target_index], constants))
             if symbol not in SEAM:
                 continue
             yield PatchSite(
@@ -144,9 +263,31 @@ def _iter_patch_sites() -> Iterator[PatchSite]:
                 lineno=node.lineno,
                 symbol=symbol,
                 keywords={kw.arg: kw.value for kw in node.keywords if kw.arg},
-                positional_new=len(node.args) > 1,
+                positional_new=len(node.args) > target_index + 1,
                 async_defs=async_defs,
+                bound_name=bound.get(id(node)),
+                late_side_effects=late,
+                scope=scopes.get(id(node), 0),
             )
+
+
+def _iter_multiple_sites() -> Iterator[str]:
+    """Every ``patch.multiple`` under tests/ that names a seam symbol."""
+    for path in sorted(TESTS_ROOT.rglob("*.py")):
+        source = path.read_text()
+        if "multiple" not in source:
+            continue
+        tree = ast.parse(source)
+        aliases = _patch_aliases(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if _patch_form(node, aliases) != "multiple":
+                continue
+            for keyword in node.keywords:
+                if keyword.arg in SEAM:
+                    rel = path.relative_to(TESTS_ROOT.parent)
+                    yield f"{rel}:{node.lineno} patches {keyword.arg}"
 
 
 def _substitute_enforces_the_signature(site: PatchSite) -> bool:
@@ -178,6 +319,44 @@ def _substitute_states_its_answer(site: PatchSite) -> bool:
         return True
     new = site.keywords.get("new")
     return isinstance(new, ast.Name) and new.id in site.async_defs
+
+
+def _returns_a_value(definition: ast.AsyncFunctionDef) -> bool:
+    """Whether a coroutine ever hands back something other than ``None``.
+
+    Returns inside a nested function belong to that function, not to
+    this one, so they do not count.
+    """
+    nested = {
+        id(inner)
+        for node in ast.walk(definition)
+        if node is not definition
+        and isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda))
+        for inner in ast.walk(node)
+    }
+    return any(
+        isinstance(node, ast.Return)
+        and node.value is not None
+        and id(node) not in nested
+        for node in ast.walk(definition)
+    )
+
+
+def _late_side_effects_without_an_answer(site: PatchSite) -> list[str]:
+    """Callbacks assigned onto this mock that fall off their end.
+
+    ``mock.side_effect = callback`` wins over the ``return_value=`` given
+    at the patch call, and a coroutine without a ``return`` answers
+    ``None`` — which the shell reads as a refused write.
+    """
+    if site.bound_name is None:
+        return []
+    silent: list[str] = []
+    for callback in site.late_side_effects.get((site.scope, site.bound_name), []):
+        definitions = site.async_defs.get(callback)
+        if definitions and not any(_returns_a_value(d) for d in definitions):
+            silent.append(callback)
+    return silent
 
 
 def test_the_seam_is_reachable_from_here():
@@ -226,4 +405,40 @@ def test_no_seam_patch_answers_with_a_bare_mock_where_the_shell_reads_it():
     ]
     assert not offenders, "adapter-seam patches with an unstated answer:\n" + "\n".join(
         offenders
+    )
+
+
+def test_no_late_side_effect_takes_the_answer_back():
+    """A callback assigned after the patch call still has to answer.
+
+    ``patch(…, return_value=True)`` followed by ``mock.side_effect = cb``
+    reads as if the answer were stated, but ``side_effect`` wins and a
+    coroutine that falls off its end answers ``None``. The shell then
+    runs its refused-write path while the test believes it is watching
+    the accepted one.
+    """
+    offenders = [
+        f"{site} then {callback}() overrides the answer with None"
+        for site in _iter_patch_sites()
+        if site.symbol in ANSWER_IS_READ
+        for callback in _late_side_effects_without_an_answer(site)
+    ]
+    assert not offenders, (
+        "adapter-seam mocks whose answer is taken back:\n" + "\n".join(offenders)
+    )
+
+
+def test_no_seam_patch_hides_in_an_unsupported_form():
+    """``patch.multiple`` may not stand in for a seam function.
+
+    Its replacements are the keyword values, so the two rules above
+    cannot read a signature or an answer off them. Rejecting the
+    spelling keeps the guard sound; the alternative — passing it over
+    quietly — is what a rule aimed only at ``patch(…)`` already did.
+    """
+    offenders = list(_iter_multiple_sites())
+    assert not offenders, (
+        "seam functions patched through patch.multiple, which this rule "
+        "cannot inspect — use patch() or patch.object() instead:\n"
+        + "\n".join(offenders)
     )

--- a/tests/unit/test_per_trv_target_temp_step.py
+++ b/tests/unit/test_per_trv_target_temp_step.py
@@ -107,8 +107,10 @@ async def _run_startup(bt, trv_state):
     )
     bt.hass.states.get.return_value = trv_state
     with (
-        patch("custom_components.better_thermostat.climate.init", AsyncMock()),
-        patch("custom_components.better_thermostat.climate.initial_tweak", AsyncMock()),
+        patch("custom_components.better_thermostat.climate.init", autospec=True),
+        patch(
+            "custom_components.better_thermostat.climate.initial_tweak", autospec=True
+        ),
         patch(
             "custom_components.better_thermostat.climate.control_trv",
             AsyncMock(return_value=True),

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -324,9 +324,9 @@ async def _run_setpoint_cycle(bt, target):
     """Run one control_trv cycle that wants ``target`` written."""
     with (
         patch(f"{_CTRL}.convert_outbound_states") as conv,
-        patch(f"{_CTRL}.set_temperature", new=AsyncMock()) as set_temp,
-        patch(f"{_CTRL}.set_hvac_mode", new=AsyncMock()),
-        patch(f"{_CTRL}.override_set_hvac_mode", new=AsyncMock(return_value=False)),
+        patch(f"{_CTRL}.set_temperature", autospec=True) as set_temp,
+        patch(f"{_CTRL}.set_hvac_mode", autospec=True),
+        patch(f"{_CTRL}.override_set_hvac_mode", autospec=True, return_value=False),
         patch("asyncio.sleep", new=AsyncMock()),
     ):
         conv.return_value = {"temperature": target, "system_mode": HVACMode.HEAT}
@@ -407,9 +407,9 @@ class TestWatchdogHeartbeat:
     async def _run_setpoint(self, bt, target):
         with (
             patch(f"{_CTRL}.convert_outbound_states") as conv,
-            patch(f"{_CTRL}.set_temperature", new=AsyncMock()) as set_temp,
-            patch(f"{_CTRL}.set_hvac_mode", new=AsyncMock()),
-            patch(f"{_CTRL}.override_set_hvac_mode", new=AsyncMock(return_value=False)),
+            patch(f"{_CTRL}.set_temperature", autospec=True) as set_temp,
+            patch(f"{_CTRL}.set_hvac_mode", autospec=True),
+            patch(f"{_CTRL}.override_set_hvac_mode", autospec=True, return_value=False),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             conv.return_value = {"temperature": target, "system_mode": HVACMode.HEAT}
@@ -439,9 +439,9 @@ class TestWatchdogHeartbeat:
         with (
             patch(f"{_CTRL}.convert_outbound_states") as conv,
             patch(f"{_CTRL}._get_valve_control", return_value=(None, None)),
-            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=None)),
-            patch(f"{_CTRL}.set_hvac_mode", new=AsyncMock()),
-            patch(f"{_CTRL}.override_set_hvac_mode", new=AsyncMock(return_value=False)),
+            patch(f"{_CTRL}.get_current_offset", autospec=True, return_value=None),
+            patch(f"{_CTRL}.set_hvac_mode", autospec=True),
+            patch(f"{_CTRL}.override_set_hvac_mode", autospec=True, return_value=False),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             conv.return_value = {
@@ -459,9 +459,9 @@ class TestWriteBudget:
     async def _run(self, bt, target):
         with (
             patch(f"{_CTRL}.convert_outbound_states") as conv,
-            patch(f"{_CTRL}.set_temperature", new=AsyncMock()) as set_temp,
-            patch(f"{_CTRL}.set_hvac_mode", new=AsyncMock()),
-            patch(f"{_CTRL}.override_set_hvac_mode", new=AsyncMock(return_value=False)),
+            patch(f"{_CTRL}.set_temperature", autospec=True) as set_temp,
+            patch(f"{_CTRL}.set_hvac_mode", autospec=True),
+            patch(f"{_CTRL}.override_set_hvac_mode", autospec=True, return_value=False),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             conv.return_value = {"temperature": target, "system_mode": HVACMode.HEAT}
@@ -529,10 +529,10 @@ class TestOffsetWriteBudget:
         with (
             patch(f"{_CTRL}.convert_outbound_states") as conv,
             patch(f"{_CTRL}._get_valve_control", return_value=(None, None)),
-            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=0.0)),
-            patch(f"{_CTRL}.set_offset", new=AsyncMock()) as set_off,
-            patch(f"{_CTRL}.set_hvac_mode", new=AsyncMock()),
-            patch(f"{_CTRL}.override_set_hvac_mode", new=AsyncMock(return_value=False)),
+            patch(f"{_CTRL}.get_current_offset", autospec=True, return_value=0.0),
+            patch(f"{_CTRL}.set_offset", autospec=True, return_value=True) as set_off,
+            patch(f"{_CTRL}.set_hvac_mode", autospec=True),
+            patch(f"{_CTRL}.override_set_hvac_mode", autospec=True, return_value=False),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             conv.return_value = {
@@ -592,9 +592,9 @@ class TestValveWriteBudget:
                 f"{_CTRL}._get_valve_control",
                 return_value=({"valve_percent": percent}, "test"),
             ),
-            patch(f"{_CTRL}.set_valve", new=AsyncMock(return_value=True)) as set_valve,
-            patch(f"{_CTRL}.set_hvac_mode", new=AsyncMock()),
-            patch(f"{_CTRL}.override_set_hvac_mode", new=AsyncMock(return_value=False)),
+            patch(f"{_CTRL}.set_valve", autospec=True, return_value=True) as set_valve,
+            patch(f"{_CTRL}.set_hvac_mode", autospec=True),
+            patch(f"{_CTRL}.override_set_hvac_mode", autospec=True, return_value=False),
             patch("asyncio.sleep", new=AsyncMock()),
         ):
             conv.return_value = {"system_mode": HVACMode.HEAT}
@@ -685,13 +685,13 @@ class TestOffsetReconcileHandoff:
         with (
             patch(f"{_CTRL}.convert_outbound_states") as conv,
             patch(f"{_CTRL}._get_valve_control", return_value=(None, None)),
-            patch(f"{_CTRL}.get_current_offset", new=AsyncMock(return_value=0.0)),
-            patch(f"{_CTRL}.set_offset", new=AsyncMock(return_value=True)) as set_off,
-            patch(f"{_CTRL}.set_temperature", new=AsyncMock()),
-            patch(f"{_CTRL}.set_hvac_mode", new=AsyncMock()),
-            patch(f"{_CTRL}.override_set_hvac_mode", new=AsyncMock(return_value=False)),
+            patch(f"{_CTRL}.get_current_offset", autospec=True, return_value=0.0),
+            patch(f"{_CTRL}.set_offset", autospec=True, return_value=True) as set_off,
+            patch(f"{_CTRL}.set_temperature", autospec=True),
+            patch(f"{_CTRL}.set_hvac_mode", autospec=True),
+            patch(f"{_CTRL}.override_set_hvac_mode", autospec=True, return_value=False),
             patch(
-                f"{_CTRL}.override_set_temperature", new=AsyncMock(return_value=False)
+                f"{_CTRL}.override_set_temperature", autospec=True, return_value=False
             ),
             patch("asyncio.sleep", new=AsyncMock()),
         ):

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -444,7 +444,7 @@ class TestInternalTemperatureChange:
         with (
             patch(
                 "custom_components.better_thermostat.events.trv.get_current_offset",
-                new_callable=AsyncMock,
+                autospec=True,
                 return_value=2.5,
             ) as mock_offset,
             patch(
@@ -481,6 +481,7 @@ class TestInternalTemperatureChange:
         with (
             patch(
                 "custom_components.better_thermostat.events.trv.get_current_offset",
+                autospec=True,
                 side_effect=pop_entry_and_return_offset,
             ),
             patch(


### PR DESCRIPTION
Mock discipline at the adapter seam, so that a shell call which drifts out of shape — or drops the answer a write channel gave it — stops being invisible to the suite.

## The gap, measured

Two independent hazards live at this seam, and they need two different answers:

* `patch()` without `autospec` accepts **any** call signature. Before this branch, **0 of 239** patches of a delegate or quirk function carried `autospec`.
* `autospec=True` settles the signature but **not** the answer — its `return_value` is still a truthy mock. Where the shell reads that answer, a refused write reads as a completed one.

Each row is one mutation of `utils/controlling.py`, run against the full suite:

| Mutation | before | after |
|---|---|---|
| extra argument to `set_hvac_mode` | 2 failed | 15 failed |
| extra argument to `set_valve` | **0 failed** | 10 failed |
| extra argument to `set_offset` | 12 failed | 20 failed |
| `set_valve`'s `False` discarded | **0 failed** | 1 failed |
| `set_offset`'s `False` discarded | 1 failed | 1 failed |

`set_valve` was blind on both axes: the shell could break the call *and* throw away the answer without a single one of 4526 tests noticing. That is the channel behind the valve-calibration issue cluster.

## What changed

Tests only; no production file is touched.

1. **`autospec=True` at all 239 seam patches** across six files. `functools.wraps` in `async_retry` lets autospec see the true signature through the decorator, and it composes with `return_value=` / `side_effect=`. Three sites that passed a `*args`-swallowing stand-in were converted to `autospec=True, side_effect=...`; three that pass a hand-written `async def` with a spelled-out parameter list were left as they are — Python binds those arguments itself.
2. **Contract return values** at the 33 patches whose answer the shell branches on: `set_offset`/`set_valve` → `True`, `override_set_*` → `False` (what `model_fixes/default.py` returns), `get_current_offset` → `0.0`.
3. **The valve channel's answer is now pinned.** A refused write leaves the budget slot stamped, so the cycle has to queue a catch-up or the valve keeps a position the device never took. Only the safety-reset call had a test for that; the main write had none.
4. **`tests/unit/test_mock_discipline.py`** keeps it that way. The seam is derived from `adapters/delegate.py` and `model_fixes/default.py` rather than listed, so a new function there is covered the day a test patches it. Removing an `autospec` or a `return_value` anywhere in `tests/` fails it with the offending `file:line`.

## Verification

- `uv run pytest tests/` — 4532 passed (baseline 4526 + 2 valve + 4 guard), no production diff.
- `uvx ruff@0.15.15 check tests/` and `format --check tests/` clean.
- The guard was itself mutation-tested: dropping one `autospec` and dropping one `return_value` each make it fail, naming the site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded valve-control coverage for retries, accepted and failed writes, safety resets, deferred updates, calibration, locking, and watchdog behavior.
  - Added checks for device-grid temperature snapping and offset convergence.
  - Strengthened mock validation to enforce accurate signatures, reachable integration points, and explicit configured results.
  - Updated startup, reconciliation, configuration, event, and calibration tests to reflect current synchronous and asynchronous behavior.
  - Improved test reliability by validating control flows and mocked interactions more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->