### PR TITLE
fix: keep the MQTT valve write inside the entity's declared bounds

### DIFF
--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -238,15 +238,24 @@ async def set_valve(self, entity_id, valve):
     # The step grid starts at the entity's minimum rather than at zero, so a
     # non-zero minimum still yields a value the entity itself offers.
     valve_entity = self.hass.states.get(valve_entity_id)
-    if valve_entity is not None:
-        min_valve = float(str(valve_entity.attributes.get("min", 0)))
-        max_valve = float(str(valve_entity.attributes.get("max", 100)))
-        pct = max(0.0, min(100.0, valve))
-        valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
-        step = float(str(valve_entity.attributes.get("step", 1)))
-        if step > 0:
-            valve = min_valve + round((valve - min_valve) / step) * step
-        valve = max(min_valve, min(max_valve, valve))
+    if valve_entity is None:
+        _LOGGER.debug(
+            "better_thermostat %s: valve entity %s for %s reports no state, "
+            "so its bounds are unknown, skip adapter write",
+            self.device_name,
+            valve_entity_id,
+            entity_id,
+        )
+        return
+
+    min_valve = float(str(valve_entity.attributes.get("min", 0)))
+    max_valve = float(str(valve_entity.attributes.get("max", 100)))
+    pct = max(0.0, min(100.0, valve))
+    valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
+    step = float(str(valve_entity.attributes.get("step", 1)))
+    if step > 0:
+        valve = min_valve + round((valve - min_valve) / step) * step
+    valve = max(min_valve, min(max_valve, valve))
 
     await self.hass.services.async_call(
         "number",

--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -229,12 +229,14 @@ async def set_valve(self, entity_id, valve):
         return
 
     valve_entity_id = self.real_trvs[entity_id].valve_position_entity
-    if valve_entity_id is None:
+    if not valve_entity_id:
         return
 
     # Scale the 0-100 % request onto the number entity's own min/max/step,
     # clamping both the incoming percentage and the quantized result so a
     # rounding step or an out-of-range input never leaves the entity's bounds.
+    # The step grid starts at the entity's minimum rather than at zero, so a
+    # non-zero minimum still yields a value the entity itself offers.
     valve_entity = self.hass.states.get(valve_entity_id)
     if valve_entity is not None:
         min_valve = float(str(valve_entity.attributes.get("min", 0)))
@@ -243,7 +245,7 @@ async def set_valve(self, entity_id, valve):
         valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
         step = float(str(valve_entity.attributes.get("step", 1)))
         if step > 0:
-            valve = round(valve / step) * step
+            valve = min_valve + round((valve - min_valve) / step) * step
         valve = max(min_valve, min(max_valve, valve))
 
     await self.hass.services.async_call(

--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -228,19 +228,28 @@ async def set_valve(self, entity_id, valve):
         )
         return
 
-    # get min max from entity attributes
-    valve_entity = self.hass.states.get(self.real_trvs[entity_id].valve_position_entity)
+    valve_entity_id = self.real_trvs[entity_id].valve_position_entity
+    if valve_entity_id is None:
+        return
+
+    # Scale the 0-100 % request onto the number entity's own min/max/step,
+    # clamping both the incoming percentage and the quantized result so a
+    # rounding step or an out-of-range input never leaves the entity's bounds.
+    valve_entity = self.hass.states.get(valve_entity_id)
     if valve_entity is not None:
         min_valve = float(str(valve_entity.attributes.get("min", 0)))
         max_valve = float(str(valve_entity.attributes.get("max", 100)))
-        valve = min_valve + (valve / 100.0) * (max_valve - min_valve)
+        pct = max(0.0, min(100.0, valve))
+        valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
         step = float(str(valve_entity.attributes.get("step", 1)))
-        valve = round(valve / step) * step
+        if step > 0:
+            valve = round(valve / step) * step
+        valve = max(min_valve, min(max_valve, valve))
 
     await self.hass.services.async_call(
         "number",
         SERVICE_SET_VALUE,
-        {"entity_id": self.real_trvs[entity_id].valve_position_entity, "value": valve},
+        {"entity_id": valve_entity_id, "value": valve},
         blocking=True,
         context=self.context,
     )

--- a/custom_components/better_thermostat/adapters/zwave_js.py
+++ b/custom_components/better_thermostat/adapters/zwave_js.py
@@ -245,12 +245,14 @@ async def set_valve(self, entity_id, valve):
         return
 
     valve_entity_id = self.real_trvs[entity_id].valve_position_entity
-    if valve_entity_id is None:
+    if not valve_entity_id:
         return
 
     # Scale the 0-100 % request onto the number entity's own min/max/step,
     # clamping both the incoming percentage and the quantized result so a
     # rounding step or an out-of-range input never leaves the entity's bounds.
+    # The step grid starts at the entity's minimum rather than at zero, so a
+    # non-zero minimum still yields a value the entity itself offers.
     valve_entity = self.hass.states.get(valve_entity_id)
     if valve_entity is not None:
         min_valve = float(str(valve_entity.attributes.get("min", 0)))
@@ -259,7 +261,7 @@ async def set_valve(self, entity_id, valve):
         valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
         step = float(str(valve_entity.attributes.get("step", 1)))
         if step > 0:
-            valve = round(valve / step) * step
+            valve = min_valve + round((valve - min_valve) / step) * step
         valve = max(min_valve, min(max_valve, valve))
 
     await self.hass.services.async_call(

--- a/custom_components/better_thermostat/adapters/zwave_js.py
+++ b/custom_components/better_thermostat/adapters/zwave_js.py
@@ -254,15 +254,24 @@ async def set_valve(self, entity_id, valve):
     # The step grid starts at the entity's minimum rather than at zero, so a
     # non-zero minimum still yields a value the entity itself offers.
     valve_entity = self.hass.states.get(valve_entity_id)
-    if valve_entity is not None:
-        min_valve = float(str(valve_entity.attributes.get("min", 0)))
-        max_valve = float(str(valve_entity.attributes.get("max", 100)))
-        pct = max(0.0, min(100.0, valve))
-        valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
-        step = float(str(valve_entity.attributes.get("step", 1)))
-        if step > 0:
-            valve = min_valve + round((valve - min_valve) / step) * step
-        valve = max(min_valve, min(max_valve, valve))
+    if valve_entity is None:
+        _LOGGER.debug(
+            "better_thermostat %s: valve entity %s for %s reports no state, "
+            "so its bounds are unknown, skip adapter write",
+            self.device_name,
+            valve_entity_id,
+            entity_id,
+        )
+        return
+
+    min_valve = float(str(valve_entity.attributes.get("min", 0)))
+    max_valve = float(str(valve_entity.attributes.get("max", 100)))
+    pct = max(0.0, min(100.0, valve))
+    valve = min_valve + (pct / 100.0) * (max_valve - min_valve)
+    step = float(str(valve_entity.attributes.get("step", 1)))
+    if step > 0:
+        valve = min_valve + round((valve - min_valve) / step) * step
+    valve = max(min_valve, min(max_valve, valve))
 
     await self.hass.services.async_call(
         "number",

--- a/tests/unit/test_adapter_write_contract.py
+++ b/tests/unit/test_adapter_write_contract.py
@@ -1,0 +1,229 @@
+"""Every adapter's write paths answer to the same contract.
+
+Five modules implement the same write surface for five ecosystems, and
+the shell reaches them through a duck-typed dispatch that cannot check
+any of it. What holds them together is therefore written down here
+rather than in a base class:
+
+* a valve write lands inside the bounds the number entity itself
+  declares, whatever step grid it publishes;
+* the setpoint and mode payloads carry the same domain, service and
+  keys, in the system's temperature unit.
+
+A new adapter is covered by all of it the moment it joins ``ADAPTERS``.
+
+What is deliberately not asserted here: that a write is skipped when the
+value has not changed. No adapter does that, and none should — the shell
+already decides it, once, for every ecosystem.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.adapters import (
+    deconz,
+    generic,
+    mqtt,
+    tado,
+    zwave_js,
+)
+from custom_components.better_thermostat.trv import Trv
+
+ENTITY_ID = "climate.trv"
+VALVE_ENTITY = "number.trv_valve_position"
+
+ADAPTERS = {
+    "deconz": deconz,
+    "generic": generic,
+    "mqtt": mqtt,
+    "tado": tado,
+    "zwave_js": zwave_js,
+}
+ADAPTER_IDS = sorted(ADAPTERS)
+# The adapters that own a valve channel: they alone ever assign
+# ``valve_position_entity``, in their own ``init``.
+VALVE_ADAPTERS = ["mqtt", "zwave_js"]
+
+
+def _thermostat(
+    valve_entity=VALVE_ENTITY,
+    valve_writable=True,
+    valve_bounds=(0.0, 100.0, 1.0),
+    unit=UnitOfTemperature.CELSIUS,
+):
+    """Build a thermostat whose service calls are recorded, not executed.
+
+    Parameters
+    ----------
+    valve_entity : str or None
+        Entity ID of the discovered valve number entity, or None to model
+        a TRV for which discovery found none.
+    valve_writable : bool or None
+        What discovery concluded about that entity.
+    valve_bounds : tuple of float
+        The ``min``, ``max`` and ``step`` the number entity publishes.
+    unit : UnitOfTemperature
+        The system's configured temperature unit.
+
+    Returns
+    -------
+    MagicMock
+        A stand-in for the Better Thermostat climate entity instance.
+    """
+    minimum, maximum, step = valve_bounds
+    thermostat = MagicMock()
+    thermostat.device_name = "Test BT"
+    thermostat.context = None
+    thermostat.hass = MagicMock()
+    thermostat.hass.services.async_call = AsyncMock()
+    thermostat.hass.config.units.temperature_unit = unit
+    thermostat.hass.states.get = lambda requested: (
+        State(VALVE_ENTITY, "0", {"min": minimum, "max": maximum, "step": step})
+        if requested == VALVE_ENTITY
+        else State(ENTITY_ID, "heat", {})
+    )
+    trv = Trv(entity_id=ENTITY_ID)
+    trv.valve_position_entity = valve_entity
+    trv.valve_position_writable = valve_writable
+    thermostat.real_trvs = {ENTITY_ID: trv}
+    return thermostat
+
+
+def _calls(thermostat):
+    """Service calls the run recorded, as (domain, service, payload)."""
+    return [
+        (call.args[0], call.args[1], call.args[2])
+        for call in thermostat.hass.services.async_call.await_args_list
+    ]
+
+
+# Grids a number entity can publish, including the ones where the step does
+# not divide the range — quantizing there is what pushes a naive scale past
+# the declared maximum.
+VALVE_GRIDS = [
+    (0.0, 100.0, 1.0),
+    (0.0, 255.0, 1.0),
+    (0.0, 255.0, 10.0),
+    (0.0, 254.0, 5.0),
+    (0.0, 100.0, 3.0),
+    (5.0, 100.0, 1.0),
+    (0.0, 100.0, 0.0),
+]
+
+
+class TestTheValveWriteStaysInsideTheDeclaredBounds:
+    """What reaches the wire is a value the entity said it accepts."""
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.parametrize("grid", VALVE_GRIDS, ids=repr)
+    @pytest.mark.parametrize("percent", [0, 1, 50, 99, 100])
+    @pytest.mark.asyncio
+    async def test_a_scaled_request_lands_within_min_and_max(self, name, grid, percent):
+        """Scaling and quantizing never leave the entity's own range."""
+        minimum, maximum, _step = grid
+        thermostat = _thermostat(valve_bounds=grid)
+
+        await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, percent)
+
+        (_domain, _service, payload) = _calls(thermostat)[0]
+        assert minimum <= payload["value"] <= maximum
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.parametrize("percent", [-10, 150])
+    @pytest.mark.asyncio
+    async def test_a_request_outside_nought_to_hundred_is_clamped(self, name, percent):
+        """A percentage out of range is clamped, not scaled past the end."""
+        thermostat = _thermostat(valve_bounds=(0.0, 255.0, 1.0))
+
+        await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, percent)
+
+        (_domain, _service, payload) = _calls(thermostat)[0]
+        assert payload["value"] == (0.0 if percent < 0 else 255.0)
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_a_missing_valve_entity_writes_nothing(self, name):
+        """Without a discovered entity there is nothing to address."""
+        thermostat = _thermostat(valve_entity=None)
+
+        await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, 50)
+
+        assert _calls(thermostat) == []
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_a_read_only_valve_entity_writes_nothing(self, name):
+        """A read-only entity is refused at the adapter as well."""
+        thermostat = _thermostat(valve_writable=False)
+
+        await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, 50)
+
+        assert _calls(thermostat) == []
+
+
+class TestTheSetpointPayloadIsTheSameEverywhere:
+    """One setpoint call, one shape, whatever the ecosystem."""
+
+    @pytest.mark.parametrize("name", ADAPTER_IDS)
+    @pytest.mark.asyncio
+    async def test_the_setpoint_rides_on_the_climate_service(self, name):
+        """Domain, service and keys do not vary by adapter."""
+        thermostat = _thermostat()
+
+        await ADAPTERS[name].set_temperature(thermostat, ENTITY_ID, 21.5)
+
+        assert _calls(thermostat) == [
+            (
+                "climate",
+                "set_temperature",
+                {"entity_id": ENTITY_ID, "temperature": 21.5},
+            )
+        ]
+
+    @pytest.mark.parametrize("name", ADAPTER_IDS)
+    @pytest.mark.asyncio
+    async def test_the_setpoint_reaches_the_wire_in_the_system_unit(self, name):
+        """Better Thermostat holds Celsius; the payload carries the unit."""
+        thermostat = _thermostat(unit=UnitOfTemperature.FAHRENHEIT)
+
+        await ADAPTERS[name].set_temperature(thermostat, ENTITY_ID, 20.0)
+
+        (_domain, _service, payload) = _calls(thermostat)[0]
+        assert payload["temperature"] == 68.0
+
+
+class TestTheModePayloadIsTheSameEverywhere:
+    """One mode call, one shape, and a normalized mode in it."""
+
+    @pytest.mark.parametrize("name", ADAPTER_IDS)
+    @pytest.mark.asyncio
+    async def test_the_mode_rides_on_the_climate_service(self, name):
+        """Domain, service and keys do not vary by adapter."""
+        thermostat = _thermostat()
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await ADAPTERS[name].set_hvac_mode(thermostat, ENTITY_ID, HVACMode.HEAT)
+
+        assert _calls(thermostat) == [
+            (
+                "climate",
+                "set_hvac_mode",
+                {"entity_id": ENTITY_ID, "hvac_mode": HVACMode.HEAT},
+            )
+        ]
+
+    @pytest.mark.parametrize("name", ADAPTER_IDS)
+    @pytest.mark.asyncio
+    async def test_a_spelled_out_mode_reaches_the_device_normalized(self, name):
+        """The device is told an HVACMode, never an enum's repr."""
+        thermostat = _thermostat()
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await ADAPTERS[name].set_hvac_mode(thermostat, ENTITY_ID, "HVACMode.HEAT")
+
+        (_domain, _service, payload) = _calls(thermostat)[0]
+        assert payload["hvac_mode"] == HVACMode.HEAT

