### PR TITLE
test: hold every adapter's write paths to one contract

### DIFF
--- a/custom_components/better_thermostat/adapters/delegate.py
+++ b/custom_components/better_thermostat/adapters/delegate.py
@@ -274,9 +274,19 @@ async def set_valve(self, entity_id, valve):
         valve_writable = (
             trv_state.valve_position_writable if trv_state is not None else None
         )
+        # The answer says a command went out, so it is tied to the adapter's
+        # own declaration rather than to the discovered entity: an ecosystem
+        # that declares no valve channel writes nothing, and reporting the
+        # discovery as a completed write would tell the caller a position was
+        # taken that the device never saw. An adapter without a declaration
+        # falls back to the discovered surface, as elsewhere.
+        declared = getattr(
+            trv_state.adapter if trv_state is not None else None, "CAPABILITIES", None
+        )
+        adapter_writes_valve = declared is None or declared.valve_write
 
         # Only write to a helper entity when we know it's writable.
-        if valve_entity and valve_writable is True:
+        if valve_entity and valve_writable is True and adapter_writes_valve:
             await self.real_trvs[entity_id].adapter.set_valve(
                 self, entity_id, target_pct
             )

--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -232,12 +232,14 @@ async def set_valve(self, entity_id, valve):
         return
 
     valve_entity_id = self.real_trvs[entity_id].valve_position_entity
-    if valve_entity_id is None:
+    if not valve_entity_id:
         return
 
     # Scale the 0-100 % request onto the number entity's own min/max/step,
     # clamping both the incoming percentage and the quantized result so a
     # rounding step or an out-of-range input never leaves the entity's bounds.
+    # The step grid starts at the entity's minimum rather than at zero, so a
+    # non-zero minimum still yields a value the entity itself offers.
     valve_entity = self.hass.states.get(valve_entity_id)
     if valve_entity is not None:
         min_valve = float(str(valve_entity.attributes.get("min", 0)))
@@ -246,7 +248,7 @@ async def set_valve(self, entity_id, valve):
         valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
         step = float(str(valve_entity.attributes.get("step", 1)))
         if step > 0:
-            valve = round(valve / step) * step
+            valve = min_valve + round((valve - min_valve) / step) * step
         valve = max(min_valve, min(max_valve, valve))
 
     await self.hass.services.async_call(

--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -231,19 +231,28 @@ async def set_valve(self, entity_id, valve):
         )
         return
 
-    # get min max from entity attributes
-    valve_entity = self.hass.states.get(self.real_trvs[entity_id].valve_position_entity)
+    valve_entity_id = self.real_trvs[entity_id].valve_position_entity
+    if valve_entity_id is None:
+        return
+
+    # Scale the 0-100 % request onto the number entity's own min/max/step,
+    # clamping both the incoming percentage and the quantized result so a
+    # rounding step or an out-of-range input never leaves the entity's bounds.
+    valve_entity = self.hass.states.get(valve_entity_id)
     if valve_entity is not None:
         min_valve = float(str(valve_entity.attributes.get("min", 0)))
         max_valve = float(str(valve_entity.attributes.get("max", 100)))
-        valve = min_valve + (valve / 100.0) * (max_valve - min_valve)
+        pct = max(0.0, min(100.0, valve))
+        valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
         step = float(str(valve_entity.attributes.get("step", 1)))
-        valve = round(valve / step) * step
+        if step > 0:
+            valve = round(valve / step) * step
+        valve = max(min_valve, min(max_valve, valve))
 
     await self.hass.services.async_call(
         "number",
         SERVICE_SET_VALUE,
-        {"entity_id": self.real_trvs[entity_id].valve_position_entity, "value": valve},
+        {"entity_id": valve_entity_id, "value": valve},
         blocking=True,
         context=self.context,
     )

--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -241,15 +241,24 @@ async def set_valve(self, entity_id, valve):
     # The step grid starts at the entity's minimum rather than at zero, so a
     # non-zero minimum still yields a value the entity itself offers.
     valve_entity = self.hass.states.get(valve_entity_id)
