### PR TITLE
Localize config-flow selectors and entity names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,9 @@ async def set_temperature(self, entity_id, temperature):
 
 ## Translations
 
-[INLANG Editor](https://inlang.com/editor/github.com/KartoffelToby/better_thermostat)
+See the [translation contributor guide](custom_components/better_thermostat/translations/README.md) for the catalog format, placeholder rules, and validation command.
+
+Translations can also be edited with the [INLANG Editor](https://inlang.com/editor/github.com/KartoffelToby/better_thermostat).
 
 ### Reporting Bugs
 

--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -69,20 +69,25 @@ CONFIG_WALKTHROUGH_URL = (
 )
 
 
+_TARGET_TEMP_STEP_SELECTOR_TO_VALUE = {
+    "auto_legacy": "0.0",
+    "auto": "",
+    "step_0_1": "0.1",
+    "step_0_2": "0.2",
+    "step_0_25": "0.25",
+    "step_0_5": "0.5",
+    "step_1_0": "1.0",
+}
+_TARGET_TEMP_STEP_VALUE_TO_SELECTOR = {
+    value: key for key, value in _TARGET_TEMP_STEP_SELECTOR_TO_VALUE.items()
+}
+
 TEMP_STEP_SELECTOR = selector.SelectSelector(
     selector.SelectSelectorConfig(
-        options=[
-            selector.SelectOptionDict(
-                value="0.0", label="Auto"
-            ),  # Keep for backwards compatibility
-            selector.SelectOptionDict(value="", label="Auto (New)"),
-            selector.SelectOptionDict(value="0.1", label="0.1 °C"),
-            selector.SelectOptionDict(value="0.2", label="0.2 °C"),
-            selector.SelectOptionDict(value="0.25", label="0.25 °C"),
-            selector.SelectOptionDict(value="0.5", label="0.5 °C"),
-            selector.SelectOptionDict(value="1.0", label="1 °C"),
-        ],
+        # Stable selector tokens keep labels translatable without changing stored values.
+        options=list(_TARGET_TEMP_STEP_SELECTOR_TO_VALUE),
         mode=selector.SelectSelectorMode.DROPDOWN,
+        translation_key="target_temp_step",
     )
 )
 
@@ -90,34 +95,17 @@ TEMP_STEP_SELECTOR = selector.SelectSelector(
 CALIBRATION_MODE_SELECTOR = selector.SelectSelector(
     selector.SelectSelectorConfig(
         options=[
-            selector.SelectOptionDict(
-                value=CalibrationMode.HEATING_POWER_CALIBRATION,
-                label="(AI) Time Based (Default)",
-            ),
-            selector.SelectOptionDict(
-                value=CalibrationMode.DEFAULT, label="External Sensor Offset Only"
-            ),
-            selector.SelectOptionDict(
-                value=CalibrationMode.MPC_CALIBRATION, label="MPC Predictive (Beta)"
-            ),
-            selector.SelectOptionDict(
-                value=CalibrationMode.MPC_V2_CALIBRATION,
-                label="(AI) MPC v2 (QP + Kalman, experimental)",
-            ),
-            selector.SelectOptionDict(
-                value=CalibrationMode.AGGRESIVE_CALIBRATION, label="Aggressive"
-            ),
-            selector.SelectOptionDict(
-                value=CalibrationMode.TPI_CALIBRATION, label="TPI Controller"
-            ),
-            selector.SelectOptionDict(
-                value=CalibrationMode.PID_CALIBRATION, label="PID Controller"
-            ),
-            selector.SelectOptionDict(
-                value=CalibrationMode.NO_CALIBRATION, label="No Calibration"
-            ),
+            CalibrationMode.HEATING_POWER_CALIBRATION,
+            CalibrationMode.DEFAULT,
+            CalibrationMode.MPC_CALIBRATION,
+            CalibrationMode.MPC_V2_CALIBRATION,
+            CalibrationMode.AGGRESIVE_CALIBRATION,
+            CalibrationMode.TPI_CALIBRATION,
+            CalibrationMode.PID_CALIBRATION,
+            CalibrationMode.NO_CALIBRATION,
         ],
         mode=selector.SelectSelectorMode.DROPDOWN,
+        translation_key="calibration_mode",
     )
 )
 
@@ -125,23 +113,13 @@ CALIBRATION_MODE_SELECTOR = selector.SelectSelector(
 MPC_V2_PLANT_PRESET_SELECTOR = selector.SelectSelector(
     selector.SelectSelectorConfig(
         options=[
-            selector.SelectOptionDict(
-                value=MpcV2PlantPreset.AUTO, label="Auto (use learned heat-loss rate)"
-            ),
-            selector.SelectOptionDict(
-                value=MpcV2PlantPreset.SMALL_ROOM,
-                label="Small room (~10 m², fast response)",
-            ),
-            selector.SelectOptionDict(
-                value=MpcV2PlantPreset.MEDIUM_ROOM,
-                label="Medium room (~20 m², standard)",
-            ),
-            selector.SelectOptionDict(
-                value=MpcV2PlantPreset.LARGE_ROOM,
-                label="Large room (~40 m², slow envelope)",
-            ),
+            MpcV2PlantPreset.AUTO,
+            MpcV2PlantPreset.SMALL_ROOM,
+            MpcV2PlantPreset.MEDIUM_ROOM,
+            MpcV2PlantPreset.LARGE_ROOM,
         ],
         mode=selector.SelectSelectorMode.DROPDOWN,
+        translation_key="mpc_v2_plant_preset",
     )
 )
 
@@ -149,13 +127,13 @@ MPC_V2_PLANT_PRESET_SELECTOR = selector.SelectSelector(
 PRESET_SELECTOR = selector.SelectSelector(
     selector.SelectSelectorConfig(
         options=[
-            selector.SelectOptionDict(value=PRESET_ECO, label="Eco"),
-            selector.SelectOptionDict(value=PRESET_AWAY, label="Away"),
-            selector.SelectOptionDict(value=PRESET_BOOST, label="Boost"),
-            selector.SelectOptionDict(value=PRESET_COMFORT, label="Comfort"),
-            selector.SelectOptionDict(value=PRESET_HOME, label="Home"),
-            selector.SelectOptionDict(value=PRESET_SLEEP, label="Sleep"),
-            selector.SelectOptionDict(value=PRESET_ACTIVITY, label="Activity"),
+            PRESET_ECO,
+            PRESET_AWAY,
+            PRESET_BOOST,
+            PRESET_COMFORT,
+            PRESET_HOME,
+            PRESET_SLEEP,
+            PRESET_ACTIVITY,
         ],
         mode=selector.SelectSelectorMode.DROPDOWN,
         multiple=True,
@@ -278,28 +256,18 @@ def _build_advanced_fields(
 
     options = []
     if support_valve:
-        options.append(
-            selector.SelectOptionDict(
-                value=CalibrationType.DIRECT_VALVE_BASED, label="Direct Valve Based"
-            )
-        )
+        options.append(CalibrationType.DIRECT_VALVE_BASED)
 
-    options.append(
-        selector.SelectOptionDict(
-            value=CalibrationType.TARGET_TEMP_BASED, label="Target Temperature Based"
-        )
-    )
+    options.append(CalibrationType.TARGET_TEMP_BASED)
 
     if support_offset:
-        options.append(
-            selector.SelectOptionDict(
-                value=CalibrationType.LOCAL_BASED, label="Offset Based"
-            )
-        )
+        options.append(CalibrationType.LOCAL_BASED)
 
     calib_selector = selector.SelectSelector(
         selector.SelectSelectorConfig(
-            options=options, mode=selector.SelectSelectorMode.DROPDOWN
+            options=options,
+            mode=selector.SelectSelectorMode.DROPDOWN,
+            translation_key="calibration_type",
         )
     )
     ordered: OrderedDict = OrderedDict()
@@ -580,7 +548,9 @@ def _build_user_fields(
         CONF_TARGET_TEMP_STEP, _USER_FIELD_DEFAULTS[CONF_TARGET_TEMP_STEP]
     )
     if target_step_default is not None:
-        target_step_default = str(target_step_default)
+        target_step_default = _TARGET_TEMP_STEP_VALUE_TO_SELECTOR.get(
+            str(target_step_default), "auto_legacy"
+        )
     add_field(CONF_TARGET_TEMP_STEP, TEMP_STEP_SELECTOR, default=target_step_default)
 
     return fields
@@ -685,7 +655,11 @@ def _normalize_user_submission(
             CONF_TARGET_TEMP_STEP, _USER_FIELD_DEFAULTS[CONF_TARGET_TEMP_STEP]
         ),
     )
-    if target_step in (None, ""):
+    target_step_key = str(target_step)
+    target_step_from_selector = target_step_key in _TARGET_TEMP_STEP_SELECTOR_TO_VALUE
+    if target_step_from_selector:
+        target_step = _TARGET_TEMP_STEP_SELECTOR_TO_VALUE[target_step_key]
+    if target_step is None or (target_step == "" and not target_step_from_selector):
         target_step = _USER_FIELD_DEFAULTS[CONF_TARGET_TEMP_STEP]
     normalized[CONF_TARGET_TEMP_STEP] = str(target_step)
 

--- a/custom_components/better_thermostat/number.py
+++ b/custom_components/better_thermostat/number.py
@@ -4,7 +4,17 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.climate.const import PRESET_NONE, HVACMode
+from homeassistant.components.climate.const import (
+    PRESET_ACTIVITY,
+    PRESET_AWAY,
+    PRESET_BOOST,
+    PRESET_COMFORT,
+    PRESET_ECO,
+    PRESET_HOME,
+    PRESET_NONE,
+    PRESET_SLEEP,
+    HVACMode,
+)
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, Platform, UnitOfTemperature
@@ -29,6 +39,24 @@ from .utils.const import (
 from .utils.helpers import async_normalize_bt_entity_ids, convert_to_float_celsius
 
 _LOGGER = logging.getLogger(__name__)
+
+_PRESET_TRANSLATION_KEYS = {
+    PRESET_ECO: "preset_eco",
+    PRESET_AWAY: "preset_away",
+    PRESET_BOOST: "preset_boost",
+    PRESET_COMFORT: "preset_comfort",
+    PRESET_HOME: "preset_home",
+    PRESET_SLEEP: "preset_sleep",
+    PRESET_ACTIVITY: "preset_activity",
+}
+# With a cooler configured the heating preset becomes the lower bound of a
+# range, so it needs its own name next to the cooling preset upper bound.
+_PRESET_MIN_TRANSLATION_KEYS = {
+    preset: f"{key}_min" for preset, key in _PRESET_TRANSLATION_KEYS.items()
+}
+_PRESET_MAX_TRANSLATION_KEYS = {
+    preset: f"{key}_max" for preset, key in _PRESET_TRANSLATION_KEYS.items()
+}
 
 
 async def async_setup_entry(
@@ -156,9 +184,9 @@ class BetterThermostatPresetNumber(NumberEntity, RestoreEntity):
         self._preset_mode = preset_mode
         self._attr_unique_id = f"{bt_climate.unique_id}_preset_{preset_mode}"
         if bt_climate.cooler_entity_id is not None:
-            self._attr_name = f"{preset_mode.capitalize()} Min"
+            self._attr_translation_key = _PRESET_MIN_TRANSLATION_KEYS[preset_mode]
         else:
-            self._attr_name = f"{preset_mode.capitalize()}"
+            self._attr_translation_key = _PRESET_TRANSLATION_KEYS[preset_mode]
 
         # Set min/max/step based on climate entity configuration
         self._attr_native_min_value = bt_climate.min_temp
@@ -234,7 +262,7 @@ class BetterThermostatPresetCoolNumber(BetterThermostatPresetNumber):
         """
         super().__init__(bt_climate, preset_mode)
         self._attr_unique_id = f"{bt_climate.unique_id}_preset_{preset_mode}_cool"
-        self._attr_name = f"{preset_mode.capitalize()} Max"
+        self._attr_translation_key = _PRESET_MAX_TRANSLATION_KEYS[preset_mode]
 
     async def async_added_to_hass(self) -> None:
         """Restore the last persisted cooling preset value.
@@ -432,9 +460,10 @@ class BetterThermostatValveMaxOpeningNumber(NumberEntity, RestoreEntity):
         if show_trv_name:
             trv_state = bt_climate.hass.states.get(trv_entity_id)
             trv_name = trv_state.name if trv_state and trv_state.name else trv_entity_id
-            self._attr_name = f"{trv_name} Valve Max Opening"
+            self._attr_translation_key = "valve_max_opening"
+            self._attr_translation_placeholders = {"trv_name": trv_name}
         else:
-            self._attr_name = "Valve Max Opening"
+            self._attr_translation_key = "valve_max_opening_no_trv"
 
         self._attr_native_min_value = 0.0
         self._attr_native_max_value = 100.0

--- a/custom_components/better_thermostat/sensor.py
+++ b/custom_components/better_thermostat/sensor.py
@@ -704,7 +704,7 @@ class _BtSimpleAttributeSensor(_BtSensorBase):
 class BetterThermostatExternalTempSensor(_BtSensorBase):
     """Representation of a Better Thermostat External Temperature Sensor (EMA)."""
 
-    _attr_name = "Temperature EMA"
+    _attr_translation_key = "external_temp_ema"
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _unique_id_suffix = "external_temp_ema"
@@ -724,7 +724,7 @@ class BetterThermostatExternalTempSensor(_BtSensorBase):
 class BetterThermostatExternalTemp1hEMASensor(_BtSensorBase):
     """Representation of a Better Thermostat External Temperature 1h EMA Sensor."""
 
-    _attr_name = "Temperature EMA 1h"
+    _attr_translation_key = "external_temp_ema_1h"
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_suggested_display_precision = 2
@@ -773,7 +773,7 @@ class BetterThermostatExternalTemp1hEMASensor(_BtSensorBase):
 class BetterThermostatTempSlopeSensor(_BtSimpleAttributeSensor):
     """Representation of a Better Thermostat Temperature Slope Sensor."""
 
-    _attr_name = "Temperature Slope"
+    _attr_translation_key = "temp_slope"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "K/min"
     _attr_icon = "mdi:chart-line"
@@ -785,7 +785,7 @@ class BetterThermostatTempSlopeSensor(_BtSimpleAttributeSensor):
 class BetterThermostatHeatingPowerSensor(_BtSimpleAttributeSensor):
     """Representation of a Better Thermostat Heating Power Sensor."""
 
-    _attr_name = "Heating Power"
+    _attr_translation_key = "heating_power"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "K/min"
     _attr_icon = "mdi:thermometer-plus"
@@ -797,7 +797,7 @@ class BetterThermostatHeatingPowerSensor(_BtSimpleAttributeSensor):
 class BetterThermostatHeatLossSensor(_BtSimpleAttributeSensor):
     """Representation of a Better Thermostat Heat Loss Sensor."""
 
-    _attr_name = "Heat Loss"
+    _attr_translation_key = "heat_loss"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "K/min"
     _attr_icon = "mdi:thermometer-minus"
@@ -809,7 +809,7 @@ class BetterThermostatHeatLossSensor(_BtSimpleAttributeSensor):
 class BetterThermostatVirtualTempSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat Virtual Temperature Sensor (MPC)."""
 
-    _attr_name = "Virtual Temperature"
+    _attr_translation_key = "virtual_temp"
     _attr_device_class = SensorDeviceClass.TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_icon = "mdi:thermometer-auto"
@@ -820,7 +820,7 @@ class BetterThermostatVirtualTempSensor(_BtMpcSensorBase):
 class BetterThermostatMpcGainSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat MPC Gain Sensor."""
 
-    _attr_name = "MPC Gain"
+    _attr_translation_key = "mpc_gain"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "K/min"
     _attr_icon = "mdi:thermometer-plus"
@@ -832,7 +832,7 @@ class BetterThermostatMpcGainSensor(_BtMpcSensorBase):
 class BetterThermostatMpcLossSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat MPC Loss Sensor."""
 
-    _attr_name = "MPC Loss"
+    _attr_translation_key = "mpc_loss"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "K/min"
     _attr_icon = "mdi:thermometer-minus"
@@ -844,7 +844,7 @@ class BetterThermostatMpcLossSensor(_BtMpcSensorBase):
 class BetterThermostatMpcKaSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat MPC Ka (Insulation) Sensor."""
 
-    _attr_name = "MPC Insulation (Ka)"
+    _attr_translation_key = "mpc_ka"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "1/min"
     _attr_icon = "mdi:home-thermometer-outline"
@@ -856,7 +856,7 @@ class BetterThermostatMpcKaSensor(_BtMpcSensorBase):
 class BetterThermostatPidKpSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat PID Kp (proportional gain) Sensor."""
 
-    _attr_name = "PID Kp"
+    _attr_translation_key = "pid_kp"
     _attr_device_class = None
     _attr_icon = "mdi:alpha-p-circle-outline"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -867,7 +867,7 @@ class BetterThermostatPidKpSensor(_BtMpcSensorBase):
 class BetterThermostatPidKiSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat PID Ki (integral gain) Sensor."""
 
-    _attr_name = "PID Ki"
+    _attr_translation_key = "pid_ki"
     _attr_device_class = None
     _attr_icon = "mdi:alpha-i-circle-outline"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -878,7 +878,7 @@ class BetterThermostatPidKiSensor(_BtMpcSensorBase):
 class BetterThermostatPidKdSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat PID Kd (derivative gain) Sensor."""
 
-    _attr_name = "PID Kd"
+    _attr_translation_key = "pid_kd"
     _attr_device_class = None
     _attr_icon = "mdi:alpha-d-circle-outline"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -889,7 +889,7 @@ class BetterThermostatPidKdSensor(_BtMpcSensorBase):
 class BetterThermostatPidOutputSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat PID Output (valve command) Sensor."""
 
-    _attr_name = "PID Output"
+    _attr_translation_key = "pid_output"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "%"
     _attr_icon = "mdi:valve"
@@ -901,7 +901,7 @@ class BetterThermostatPidOutputSensor(_BtMpcSensorBase):
 class BetterThermostatPidErrorSensor(_BtMpcSensorBase):
     """Representation of a Better Thermostat PID Error (setpoint deviation) Sensor."""
 
-    _attr_name = "PID Error"
+    _attr_translation_key = "pid_error"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "K"
     _attr_icon = "mdi:thermometer-alert"
@@ -913,7 +913,7 @@ class BetterThermostatPidErrorSensor(_BtMpcSensorBase):
 class BetterThermostatSolarIntensitySensor(_BtSensorBase):
     """Representation of a Better Thermostat Solar Intensity Sensor."""
 
-    _attr_name = "Sun Intensity Heatup"
+    _attr_translation_key = "solar_intensity"
     _attr_device_class = None
     _attr_native_unit_of_measurement = "%"
     _attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/custom_components/better_thermostat/strings.json
+++ b/custom_components/better_thermostat/strings.json
@@ -186,6 +186,44 @@
         "sleep": "Sleep",
         "activity": "Activity"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Auto (legacy)",
+        "auto": "Auto",
+        "step_0_1": "0.1 °C",
+        "step_0_2": "0.2 °C",
+        "step_0_25": "0.25 °C",
+        "step_0_5": "0.5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "(AI) Time Based (Default)",
+        "default": "External Sensor Offset Only",
+        "mpc_calibration": "MPC Predictive (Beta)",
+        "mpc_v2_calibration": "(AI) MPC v2 (QP + Kalman, experimental)",
+        "fix_calibration": "Aggressive",
+        "tpi_calibration": "TPI Controller",
+        "pid_calibration": "PID Controller",
+        "no_calibration": "No Calibration"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Direct Valve Based",
+        "target_temp_based": "Target Temperature Based",
+        "local_calibration_based": "Offset Based"
+      }
+    },
+    "mpc_v2_plant_preset": {
+      "options": {
+        "auto": "Auto (use learned heat-loss rate)",
+        "small_room": "Small room (~10 m², fast response)",
+        "medium_room": "Medium room (~20 m², standard)",
+        "large_room": "Large room (~40 m², slow envelope)"
+      }
     }
   },
   "entity": {
@@ -207,6 +245,75 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (Derivative)"
+      },
+      "preset_eco": {
+        "name": "Eco"
+      },
+      "preset_eco_min": {
+        "name": "Eco Min"
+      },
+      "preset_eco_max": {
+        "name": "Eco Max"
+      },
+      "preset_away": {
+        "name": "Away"
+      },
+      "preset_away_min": {
+        "name": "Away Min"
+      },
+      "preset_away_max": {
+        "name": "Away Max"
+      },
+      "preset_boost": {
+        "name": "Boost"
+      },
+      "preset_boost_min": {
+        "name": "Boost Min"
+      },
+      "preset_boost_max": {
+        "name": "Boost Max"
+      },
+      "preset_comfort": {
+        "name": "Comfort"
+      },
+      "preset_comfort_min": {
+        "name": "Comfort Min"
+      },
+      "preset_comfort_max": {
+        "name": "Comfort Max"
+      },
+      "preset_home": {
+        "name": "Home"
+      },
+      "preset_home_min": {
+        "name": "Home Min"
+      },
+      "preset_home_max": {
+        "name": "Home Max"
+      },
+      "preset_sleep": {
+        "name": "Sleep"
+      },
+      "preset_sleep_min": {
+        "name": "Sleep Min"
+      },
+      "preset_sleep_max": {
+        "name": "Sleep Max"
+      },
+      "preset_activity": {
+        "name": "Activity"
+      },
+      "preset_activity_min": {
+        "name": "Activity Min"
+      },
+      "preset_activity_max": {
+        "name": "Activity Max"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name} Valve Max Opening"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Valve Max Opening"
       }
     },
     "switch": {
@@ -235,6 +342,51 @@
           "door_open": "turned off because a door was opened",
           "door_close": "resumed heating because a door was closed"
         }
+      },
+      "external_temp_ema": {
+        "name": "Temperature EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Temperature EMA 1h"
+      },
+      "temp_slope": {
+        "name": "Temperature Slope"
+      },
+      "heating_power": {
+        "name": "Heating Power"
+      },
+      "heat_loss": {
+        "name": "Heat Loss"
+      },
+      "virtual_temp": {
+        "name": "Virtual Temperature"
+      },
+      "mpc_gain": {
+        "name": "MPC Gain"
+      },
+      "mpc_loss": {
+        "name": "MPC Loss"
+      },
+      "mpc_ka": {
+        "name": "MPC Insulation (Ka)"
+      },
+      "pid_kp": {
+        "name": "PID Kp"
+      },
+      "pid_ki": {
+        "name": "PID Ki"
+      },
+      "pid_kd": {
+        "name": "PID Kd"
+      },
+      "pid_output": {
+        "name": "PID Output"
+      },
+      "pid_error": {
+        "name": "PID Error"
+      },
+      "solar_intensity": {
+        "name": "Sun Intensity Heatup"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/README.md
+++ b/custom_components/better_thermostat/translations/README.md
@@ -1,0 +1,50 @@
+# Better Thermostat translations
+
+Better Thermostat uses Home Assistant's native custom-integration localization.
+Home Assistant selects the catalog from the user's frontend language; no locale
+switch or Python registration table is needed.
+
+## Catalog layout
+
+- `en.json` is the canonical runtime catalog and English fallback.
+- `<language-tag>.json` contains one complete translation. File names use BCP 47
+  language tags, for example `ru.json`, `de.json`, or `pt-BR.json`.
+- `../strings.json` mirrors `en.json` for repository tooling and must remain
+  byte-for-byte equivalent after JSON parsing.
+- `../../../project.inlang.json` lists every catalog for the Inlang editor.
+
+The catalogs cover config and options flows, repairs, services, selectors,
+device automations, and entity names. Python entities reference these strings by
+stable `translation_key`; do not add user-facing `_attr_name` strings to entity
+classes. Config-flow dropdowns work the same way: a `SelectSelector` carries a
+`translation_key` and lists bare option values, and every option needs a label
+under `selector.<key>.options`.
+
+## Add a language
+
+1. Copy `en.json` to `<language-tag>.json`.
+2. Translate values only. Preserve object keys, Markdown, line breaks, and every
+   placeholder such as `{name}`, `{trv_name}`, or `{docs_url}` exactly.
+3. Add the language tag to `project.inlang.json` so it appears in the Inlang
+   editor.
+4. Run:
+
+   ```bash
+   uv run pytest tests/test_translations.py
+   ```
+
+The validation checks JSON structure, complete key coverage, unknown keys,
+placeholder parity, non-empty values, entity translation coverage, and the
+Inlang catalog list. A developer can therefore add another language without
+changing the integration's Python logic.
+
+## Add or change a source string
+
+1. Edit the English value in `en.json` and mirror the same structure in
+   `../strings.json`.
+2. Update every language catalog. Until a translator supplies localized copy,
+   use the English value rather than omitting the key, so Home Assistant never
+   exposes a raw translation key.
+3. When adding an entity name, add its key below `entity.<platform>` and set the
+   entity's `_attr_translation_key` to that stable key.
+4. Run the translation tests before opening a pull request.

--- a/custom_components/better_thermostat/translations/da.json
+++ b/custom_components/better_thermostat/translations/da.json
@@ -186,6 +186,44 @@
         "sleep": "Søvn",
         "activity": "Aktivitet"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Automatisk (gammel)",
+        "auto": "Automatisk",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "AI tidsbaseret (standard)",
+        "default": "Kun ekstern sensorforskydning",
+        "mpc_calibration": "MPC forudsigende (beta)",
+        "mpc_v2_calibration": "(AI) MPC v2 (QP + Kalman, eksperimentel)",
+        "fix_calibration": "Aggressiv",
+        "tpi_calibration": "TPI-regulator",
+        "pid_calibration": "PID-regulator",
+        "no_calibration": "Ingen kalibrering"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Direkte ventilstyring",
+        "target_temp_based": "Baseret på måltemperatur",
+        "local_calibration_based": "Baseret på forskydning"
+      }
+    },
+    "mpc_v2_plant_preset": {
+      "options": {
+        "auto": "Automatisk (brug den lærte varmetabsrate)",
+        "small_room": "Lille rum (~10 m², hurtig reaktion)",
+        "medium_room": "Mellemstort rum (~20 m², standard)",
+        "large_room": "Stort rum (~40 m², langsom klimaskærm)"
+      }
     }
   },
   "entity": {
@@ -207,6 +245,75 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (differentiel)"
+      },
+      "preset_eco": {
+        "name": "Eco"
+      },
+      "preset_eco_min": {
+        "name": "Eco Min"
+      },
+      "preset_eco_max": {
+        "name": "Eco Max"
+      },
+      "preset_away": {
+        "name": "Ude"
+      },
+      "preset_away_min": {
+        "name": "Ude Min"
+      },
+      "preset_away_max": {
+        "name": "Ude Max"
+      },
+      "preset_boost": {
+        "name": "Boost"
+      },
+      "preset_boost_min": {
+        "name": "Boost Min"
+      },
+      "preset_boost_max": {
+        "name": "Boost Max"
+      },
+      "preset_comfort": {
+        "name": "Komfort"
+      },
+      "preset_comfort_min": {
+        "name": "Komfort Min"
+      },
+      "preset_comfort_max": {
+        "name": "Komfort Max"
+      },
+      "preset_home": {
+        "name": "Hjemme"
+      },
+      "preset_home_min": {
+        "name": "Hjemme Min"
+      },
+      "preset_home_max": {
+        "name": "Hjemme Max"
+      },
+      "preset_sleep": {
+        "name": "Søvn"
+      },
+      "preset_sleep_min": {
+        "name": "Søvn Min"
+      },
+      "preset_sleep_max": {
+        "name": "Søvn Max"
+      },
+      "preset_activity": {
+        "name": "Aktivitet"
+      },
+      "preset_activity_min": {
+        "name": "Aktivitet Min"
+      },
+      "preset_activity_max": {
+        "name": "Aktivitet Max"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: maksimal ventilåbning"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Maksimal ventilåbning"
       }
     },
     "switch": {
@@ -235,6 +342,51 @@
           "door_open": "turned off because a door was opened",
           "door_close": "resumed heating because a door was closed"
         }