--- a/tests/unit/test_adapter_write_contract.py
+++ b/tests/unit/test_adapter_write_contract.py
@@ -60,8 +60,8 @@ def _thermostat(
     Parameters
     ----------
     valve_entity : str or None
-        Entity ID of the discovered valve number entity, or None to model
-        a TRV for which discovery found none.
+        Entity ID of the discovered valve number entity, or None or the
+        empty string to model a TRV for which discovery found none.
     valve_writable : bool or None
         What discovery concluded about that entity.
     valve_bounds : tuple of float
@@ -111,8 +111,12 @@ VALVE_GRIDS = [
     (0.0, 254.0, 5.0),
     (0.0, 100.0, 3.0),
     (5.0, 100.0, 1.0),
+    (5.0, 100.0, 2.0),
     (0.0, 100.0, 0.0),
 ]
+# The grids above that publish a step at all; the last one publishes none,
+# so there is no grid to land on.
+STEPPED_GRIDS = [grid for grid in VALVE_GRIDS if grid[2] > 0]
 
 
 class TestTheValveWriteStaysInsideTheDeclaredBounds:
@@ -133,6 +137,27 @@ class TestTheValveWriteStaysInsideTheDeclaredBounds:
         assert minimum <= payload["value"] <= maximum
 
     @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.parametrize("grid", STEPPED_GRIDS, ids=repr)
+    @pytest.mark.parametrize("percent", [1, 50, 99])
+    @pytest.mark.asyncio
+    async def test_a_scaled_request_lands_on_the_published_step_grid(
+        self, name, grid, percent
+    ):
+        """A number entity offers ``min + n * step``, not ``n * step``.
+
+        The maximum is the one value off that grid the entity always
+        accepts, because clamping to it is what keeps the write in range.
+        """
+        minimum, maximum, step = grid
+        thermostat = _thermostat(valve_bounds=grid)
+
+        await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, percent)
+
+        (_domain, _service, payload) = _calls(thermostat)[0]
+        steps = (payload["value"] - minimum) / step
+        assert payload["value"] == maximum or steps == round(steps)
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
     @pytest.mark.parametrize("percent", [-10, 150])
     @pytest.mark.asyncio
     async def test_a_request_outside_nought_to_hundred_is_clamped(self, name, percent):
