### PR TITLE
fix(trvzb): land the requested valve position after a de-sticking bump

### DIFF
--- a/custom_components/better_thermostat/model_fixes/TRVZB.py
+++ b/custom_components/better_thermostat/model_fixes/TRVZB.py
@@ -19,18 +19,41 @@ VALVE_MAINTENANCE_INTERVAL_HOURS = 84
 # fail to fully close the valve when commanded to very small openings.
 #
 # Workaround: when requesting a further close (target_pct < last_pct), briefly
-# command the valve to open a bit more and then to the requested target.
+# command the valve to open a bit more and then to the requested target. A
+# close that arrives while that delayed write is still due is written straight
+# away instead of bumping again, so the requested position always reaches the
+# device.
 _TRVZB_CLOSE_BUMP_OPEN_DELTA_PCT = 10
 _TRVZB_CLOSE_BUMP_DELAY_S = 5.0
 
 
-def _cancel_pending_valve_bump(trv_state) -> None:
+def _cancel_pending_valve_bump(trv_state) -> bool:
+    """Cancel a scheduled valve write and report whether one was still due.
+
+    A task that has already run is not a pending write; it is only the
+    reference the last completed bump left behind.
+
+    Parameters
+    ----------
+    trv_state :
+        Domain object of the TRV whose pending write is to be dropped.
+
+    Returns
+    -------
+    bool
+        True when a write was still due and has been cancelled, False when
+        there was none or it had already run.
+    """
     task = trv_state.extra.pop("_trvzb_valve_bump_task", None)
-    if task is not None:
-        try:
-            task.cancel()
-        except asyncio.CancelledError, RuntimeError:
-            pass
+    if task is None:
+        return False
+    try:
+        if task.done():
+            return False
+        task.cancel()
+    except asyncio.CancelledError, RuntimeError:
+        return False
+    return True
 
 
 def fix_local_calibration(self, entity_id, offset):
@@ -289,7 +312,7 @@ async def override_set_valve(self, entity_id, percent: int):
             return bool(ok)
 
         # Cancel any previous pending delayed "bump then set".
-        _cancel_pending_valve_bump(trv_state)
+        bump_pending = _cancel_pending_valve_bump(trv_state)
 
         last_pct_raw = trv_state.last_valve_percent
         try:
@@ -302,8 +325,9 @@ async def override_set_valve(self, entity_id, percent: int):
             ok = await maybe_set_sonoff_valve_percent(self, entity_id, target_pct)
             return bool(ok)
 
-        # Only apply workaround when closing further.
-        if target_pct < last_pct:
+        # Only apply workaround when closing further, and only when the motor
+        # was not already driven open by a bump whose write is still due.
+        if target_pct < last_pct and not bump_pending:
             bump_pct = min(100, int(last_pct) + _TRVZB_CLOSE_BUMP_OPEN_DELTA_PCT)
 
             # If we can't "bump open", fall back to direct set.
@@ -340,7 +364,10 @@ async def override_set_valve(self, entity_id, percent: int):
             )
             return True
 
-        # Opening (or same) => set directly.
+        # Opening, unchanged, or a close following a bump that has not run yet:
+        # write the requested position. Bumping again would drive the valve
+        # further open on every closing step while the target the cancelled
+        # write was carrying never reaches the device.
         ok = await maybe_set_sonoff_valve_percent(self, entity_id, target_pct)
         return bool(ok)
     except TypeError, ValueError, KeyError, AttributeError:

--- a/tests/unit/test_trvzb_quirk_overrides.py
+++ b/tests/unit/test_trvzb_quirk_overrides.py
@@ -1,5 +1,6 @@
-"""Tests for the TRVZB setpoint and HVAC mode override quirks."""
+"""Tests for the TRVZB setpoint, HVAC mode and valve override quirks."""
 
+import asyncio
 import importlib
 from unittest.mock import AsyncMock, Mock
 
@@ -43,3 +44,144 @@ class TestOverrideSetHvacMode:
 
         assert handled is False
         mock_self.hass.services.async_call.assert_not_awaited()