+      },
+      "external_temp_ema": {
+        "name": "Temperatur-EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Temperatur-EMA (1 time)"
+      },
+      "temp_slope": {
+        "name": "Temperaturændring"
+      },
+      "heating_power": {
+        "name": "Varmeydelse"
+      },
+      "heat_loss": {
+        "name": "Varmetab"
+      },
+      "virtual_temp": {
+        "name": "Virtuel temperatur"
+      },
+      "mpc_gain": {
+        "name": "MPC-varmeforstærkning"
+      },
+      "mpc_loss": {
+        "name": "MPC-varmetab"
+      },
+      "mpc_ka": {
+        "name": "MPC-isolering (Ka)"
+      },
+      "pid_kp": {
+        "name": "PID Kp"
+      },
+      "pid_ki": {
+        "name": "PID Ki"
+      },
+      "pid_kd": {
+        "name": "PID Kd"
+      },
+      "pid_output": {
+        "name": "PID-udgang"
+      },
+      "pid_error": {
+        "name": "PID-afvigelse"
+      },
+      "solar_intensity": {
+        "name": "Solvarmetilskud"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/de.json
+++ b/custom_components/better_thermostat/translations/de.json
@@ -186,6 +186,44 @@
         "sleep": "Schlafen",
         "activity": "Aktivität"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Automatisch (alt)",
+        "auto": "Automatisch",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "KI zeitbasiert (Standard)",
+        "default": "Nur externer Sensorversatz",
+        "mpc_calibration": "MPC prädiktiv (Beta)",
+        "mpc_v2_calibration": "(KI) MPC v2 (QP + Kalman, experimentell)",
+        "fix_calibration": "Aggressiv",
+        "tpi_calibration": "TPI-Regler",
+        "pid_calibration": "PID-Regler",
+        "no_calibration": "Keine Kalibrierung"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Direkte Ventilsteuerung",
+        "target_temp_based": "Zieltemperaturbasiert",
+        "local_calibration_based": "Versatzbasiert"
+      }
+    },
+    "mpc_v2_plant_preset": {
+      "options": {
+        "auto": "Automatisch (gelernte Wärmeverlustrate verwenden)",
+        "small_room": "Kleiner Raum (~10 m², schnelle Reaktion)",
+        "medium_room": "Mittlerer Raum (~20 m², Standard)",
+        "large_room": "Großer Raum (~40 m², träge Gebäudehülle)"
+      }
     }
   },
   "entity": {
@@ -207,6 +245,75 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (Differential)"
+      },
+      "preset_eco": {
+        "name": "Eco"
+      },
+      "preset_eco_min": {
+        "name": "Eco Min"
+      },
+      "preset_eco_max": {
+        "name": "Eco Max"
+      },
+      "preset_away": {
+        "name": "Abwesend"
+      },
+      "preset_away_min": {
+        "name": "Abwesend Min"
+      },
+      "preset_away_max": {
+        "name": "Abwesend Max"
+      },
+      "preset_boost": {
+        "name": "Boost"
+      },
+      "preset_boost_min": {
+        "name": "Boost Min"
+      },
+      "preset_boost_max": {
+        "name": "Boost Max"
+      },
+      "preset_comfort": {
+        "name": "Komfort"
+      },
+      "preset_comfort_min": {
+        "name": "Komfort Min"
+      },
+      "preset_comfort_max": {
+        "name": "Komfort Max"
+      },
+      "preset_home": {
+        "name": "Zuhause"
+      },
+      "preset_home_min": {
+        "name": "Zuhause Min"
+      },
+      "preset_home_max": {
+        "name": "Zuhause Max"
+      },
+      "preset_sleep": {
+        "name": "Schlafen"
+      },
+      "preset_sleep_min": {
+        "name": "Schlafen Min"
+      },
+      "preset_sleep_max": {
+        "name": "Schlafen Max"
+      },
+      "preset_activity": {
+        "name": "Aktivität"
+      },
+      "preset_activity_min": {
+        "name": "Aktivität Min"
+      },
+      "preset_activity_max": {
+        "name": "Aktivität Max"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: maximale Ventilöffnung"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Maximale Ventilöffnung"
       }
     },
     "switch": {
@@ -235,6 +342,51 @@
           "door_open": "abgeschaltet, weil eine Tür geöffnet wurde",
           "door_close": "heizt wieder, weil eine Tür geschlossen wurde"
         }