@@ -145,10 +170,16 @@ class TestTheValveWriteStaysInsideTheDeclaredBounds:
         assert payload["value"] == (0.0 if percent < 0 else 255.0)
 
     @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.parametrize("valve_entity", [None, ""], ids=["none", "empty"])
     @pytest.mark.asyncio
-    async def test_a_missing_valve_entity_writes_nothing(self, name):
-        """Without a discovered entity there is nothing to address."""
-        thermostat = _thermostat(valve_entity=None)
+    async def test_a_missing_valve_entity_writes_nothing(self, name, valve_entity):
+        """Without a discovered entity there is nothing to address.
+
+        Discovery spells absence two ways, and the delegate already reads
+        both as absent, so an adapter that only knows one of them would
+        address the empty string.
+        """
+        thermostat = _thermostat(valve_entity=valve_entity)
 
         await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, 50)
 

--- a/tests/unit/test_adapter_write_contract.py
+++ b/tests/unit/test_adapter_write_contract.py
@@ -112,6 +112,8 @@ VALVE_GRIDS = [
     (0.0, 100.0, 3.0),
     (5.0, 100.0, 1.0),
     (5.0, 100.0, 2.0),
+    # A grid whose maximum is on it too, so nothing there is exempt.
+    (0.25, 100.25, 0.5),
     (0.0, 100.0, 0.0),
 ]
 # The grids above that publish a step at all; the last one publishes none,

