### PR TITLE
fix(mpc_v2): bound the disturbance estimate without dropping short intervals

### DIFF
--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -556,7 +556,7 @@ def _record_mpc_v2_reid_sample(
         return
     try:
         u_frac = float(applied_valve_pct) / 100.0
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         # A current MPC proposal is not evidence of a physical valve input:
         # the write can still be deferred, clamped, or fail.
         return
@@ -591,7 +591,7 @@ def _confirmed_valve_pct(trv_state) -> float | None:
             continue
         try:
             pct = float(value)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             continue
         if math.isfinite(pct) and 0.0 <= pct <= 100.0:
             return pct

--- a/custom_components/better_thermostat/calibration.py
+++ b/custom_components/better_thermostat/calibration.py
@@ -587,6 +587,8 @@ def _confirmed_valve_pct(trv_state) -> float | None:
         getattr(trv_state, "valve_position", None),
         getattr(trv_state, "last_valve_percent", None),
     ):
+        if value is None:
+            continue
         try:
             pct = float(value)
         except (TypeError, ValueError):

--- a/custom_components/better_thermostat/utils/calibration/mpc_v2_internals/dob.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc_v2_internals/dob.py
@@ -50,13 +50,18 @@ class DisturbanceObserver:
         ``60 * innovation_K / tau_s`` even for near-zero intervals, as they
         occur when a shared group controller is stepped once per TRV within
         the same control pass.