-    if valve_entity is not None:
-        min_valve = float(str(valve_entity.attributes.get("min", 0)))
-        max_valve = float(str(valve_entity.attributes.get("max", 100)))
-        pct = max(0.0, min(100.0, valve))
-        valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
-        step = float(str(valve_entity.attributes.get("step", 1)))
-        if step > 0:
-            valve = min_valve + round((valve - min_valve) / step) * step
-        valve = max(min_valve, min(max_valve, valve))
+    if valve_entity is None:
+        _LOGGER.debug(
+            "better_thermostat %s: valve entity %s for %s reports no state, "
+            "so its bounds are unknown, skip adapter write",
+            self.device_name,
+            valve_entity_id,
+            entity_id,
+        )
+        return
+
+    min_valve = float(str(valve_entity.attributes.get("min", 0)))
+    max_valve = float(str(valve_entity.attributes.get("max", 100)))
+    pct = max(0.0, min(100.0, valve))
+    valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
+    step = float(str(valve_entity.attributes.get("step", 1)))
+    if step > 0:
+        valve = min_valve + round((valve - min_valve) / step) * step
+    valve = max(min_valve, min(max_valve, valve))
 
     await self.hass.services.async_call(
         "number",

--- a/custom_components/better_thermostat/adapters/zwave_js.py
+++ b/custom_components/better_thermostat/adapters/zwave_js.py
@@ -249,12 +249,14 @@ async def set_valve(self, entity_id, valve):
         return
 
     valve_entity_id = self.real_trvs[entity_id].valve_position_entity
-    if valve_entity_id is None:
+    if not valve_entity_id:
         return
 
     # Scale the 0-100 % request onto the number entity's own min/max/step,
     # clamping both the incoming percentage and the quantized result so a
     # rounding step or an out-of-range input never leaves the entity's bounds.
+    # The step grid starts at the entity's minimum rather than at zero, so a
+    # non-zero minimum still yields a value the entity itself offers.
     valve_entity = self.hass.states.get(valve_entity_id)
     if valve_entity is not None:
         min_valve = float(str(valve_entity.attributes.get("min", 0)))
@@ -263,7 +265,7 @@ async def set_valve(self, entity_id, valve):
         valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
         step = float(str(valve_entity.attributes.get("step", 1)))
         if step > 0:
-            valve = round(valve / step) * step
+            valve = min_valve + round((valve - min_valve) / step) * step
         valve = max(min_valve, min(max_valve, valve))
 
     await self.hass.services.async_call(

--- a/custom_components/better_thermostat/adapters/zwave_js.py
+++ b/custom_components/better_thermostat/adapters/zwave_js.py
@@ -21,13 +21,17 @@ from ..utils.helpers import (
     find_valve_entity,
     get_device_model,
 )
-from .base import wait_for_calibration_entity_or_timeout
+from .base import AdapterCapabilities, wait_for_calibration_entity_or_timeout
 from .generic import (
     set_hvac_mode as generic_set_hvac_mode,
     set_temperature as generic_set_temperature,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Z-Wave JS: both channels ride on a discovered number entity, so each is
+# offered only for devices that expose one.
+CAPABILITIES = AdapterCapabilities(offset_write=True, valve_write=True)
 
 # Models whose valve is driven through a model quirk (Multilevel Switch command
 # class while in manufacturer-specific mode) rather than a writable number

--- a/custom_components/better_thermostat/adapters/zwave_js.py
+++ b/custom_components/better_thermostat/adapters/zwave_js.py
@@ -258,15 +258,24 @@ async def set_valve(self, entity_id, valve):
     # The step grid starts at the entity's minimum rather than at zero, so a
     # non-zero minimum still yields a value the entity itself offers.
     valve_entity = self.hass.states.get(valve_entity_id)
-    if valve_entity is not None:
-        min_valve = float(str(valve_entity.attributes.get("min", 0)))
-        max_valve = float(str(valve_entity.attributes.get("max", 100)))
-        pct = max(0.0, min(100.0, valve))
-        valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
-        step = float(str(valve_entity.attributes.get("step", 1)))
-        if step > 0:
-            valve = min_valve + round((valve - min_valve) / step) * step
-        valve = max(min_valve, min(max_valve, valve))
+    if valve_entity is None:
+        _LOGGER.debug(
+            "better_thermostat %s: valve entity %s for %s reports no state, "
+            "so its bounds are unknown, skip adapter write",
+            self.device_name,
+            valve_entity_id,
+            entity_id,
+        )
+        return
+
+    min_valve = float(str(valve_entity.attributes.get("min", 0)))
+    max_valve = float(str(valve_entity.attributes.get("max", 100)))
+    pct = max(0.0, min(100.0, valve))
+    valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
+    step = float(str(valve_entity.attributes.get("step", 1)))
+    if step > 0:
+        valve = min_valve + round((valve - min_valve) / step) * step
+    valve = max(min_valve, min(max_valve, valve))
 
     await self.hass.services.async_call(
         "number",

--- a/tests/unit/test_adapter_write_contract.py
+++ b/tests/unit/test_adapter_write_contract.py
@@ -1,0 +1,310 @@
+"""Every adapter's write paths answer to the same contract.
+
+Six modules implement the same write surface for six ecosystems, and the
+shell reaches them through a duck-typed dispatch that cannot check any of
+it. What holds them together is therefore written down here rather than
+in a base class:
+
+* an adapter's ``CAPABILITIES`` declaration is what the delegate keys the
+  valve channel on, so the declaration and the wire have to agree — an
+  ecosystem that declares no valve channel must not be reported as having
+  taken a position;
+* a valve write lands inside the bounds the number entity itself declares,
+  whatever step grid it publishes;
+* the setpoint and mode payloads carry the same domain, service and keys,
+  in the system's temperature unit.
+
+A new adapter is covered by all of it the moment it joins ``ADAPTERS``.
+
+What is deliberately not asserted here: that a write is skipped when the
+value has not changed. No adapter does that, and none should — the shell
+already decides it, once, for every ecosystem.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.adapters import (
+    deconz,
+    delegate,
+    generic,
+    mqtt,
+    tado,
+    zwave_js,
+)
+from custom_components.better_thermostat.trv import Trv
+
+ENTITY_ID = "climate.trv"
+VALVE_ENTITY = "number.trv_valve_position"
+
+ADAPTERS = {
+    "deconz": deconz,
+    "generic": generic,
+    "mqtt": mqtt,
+    "tado": tado,
+    "zwave_js": zwave_js,
+}
+ADAPTER_IDS = sorted(ADAPTERS)
+
+
+def _declares_valve_write(module):
+    """Whether the module's own declaration offers a valve channel.
+
+    Read through ``getattr`` so a module that declares nothing at all
+    fails the declaration test alone, instead of taking the rest of this
+    file down with an import-time error.
+    """
+    declared = getattr(module, "CAPABILITIES", None)
+    return declared is not None and declared.valve_write
+
+
+VALVE_ADAPTERS = sorted(
+    name for name, module in ADAPTERS.items() if _declares_valve_write(module)
+)
+NON_VALVE_ADAPTERS = sorted(set(ADAPTER_IDS) - set(VALVE_ADAPTERS))
+
+
+def _thermostat(
+    adapter=None,
+    valve_entity=VALVE_ENTITY,
+    valve_writable=True,
+    valve_bounds=(0.0, 100.0, 1.0),
+    unit=UnitOfTemperature.CELSIUS,
+):
+    """Build a thermostat whose service calls are recorded, not executed.
+
+    Parameters
+    ----------
+    adapter : module or None
+        Adapter module the TRV resolved to, for delegate-level calls.
+    valve_entity : str or None
+        Entity ID of the discovered valve number entity, or None to model
+        a TRV for which discovery found none.
+    valve_writable : bool or None
+        What discovery concluded about that entity.
+    valve_bounds : tuple of float
+        The ``min``, ``max`` and ``step`` the number entity publishes.
+    unit : UnitOfTemperature
+        The system's configured temperature unit.
+
+    Returns
+    -------
+    MagicMock
+        A stand-in for the Better Thermostat climate entity instance.
+    """
+    minimum, maximum, step = valve_bounds
+    thermostat = MagicMock()
+    thermostat.device_name = "Test BT"
+    thermostat.context = None
+    thermostat.hass = MagicMock()
+    thermostat.hass.services.async_call = AsyncMock()
+    thermostat.hass.config.units.temperature_unit = unit
+    thermostat.hass.states.get = lambda requested: (
+        State(VALVE_ENTITY, "0", {"min": minimum, "max": maximum, "step": step})
+        if requested == VALVE_ENTITY
+        else State(ENTITY_ID, "heat", {})
+    )
+    trv = Trv(entity_id=ENTITY_ID)
+    trv.valve_position_entity = valve_entity
+    trv.valve_position_writable = valve_writable
+    trv.adapter = adapter
+    # A quirk surface with no override, so the delegate reaches the adapter.
+    trv.model_quirks = MagicMock(spec=[])
+    thermostat.real_trvs = {ENTITY_ID: trv}
+    return thermostat
+
+
+def _calls(thermostat):
+    """Service calls the run recorded, as (domain, service, payload)."""
+    return [
+        (call.args[0], call.args[1], call.args[2])
+        for call in thermostat.hass.services.async_call.await_args_list
+    ]
+
+
+class TestTheDeclarationIsTheContract:
+    """The delegate keys the valve channel on what the adapter declares."""
+
+    @pytest.mark.parametrize("name", ADAPTER_IDS)
+    def test_every_adapter_declares_its_capabilities(self, name):
+        """The declaration exists, so the fallback stays a fallback."""
+        assert hasattr(ADAPTERS[name], "CAPABILITIES")
+
+    @pytest.mark.parametrize("name", NON_VALVE_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_an_undeclared_valve_channel_is_never_reported_as_written(self, name):
+        """No write goes out and none is claimed to have gone out.
+
+        Discovery can hand any adapter a valve entity; only the declaration
+        says whether the ecosystem can act on it.
+        """
+        thermostat = _thermostat(adapter=ADAPTERS[name])
+
+        answer = await delegate.set_valve(thermostat, ENTITY_ID, 50)
+
+        assert answer is False
+        assert _calls(thermostat) == []
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_a_declared_valve_channel_writes_and_says_so(self, name):
+        """The answer and the wire agree the other way round too."""
+        thermostat = _thermostat(adapter=ADAPTERS[name])
+
+        answer = await delegate.set_valve(thermostat, ENTITY_ID, 50)
+
+        assert answer is True
+        assert len(_calls(thermostat)) == 1
+
+    @pytest.mark.parametrize("name", ADAPTER_IDS)
+    @pytest.mark.parametrize(
+        ("valve_entity", "valve_writable"),
+        [(None, True), (VALVE_ENTITY, False), (VALVE_ENTITY, None)],
+    )
+    @pytest.mark.asyncio
+    async def test_an_unusable_valve_entity_is_never_reported_as_written(
+        self, name, valve_entity, valve_writable
+    ):
+        """A missing or read-only entity is no channel either."""
+        thermostat = _thermostat(
+            adapter=ADAPTERS[name],
+            valve_entity=valve_entity,
+            valve_writable=valve_writable,
+        )
+
+        answer = await delegate.set_valve(thermostat, ENTITY_ID, 50)
+
+        assert answer is False
+        assert _calls(thermostat) == []
+
+
+# Grids a number entity can publish, including the ones where the step does
+# not divide the range — quantizing there is what pushes a naive scale past
+# the declared maximum.
+VALVE_GRIDS = [
+    (0.0, 100.0, 1.0),
+    (0.0, 255.0, 1.0),
+    (0.0, 255.0, 10.0),
+    (0.0, 254.0, 5.0),
+    (0.0, 100.0, 3.0),
+    (5.0, 100.0, 1.0),
+    (0.0, 100.0, 0.0),
+]
+
+
+class TestTheValveWriteStaysInsideTheDeclaredBounds:
+    """What reaches the wire is a value the entity said it accepts."""
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.parametrize("grid", VALVE_GRIDS, ids=repr)
+    @pytest.mark.parametrize("percent", [0, 1, 50, 99, 100])
+    @pytest.mark.asyncio
+    async def test_a_scaled_request_lands_within_min_and_max(self, name, grid, percent):
+        """Scaling and quantizing never leave the entity's own range."""
+        minimum, maximum, _step = grid
+        thermostat = _thermostat(valve_bounds=grid)
+
+        await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, percent)
+
+        (_domain, _service, payload) = _calls(thermostat)[0]
+        assert minimum <= payload["value"] <= maximum
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.parametrize("percent", [-10, 150])
+    @pytest.mark.asyncio
+    async def test_a_request_outside_nought_to_hundred_is_clamped(self, name, percent):
+        """A percentage out of range is clamped, not scaled past the end."""
+        thermostat = _thermostat(valve_bounds=(0.0, 255.0, 1.0))
+
+        await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, percent)
+
+        (_domain, _service, payload) = _calls(thermostat)[0]
+        assert payload["value"] == (0.0 if percent < 0 else 255.0)
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_a_missing_valve_entity_writes_nothing(self, name):
+        """Without a discovered entity there is nothing to address."""
+        thermostat = _thermostat(valve_entity=None)
+
+        await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, 50)
+
+        assert _calls(thermostat) == []
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_a_read_only_valve_entity_writes_nothing(self, name):
+        """A read-only entity is refused at the adapter as well."""
+        thermostat = _thermostat(valve_writable=False)
+
+        await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, 50)
+
+        assert _calls(thermostat) == []
+
+
+class TestTheSetpointPayloadIsTheSameEverywhere:
+    """One setpoint call, one shape, whatever the ecosystem."""
+
+    @pytest.mark.parametrize("name", ADAPTER_IDS)
+    @pytest.mark.asyncio
+    async def test_the_setpoint_rides_on_the_climate_service(self, name):
+        """Domain, service and keys do not vary by adapter."""
+        thermostat = _thermostat()
+
+        await ADAPTERS[name].set_temperature(thermostat, ENTITY_ID, 21.5)
+
+        assert _calls(thermostat) == [
+            (
+                "climate",
+                "set_temperature",
+                {"entity_id": ENTITY_ID, "temperature": 21.5},
+            )
+        ]
+
+    @pytest.mark.parametrize("name", ADAPTER_IDS)
+    @pytest.mark.asyncio
+    async def test_the_setpoint_reaches_the_wire_in_the_system_unit(self, name):
+        """Better Thermostat holds Celsius; the payload carries the unit."""
+        thermostat = _thermostat(unit=UnitOfTemperature.FAHRENHEIT)
+
+        await ADAPTERS[name].set_temperature(thermostat, ENTITY_ID, 20.0)
+
+        (_domain, _service, payload) = _calls(thermostat)[0]
+        assert payload["temperature"] == 68.0
+
+
+class TestTheModePayloadIsTheSameEverywhere:
+    """One mode call, one shape, and a normalized mode in it."""
+
+    @pytest.mark.parametrize("name", ADAPTER_IDS)
+    @pytest.mark.asyncio
+    async def test_the_mode_rides_on_the_climate_service(self, name):
+        """Domain, service and keys do not vary by adapter."""
+        thermostat = _thermostat()
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await ADAPTERS[name].set_hvac_mode(thermostat, ENTITY_ID, HVACMode.HEAT)
+
+        assert _calls(thermostat) == [
+            (
+                "climate",
+                "set_hvac_mode",
+                {"entity_id": ENTITY_ID, "hvac_mode": HVACMode.HEAT},
+            )
+        ]
+
+    @pytest.mark.parametrize("name", ADAPTER_IDS)
+    @pytest.mark.asyncio
+    async def test_a_spelled_out_mode_reaches_the_device_normalized(self, name):
+        """The device is told an HVACMode, never an enum's repr."""
+        thermostat = _thermostat()
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await ADAPTERS[name].set_hvac_mode(thermostat, ENTITY_ID, "HVACMode.HEAT")
+
+        (_domain, _service, payload) = _calls(thermostat)[0]
+        assert payload["hvac_mode"] == HVACMode.HEAT