+
+
+ENTITY = "climate.trv1"
+
+
+def _make_valve_self(last_pct=40, *, in_maintenance=False):
+    """Create a mock BetterThermostat whose TRV records a commanded valve percent."""
+    mock_self = _make_self()
+    mock_self.in_maintenance = in_maintenance
+    trv_state = Mock()
+    trv_state.last_valve_percent = last_pct
+    trv_state.extra = {}
+    mock_self.real_trvs = {ENTITY: trv_state}
+    mock_self.hass.async_create_background_task = lambda coro, name=None: (
+        asyncio.ensure_future(coro)
+    )
+    return mock_self, trv_state
+
+
+@pytest.fixture
+def writes(monkeypatch):
+    """Record every valve percentage the quirk puts on the wire."""
+    recorded = []
+
+    async def _write(_self, _entity_id, percent):
+        recorded.append(percent)
+        return True
+
+    monkeypatch.setattr(quirk, "maybe_set_sonoff_valve_percent", _write)
+    return recorded
+
+
+class TestOverrideSetValve:
+    """The de-sticking bump must never cost the requested position."""
+
+    @pytest.mark.asyncio
+    async def test_a_close_bumps_open_and_defers_the_target(self, writes):
+        """A close drives the valve open first and schedules the target."""
+        mock_self, trv_state = _make_valve_self(last_pct=40)
+
+        handled = await quirk.override_set_valve(mock_self, ENTITY, 30)
+        task = trv_state.extra.get("_trvzb_valve_bump_task")
+
+        try:
+            assert handled is True
+            assert writes == [50]
+            assert task is not None and not task.done()
+        finally:
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_a_close_superseding_a_due_bump_writes_the_target(self, writes):
+        """A close arriving before the deferred write lands goes out directly."""
+        mock_self, trv_state = _make_valve_self(last_pct=40)
+        await quirk.override_set_valve(mock_self, ENTITY, 30)
+        first_task = trv_state.extra["_trvzb_valve_bump_task"]
+        trv_state.last_valve_percent = 30
+
+        handled = await quirk.override_set_valve(mock_self, ENTITY, 20)
+        await asyncio.sleep(0)
+
+        assert handled is True
+        # 50 is the de-sticking bump of the first close; 20 is the new target.
+        # A second bump would drive the valve open again and drop the target.
+        assert writes == [50, 20]
+        assert first_task.done()
+        assert "_trvzb_valve_bump_task" not in trv_state.extra
+
+    @pytest.mark.asyncio
+    async def test_repeated_closes_always_land_the_latest_target(
+        self, writes, monkeypatch
+    ):
+        """Closes faster than the delay still put the newest position on the wire."""
+        monkeypatch.setattr(quirk, "_TRVZB_CLOSE_BUMP_DELAY_S", 30.0)
+        mock_self, trv_state = _make_valve_self(last_pct=40)
+
+        for target in (38, 36, 34, 32):
+            await quirk.override_set_valve(mock_self, ENTITY, target)
+            trv_state.last_valve_percent = target
+        await asyncio.sleep(0)
+
+        pending = trv_state.extra.get("_trvzb_valve_bump_task")
+        if pending is not None:
+            pending.cancel()
+
+        assert writes[-1] == 32, (
+            "the newest requested position never reached the device"
+        )
+        assert max(writes) == 50, "the valve was driven further open than any bump"
+
+    @pytest.mark.asyncio
+    async def test_a_completed_bump_does_not_suppress_the_next_de_stick(
+        self, writes, monkeypatch
+    ):
+        """Once the deferred write has run, the next close bumps again."""
+        monkeypatch.setattr(quirk, "_TRVZB_CLOSE_BUMP_DELAY_S", 0.0)
+        mock_self, trv_state = _make_valve_self(last_pct=40)
+
+        await quirk.override_set_valve(mock_self, ENTITY, 30)
+        await trv_state.extra["_trvzb_valve_bump_task"]
+        trv_state.last_valve_percent = 30
+
+        await quirk.override_set_valve(mock_self, ENTITY, 20)
+        pending = trv_state.extra.get("_trvzb_valve_bump_task")
+        if pending is not None:
+            pending.cancel()
+
+        assert writes == [50, 30, 40]
+
+    @pytest.mark.asyncio
+    async def test_an_opening_command_writes_directly(self, writes):
+        """Opening needs no de-sticking, so the position goes out unchanged."""
+        mock_self, trv_state = _make_valve_self(last_pct=40)
+
+        handled = await quirk.override_set_valve(mock_self, ENTITY, 60)
+
+        assert handled is True
+        assert writes == [60]
+        assert "_trvzb_valve_bump_task" not in trv_state.extra
+
+    @pytest.mark.asyncio
+    async def test_valve_maintenance_writes_directly(self, writes):
+        """Maintenance drives the valve itself and takes no deferred steps."""
+        mock_self, trv_state = _make_valve_self(last_pct=40, in_maintenance=True)
+
+        handled = await quirk.override_set_valve(mock_self, ENTITY, 0)
+
+        assert handled is True
+        assert writes == [0]
+        assert "_trvzb_valve_bump_task" not in trv_state.extra
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_last_position_writes_directly(self, writes):
+        """With no recorded position there is nothing to close further from."""
+        mock_self, trv_state = _make_valve_self(last_pct=None)
+
+        handled = await quirk.override_set_valve(mock_self, ENTITY, 30)
+
+        assert handled is True
+        assert writes == [30]
+        assert "_trvzb_valve_bump_task" not in trv_state.extra