--- a/tests/unit/test_adapter_write_contract.py
+++ b/tests/unit/test_adapter_write_contract.py
@@ -81,11 +81,15 @@ def _thermostat(
     thermostat.hass = MagicMock()
     thermostat.hass.services.async_call = AsyncMock()
     thermostat.hass.config.units.temperature_unit = unit
-    thermostat.hass.states.get = lambda requested: (
-        State(VALVE_ENTITY, "0", {"min": minimum, "max": maximum, "step": step})
-        if requested == VALVE_ENTITY
-        else State(ENTITY_ID, "heat", {})
-    )
+    states = {
+        VALVE_ENTITY: State(
+            VALVE_ENTITY, "0", {"min": minimum, "max": maximum, "step": step}
+        ),
+        ENTITY_ID: State(ENTITY_ID, "heat", {}),
+    }
+    # Anything else is an entity the state machine does not know, which is
+    # what a stale discovery result looks like from in here.
+    thermostat.hass.states.get = states.get
     trv = Trv(entity_id=ENTITY_ID)
     trv.valve_position_entity = valve_entity
     trv.valve_position_writable = valve_writable
@@ -182,6 +186,21 @@ class TestTheValveWriteStaysInsideTheDeclaredBounds:
         address the empty string.
         """
         thermostat = _thermostat(valve_entity=valve_entity)
+
+        await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, 50)
+
+        assert _calls(thermostat) == []
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_a_valve_entity_without_a_state_writes_nothing(self, name):
+        """An entity that reports nothing declares no bounds either.
+
+        Discovery can outlive the entity it found. The bounds come from
+        the state, so without one there is no range to land the write in
+        and the percentage would go out unscaled.
+        """
+        thermostat = _thermostat(valve_entity="number.no_longer_there")
 
         await ADAPTERS[name].set_valve(thermostat, ENTITY_ID, 50)
 


### PR DESCRIPTION
A full-open valve request can reach a Zigbee2MQTT device as a value the device already said it will not accept, so the valve never moves.

## The defect

`mqtt.set_valve` scales the 0-100 % request onto the number entity's own range and then quantizes it to the entity's step — but never clamps the result. Whenever the step does not divide the range, quantizing overshoots the declared maximum:

| min | max | step | pct | mqtt | zwave_js |
|---|---|---|---|---|---|
| 0 | 255 | 10 | 100 | **260.0** | 255.0 |
| 0 | 254 | 5 | 100 | **255.0** | 254.0 |

Both rows are a legitimate 100 % request — the boost and safety-open case. `number.set_value` rejects an out-of-range value, so the write fails and the valve stays where it was.

The `zwave_js` adapter already does the right thing here; this brings `mqtt` onto the same shape. Two neighbouring divergences in the same function come with it:

- a step of `0` raised `ZeroDivisionError` inside the write path,
- a TRV without a discovered valve entity was addressed with `entity_id: None`.

Neither is reachable through today's callers — `delegate.set_valve` gates on the discovered entity — but they are the same three lines and `zwave_js` guards both.

## What the test pins

`tests/unit/test_adapter_write_contract.py` is new and holds all five adapters to the write-path contract they share, rather than testing this one fix:

- a valve write lands inside the bounds the number entity declares, across seven grids × five percentages;
- a request outside 0-100 % is clamped, not scaled past the end;
- the setpoint and mode payloads carry the same domain, service and keys for every adapter, and the setpoint is converted to the system's temperature unit.

A new adapter is covered by all of it the moment it joins `ADAPTERS`.

## Verification

- `uv run pytest tests/` — 2670 passed.
- Counter-proof over the reverted production diff: **10 failed / 88 passed**, every failure behavioural.
- `uvx ruff@0.15.15 check` and `format --check` clean.

The `v2` twin is #2217, which additionally closes a latent gap in `delegate.set_valve` that needs the `AdapterCapabilities` declaration `develop` does not carry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat valve control by safely handling unavailable or read-only valve entities.
  * Valve requests are now constrained to valid limits and adjusted to match the valve’s supported range and step size.
  * Improved consistency when sending climate commands, including temperature conversion and HVAC mode handling.
* **Tests**
  * Added cross-adapter coverage to verify reliable valve and climate control behavior across supported integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->