+      },
+      "external_temp_ema": {
+        "name": "Temperatur-EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Temperatur-EMA (1 Stunde)"
+      },
+      "temp_slope": {
+        "name": "Temperaturänderung"
+      },
+      "heating_power": {
+        "name": "Heizleistung"
+      },
+      "heat_loss": {
+        "name": "Wärmeverlust"
+      },
+      "virtual_temp": {
+        "name": "Virtuelle Temperatur"
+      },
+      "mpc_gain": {
+        "name": "MPC-Heizverstärkung"
+      },
+      "mpc_loss": {
+        "name": "MPC-Wärmeverlust"
+      },
+      "mpc_ka": {
+        "name": "MPC-Isolierung (Ka)"
+      },
+      "pid_kp": {
+        "name": "PID Kp"
+      },
+      "pid_ki": {
+        "name": "PID Ki"
+      },
+      "pid_kd": {
+        "name": "PID Kd"
+      },
+      "pid_output": {
+        "name": "PID-Ausgang"
+      },
+      "pid_error": {
+        "name": "PID-Abweichung"
+      },
+      "solar_intensity": {
+        "name": "Solare Wärmeaufnahme"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/el.json
+++ b/custom_components/better_thermostat/translations/el.json
@@ -186,6 +186,44 @@
         "sleep": "Ύπνος",
         "activity": "Δραστηριότητα"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Αυτόματο (παλιό)",
+        "auto": "Αυτόματο",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "AI βάσει χρόνου (προεπιλογή)",
+        "default": "Μόνο μετατόπιση εξωτερικού αισθητήρα",
+        "mpc_calibration": "Προγνωστικό MPC (beta)",
+        "mpc_v2_calibration": "(AI) MPC v2 (QP + Kalman, πειραματικό)",
+        "fix_calibration": "Επιθετικό",
+        "tpi_calibration": "Ελεγκτής TPI",
+        "pid_calibration": "Ελεγκτής PID",
+        "no_calibration": "Χωρίς βαθμονόμηση"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Άμεσος έλεγχος βαλβίδας",
+        "target_temp_based": "Βάσει επιθυμητής θερμοκρασίας",
+        "local_calibration_based": "Βάσει μετατόπισης"
+      }
+    },
+    "mpc_v2_plant_preset": {
+      "options": {
+        "auto": "Αυτόματο (χρήση του εκτιμώμενου ρυθμού απωλειών)",
+        "small_room": "Μικρό δωμάτιο (~10 m², γρήγορη απόκριση)",
+        "medium_room": "Μεσαίο δωμάτιο (~20 m², τυπικό)",
+        "large_room": "Μεγάλο δωμάτιο (~40 m², αργό κέλυφος)"
+      }
     }
   },
   "entity": {
@@ -207,6 +245,75 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (διαφορικό)"
+      },
+      "preset_eco": {
+        "name": "Οικονομία"
+      },
+      "preset_eco_min": {
+        "name": "Οικονομία Min"
+      },
+      "preset_eco_max": {
+        "name": "Οικονομία Max"
+      },
+      "preset_away": {
+        "name": "Εκτός σπιτιού"
+      },
+      "preset_away_min": {
+        "name": "Εκτός σπιτιού Min"
+      },
+      "preset_away_max": {
+        "name": "Εκτός σπιτιού Max"
+      },
+      "preset_boost": {
+        "name": "Ενίσχυση"
+      },
+      "preset_boost_min": {
+        "name": "Ενίσχυση Min"
+      },
+      "preset_boost_max": {
+        "name": "Ενίσχυση Max"
+      },
+      "preset_comfort": {
+        "name": "Άνεση"
+      },
+      "preset_comfort_min": {
+        "name": "Άνεση Min"
+      },
+      "preset_comfort_max": {
+        "name": "Άνεση Max"
+      },
+      "preset_home": {
+        "name": "Σπίτι"
+      },
+      "preset_home_min": {
+        "name": "Σπίτι Min"
+      },
+      "preset_home_max": {
+        "name": "Σπίτι Max"
+      },
+      "preset_sleep": {
+        "name": "Ύπνος"
+      },
+      "preset_sleep_min": {
+        "name": "Ύπνος Min"
+      },
+      "preset_sleep_max": {
+        "name": "Ύπνος Max"
+      },
+      "preset_activity": {
+        "name": "Δραστηριότητα"
+      },
+      "preset_activity_min": {
+        "name": "Δραστηριότητα Min"
+      },
+      "preset_activity_max": {
+        "name": "Δραστηριότητα Max"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: μέγιστο άνοιγμα βαλβίδας"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Μέγιστο άνοιγμα βαλβίδας"
       }
     },
     "switch": {
@@ -235,6 +342,51 @@
           "door_open": "turned off because a door was opened",
           "door_close": "resumed heating because a door was closed"
         }