--- a/tests/unit/test_trvzb_quirk_overrides.py
+++ b/tests/unit/test_trvzb_quirk_overrides.py
@@ -66,11 +66,14 @@ def _make_valve_self(last_pct=40, *, in_maintenance=False):
 
 
 async def _settle(task):
-    """Cancel a scheduled valve write and wait for it to finish.
+    """Cancel a scheduled valve write, if there is one, and wait for it.
 
     ``Task.cancel()`` only requests cancellation, so a test that ends on it
-    leaves the write pending into teardown.
+    leaves the write pending into teardown. ``None`` stands for a call that
+    scheduled nothing, which is a state several of these tests assert on.
     """
+    if task is None:
+        return
     task.cancel()
     with contextlib.suppress(asyncio.CancelledError):
         await task
@@ -138,9 +141,7 @@ class TestOverrideSetValve:
             trv_state.last_valve_percent = target
         await asyncio.sleep(0)
 
-        pending = trv_state.extra.get("_trvzb_valve_bump_task")
-        if pending is not None:
-            await _settle(pending)
+        await _settle(trv_state.extra.get("_trvzb_valve_bump_task"))
 
         assert writes[-1] == 32, (
             "the newest requested position never reached the device"
@@ -160,9 +161,7 @@ class TestOverrideSetValve:
         trv_state.last_valve_percent = 30
 
         await quirk.override_set_valve(mock_self, ENTITY, 20)
-        pending = trv_state.extra.get("_trvzb_valve_bump_task")
-        if pending is not None:
-            await _settle(pending)
+        await _settle(trv_state.extra.get("_trvzb_valve_bump_task"))
 
         assert writes == [50, 30, 40]
 

--- a/tests/unit/test_trvzb_quirk_overrides.py
+++ b/tests/unit/test_trvzb_quirk_overrides.py
@@ -3,7 +3,7 @@
 import asyncio
 import contextlib
 import importlib
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -14,9 +14,9 @@ quirk = importlib.import_module("custom_components.better_thermostat.model_fixes
 
 def _make_self():
     """Create a mock BetterThermostat with a spied service-call layer."""
-    mock_self = Mock()
+    mock_self = MagicMock()
     mock_self.device_name = "test_thermostat"
-    mock_self.context = Mock()
+    mock_self.context = MagicMock()
     mock_self.hass.services.async_call = AsyncMock()
     return mock_self
 

--- a/tests/unit/test_trvzb_quirk_overrides.py
+++ b/tests/unit/test_trvzb_quirk_overrides.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from custom_components.better_thermostat.trv import Trv
+
 quirk = importlib.import_module("custom_components.better_thermostat.model_fixes.TRVZB")
 
 
@@ -53,9 +55,8 @@ def _make_valve_self(last_pct=40, *, in_maintenance=False):
     """Create a mock BetterThermostat whose TRV records a commanded valve percent."""
     mock_self = _make_self()
     mock_self.in_maintenance = in_maintenance
-    trv_state = Mock()
+    trv_state = Trv(entity_id=ENTITY)
     trv_state.last_valve_percent = last_pct
-    trv_state.extra = {}
     mock_self.real_trvs = {ENTITY: trv_state}
     mock_self.hass.async_create_background_task = lambda coro, name=None: (
         asyncio.ensure_future(coro)

--- a/tests/unit/test_trvzb_quirk_overrides.py
+++ b/tests/unit/test_trvzb_quirk_overrides.py
@@ -1,6 +1,7 @@
 """Tests for the TRVZB setpoint, HVAC mode and valve override quirks."""
 
 import asyncio
+import contextlib
 import importlib
 from unittest.mock import AsyncMock, Mock
 
@@ -64,6 +65,17 @@ def _make_valve_self(last_pct=40, *, in_maintenance=False):
     return mock_self, trv_state
 
 
+async def _settle(task):
+    """Cancel a scheduled valve write and wait for it to finish.
+
+    ``Task.cancel()`` only requests cancellation, so a test that ends on it
+    leaves the write pending into teardown.
+    """
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
 @pytest.fixture
 def writes(monkeypatch):
     """Record every valve percentage the quirk puts on the wire."""
@@ -93,7 +105,7 @@ class TestOverrideSetValve:
             assert writes == [50]
             assert task is not None and not task.done()
         finally:
-            task.cancel()
+            await _settle(task)
 
     @pytest.mark.asyncio
     async def test_a_close_superseding_a_due_bump_writes_the_target(self, writes):
@@ -128,7 +140,7 @@ class TestOverrideSetValve:
 
         pending = trv_state.extra.get("_trvzb_valve_bump_task")
         if pending is not None:
-            pending.cancel()
+            await _settle(pending)
 
         assert writes[-1] == 32, (
             "the newest requested position never reached the device"
@@ -150,7 +162,7 @@ class TestOverrideSetValve:
         await quirk.override_set_valve(mock_self, ENTITY, 20)
         pending = trv_state.extra.get("_trvzb_valve_bump_task")
         if pending is not None:
-            pending.cancel()
+            await _settle(pending)
 
         assert writes == [50, 30, 40]
 


### PR DESCRIPTION
## What is wrong

`model_fixes/TRVZB.py` carries a motor de-sticking workaround: when a closing command arrives (`target_pct < last_pct`), the valve is first driven 10 % further **open**, and the requested position is written five seconds later from a background task.

Every call to `override_set_valve` cancels the pending write before scheduling its own. When closing commands arrive faster than that delay, each one cancels its predecessor's write and issues another bump, so the device receives only bump values and never a requested position — while it drifts *open*:

```
last=40   target 38 < 40  → write 50, schedule 38 at t+5s
last=38   target 36 < 38  → cancel the pending 38, write 48, schedule 36 at t+5s
last=36   target 34 < 36  → cancel the pending 36, write 46, schedule 34 at t+5s
```

Meanwhile `delegate.set_valve` records `last_valve_percent = target_pct` on the override's `True`, so Better Thermostat's own picture says the valve is closing down through 38, 36, 34. That same figure feeds the heating/idle reporting in `utils/hvac_action.py`.

Measured against the unpatched code, the added test closes 40 → 38 → 36 → 34 → 32 and the last position the device sees is **44 %**, not 32 %.

## What changes

A close that supersedes a write which is still due is written straight away instead of bumping again. The motor was already driven open by that pending bump, so the de-sticking has happened; repeating it is what drove the valve open on every step and dropped the target the cancelled write was carrying.

`_cancel_pending_valve_bump` now reports whether a write was genuinely still due. A task that has already run is only the reference the last completed bump left behind, so it no longer counts as pending and the de-sticking step still precedes the next closing command.

## Verification

Seven tests in `tests/unit/test_trvzb_quirk_overrides.py`, which had no coverage of the valve override at all. Reverting the production diff turns two of them red with `assert 44 == 32` — the drift above. Full suite green.

## Not covered here

The bump fires on *every* closing step, so a long closing ramp still oscillates between the bump and the target. That is the existing workaround's design, and narrowing it to the small openings its comment describes needs device feedback rather than a guess.

Related to #1935, but deliberately not marked as closing it: whether this fully explains the 0/100 report there depends on how often that user's control cycles fire, and the measurements posted in that issue show the TPI controller itself produces graded output. The ratchet is wrong either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat valve control when closing follows a pending opening adjustment.
  * Ensured requested temperature targets are written directly instead of triggering unnecessary valve movements.
  * Improved handling of repeated commands, completed adjustments, maintenance mode, and unknown valve positions.
  * Reduced unnecessary valve activity for more predictable temperature control.

* **Tests**
  * Added comprehensive coverage for valve overrides and delayed adjustment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->