### PR TITLE
fix: apply the scheduled slot's preset and keep the submitted step selection

### DIFF
--- a/blueprints/weekly_heating_schedule.yaml
+++ b/blueprints/weekly_heating_schedule.yaml
@@ -597,10 +597,12 @@ variables:
     {% endif %}
 
   # ── Preset that should currently be active (for startup / resume) ─────────
+  # `active_slot` arrives here as an integer: Home Assistant runs `literal_eval`
+  # over a rendered variable, so the bare digit becomes a number.
   current_schedule_preset: >
-    {% if active_slot == '1' %}{{ preset_slot1 }}
-    {% elif active_slot == '2' %}{{ preset_slot2 }}
-    {% elif active_slot == '3' %}{{ preset_slot3 }}
+    {% if active_slot | int == 1 %}{{ preset_slot1 }}
+    {% elif active_slot | int == 2 %}{{ preset_slot2 }}
+    {% elif active_slot | int == 3 %}{{ preset_slot3 }}
     {% else %}{{ preset_slot4 }}
     {% endif %}
 

--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -548,9 +548,14 @@ def _build_user_fields(
         CONF_TARGET_TEMP_STEP, _USER_FIELD_DEFAULTS[CONF_TARGET_TEMP_STEP]
     )
     if target_step_default is not None:
-        target_step_default = _TARGET_TEMP_STEP_VALUE_TO_SELECTOR.get(
-            str(target_step_default), "auto_legacy"
-        )
+        target_step_key = str(target_step_default)
+        if target_step_key in _TARGET_TEMP_STEP_SELECTOR_TO_VALUE:
+            # A re-displayed form carries the submitted selector token, not a stored value.
+            target_step_default = target_step_key
+        else:
+            target_step_default = _TARGET_TEMP_STEP_VALUE_TO_SELECTOR.get(
+                target_step_key, "auto_legacy"
+            )
     add_field(CONF_TARGET_TEMP_STEP, TEMP_STEP_SELECTOR, default=target_step_default)
 
     return fields

--- a/docs/setup/automation-blueprints.md
+++ b/docs/setup/automation-blueprints.md
@@ -172,8 +172,8 @@ All 8 BT presets are available per slot per day type: `none`, `eco`, `away`,
 
 | Feature | How it works |
 |---|---|
-| **Presence-based away mode** | Enable + select a `person.*` / `device_tracker.*` / `binary_sensor.*`. While nobody is home the *Vacation preset* is applied instead of the schedule. Returns to the correct slot automatically on arrival. |
-| **Schedule pause switch** | Point to an `input_boolean` helper. Turning it on freezes the schedule; turning it off immediately re-applies the correct slot. |
+| **Presence-based away mode** | Enable + select one or more `person.*` / `device_tracker.*` / `binary_sensor.*` entities (leave empty to disable). While none of them is home the *Vacation preset* is applied instead of the schedule. Returns to the correct slot automatically on arrival. |
+| **Schedule pause switch** | Point to one or more `input_boolean` helpers (leave empty to disable). The schedule is frozen while at least one of them is on; turning them off immediately re-applies the correct slot. |
 | **HA restart recovery** | After a restart, waits 30 s for entities to load, then applies the currently correct slot (or vacation preset). |
 | **Notifications** | Optional `notify.*` service receives a message on every slot change, presence event, and startup recovery. |
 
@@ -188,8 +188,8 @@ All 8 BT presets are available per slot per day type: `none`, `eco`, `away`,
 | Slot 2 | Start times & presets (Weekday / Saturday / Sunday) |
 | Slot 3 | Start times & presets (Weekday / Saturday / Sunday) |
 | Slot 4 | Start times & presets (Weekday / Saturday / Sunday) |