+
+        The estimate itself is bounded by ``max_abs_K_per_min`` so a quantised
+        sensor jump cannot become an implausible steady-state load. That bound
+        belongs on the estimate rather than on the incoming rate: clamping the
+        rate first would scale it by the dt-proportional weight as well, which
+        drops the short-interval innovations this observer is meant to fold in.
         """
         if dt_s <= 0.0:
             return self.D_hat_K_per_min
         innov_rate = innovation_K / (dt_s / 60.0)
-        max_abs = max(0.0, self.params.max_abs_K_per_min)
-        innov_rate = max(-max_abs, min(max_abs, innov_rate))
         a = min(1.0, dt_s / max(self.params.tau_s, dt_s))
+        max_abs = max(0.0, self.params.max_abs_K_per_min)
         self.D_hat_K_per_min = (1.0 - a) * self.D_hat_K_per_min + a * innov_rate
         self.D_hat_K_per_min = max(-max_abs, min(max_abs, self.D_hat_K_per_min))
         return self.D_hat_K_per_min

--- a/tests/unit/mpc_v2/test_dob.py
+++ b/tests/unit/mpc_v2/test_dob.py
@@ -57,11 +57,18 @@ def test_two_near_zero_dt_updates_do_not_amplify() -> None:
 
 
 def test_regular_dt_converges_towards_innovation_rate() -> None:
-    """Repeated same-sign innovations at tau-scale dt approach the rate."""
+    """Repeated same-sign innovations at tau-scale dt approach the rate.
+
+    The innovation is sized so its rate stays inside ``max_abs_K_per_min``,
+    leaving the EMA rather than the bound to decide where the estimate ends
+    up; the bound itself is covered by
+    ``test_large_sensor_jump_is_bounded_before_feed_forward``.
+    """
     tau_s = 600.0
     dt_s = 300.0
-    innovation_K = 0.5
+    innovation_K = 0.1
     innov_rate = innovation_K / (dt_s / 60.0)
+    assert innov_rate < DobParams().max_abs_K_per_min
 
     dob = DisturbanceObserver(DobParams(tau_s=tau_s))
     for _ in range(50):

--- a/tests/unit/mpc_v2/test_kalman.py
+++ b/tests/unit/mpc_v2/test_kalman.py
@@ -65,9 +65,7 @@ def test_innovation_matches_measurement_minus_predicted_y() -> None:
 
 def test_observer_uses_actual_elapsed_time() -> None:
     """A sparse HA event advances the model by its full interval, not 30 s."""
-    plant = PlantModelRC2(
-        PlantParams(tau_room_min=120.0, tau_rad_min=8.0), dt_s=30.0
-    )
+    plant = PlantModelRC2(PlantParams(tau_room_min=120.0, tau_rad_min=8.0), dt_s=30.0)
     obs = _make_observer(plant)
     obs.initialise(np.array([20.0, 35.0]))
     y_meas = 20.2

--- a/tests/unit/test_calibration_sensor_fallback.py
+++ b/tests/unit/test_calibration_sensor_fallback.py
@@ -264,11 +264,7 @@ def test_reid_sample_records_open_door_as_open_contact() -> None:
     bt.contact_open = bool(bt.window_open) or bool(bt.door_open)
 
     _record_mpc_v2_reid_sample(
-        bt,
-        "key",
-        applied_valve_pct=40.0,
-        trv_temp=21.0,
-        outdoor_temp=5.0,
+        bt, "key", applied_valve_pct=40.0, trv_temp=21.0, outdoor_temp=5.0
     )
 
     samples = state_mgr.get_mpc_v2_reid_runtime("key").buffer.samples


### PR DESCRIPTION
## Why `v2` is red

Three `tests/unit/mpc_v2/test_dob.py` tests fail on `origin/v2` today, and `pyrefly` reports one error. Neither is caused by any open pull request. With this branch the whole suite is green — **6961 passed**, and `ruff`, `ruff format` and `pyrefly` are all clean.

## The disturbance observer clamped twice

`1f49a1a0` introduced `DobParams.max_abs_K_per_min = 0.05` so that a quantised room-sensor jump cannot turn into an implausible permanent load in the steady-state feed-forward term. That is the right guard, but it was applied in two places: to the incoming innovation rate *before* the EMA, and to the estimate after it.

Clamping the rate first means the clamped value is then scaled by the dt-proportional EMA weight as well. An update arriving 1 ms after the previous one therefore contributed `a * 0.05` ≈ **8.3e-08 K/min** instead of the `60 * innovation / tau_s` = 0.05 the module docstring describes — three orders of magnitude short. Those short intervals are not hypothetical: they are what a shared group controller produces when it is stepped once per TRV inside one control pass, which is exactly the case the docstring calls out.

The bound belongs on the estimate, which is what actually feeds forward. Keeping it only there:

- still stops a quantised jump from becoming an implausible load — `test_large_sensor_jump_is_bounded_before_feed_forward`, added by the same commit, passes unchanged;
- restores the documented dt-proportionality;
- leaves a sub-bound disturbance rate converging exactly as before.

| | rate + estimate clamped | estimate clamped |
|---|---|---|
| tiny-dt single update | 8.3e-08 | 0.05 |
| two tiny-dt updates | 1.7e-07 | 0.05 |
| large sensor jump | 0.05 | 0.05 |
| sustained sub-bound rate | tracks it | tracks it |

`test_regular_dt_converges_towards_innovation_rate` asked the observer to converge to 0.1 K/min, which is above the 0.05 bound — it could not pass once the bound existed, in either shape. It predates the bound. Its innovation is now sized to stay inside it, so the EMA rather than the clamp decides the outcome; the bound itself stays covered by the test written for it.

Counter-check: putting the pre-EMA clamp back turns two of these tests red again.

## The other two commits

- `_confirmed_valve_pct` relied on `float(None)` raising to skip a missing reading. It reads as an accident, and it is the one error `pyrefly` reports on this branch. The `None` case is now skipped explicitly.
- Three files had drifted from `ruff format`, which kept the lint job from passing. Formatter output only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved disturbance estimation so smoothing is applied before enforcing configured limits.
  - Preserved protection against excessive disturbance estimates while allowing more accurate convergence.

- **Tests**
  - Updated convergence coverage to distinguish smoothing behavior from limit enforcement.
  - Reformatted test code without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->