+      },
+      "external_temp_ema": {
+        "name": "Θερμοκρασία EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Θερμοκρασία EMA (1 ώρα)"
+      },
+      "temp_slope": {
+        "name": "Ρυθμός μεταβολής θερμοκρασίας"
+      },
+      "heating_power": {
+        "name": "Ισχύς θέρμανσης"
+      },
+      "heat_loss": {
+        "name": "Απώλεια θερμότητας"
+      },
+      "virtual_temp": {
+        "name": "Εικονική θερμοκρασία"
+      },
+      "mpc_gain": {
+        "name": "Κέρδος θέρμανσης MPC"
+      },
+      "mpc_loss": {
+        "name": "Απώλεια θερμότητας MPC"
+      },
+      "mpc_ka": {
+        "name": "Μόνωση MPC (Ka)"
+      },
+      "pid_kp": {
+        "name": "PID Kp"
+      },
+      "pid_ki": {
+        "name": "PID Ki"
+      },
+      "pid_kd": {
+        "name": "PID Kd"
+      },
+      "pid_output": {
+        "name": "Έξοδος PID"
+      },
+      "pid_error": {
+        "name": "Σφάλμα PID"
+      },
+      "solar_intensity": {
+        "name": "Ηλιακό θερμικό κέρδος"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/en.json
+++ b/custom_components/better_thermostat/translations/en.json
@@ -186,6 +186,44 @@
         "sleep": "Sleep",
         "activity": "Activity"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Auto (legacy)",
+        "auto": "Auto",
+        "step_0_1": "0.1 °C",
+        "step_0_2": "0.2 °C",
+        "step_0_25": "0.25 °C",
+        "step_0_5": "0.5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "(AI) Time Based (Default)",
+        "default": "External Sensor Offset Only",
+        "mpc_calibration": "MPC Predictive (Beta)",
+        "mpc_v2_calibration": "(AI) MPC v2 (QP + Kalman, experimental)",
+        "fix_calibration": "Aggressive",
+        "tpi_calibration": "TPI Controller",
+        "pid_calibration": "PID Controller",
+        "no_calibration": "No Calibration"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Direct Valve Based",
+        "target_temp_based": "Target Temperature Based",
+        "local_calibration_based": "Offset Based"
+      }
+    },
+    "mpc_v2_plant_preset": {
+      "options": {
+        "auto": "Auto (use learned heat-loss rate)",
+        "small_room": "Small room (~10 m², fast response)",
+        "medium_room": "Medium room (~20 m², standard)",
+        "large_room": "Large room (~40 m², slow envelope)"
+      }
     }
   },
   "entity": {
@@ -207,6 +245,75 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (Derivative)"
+      },
+      "preset_eco": {
+        "name": "Eco"
+      },
+      "preset_eco_min": {
+        "name": "Eco Min"
+      },
+      "preset_eco_max": {
+        "name": "Eco Max"
+      },
+      "preset_away": {
+        "name": "Away"
+      },
+      "preset_away_min": {
+        "name": "Away Min"
+      },
+      "preset_away_max": {
+        "name": "Away Max"
+      },
+      "preset_boost": {
+        "name": "Boost"
+      },
+      "preset_boost_min": {
+        "name": "Boost Min"
+      },
+      "preset_boost_max": {
+        "name": "Boost Max"
+      },
+      "preset_comfort": {
+        "name": "Comfort"
+      },
+      "preset_comfort_min": {
+        "name": "Comfort Min"
+      },
+      "preset_comfort_max": {
+        "name": "Comfort Max"
+      },
+      "preset_home": {
+        "name": "Home"
+      },
+      "preset_home_min": {
+        "name": "Home Min"
+      },
+      "preset_home_max": {
+        "name": "Home Max"
+      },
+      "preset_sleep": {
+        "name": "Sleep"
+      },
+      "preset_sleep_min": {
+        "name": "Sleep Min"
+      },
+      "preset_sleep_max": {
+        "name": "Sleep Max"
+      },
+      "preset_activity": {
+        "name": "Activity"
+      },
+      "preset_activity_min": {
+        "name": "Activity Min"
+      },
+      "preset_activity_max": {
+        "name": "Activity Max"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name} Valve Max Opening"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Valve Max Opening"
       }
     },
     "switch": {
@@ -235,6 +342,51 @@
           "door_open": "turned off because a door was opened",
           "door_close": "resumed heating because a door was closed"
         }
+      },
+      "external_temp_ema": {
+        "name": "Temperature EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Temperature EMA 1h"
+      },
+      "temp_slope": {
+        "name": "Temperature Slope"
+      },
+      "heating_power": {
+        "name": "Heating Power"
+      },
+      "heat_loss": {
+        "name": "Heat Loss"
+      },
+      "virtual_temp": {
+        "name": "Virtual Temperature"
+      },
+      "mpc_gain": {
+        "name": "MPC Gain"
+      },
+      "mpc_loss": {
+        "name": "MPC Loss"
+      },
+      "mpc_ka": {
+        "name": "MPC Insulation (Ka)"
+      },
+      "pid_kp": {
+        "name": "PID Kp"
+      },
+      "pid_ki": {
+        "name": "PID Ki"
+      },
+      "pid_kd": {
+        "name": "PID Kd"
+      },
+      "pid_output": {
+        "name": "PID Output"
+      },
+      "pid_error": {
+        "name": "PID Error"
+      },
+      "solar_intensity": {
+        "name": "Sun Intensity Heatup"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/fr.json
+++ b/custom_components/better_thermostat/translations/fr.json
@@ -186,6 +186,44 @@
         "sleep": "Sommeil",
         "activity": "Activité"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Auto (ancien)",
+        "auto": "Auto",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "IA basée sur le temps (par défaut)",
+        "default": "Décalage du capteur externe uniquement",
+        "mpc_calibration": "MPC prédictif (bêta)",
+        "mpc_v2_calibration": "(IA) MPC v2 (QP + Kalman, expérimental)",
+        "fix_calibration": "Agressif",
+        "tpi_calibration": "Contrôleur TPI",
+        "pid_calibration": "Contrôleur PID",
+        "no_calibration": "Sans étalonnage"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Commande directe de la vanne",
+        "target_temp_based": "Basé sur la température cible",
+        "local_calibration_based": "Basé sur le décalage"
+      }
+    },
+    "mpc_v2_plant_preset": {
+      "options": {
+        "auto": "Auto (utiliser le taux de déperdition appris)",
+        "small_room": "Petite pièce (~10 m², réponse rapide)",
+        "medium_room": "Pièce moyenne (~20 m², standard)",
+        "large_room": "Grande pièce (~40 m², enveloppe lente)"
+      }
     }
   },
   "entity": {
@@ -207,6 +245,75 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (dérivé)"
+      },
+      "preset_eco": {
+        "name": "Éco"
+      },
+      "preset_eco_min": {
+        "name": "Éco Min"
+      },
+      "preset_eco_max": {
+        "name": "Éco Max"
+      },
+      "preset_away": {
+        "name": "Absent"
+      },
+      "preset_away_min": {
+        "name": "Absent Min"
+      },
+      "preset_away_max": {
+        "name": "Absent Max"
+      },
+      "preset_boost": {
+        "name": "Boost"
+      },
+      "preset_boost_min": {
+        "name": "Boost Min"
+      },
+      "preset_boost_max": {
+        "name": "Boost Max"
+      },
+      "preset_comfort": {
+        "name": "Confort"
+      },
+      "preset_comfort_min": {
+        "name": "Confort Min"
+      },
+      "preset_comfort_max": {
+        "name": "Confort Max"
+      },
+      "preset_home": {
+        "name": "Maison"
+      },
+      "preset_home_min": {
+        "name": "Maison Min"
+      },
+      "preset_home_max": {
+        "name": "Maison Max"
+      },
+      "preset_sleep": {
+        "name": "Sommeil"
+      },
+      "preset_sleep_min": {
+        "name": "Sommeil Min"
+      },
+      "preset_sleep_max": {
+        "name": "Sommeil Max"
+      },
+      "preset_activity": {
+        "name": "Activité"
+      },
+      "preset_activity_min": {
+        "name": "Activité Min"
+      },
+      "preset_activity_max": {
+        "name": "Activité Max"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name} : ouverture maximale de la vanne"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Ouverture maximale de la vanne"
       }
     },
     "switch": {
@@ -235,6 +342,51 @@
           "door_open": "éteint parce qu'une porte a été ouverte",
           "door_close": "chauffage repris parce qu'une porte a été fermée"
         }