--- a/tests/unit/test_adapter_write_contract.py
+++ b/tests/unit/test_adapter_write_contract.py
@@ -103,11 +103,15 @@ def _thermostat(
     thermostat.hass = MagicMock()
     thermostat.hass.services.async_call = AsyncMock()
     thermostat.hass.config.units.temperature_unit = unit
-    thermostat.hass.states.get = lambda requested: (
-        State(VALVE_ENTITY, "0", {"min": minimum, "max": maximum, "step": step})
-        if requested == VALVE_ENTITY
-        else State(ENTITY_ID, "heat", {})
-    )
+    states = {
+        VALVE_ENTITY: State(
+            VALVE_ENTITY, "0", {"min": minimum, "max": maximum, "step": step}
+        ),
+        ENTITY_ID: State(ENTITY_ID, "heat", {}),
+    }
+    # Anything else is an entity the state machine does not know, which is
+    # what a stale discovery result looks like from in here.
+    thermostat.hass.states.get = states.get
     trv = Trv(entity_id=ENTITY_ID)
     trv.valve_position_entity = valve_entity
     trv.valve_position_writable = valve_writable
@@ -263,6 +267,21 @@ class TestTheValveWriteStaysInsideTheDeclaredBounds:
         address the empty string.
         """
         thermostat = _thermostat(valve_entity=valve_entity)
+
+        await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, 50)
+
+        assert _calls(thermostat) == []
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_a_valve_entity_without_a_state_writes_nothing(self, name):
+        """An entity that reports nothing declares no bounds either.
+
+        Discovery can outlive the entity it found. The bounds come from
+        the state, so without one there is no range to land the write in
+        and the percentage would go out unscaled.
+        """
+        thermostat = _thermostat(valve_entity="number.no_longer_there")
 
         await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, 50)
 

--- a/tests/unit/test_adapter_write_contract.py
+++ b/tests/unit/test_adapter_write_contract.py
@@ -193,6 +193,8 @@ VALVE_GRIDS = [
     (0.0, 100.0, 3.0),
     (5.0, 100.0, 1.0),
     (5.0, 100.0, 2.0),
+    # A grid whose maximum is on it too, so nothing there is exempt.
+    (0.25, 100.25, 0.5),
     (0.0, 100.0, 0.0),
 ]
 # The grids above that publish a step at all; the last one publishes none,

--- a/tests/unit/test_adapter_write_contract.py
+++ b/tests/unit/test_adapter_write_contract.py
@@ -82,8 +82,8 @@ def _thermostat(
     adapter : module or None
         Adapter module the TRV resolved to, for delegate-level calls.
     valve_entity : str or None
-        Entity ID of the discovered valve number entity, or None to model
-        a TRV for which discovery found none.
+        Entity ID of the discovered valve number entity, or None or the
+        empty string to model a TRV for which discovery found none.
     valve_writable : bool or None
         What discovery concluded about that entity.
     valve_bounds : tuple of float
@@ -192,8 +192,12 @@ VALVE_GRIDS = [
     (0.0, 254.0, 5.0),
     (0.0, 100.0, 3.0),
     (5.0, 100.0, 1.0),
+    (5.0, 100.0, 2.0),
     (0.0, 100.0, 0.0),
 ]
+# The grids above that publish a step at all; the last one publishes none,
+# so there is no grid to land on.
+STEPPED_GRIDS = [grid for grid in VALVE_GRIDS if grid[2] > 0]
 
 
 class TestTheValveWriteStaysInsideTheDeclaredBounds:
@@ -214,6 +218,27 @@ class TestTheValveWriteStaysInsideTheDeclaredBounds:
         assert minimum <= payload["value"] <= maximum
 
     @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.parametrize("grid", STEPPED_GRIDS, ids=repr)
+    @pytest.mark.parametrize("percent", [1, 50, 99])
+    @pytest.mark.asyncio
+    async def test_a_scaled_request_lands_on_the_published_step_grid(
+        self, name, grid, percent
+    ):
+        """A number entity offers ``min + n * step``, not ``n * step``.
+
+        The maximum is the one value off that grid the entity always
+        accepts, because clamping to it is what keeps the write in range.
+        """
+        minimum, maximum, step = grid
+        thermostat = _thermostat(valve_bounds=grid)
+
+        await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, percent)
+
+        (_domain, _service, payload) = _calls(thermostat)[0]
+        steps = (payload["value"] - minimum) / step
+        assert payload["value"] == maximum or steps == round(steps)
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
     @pytest.mark.parametrize("percent", [-10, 150])
     @pytest.mark.asyncio
     async def test_a_request_outside_nought_to_hundred_is_clamped(self, name, percent):
@@ -226,10 +251,16 @@ class TestTheValveWriteStaysInsideTheDeclaredBounds:
         assert payload["value"] == (0.0 if percent < 0 else 255.0)
 
     @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.parametrize("valve_entity", [None, ""], ids=["none", "empty"])
     @pytest.mark.asyncio
-    async def test_a_missing_valve_entity_writes_nothing(self, name):
-        """Without a discovered entity there is nothing to address."""
-        thermostat = _thermostat(valve_entity=None)
+    async def test_a_missing_valve_entity_writes_nothing(self, name, valve_entity):
+        """Without a discovered entity there is nothing to address.
+
+        Discovery spells absence two ways, and the delegate already reads
+        both as absent, so an adapter that only knows one of them would
+        address the empty string.
+        """
+        thermostat = _thermostat(valve_entity=valve_entity)
 
         await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, 50)
 


### PR DESCRIPTION
A contract test across all five adapters' write paths, plus the two defects writing it turned up.

## What the measurement found

Asking "what is the shared contract?" against the code rather than against the ticket:

| | finding | live? |
|---|---|---|
| ① | `mqtt.set_valve` leaves the entity's declared bounds on a legitimate 100 % request | **yes** |
| ② | `delegate.set_valve` reports a completed write for an ecosystem with no valve channel | no — latent |
| ③ | `zwave_js` is the only adapter without a `CAPABILITIES` declaration | no — cleanup |

**① is a real write failure.** Scaling a percentage onto the number entity's range and then quantizing to its step overshoots whenever the step does not divide the range. `zwave_js` clamps after quantizing; `mqtt` did not:

| min | max | step | pct | mqtt | zwave_js |
|---|---|---|---|---|---|
| 0 | 255 | 10 | 100 | **260.0** | 255.0 |
| 0 | 254 | 5 | 100 | **255.0** | 254.0 |

The entity rejects the value, so a boost on such a device never opens the valve. Two neighbouring divergences in the same function are fixed with it: a step of zero raised `ZeroDivisionError`, and a TRV without a discovered valve entity was addressed with `entity_id: None`.

**② is latent, not shipping.** `delegate.set_valve` derived its `True` from the *discovered surface* (`valve_position_entity and valve_position_writable`) instead of from the adapter's ability. `generic`, `deconz` and `tado` all declare `valve_write=False` and answered `True` with zero service calls. It cannot happen today — `valve_position_entity` is assigned in exactly two places, both in the `init` of `mqtt` and `zwave_js` — but any future adapter that discovers a valve entity without writing to one inherits the false claim, and the caller skips the catch-up cycle on the strength of it. The answer now follows `CAPABILITIES.valve_write`.

## Verification of the `delegate` change

`gitnexus_impact` rates `delegate.set_valve` **HIGH** (8 symbols, 4 execution flows), so the change is backed by a full behaviour matrix — 5 adapters × entity present/absent × writable true/false/unknown × quirk present/absent, 60 rows. Every row that answers `True` made exactly one service call, and every row that made none answers `False`. The two adapters that can reach the path, `mqtt` and `zwave_js`, behave identically to before.

## What the contract does *not* claim

Three of the assumptions this test was scoped from do not survive contact with the code, and the test says so rather than asserting them:

- **`set_temperature` and `set_hvac_mode` have no return contract.** Every adapter returns `None`, and no caller in `custom_components/` reads the value. A boolean there would be a change with no consumer. What they do share is the payload — domain, service, keys, and the Celsius→system-unit conversion — and that is what is pinned.
- **They are not six independent implementations.** `deconz`, `tado`, `zwave_js` and `mqtt` all call the `generic` functions for both. One implementation, reused.
- **"No write when the value is unchanged" is not an adapter contract.** No adapter does it and none should — the shell already decides it once for every ecosystem.

## Verification

- `uv run pytest tests/` — 4649 passed (baseline 4526 + 123 contract tests).
- Counter-proof over the reverted production diff: **15 failed / 69 passed**, every failure behavioural and traceable to one of ①②③.
- `uvx ruff@0.15.15 check` and `format --check` clean over `custom_components/` and `tests/`.

The ① fix also applies to `develop`; a twin PR follows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved valve control compatibility across supported thermostat adapters.
  * Prevented valve commands when no usable or writable valve is available.
  * Ensured valve percentages respect valid limits, device ranges, minimums, and increments.
  * Added valve and temperature-offset write support for Z-Wave JS devices.
  * Improved consistency of setpoint values, unit conversion, and HVAC mode handling.

* **Tests**
  * Added comprehensive coverage for adapter write behavior and boundary conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->