-| Presence | Enable toggle · presence entity · vacation preset |
-| Pause | Enable toggle · input_boolean helper |
+| Presence | Enable toggle · presence entities · vacation preset |
+| Pause | Enable toggle · input_boolean helpers |
 | Notifications | notify.* target |
 
 [![Import blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2FKartoffelToby%2Fbetter_thermostat%2Fblob%2Fmaster%2Fblueprints%2Fweekly_heating_schedule.yaml)

--- a/tests/test_config_flow_localization.py
+++ b/tests/test_config_flow_localization.py
@@ -1,6 +1,9 @@
 """Regression tests for localized config-flow selector values."""
 
-from custom_components.better_thermostat.config_flow import _normalize_user_submission
+from custom_components.better_thermostat.config_flow import (
+    _build_user_fields,
+    _normalize_user_submission,
+)
 from custom_components.better_thermostat.utils.const import CONF_TARGET_TEMP_STEP
 
 
@@ -34,3 +37,33 @@ def test_empty_target_temperature_step_uses_legacy_default():
     normalized = _normalize_user_submission({CONF_TARGET_TEMP_STEP: ""}, mode="create")
 
     assert normalized[CONF_TARGET_TEMP_STEP] == "0.0"
+
+
+def _target_step_default(fields):
+    """Return the schema default the form offers for the target temperature step."""
+    for marker in fields:
+        if marker == CONF_TARGET_TEMP_STEP:
+            return marker.default()
+    raise AssertionError("target temperature step field missing from the form")
+
+
+def test_redisplayed_form_keeps_the_submitted_selector_token():
+    """A form rebuilt after a validation error keeps the token the user picked."""
+    for token in ("auto", "auto_legacy", "step_0_5"):
+        fields = _build_user_fields(
+            mode="create",
+            current={CONF_TARGET_TEMP_STEP: "0.1"},
+            user_input={CONF_TARGET_TEMP_STEP: token},
+        )
+
+        assert _target_step_default(fields) == token
+
+
+def test_form_maps_stored_values_to_selector_tokens():
+    """A freshly built form translates the stored value into its selector token."""
+    for stored, token in (("", "auto"), ("0.0", "auto_legacy"), ("0.5", "step_0_5")):
+        fields = _build_user_fields(
+            mode="update", current={CONF_TARGET_TEMP_STEP: stored}
+        )
+
+        assert _target_step_default(fields) == token

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -18,6 +18,7 @@ import traceback
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
+from homeassistant.core import State
 import pytest
 
 from custom_components.better_thermostat.trv import Trv
@@ -1131,11 +1132,8 @@ class TestWriteConfirmTimeout:
     @pytest.mark.asyncio
     async def test_system_mode_polls_for_the_shared_window(self):
         """check_system_mode polls one second at a time up to the window."""
-        mock_state = Mock()
-        mock_state.state = HVACMode.OFF
-
         mock_hass = Mock()
-        mock_hass.states.get.return_value = mock_state
+        mock_hass.states.get.return_value = State("climate.trv1", HVACMode.OFF)
 
         mock_self = Mock()
         mock_self.device_name = "test_thermostat"
@@ -1155,11 +1153,10 @@ class TestWriteConfirmTimeout:
     @pytest.mark.asyncio
     async def test_target_temperature_polls_for_the_shared_window(self):
         """check_target_temperature polls one second at a time up to the window."""
-        mock_state = Mock()
-        mock_state.attributes = {"temperature": 20.0}
-
         mock_hass = Mock()
-        mock_hass.states.get.return_value = mock_state
+        mock_hass.states.get.return_value = State(
+            "climate.trv1", HVACMode.HEAT, {"temperature": 20.0}
+        )
 
         mock_self = Mock()
         mock_self.device_name = "test_thermostat"

--- a/tests/unit/controlling/test_helpers.py
+++ b/tests/unit/controlling/test_helpers.py
@@ -1132,10 +1132,10 @@ class TestWriteConfirmTimeout:
     @pytest.mark.asyncio
     async def test_system_mode_polls_for_the_shared_window(self):
         """check_system_mode polls one second at a time up to the window."""
-        mock_hass = Mock()
+        mock_hass = MagicMock()
         mock_hass.states.get.return_value = State("climate.trv1", HVACMode.OFF)
 
-        mock_self = Mock()
+        mock_self = MagicMock()
         mock_self.device_name = "test_thermostat"
         mock_self.hass = mock_hass
         mock_self.real_trvs = {
@@ -1153,12 +1153,12 @@ class TestWriteConfirmTimeout:
     @pytest.mark.asyncio
     async def test_target_temperature_polls_for_the_shared_window(self):
         """check_target_temperature polls one second at a time up to the window."""
-        mock_hass = Mock()
+        mock_hass = MagicMock()
         mock_hass.states.get.return_value = State(
             "climate.trv1", HVACMode.HEAT, {"temperature": 20.0}
         )
 
-        mock_self = Mock()
+        mock_self = MagicMock()
         mock_self.device_name = "test_thermostat"
         mock_self.hass = mock_hass
         mock_self.real_trvs = {

--- a/tests/unit/test_blueprints.py
+++ b/tests/unit/test_blueprints.py
@@ -19,6 +19,7 @@ instance.
 """
 
 from ast import literal_eval
+from datetime import datetime
 from pathlib import Path
 
 from homeassistant.components.automation import config as automation_config
@@ -276,16 +277,17 @@ async def test_weekly_schedule_rejects_an_empty_string_input(hass):
 def _render(template_text: str, context: dict, states: dict):
     """Render a blueprint variable the way Home Assistant would.
 
-    Home Assistant renders a `variables:` entry and then runs `literal_eval`
-    over the result (`homeassistant.helpers.template._parse_result`), keeping
-    the raw string when that fails. A branch rendering the bare word `false`
-    therefore yields the *string* `"false"`, which is truthy -- so the value a
-    template produces has to be a Python literal, not just look like one.
+    Home Assistant strips a rendered `variables:` entry and then runs
+    `literal_eval` over the result (`homeassistant.helpers.template.
+    _parse_result`), keeping the raw string when that fails. A branch
+    rendering the bare word `false` therefore yields the *string* `"false"`,
+    which is truthy -- so the value a template produces has to be a Python
+    literal, not just look like one.
     """
     env = jinja2.Environment()
     env.globals["states"] = lambda entity: states.get(entity, "unknown")
     env.globals["is_state"] = lambda entity, value: states.get(entity) == value
-    rendered = env.from_string(template_text).render(**context)
+    rendered = env.from_string(template_text).render(**context).strip()
     try:
         return literal_eval(rendered)
     except ValueError, TypeError, SyntaxError, MemoryError:
@@ -412,6 +414,53 @@ def test_disabled_branches_render_real_booleans(
 
     assert isinstance(result, bool), f"{name} rendered {result!r}, not a bool"
     assert result is expected
+
+
+_SLOT_TIMES = {
+    "slot1_time": "06:30:00",
+    "slot2_time": "08:30:00",
+    "slot3_time": "17:00:00",
+    "slot4_time": "22:30:00",
+}
+
+
+@pytest.mark.parametrize(
+    ("clock", "expected_slot"),
+    [
+        pytest.param("06:30:00", 1, id="start-of-slot1"),
+        pytest.param("07:15:00", 1, id="inside-slot1"),
+        pytest.param("09:00:00", 2, id="inside-slot2"),
+        pytest.param("18:00:00", 3, id="inside-slot3"),
+        pytest.param("23:00:00", 4, id="inside-slot4"),
+        pytest.param("03:00:00", 4, id="before-slot1-belongs-to-the-night-slot"),
+    ],
+)
+def test_current_schedule_preset_follows_the_active_slot(
+    schedule_variables, clock, expected_slot
+):
+    """Startup recovery, pause resume and arrival apply the current slot's preset.
+
+    `active_slot` renders a bare digit, so `literal_eval` hands it on as an
+    integer. A comparison against the strings `'1'`/`'2'`/`'3'` matches
+    nothing and sends all three paths to the slot 4 preset.
+    """
+    active_slot = _render(
+        schedule_variables["active_slot"],
+        {"now": lambda: datetime.strptime(clock, "%H:%M:%S"), **_SLOT_TIMES},
+        {},
+    )
+
+    assert active_slot == expected_slot
+    assert isinstance(active_slot, int)
+
+    preset = _render(
+        schedule_variables["current_schedule_preset"],
+        {"active_slot": active_slot}
+        | {f"preset_slot{i}": f"preset{i}" for i in range(1, 5)},
+        {},
+    )
+
+    assert preset == f"preset{expected_slot}"
 
 
 def _branch_for_trigger(node, trigger_id):

--- a/tests/unit/test_climate_reset_pid.py
+++ b/tests/unit/test_climate_reset_pid.py
@@ -139,9 +139,9 @@ async def test_seeding_preserves_other_state_fields(bt):
     """Seeding only updates gains; learned fields like the integral survive.
 
     Note: this isolates the seeding code path by mocking
-    ``reset_pid_states`` (line 142) so the full reset is not run. The
-    assertions therefore verify seeding-in-isolation, not that learned
-    fields survive a complete ``reset_pid_learnings_service`` execution.
+    ``reset_pid_states`` so the full reset is not run. The assertions
+    therefore verify seeding-in-isolation, not that learned fields
+    survive a complete ``reset_pid_learnings_service`` execution.
     """
     bt.state_mgr.pid["uid:climate.trv:t21.0"] = PIDState(pid_integral=7.5)
     # Reset clears the entry, so seed into a pre-populated *fresh* manager:


### PR DESCRIPTION
## What this fixes

Two user-visible defects and three pieces of hygiene, all found while reviewing the `develop` → `v2` sync (#2231). The same fixes are already on that branch; this keeps the two lines from diverging.

### The weekly schedule always fell back to slot 4

`current_schedule_preset` compared `active_slot` against the strings `'1'`, `'2'` and `'3'`. Home Assistant renders each `variables:` entry with `parse_result=True`, so `literal_eval` turns the bare digit the template emits into an **integer** before the comparison runs. All three branches therefore missed, and startup recovery, pause resume and arrival applied the slot-4 preset regardless of the time of day.

Confirmed against Home Assistant's own renderer rather than by reading: driving `ScriptVariables.async_render` with slot times around midnight yields `active_slot: 2 (int)` and `preset_slot4` where `preset_slot2` is meant.

The comparisons now run through `| int`, and a parametrised test walks the clock across all four slots. Counter-check: reverting the blueprint change fails 4 of the test's 6 cases — the two slot-4 cases still pass, since the broken `else` branch happens to be right there.

### A config-flow validation error discarded the temperature-step choice

`async_step_user` re-enters `_build_user_fields` with the raw submission after setting an error, so the value reaching the selector default is a selector token (`auto`, `step_0_5`, …). The reverse map is keyed by *stored* values only, so no token matched and **every** selection collapsed to `auto_legacy`; the retry then stored `0.0` whatever the user had picked.

A value that is already a selector token now passes through unchanged — the same token-first shape `_normalize_user_submission` already uses — and the stored-value path keeps its mapping. Both directions have a regression test; reverting the production change fails the new one.

### Hygiene

- `docs/setup/automation-blueprints.md` still described one presence entity and one `input_boolean` helper. Both selectors have taken a list since #2170: an empty list disables the feature, any entity being on is enough.
- The two write-confirmation watchdog tests built their entity state from `Mock`. The code under test reads only `state` and `attributes`, so a real `State` works and is the more faithful fixture.
- A test docstring pointed at a line number that pointed at itself.

## Verification

`uv run pytest tests/` → **5016 passed**, 1 skipped. `ruff check`, `ruff format --check` and `pyrefly check` all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weekly heating schedule slot detection across day boundaries.
  * Preserved selected target-temperature step options when configuration forms are redisplayed.
  * Improved compatibility with Home Assistant’s rendered schedule values.

* **Documentation**
  * Clarified that presence-based away mode and schedule pause support multiple entities.
  * Documented that leaving these selections empty disables the features.
  * Clarified schedule pause freeze and re-apply behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->