+      },
+      "external_temp_ema": {
+        "name": "Température EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Température EMA (1 heure)"
+      },
+      "temp_slope": {
+        "name": "Variation de température"
+      },
+      "heating_power": {
+        "name": "Puissance de chauffage"
+      },
+      "heat_loss": {
+        "name": "Perte de chaleur"
+      },
+      "virtual_temp": {
+        "name": "Température virtuelle"
+      },
+      "mpc_gain": {
+        "name": "Gain de chauffage MPC"
+      },
+      "mpc_loss": {
+        "name": "Perte thermique MPC"
+      },
+      "mpc_ka": {
+        "name": "Isolation MPC (Ka)"
+      },
+      "pid_kp": {
+        "name": "PID Kp"
+      },
+      "pid_ki": {
+        "name": "PID Ki"
+      },
+      "pid_kd": {
+        "name": "PID Kd"
+      },
+      "pid_output": {
+        "name": "Sortie PID"
+      },
+      "pid_error": {
+        "name": "Écart PID"
+      },
+      "solar_intensity": {
+        "name": "Apport de chaleur solaire"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/it.json
+++ b/custom_components/better_thermostat/translations/it.json
@@ -186,6 +186,44 @@
         "sleep": "Notte",
         "activity": "Attività"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Automatico (precedente)",
+        "auto": "Automatico",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "IA basata sul tempo (predefinito)",
+        "default": "Solo offset sensore esterno",
+        "mpc_calibration": "MPC predittivo (beta)",
+        "mpc_v2_calibration": "(IA) MPC v2 (QP + Kalman, sperimentale)",
+        "fix_calibration": "Aggressivo",
+        "tpi_calibration": "Controller TPI",
+        "pid_calibration": "Controller PID",
+        "no_calibration": "Nessuna calibrazione"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Controllo diretto della valvola",
+        "target_temp_based": "Basato sulla temperatura obiettivo",
+        "local_calibration_based": "Basato sull’offset"
+      }
+    },
+    "mpc_v2_plant_preset": {
+      "options": {
+        "auto": "Automatico (usa il tasso di dispersione appreso)",
+        "small_room": "Stanza piccola (~10 m², risposta rapida)",
+        "medium_room": "Stanza media (~20 m², standard)",
+        "large_room": "Stanza grande (~40 m², involucro lento)"
+      }
     }
   },
   "entity": {
@@ -207,6 +245,75 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (derivativo)"
+      },
+      "preset_eco": {
+        "name": "Eco"
+      },
+      "preset_eco_min": {
+        "name": "Eco Min"
+      },
+      "preset_eco_max": {
+        "name": "Eco Max"
+      },
+      "preset_away": {
+        "name": "Fuori casa"
+      },
+      "preset_away_min": {
+        "name": "Fuori casa Min"
+      },
+      "preset_away_max": {
+        "name": "Fuori casa Max"
+      },
+      "preset_boost": {
+        "name": "Boost"
+      },
+      "preset_boost_min": {
+        "name": "Boost Min"
+      },
+      "preset_boost_max": {
+        "name": "Boost Max"
+      },
+      "preset_comfort": {
+        "name": "Comfort"
+      },
+      "preset_comfort_min": {
+        "name": "Comfort Min"
+      },
+      "preset_comfort_max": {
+        "name": "Comfort Max"
+      },
+      "preset_home": {
+        "name": "A casa"
+      },
+      "preset_home_min": {
+        "name": "A casa Min"
+      },
+      "preset_home_max": {
+        "name": "A casa Max"
+      },
+      "preset_sleep": {
+        "name": "Notte"
+      },
+      "preset_sleep_min": {
+        "name": "Notte Min"
+      },
+      "preset_sleep_max": {
+        "name": "Notte Max"
+      },
+      "preset_activity": {
+        "name": "Attività"
+      },
+      "preset_activity_min": {
+        "name": "Attività Min"
+      },
+      "preset_activity_max": {
+        "name": "Attività Max"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: apertura massima della valvola"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Apertura massima della valvola"
       }
     },
     "switch": {
@@ -235,6 +342,51 @@
           "door_open": "turned off because a door was opened",
           "door_close": "resumed heating because a door was closed"
         }
+      },
+      "external_temp_ema": {
+        "name": "Temperatura EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Temperatura EMA (1 ora)"
+      },
+      "temp_slope": {
+        "name": "Variazione della temperatura"
+      },
+      "heating_power": {
+        "name": "Potenza di riscaldamento"
+      },
+      "heat_loss": {
+        "name": "Perdita di calore"
+      },
+      "virtual_temp": {
+        "name": "Temperatura virtuale"
+      },
+      "mpc_gain": {
+        "name": "Guadagno di riscaldamento MPC"
+      },
+      "mpc_loss": {
+        "name": "Perdita di calore MPC"
+      },
+      "mpc_ka": {
+        "name": "Isolamento MPC (Ka)"
+      },
+      "pid_kp": {
+        "name": "PID Kp"
+      },
+      "pid_ki": {
+        "name": "PID Ki"
+      },
+      "pid_kd": {
+        "name": "PID Kd"
+      },
+      "pid_output": {
+        "name": "Uscita PID"
+      },
+      "pid_error": {
+        "name": "Errore PID"
+      },
+      "solar_intensity": {
+        "name": "Apporto di calore solare"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/pl.json
+++ b/custom_components/better_thermostat/translations/pl.json
@@ -186,6 +186,44 @@
         "sleep": "Sen",
         "activity": "Aktywność"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Automatycznie (stare)",
+        "auto": "Automatycznie",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "AI na podstawie czasu (domyślne)",
+        "default": "Tylko przesunięcie czujnika zewnętrznego",
+        "mpc_calibration": "Predykcyjne MPC (beta)",
+        "mpc_v2_calibration": "(AI) MPC v2 (QP + Kalman, eksperymentalne)",
+        "fix_calibration": "Agresywne",
+        "tpi_calibration": "Regulator TPI",
+        "pid_calibration": "Regulator PID",
+        "no_calibration": "Bez kalibracji"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Bezpośrednie sterowanie zaworem",
+        "target_temp_based": "Na podstawie temperatury docelowej",
+        "local_calibration_based": "Na podstawie przesunięcia"
+      }
+    },
+    "mpc_v2_plant_preset": {
+      "options": {
+        "auto": "Automatycznie (użyj wyuczonej szybkości strat ciepła)",
+        "small_room": "Małe pomieszczenie (~10 m², szybka reakcja)",
+        "medium_room": "Średnie pomieszczenie (~20 m², standard)",
+        "large_room": "Duże pomieszczenie (~40 m², wolna przegroda)"
+      }
     }
   },
   "entity": {
@@ -207,6 +245,75 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (różniczkujący)"
+      },
+      "preset_eco": {
+        "name": "Eko"
+      },
+      "preset_eco_min": {
+        "name": "Eko Min"
+      },
+      "preset_eco_max": {
+        "name": "Eko Max"
+      },
+      "preset_away": {
+        "name": "Poza domem"
+      },
+      "preset_away_min": {
+        "name": "Poza domem Min"
+      },
+      "preset_away_max": {
+        "name": "Poza domem Max"
+      },
+      "preset_boost": {
+        "name": "Boost"
+      },
+      "preset_boost_min": {
+        "name": "Boost Min"
+      },
+      "preset_boost_max": {
+        "name": "Boost Max"
+      },
+      "preset_comfort": {
+        "name": "Komfort"
+      },
+      "preset_comfort_min": {
+        "name": "Komfort Min"
+      },
+      "preset_comfort_max": {
+        "name": "Komfort Max"
+      },
+      "preset_home": {
+        "name": "W domu"
+      },
+      "preset_home_min": {
+        "name": "W domu Min"
+      },
+      "preset_home_max": {
+        "name": "W domu Max"
+      },
+      "preset_sleep": {
+        "name": "Sen"
+      },
+      "preset_sleep_min": {
+        "name": "Sen Min"
+      },
+      "preset_sleep_max": {
+        "name": "Sen Max"
+      },
+      "preset_activity": {
+        "name": "Aktywność"
+      },
+      "preset_activity_min": {
+        "name": "Aktywność Min"
+      },
+      "preset_activity_max": {
+        "name": "Aktywność Max"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: maksymalne otwarcie zaworu"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Maksymalne otwarcie zaworu"
       }
     },
     "switch": {
@@ -235,6 +342,51 @@
           "door_open": "turned off because a door was opened",
           "door_close": "resumed heating because a door was closed"
         }
+      },
+      "external_temp_ema": {
+        "name": "Temperatura EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Temperatura EMA (1 godzina)"
+      },
+      "temp_slope": {
+        "name": "Tempo zmian temperatury"
+      },
+      "heating_power": {
+        "name": "Moc grzewcza"
+      },
+      "heat_loss": {
+        "name": "Straty ciepła"
+      },
+      "virtual_temp": {
+        "name": "Temperatura wirtualna"
+      },
+      "mpc_gain": {
+        "name": "Wzmocnienie grzania MPC"
+      },
+      "mpc_loss": {
+        "name": "Straty ciepła MPC"
+      },
+      "mpc_ka": {
+        "name": "Izolacja MPC (Ka)"
+      },
+      "pid_kp": {
+        "name": "PID Kp"
+      },
+      "pid_ki": {
+        "name": "PID Ki"
+      },
+      "pid_kd": {
+        "name": "PID Kd"
+      },
+      "pid_output": {
+        "name": "Wyjście PID"
+      },
+      "pid_error": {
+        "name": "Uchyb PID"
+      },
+      "solar_intensity": {
+        "name": "Zysk ciepła od słońca"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/ru.json
+++ b/custom_components/better_thermostat/translations/ru.json
@@ -186,6 +186,44 @@
         "sleep": "Сон",
         "activity": "Активность"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Авто (старый режим)",
+        "auto": "Авто",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "ИИ на основе времени (по умолчанию)",
+        "default": "Только смещение по внешнему датчику",
+        "mpc_calibration": "Предиктивный MPC (бета)",
+        "mpc_v2_calibration": "(ИИ) MPC v2 (QP + Kalman, экспериментально)",
+        "fix_calibration": "Агрессивный",
+        "tpi_calibration": "TPI-регулятор",
+        "pid_calibration": "PID-регулятор",
+        "no_calibration": "Без калибровки"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Прямое управление клапаном",
+        "target_temp_based": "По целевой температуре",
+        "local_calibration_based": "По смещению"
+      }
+    },
+    "mpc_v2_plant_preset": {
+      "options": {
+        "auto": "Авто (использовать вычисленную скорость теплопотерь)",
+        "small_room": "Небольшая комната (~10 m², быстрый отклик)",
+        "medium_room": "Средняя комната (~20 m², стандарт)",
+        "large_room": "Большая комната (~40 m², медленная оболочка)"
+      }
     }
   },
   "entity": {
@@ -207,6 +245,75 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (дифференциальный коэффициент)"
+      },
+      "preset_eco": {
+        "name": "Эко"
+      },
+      "preset_eco_min": {
+        "name": "Эко Min"
+      },
+      "preset_eco_max": {
+        "name": "Эко Max"
+      },
+      "preset_away": {
+        "name": "Вне дома"
+      },
+      "preset_away_min": {
+        "name": "Вне дома Min"
+      },
+      "preset_away_max": {
+        "name": "Вне дома Max"
+      },
+      "preset_boost": {
+        "name": "Форсаж"
+      },
+      "preset_boost_min": {
+        "name": "Форсаж Min"
+      },
+      "preset_boost_max": {
+        "name": "Форсаж Max"
+      },
+      "preset_comfort": {
+        "name": "Комфорт"
+      },
+      "preset_comfort_min": {
+        "name": "Комфорт Min"
+      },
+      "preset_comfort_max": {
+        "name": "Комфорт Max"
+      },
+      "preset_home": {
+        "name": "Дома"
+      },
+      "preset_home_min": {
+        "name": "Дома Min"
+      },
+      "preset_home_max": {
+        "name": "Дома Max"
+      },
+      "preset_sleep": {
+        "name": "Сон"
+      },
+      "preset_sleep_min": {
+        "name": "Сон Min"
+      },
+      "preset_sleep_max": {
+        "name": "Сон Max"
+      },
+      "preset_activity": {
+        "name": "Активность"
+      },
+      "preset_activity_min": {
+        "name": "Активность Min"
+      },
+      "preset_activity_max": {
+        "name": "Активность Max"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: максимальное открытие клапана"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Максимальное открытие клапана"
       }
     },
     "switch": {
@@ -235,6 +342,51 @@
           "door_open": "turned off because a door was opened",
           "door_close": "resumed heating because a door was closed"
         }
+      },
+      "external_temp_ema": {
+        "name": "Сглаженная температура (EMA)"
+      },
+      "external_temp_ema_1h": {
+        "name": "Сглаженная температура (EMA, 1 час)"
+      },
+      "temp_slope": {
+        "name": "Скорость изменения температуры"
+      },
+      "heating_power": {
+        "name": "Мощность нагрева"
+      },
+      "heat_loss": {
+        "name": "Теплопотери"
+      },
+      "virtual_temp": {
+        "name": "Виртуальная температура"
+      },
+      "mpc_gain": {
+        "name": "Коэффициент нагрева MPC"
+      },
+      "mpc_loss": {
+        "name": "Коэффициент теплопотерь MPC"
+      },
+      "mpc_ka": {
+        "name": "Теплоизоляция MPC (Ka)"
+      },
+      "pid_kp": {
+        "name": "PID Kp"
+      },
+      "pid_ki": {
+        "name": "PID Ki"
+      },
+      "pid_kd": {
+        "name": "PID Kd"
+      },
+      "pid_output": {
+        "name": "Выход ПИД"
+      },
+      "pid_error": {
+        "name": "Ошибка ПИД"
+      },
+      "solar_intensity": {
+        "name": "Нагрев от солнечного излучения"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/sk.json
+++ b/custom_components/better_thermostat/translations/sk.json
@@ -186,6 +186,44 @@
         "sleep": "Spánok",
         "activity": "Aktivita"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Automaticky (staré)",
+        "auto": "Automaticky",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "AI podľa času (predvolené)",
+        "default": "Iba posun externého snímača",
+        "mpc_calibration": "Prediktívne MPC (beta)",
+        "mpc_v2_calibration": "(AI) MPC v2 (QP + Kalman, experimentálne)",
+        "fix_calibration": "Agresívne",
+        "tpi_calibration": "Regulátor TPI",
+        "pid_calibration": "Regulátor PID",
+        "no_calibration": "Bez kalibrácie"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Priame ovládanie ventilu",
+        "target_temp_based": "Podľa cieľovej teploty",
+        "local_calibration_based": "Podľa posunu"
+      }
+    },
+    "mpc_v2_plant_preset": {
+      "options": {
+        "auto": "Automaticky (použiť naučenú mieru tepelných strát)",
+        "small_room": "Malá miestnosť (~10 m², rýchla odozva)",
+        "medium_room": "Stredná miestnosť (~20 m², štandard)",
+        "large_room": "Veľká miestnosť (~40 m², pomalý obvodový plášť)"
+      }
     }
   },
   "entity": {
@@ -207,6 +245,75 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (Derivačné)"
+      },
+      "preset_eco": {
+        "name": "Eko"
+      },
+      "preset_eco_min": {
+        "name": "Eko Min"
+      },
+      "preset_eco_max": {
+        "name": "Eko Max"
+      },
+      "preset_away": {
+        "name": "Preč"
+      },
+      "preset_away_min": {
+        "name": "Preč Min"
+      },
+      "preset_away_max": {
+        "name": "Preč Max"
+      },
+      "preset_boost": {
+        "name": "Boost"
+      },
+      "preset_boost_min": {
+        "name": "Boost Min"
+      },
+      "preset_boost_max": {
+        "name": "Boost Max"
+      },
+      "preset_comfort": {
+        "name": "Komfort"
+      },
+      "preset_comfort_min": {
+        "name": "Komfort Min"
+      },
+      "preset_comfort_max": {
+        "name": "Komfort Max"
+      },
+      "preset_home": {
+        "name": "Doma"
+      },
+      "preset_home_min": {
+        "name": "Doma Min"
+      },
+      "preset_home_max": {
+        "name": "Doma Max"
+      },
+      "preset_sleep": {
+        "name": "Spánok"
+      },
+      "preset_sleep_min": {
+        "name": "Spánok Min"
+      },
+      "preset_sleep_max": {
+        "name": "Spánok Max"
+      },
+      "preset_activity": {
+        "name": "Aktivita"
+      },
+      "preset_activity_min": {
+        "name": "Aktivita Min"
+      },
+      "preset_activity_max": {
+        "name": "Aktivita Max"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: maximálne otvorenie ventilu"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Maximálne otvorenie ventilu"
       }
     },
     "switch": {
@@ -235,6 +342,51 @@
           "door_open": "turned off because a door was opened",
           "door_close": "resumed heating because a door was closed"
         }
+      },
+      "external_temp_ema": {
+        "name": "Teplota EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Teplota EMA (1 hodina)"
+      },
+      "temp_slope": {
+        "name": "Rýchlosť zmeny teploty"
+      },
+      "heating_power": {
+        "name": "Vykurovací výkon"
+      },
+      "heat_loss": {
+        "name": "Tepelná strata"
+      },
+      "virtual_temp": {
+        "name": "Virtuálna teplota"
+      },
+      "mpc_gain": {
+        "name": "Zisk vykurovania MPC"
+      },
+      "mpc_loss": {
+        "name": "Tepelná strata MPC"
+      },
+      "mpc_ka": {
+        "name": "Izolácia MPC (Ka)"
+      },
+      "pid_kp": {
+        "name": "PID Kp"
+      },
+      "pid_ki": {
+        "name": "PID Ki"
+      },
+      "pid_kd": {
+        "name": "PID Kd"
+      },
+      "pid_output": {
+        "name": "Výstup PID"
+      },
+      "pid_error": {
+        "name": "Odchýlka PID"
+      },
+      "solar_intensity": {
+        "name": "Solárny tepelný zisk"
       }
     }
   },

--- a/custom_components/better_thermostat/translations/tr.json
+++ b/custom_components/better_thermostat/translations/tr.json
@@ -186,6 +186,44 @@
         "sleep": "Uyku",
         "activity": "Aktivite"
       }
+    },
+    "target_temp_step": {
+      "options": {
+        "auto_legacy": "Otomatik (eski)",
+        "auto": "Otomatik",
+        "step_0_1": "0,1 °C",
+        "step_0_2": "0,2 °C",
+        "step_0_25": "0,25 °C",
+        "step_0_5": "0,5 °C",
+        "step_1_0": "1 °C"
+      }
+    },
+    "calibration_mode": {
+      "options": {
+        "heating_power_calibration": "Zamana dayalı yapay zekâ (varsayılan)",
+        "default": "Yalnızca harici sensör ofseti",
+        "mpc_calibration": "MPC öngörülü (beta)",
+        "mpc_v2_calibration": "(Yapay zekâ) MPC v2 (QP + Kalman, deneysel)",
+        "fix_calibration": "Agresif",
+        "tpi_calibration": "TPI denetleyici",
+        "pid_calibration": "PID denetleyici",
+        "no_calibration": "Kalibrasyon yok"
+      }
+    },
+    "calibration_type": {
+      "options": {
+        "direct_valve_based": "Doğrudan vana kontrolü",
+        "target_temp_based": "Hedef sıcaklığa dayalı",
+        "local_calibration_based": "Ofsete dayalı"
+      }
+    },
+    "mpc_v2_plant_preset": {
+      "options": {
+        "auto": "Otomatik (öğrenilen ısı kaybı oranını kullan)",
+        "small_room": "Küçük oda (~10 m², hızlı tepki)",
+        "medium_room": "Orta oda (~20 m², standart)",
+        "large_room": "Büyük oda (~40 m², yavaş yapı kabuğu)"
+      }
     }
   },
   "entity": {
@@ -207,6 +245,75 @@
       },
       "pid_kd_no_trv": {
         "name": "PID Kd (türevsel)"
+      },
+      "preset_eco": {
+        "name": "Eko"
+      },
+      "preset_eco_min": {
+        "name": "Eko Min"
+      },
+      "preset_eco_max": {
+        "name": "Eko Max"
+      },
+      "preset_away": {
+        "name": "Dışarıda"
+      },
+      "preset_away_min": {
+        "name": "Dışarıda Min"
+      },
+      "preset_away_max": {
+        "name": "Dışarıda Max"
+      },
+      "preset_boost": {
+        "name": "Boost"
+      },
+      "preset_boost_min": {
+        "name": "Boost Min"
+      },
+      "preset_boost_max": {
+        "name": "Boost Max"
+      },
+      "preset_comfort": {
+        "name": "Konfor"
+      },
+      "preset_comfort_min": {
+        "name": "Konfor Min"
+      },
+      "preset_comfort_max": {
+        "name": "Konfor Max"
+      },
+      "preset_home": {
+        "name": "Evde"
+      },
+      "preset_home_min": {
+        "name": "Evde Min"
+      },
+      "preset_home_max": {
+        "name": "Evde Max"
+      },
+      "preset_sleep": {
+        "name": "Uyku"
+      },
+      "preset_sleep_min": {
+        "name": "Uyku Min"
+      },
+      "preset_sleep_max": {
+        "name": "Uyku Max"
+      },
+      "preset_activity": {
+        "name": "Aktivite"
+      },
+      "preset_activity_min": {
+        "name": "Aktivite Min"
+      },
+      "preset_activity_max": {
+        "name": "Aktivite Max"
+      },
+      "valve_max_opening": {
+        "name": "{trv_name}: maksimum vana açıklığı"
+      },
+      "valve_max_opening_no_trv": {
+        "name": "Maksimum vana açıklığı"
       }
     },
     "switch": {
@@ -235,6 +342,51 @@
           "door_open": "turned off because a door was opened",
           "door_close": "resumed heating because a door was closed"
         }
+      },
+      "external_temp_ema": {
+        "name": "Sıcaklık EMA"
+      },
+      "external_temp_ema_1h": {
+        "name": "Sıcaklık EMA (1 saat)"
+      },
+      "temp_slope": {
+        "name": "Sıcaklık değişim hızı"
+      },
+      "heating_power": {
+        "name": "Isıtma gücü"
+      },
+      "heat_loss": {
+        "name": "Isı kaybı"
+      },
+      "virtual_temp": {
+        "name": "Sanal sıcaklık"
+      },
+      "mpc_gain": {
+        "name": "MPC ısıtma kazancı"
+      },
+      "mpc_loss": {
+        "name": "MPC ısı kaybı"
+      },
+      "mpc_ka": {
+        "name": "MPC yalıtımı (Ka)"
+      },
+      "pid_kp": {
+        "name": "PID Kp"
+      },
+      "pid_ki": {
+        "name": "PID Ki"
+      },
+      "pid_kd": {
+        "name": "PID Kd"
+      },
+      "pid_output": {
+        "name": "PID çıkışı"
+      },
+      "pid_error": {
+        "name": "PID hatası"
+      },
+      "solar_intensity": {
+        "name": "Güneş ısı kazancı"
       }
     }
   },

--- a/project.inlang.json
+++ b/project.inlang.json
@@ -3,9 +3,13 @@
     "languageTags": [
         "da",
         "de",
+        "el",
         "en",
         "fr",
+        "it",
         "pl",
+        "ru",
+        "sk",
         "tr"
     ],
     "modules": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from functools import cache
+import json
 from pathlib import Path
 import sys
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -11,13 +13,50 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+DOMAIN = "better_thermostat"
+ENGLISH_CATALOG = REPO_ROOT / "custom_components" / DOMAIN / "translations" / "en.json"
+
+
+def _flatten(obj: dict, prefix: str) -> dict[str, str]:
+    """Flatten a catalog into Home Assistant's dotted translation keys."""
+    flat: dict[str, str] = {}
+    for key, value in obj.items():
+        path = f"{prefix}.{key}"
+        if isinstance(value, dict):
+            flat.update(_flatten(value, path))
+        else:
+            flat[path] = value
+    return flat
+
+
+@cache
+def _english_translations() -> dict[str, str]:
+    """Return the English catalog keyed the way Home Assistant serves it."""
+    catalog = json.loads(ENGLISH_CATALOG.read_text(encoding="utf-8"))
+    return _flatten(catalog, f"component.{DOMAIN}")
+
 
 @pytest.fixture(autouse=True)
 def mock_async_get_translations():
-    """Mock Home Assistant's translation fetching across all tests."""
+    """Serve Better Thermostat's own catalog instead of hitting the store.
+
+    Entities name themselves from ``translation_key``, so the catalog has to
+    be readable for a translated entity to get a name at all — and the name
+    is what Home Assistant derives the entity_id from.
+    """
+
+    async def _get_translations(hass, language, category, integrations=None, *args):
+        if integrations is not None and DOMAIN not in integrations:
+            return {}
+        prefix = f"component.{DOMAIN}.{category}."
+        return {
+            key: value
+            for key, value in _english_translations().items()
+            if key.startswith(prefix)
+        }
+
     with patch(
         "homeassistant.helpers.translation.async_get_translations",
-        new_callable=AsyncMock,
-        return_value={},
+        side_effect=_get_translations,
     ) as mock_get_translations:
         yield mock_get_translations

--- a/tests/test_config_flow_localization.py
+++ b/tests/test_config_flow_localization.py
@@ -1,0 +1,36 @@
+"""Regression tests for localized config-flow selector values."""
+
+from custom_components.better_thermostat.config_flow import _normalize_user_submission
+from custom_components.better_thermostat.utils.const import CONF_TARGET_TEMP_STEP
+
+
+def test_new_auto_target_temperature_step_is_preserved():
+    """The translated Auto selector must persist the new empty-string value."""
+    normalized = _normalize_user_submission(
+        {CONF_TARGET_TEMP_STEP: "auto"}, mode="create"
+    )
+
+    assert normalized[CONF_TARGET_TEMP_STEP] == ""
+
+
+def test_legacy_auto_target_temperature_step_is_preserved():
+    """The legacy Auto selector must continue to persist 0.0."""
+    normalized = _normalize_user_submission(
+        {CONF_TARGET_TEMP_STEP: "auto_legacy"}, mode="create"
+    )
+
+    assert normalized[CONF_TARGET_TEMP_STEP] == "0.0"
+
+
+def test_missing_target_temperature_step_uses_legacy_default():
+    """A genuinely missing selector value must retain the existing fallback."""
+    normalized = _normalize_user_submission({}, mode="create")
+
+    assert normalized[CONF_TARGET_TEMP_STEP] == "0.0"
+
+
+def test_empty_target_temperature_step_uses_legacy_default():
+    """An explicit empty selector value must use the legacy fallback."""
+    normalized = _normalize_user_submission({CONF_TARGET_TEMP_STEP: ""}, mode="create")
+
+    assert normalized[CONF_TARGET_TEMP_STEP] == "0.0"

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,5 +1,8 @@
-"""Consistency checks for strings.json and the translation files."""
+"""Consistency checks for the Better Thermostat localization catalogs."""
 
+from __future__ import annotations
+
+import ast
 import json
 from pathlib import Path
 import re
@@ -7,110 +10,210 @@ import re
 import pytest
 import yaml
 
-COMPONENT = Path(__file__).parents[1] / "custom_components" / "better_thermostat"
+ROOT = Path(__file__).parents[1]
+COMPONENT = ROOT / "custom_components" / "better_thermostat"
 TRANSLATIONS = COMPONENT / "translations"
+PROJECT_INLANG = ROOT / "project.inlang.json"
 
-LANGUAGES = sorted(p.stem for p in TRANSLATIONS.glob("*.json") if p.stem != "en")
+ALL_LANGUAGES = sorted(path.stem for path in TRANSLATIONS.glob("*.json"))
+LANGUAGES = [language for language in ALL_LANGUAGES if language != "en"]
+
+ENTITY_TRANSLATION_KEYS = {
+    "sensor": {
+        "external_temp_ema",
+        "external_temp_ema_1h",
+        "temp_slope",
+        "heating_power",
+        "heat_loss",
+        "virtual_temp",
+        "mpc_gain",
+        "mpc_loss",
+        "mpc_ka",
+        "pid_kp",
+        "pid_ki",
+        "pid_kd",
+        "pid_output",
+        "pid_error",
+        "solar_intensity",
+    },
+    "number": {
+        *(
+            f"preset_{preset}{suffix}"
+            for preset in (
+                "eco",
+                "away",
+                "boost",
+                "comfort",
+                "home",
+                "sleep",
+                "activity",
+            )
+            for suffix in ("", "_min", "_max")
+        ),
+        "pid_kp",
+        "pid_ki",
+        "pid_kd",
+        "pid_kp_no_trv",
+        "pid_ki_no_trv",
+        "pid_kd_no_trv",
+        "valve_max_opening",
+        "valve_max_opening_no_trv",
+    },
+    "switch": {
+        "pid_auto_tune",
+        "pid_auto_tune_no_trv",
+        "child_lock",
+        "child_lock_no_trv",
+    },
+}
 
 
-def _flatten(obj: dict, prefix: str = "") -> dict[str, str]:
-    """Flatten nested dict values into dotted-key paths.
-
-    Parameters
-    ----------
-    obj : dict
-        Mapping to flatten.
-    prefix : str
-        Prefix for generated dotted paths.
-
-    Returns
-    -------
-    dict[str, str]
-        Flattened mapping where nested keys are represented as dotted paths.
-    """
-    flat: dict[str, str] = {}
+def _flatten(obj: dict, prefix: str = "") -> dict[str, object]:
+    """Flatten nested dictionary values into dotted-key paths."""
+    flat: dict[str, object] = {}
     for key, value in obj.items():
         path = f"{prefix}.{key}" if prefix else key
-        if isinstance(value, dict):
+        if isinstance(value, dict) and value:
             flat.update(_flatten(value, path))
         else:
             flat[path] = value
     return flat
 
 
-def _load(path: Path) -> dict[str, str]:
-    """Load a JSON file and flatten it into dotted-key paths.
-
-    Parameters
-    ----------
-    path : Path
-        JSON file path to read.
-
-    Returns
-    -------
-    dict[str, str]
-        Flattened JSON mapping for translation key comparisons.
-    """
-    return _flatten(json.loads(path.read_text(encoding="utf-8")))
+def test_flatten_preserves_empty_object_leaves():
+    """Empty catalog objects must remain visible to value validation."""
+    assert _flatten({"config": {"name": {}}}) == {"config.name": {}}
 
 
-def _placeholders(text: str) -> list[str]:
-    """Return sorted placeholder tokens found in a string.
+def _load_json(path: Path) -> dict:
+    """Load a JSON object from path."""
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict), f"{path} must contain a JSON object"
+    return value
 
-    Parameters
-    ----------
-    text : str
-        Input text that may contain placeholders such as ``{name}``.
 
-    Returns
-    -------
-    list[str]
-        Sorted placeholder tokens extracted from the text.
-    """
+def _load(path: Path) -> dict[str, object]:
+    """Load and flatten a translation catalog."""
+    return _flatten(_load_json(path))
+
+
+def _placeholders(text: object) -> list[str]:
+    """Return sorted placeholder tokens found in a translation string."""
+    assert isinstance(text, str), f"translation value must be a string, got {text!r}"
     return sorted(re.findall(r"\{[^}]*\}", text))
 
 
 def test_strings_json_matches_en_json():
-    """strings.json (source) and translations/en.json must be identical."""
+    """The authoring source and runtime English catalog must be identical."""
     assert _load(COMPONENT / "strings.json") == _load(TRANSLATIONS / "en.json")
+
+
+def test_inlang_languages_match_translation_catalogs():
+    """Every catalog must be discoverable by the Inlang contributor tooling."""
+    project = _load_json(PROJECT_INLANG)
+
+    assert project["sourceLanguageTag"] == "en"
+    assert sorted(project["languageTags"]) == ALL_LANGUAGES
+    assert (
+        project["plugin.inlang.i18next"]["pathPattern"]
+        == "./custom_components/better_thermostat/translations/{languageTag}.json"
+    )
+
+
+@pytest.mark.parametrize("lang", ALL_LANGUAGES)
+def test_translation_values_are_non_empty_strings(lang: str):
+    """Catalog leaves must contain non-empty text rather than nulls or objects."""
+    invalid = {
+        key: value
+        for key, value in _load(TRANSLATIONS / f"{lang}.json").items()
+        if not isinstance(value, str) or not value.strip()
+    }
+    assert not invalid, f"{lang}.json has invalid translation values: {invalid}"
 
 
 @pytest.mark.parametrize("lang", LANGUAGES)
 def test_no_unknown_keys(lang: str):
-    """Translation files must not contain keys that do not exist in en.json."""
-    en = _load(TRANSLATIONS / "en.json")
+    """Translation files must not contain keys absent from English."""
+    english = _load(TRANSLATIONS / "en.json")
     translated = _load(TRANSLATIONS / f"{lang}.json")
-    unknown = sorted(key for key in translated if key not in en)
+    unknown = sorted(key for key in translated if key not in english)
     assert not unknown, f"{lang}.json has keys unknown to en.json: {unknown}"
 
 
 @pytest.mark.parametrize("lang", LANGUAGES)
 def test_all_keys_translated(lang: str):
-    """Translation files must cover every key of en.json."""
-    en = _load(TRANSLATIONS / "en.json")
+    """Every language must cover every runtime English key."""
+    english = _load(TRANSLATIONS / "en.json")
     translated = _load(TRANSLATIONS / f"{lang}.json")
-    missing = sorted(key for key in en if key not in translated)
+    missing = sorted(key for key in english if key not in translated)
     assert not missing, f"{lang}.json is missing keys: {missing}"
 
 
 @pytest.mark.parametrize("lang", LANGUAGES)
 def test_placeholders_match(lang: str):
-    """Shared keys must use exactly the same placeholders as en.json."""
-    en = _load(TRANSLATIONS / "en.json")
+    """Shared keys must preserve exactly the English placeholders."""
+    english = _load(TRANSLATIONS / "en.json")
     translated = _load(TRANSLATIONS / f"{lang}.json")
     mismatched = {
-        key: (en[key], translated[key])
-        for key in en.keys() & translated.keys()
-        if _placeholders(en[key]) != _placeholders(translated[key])
+        key: (english[key], translated[key])
+        for key in english.keys() & translated.keys()
+        if _placeholders(english[key]) != _placeholders(translated[key])
     }
     assert not mismatched, f"{lang}.json placeholder mismatch: {mismatched}"
 
 
+def test_entity_translation_catalog_covers_platform_keys():
+    """All stable translation keys used by entity platforms must be cataloged."""
+    english_entities = _load_json(TRANSLATIONS / "en.json").get("entity", {})
+
+    for platform, expected_keys in ENTITY_TRANSLATION_KEYS.items():
+        actual_keys = set(english_entities.get(platform, {}))
+        missing = expected_keys - actual_keys
+        assert not missing, f"entity.{platform} is missing translation keys: {missing}"
+
+
+def _is_attr_name_target(target: ast.expr) -> bool:
+    """Return whether an assignment target writes Home Assistant's name field."""
+    return (isinstance(target, ast.Name) and target.id == "_attr_name") or (
+        isinstance(target, ast.Attribute) and target.attr == "_attr_name"
+    )
+
+
+@pytest.mark.parametrize("platform", ["sensor.py", "number.py", "switch.py"])
+def test_entity_platforms_do_not_hardcode_natural_language_names(platform: str):
+    """Entity names must use translation keys instead of English Python text."""
+    source_path = COMPONENT / platform
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    hardcoded: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        targets: list[ast.expr] = []
+        value: ast.expr | None = None
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+
+        if value is None or not any(_is_attr_name_target(target) for target in targets):
+            continue
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            hardcoded.append((node.lineno, value.value))
+        elif isinstance(value, ast.JoinedStr):
+            hardcoded.append((node.lineno, ast.unparse(value)))
+
+    assert not hardcoded, (
+        f"{platform} hardcodes user-facing entity names instead of "
+        f"translation_key: {hardcoded}"
+    )
+
+
 def test_services_yaml_covered():
-    """Every service and service field in services.yaml has a translation."""
+    """Every service and service field in services.yaml has an English string."""
     services = yaml.safe_load((COMPONENT / "services.yaml").read_text(encoding="utf-8"))
-    en = json.loads((TRANSLATIONS / "en.json").read_text(encoding="utf-8"))
-    translated_services = en.get("services", {})
+    english = _load_json(TRANSLATIONS / "en.json")
+    translated_services = english.get("services", {})
 
     assert set(services) == set(translated_services)
     for name, spec in services.items():
@@ -118,4 +221,60 @@ def test_services_yaml_covered():
         translated_fields = set(translated_services[name].get("fields", {}))
         assert expected_fields == translated_fields, (
             f"service {name}: fields in services.yaml and en.json differ"
+        )
+
+
+def test_select_selectors_declare_translation_keys():
+    """Config-flow dropdowns must be translatable instead of carrying labels."""
+    source_path = COMPONENT / "config_flow.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    offenders: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute) and func.attr == "SelectSelectorConfig"
+        ):
+            continue
+        keywords = {keyword.arg for keyword in node.keywords}
+        if "translation_key" not in keywords:
+            offenders.append((node.lineno, "missing translation_key"))
+        for keyword in node.keywords:
+            if keyword.arg != "options":
+                continue
+            for option in ast.walk(keyword.value):
+                if (
+                    isinstance(option, ast.Call)
+                    and isinstance(option.func, ast.Attribute)
+                    and option.func.attr == "SelectOptionDict"
+                    and any(inner.arg == "label" for inner in option.keywords)
+                ):
+                    offenders.append((option.lineno, "hardcoded option label"))
+
+    assert not offenders, f"config_flow.py selectors are not localizable: {offenders}"
+
+
+def test_selector_catalog_covers_every_option():
+    """Every value a dropdown can emit must have an English label."""
+    from custom_components.better_thermostat.config_flow import (
+        _TARGET_TEMP_STEP_SELECTOR_TO_VALUE,
+    )
+    from custom_components.better_thermostat.utils.const import (
+        CalibrationMode,
+        CalibrationType,
+        MpcV2PlantPreset,
+    )
+
+    catalog = _load_json(TRANSLATIONS / "en.json")["selector"]
+    expected = {
+        "calibration_mode": {member.value for member in CalibrationMode},
+        "calibration_type": {member.value for member in CalibrationType},
+        "mpc_v2_plant_preset": {member.value for member in MpcV2PlantPreset},
+        "target_temp_step": set(_TARGET_TEMP_STEP_SELECTOR_TO_VALUE),
+    }
+    for key, options in expected.items():
+        assert set(catalog[key]["options"]) == options, (
+            f"selector.{key} options and the catalog have drifted apart"
         )

--- a/tests/unit/test_calibration_mode_default.py
+++ b/tests/unit/test_calibration_mode_default.py
@@ -10,6 +10,8 @@ offered as the default.
 from __future__ import annotations
 
 import inspect
+import json
+import pathlib
 from unittest.mock import MagicMock
 
 import pytest
@@ -153,15 +155,20 @@ def test_config_flow_uses_the_shared_default():
 
 def test_only_the_real_default_is_labelled_default():
     """Exactly one dropdown entry carries the (Default) marker, and it is the default."""
-    options = config_flow_module.CALIBRATION_MODE_SELECTOR.config["options"]
-    marked = [opt for opt in options if "(Default)" in opt["label"]]
-    assert len(marked) == 1
-    assert marked[0]["value"] == DEFAULT_CALIBRATION_MODE
+    catalog = json.loads(
+        (
+            pathlib.Path(config_flow_module.__file__).parent
+            / "translations"
+            / "en.json"
+        ).read_text(encoding="utf-8")
+    )
+    labels = catalog["selector"]["calibration_mode"]["options"]
+    marked = [mode for mode, label in labels.items() if "(Default)" in label]
+    assert marked == [DEFAULT_CALIBRATION_MODE]
 
 
 def test_every_mode_is_offered_exactly_once():
     """The selector stays a faithful listing of the enum."""
-    options = config_flow_module.CALIBRATION_MODE_SELECTOR.config["options"]
-    values = [opt["value"] for opt in options]
+    values = list(config_flow_module.CALIBRATION_MODE_SELECTOR.config["options"])
     assert len(values) == len(set(values))
     assert set(values) == set(CalibrationMode)


### PR DESCRIPTION
## Motivation

Adopts #2150 (by @SHAREN) onto `develop`. The original targets `master` at 1.8.2 and no longer merges: 13 conflicting files, plus two areas that only exist on `develop` and were therefore uncovered.

Config-flow dropdown labels and entity names were hardcoded English in Python, so they stayed English regardless of the Home Assistant frontend language.

## Changes

- Four selectors (`target_temp_step`, `calibration_mode`, `calibration_type`, `presets`) list bare option values and resolve labels through `translation_key`.
- `mpc_v2_plant_preset` is localized as well — it was added to `develop` after #2150 was written and still carried hardcoded labels.
- Diagnostic sensors, preset numbers and the valve limit resolve their names from `entity.<platform>.<key>.name`. This includes the five PID sensors and the cooler-dependent `Min`/`Max` preset names, both of which only exist on `develop`.
- All ten catalogs plus `strings.json` gain the new keys, fully translated.
- Contributor guide under `custom_components/better_thermostat/translations/README.md`, linked from `CONTRIBUTING.md`; `project.inlang.json` lists every catalog.

### English wording is unchanged

Every English string is exactly what `develop` renders today, so no entity is silently renamed and no `entity_id` changes — verified end to end against the entity registry. #2150 reworded a number of them (`Sun Intensity Heatup` → `Solar heat gain`, `Preset Eco` → `Eco preset temperature`, …); those changes are dropped here because they would give new installs different `entity_id`s. Only `target_temp_step` keeps the clearer `Auto (legacy)` / `Auto` split, which is a dropdown label with no entity attached.

## Tests

Two guard tests pin the code to the catalogs, covering the exact way #2150 fell behind:

- `test_select_selectors_declare_translation_keys` — every `SelectSelectorConfig` declares a `translation_key` and carries no `label=`.
- `test_selector_catalog_covers_every_option` — every `CalibrationMode`, `CalibrationType`, `MpcV2PlantPreset` and temperature-step token has an English label.

`tests/conftest.py` stubbed `async_get_translations` to `{}` for the whole suite, which left every translation-key entity nameless in tests; the `entity_id`s the suite asserted therefore differed from production, and the pre-existing `child_lock` and `pid_*` entities were never exercised. The fixture now serves the integration's own English catalog.

Full suite: 4978 passed, 1 skipped. Ruff check and format clean.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## New device mappings

- [x] I avoided any changes to other device mappings
- [x] There are no changes in climate.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized labels for configuration options, presets, calibration settings, and sensor entities.
  * Added support for Greek, Italian, Russian, and Slovak translations.
  * Improved translated display names for preset temperature limits and valve settings.
  * Added contributor guidance for translation catalogs, placeholders, and validation.

* **Bug Fixes**
  * Improved handling of target-temperature step values, including legacy and empty settings.

* **Tests**
  * Expanded translation and localization coverage to verify labels, placeholders, selectors, and language consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->