### PR TITLE
test(integration): drive the config and options flows through Home Assistant

### DIFF
--- a/custom_components/better_thermostat/__init__.py
+++ b/custom_components/better_thermostat/__init__.py
@@ -31,7 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.CLIMATE, Platform.SENSOR, Platform.NUMBER, Platform.SWITCH]
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
-config_entry_update_listener_lock = Lock()
+RELOAD_LOCKS = f"{DOMAIN}_reload_locks"
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -61,9 +61,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+def _reload_lock(hass: HomeAssistant, entry: ConfigEntry) -> Lock:
+    """Return the lock one entry serializes its own reloads on.
+
+    The lock lives on the Home Assistant instance and is keyed by entry, so
+    two thermostats reload independently and a lock never outlives the
+    instance it was created for. It has to survive the reload it guards,
+    which is why it does not live in the per-entry data the unload clears.
+
+    Parameters
+    ----------
+    hass : HomeAssistant
+        The running Home Assistant instance.
+    entry : ConfigEntry
+        The config entry about to reload.
+
+    Returns
+    -------
+    Lock
+        The lock for this entry, created on first use.
+    """
+    return hass.data.setdefault(RELOAD_LOCKS, {}).setdefault(entry.entry_id, Lock())
+
+
 async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
-    async with config_entry_update_listener_lock:
+    async with _reload_lock(hass, entry):
         await hass.config_entries.async_reload(entry.entry_id)
 
 
@@ -90,6 +113,8 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
         The config entry being removed.
     """
     from .utils.state_manager import StateManager
+
+    hass.data.get(RELOAD_LOCKS, {}).pop(entry.entry_id, None)
 
     try:
         await StateManager.async_remove_store(hass, entry.entry_id)

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -1,0 +1,394 @@
+"""Config and options flow, driven through Home Assistant's flow helpers.
+
+The unit suite calls the flow handlers directly and hands them mocked
+registries. That skips what Home Assistant does between two steps: it
+validates a submission against the schema the step published, it decides
+which keys reach the handler when a field is left empty, and it sets up the
+entry the flow produced. Two things only exist in that gap: the model a
+swapped thermostat has to be resolved to from scratch, and the key an
+emptied entity selector does *not* send.
+
+So these tests submit forms instead of calling handlers, and end on the
+entry: what was stored, and what the thermostat that came up from it drives.
+"""
+
+import asyncio
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.data_entry_flow import FlowResultType
+import pytest
+import voluptuous as vol
+
+from custom_components.better_thermostat import RELOAD_LOCKS
+from custom_components.better_thermostat.utils.const import (
+    CONF_CALIBRATION,
+    CONF_CHILD_LOCK,
+    CONF_COOLER,
+    CONF_HEATER,
+    CONF_MODEL,
+    CONF_OUTDOOR_SENSOR,
+    CONF_SENSOR,
+    CONF_SENSOR_WINDOW,
+    CalibrationType,
+)
+
+from .conftest import (
+    BT_ENTITY,
+    DOMAIN,
+    SENSOR_ID,
+    WINDOW_ID,
+    assert_profile_adopted,
+    build_devices,
+    profile_id,
+    set_room_sensor,
+    wait_for_startup,
+)
+from .device_profiles import (
+    COOLER_ID,
+    GENERIC_HEAT_TRV,
+    MQTT_OFFSET_TRV,
+    ROOM_AC_COOLER,
+    SPARE_HEAT_TRV,
+    SPARE_TRV_ID,
+    TRV_ID,
+    DeviceProfile,
+    OffsetChannel,
+)
+
+ENTRY_NAME = "BT Test"
+OUTDOOR_ID = "sensor.outdoor_temperature"
+
+# How long a reload that is not waiting on another entry may take. Only ever
+# paid in full when the entries do share a lock, where the wait has no end.
+RELOAD_TIMEOUT_S = 10
+
+
+def _marker(form, key: str) -> vol.Marker:
+    """Return the voluptuous marker a step published for ``key``."""
+    for marker in form["data_schema"].schema:
+        if marker == key:
+            return marker
+    raise AssertionError(f"step {form['step_id']} publishes no field {key!r}")
+
+
+def _field_default(form, key: str):
+    """Return the value a step's form pre-fills ``key`` with."""
+    marker = _marker(form, key)
+    assert marker.default is not vol.UNDEFINED, f"{key} carries no default"
+    return marker.default()
+
+
+def _field_options(form, key: str) -> list[str]:
+    """Return the options a step's select field offers for ``key``."""
+    return list(form["data_schema"].schema[_marker(form, key)].config["options"])
+
+
+def _expected_calibration_options(profile: DeviceProfile) -> list[str]:
+    """Return the calibration strategies this device's channels allow.
+
+    The setpoint is always writable, so target-temperature calibration is
+    offered for every device; the local-offset strategy needs a calibration
+    channel the flow could discover behind the entity.
+    """
+    options = [CalibrationType.TARGET_TEMP_BASED]
+    if profile.offset_channel is OffsetChannel.NUMBER_ENTITY:
+        options.append(CalibrationType.LOCAL_BASED)
+    return options
+
+
+def _expected_calibration(profile: DeviceProfile) -> str:
+    """Return the calibration strategy a device's channels make the default."""
+    return _expected_calibration_options(profile)[-1]
+
+
+def _user_step_input(thermostat: str, **overrides) -> dict:
+    """Return a submission for the user step, naming the entities it wires."""
+    return {
+        "name": ENTRY_NAME,
+        CONF_HEATER: [thermostat],
+        CONF_SENSOR: SENSOR_ID,
+    } | overrides
+
+
+async def _run_create_flow(hass, user_input, advanced=None):
+    """Run the create flow to its end and return the finished flow result.
+
+    The three steps are the whole flow: the user step names the entities, the
+    advanced step settles the per-device options, and the confirm step writes
+    the entry. Every step submits through Home Assistant, so a field the step
+    did not publish is rejected here rather than silently stored.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    assert result["step_id"] == "user"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input
+    )
+    assert result["type"] is FlowResultType.FORM, result
+    assert result["step_id"] == "advanced", result
+    advanced_form = result
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], advanced or {}
+    )
+    assert result["step_id"] == "confirm", result
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] is FlowResultType.CREATE_ENTRY, result
+    await hass.async_block_till_done()
+    return advanced_form, result
+
+
+async def _run_options_flow(hass, entry, user_input, advanced=None):
+    """Re-run the options flow over an existing entry and return its forms.
+
+    Returns the advanced form and the final result, like the create flow, so
+    a test can assert on what the form pre-filled as well as on what was
+    written. The entry reloads on the update, so the caller waits for the
+    thermostat that comes back up rather than reusing the old one.
+    """
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["step_id"] == "user"
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input
+    )
+    assert result["type"] is FlowResultType.FORM, result
+    assert result["step_id"] == "advanced", result
+    advanced_form = result
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], advanced or {}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY, result
+    await hass.async_block_till_done()
+    return advanced_form, result
+
+
+def _only_entry(hass):
+    """Return the single Better Thermostat entry this test created."""
+    (entry,) = hass.config_entries.async_entries(DOMAIN)
+    return entry
+
+
+def _entry_named(hass, name: str):
+    """Return the Better Thermostat entry a flow created under ``name``."""
+    (entry,) = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.data["name"] == name
+    ]
+    return entry
+
+
+def _stored_trv(entry, index: int = 0) -> dict:
+    """Return one device bundle out of an entry's stored thermostat list."""
+    return entry.data[CONF_HEATER][index]
+
+
+@pytest.mark.parametrize(
+    "fake_trv", [GENERIC_HEAT_TRV, MQTT_OFFSET_TRV], indirect=True, ids=profile_id
+)
+async def test_create_flow_offers_the_calibration_the_device_can_take(hass, fake_trv):
+    """The advanced step offers the strategies this device's channels support.
+
+    Calibration is the one option in the flow that is not a preference: the
+    strategies a device can take follow from the channels found behind its
+    entity, and a device without a calibration channel must not be offered
+    one. The default is the best of what was found.
+    """
+    profile = fake_trv.profile
+    set_room_sensor(hass, 19.0)
+
+    advanced_form, _ = await _run_create_flow(hass, _user_step_input(profile.entity_id))
+
+    assert _field_options(advanced_form, CONF_CALIBRATION) == (
+        _expected_calibration_options(profile)
+    )
+    assert _field_default(advanced_form, CONF_CALIBRATION) == (
+        _expected_calibration(profile)
+    )
+
+
+@pytest.mark.parametrize(
+    "fake_trv", [GENERIC_HEAT_TRV, MQTT_OFFSET_TRV], indirect=True, ids=profile_id
+)
+async def test_create_flow_ends_in_a_thermostat_driving_the_device(hass, fake_trv):
+    """A flow run start to finish leaves a loaded entry and a live thermostat.
+
+    The flow's product is not the dict it stores but the entry that comes up
+    from it, so this ends where the lifecycle tests begin: an entity that has
+    read this device's capabilities.
+    """
+    profile = fake_trv.profile
+    set_room_sensor(hass, 19.0)
+
+    _, result = await _run_create_flow(hass, _user_step_input(profile.entity_id))
+
+    entry = _only_entry(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    assert result["title"] == ENTRY_NAME
+    assert _stored_trv(entry)["trv"] == profile.entity_id
+    assert _stored_trv(entry)["advanced"][CONF_CALIBRATION] == (
+        _expected_calibration(profile)
+    )
+
+    bt = await wait_for_startup(hass, entry)
+    assert hass.states.get(BT_ENTITY) is not None
+    assert_profile_adopted(bt, profile)
+
+
+async def test_create_flow_stores_the_generic_model_for_a_device_less_thermostat(hass):
+    """A thermostat with no device behind it resolves to the generic model.
+
+    Model resolution reads the device registry, and a device-less entity —
+    a ``generic_thermostat`` helper, say — leaves that lookup empty. What is
+    stored then decides which quirk module the entry loads later, so the
+    fallback is a stored value, not an internal detail.
+    """
+    set_room_sensor(hass, 19.0)
+    (trv,) = await build_devices(hass, GENERIC_HEAT_TRV)
+
+    await _run_create_flow(hass, _user_step_input(trv.entity_id))
+
+    entry = _only_entry(hass)
+    assert _stored_trv(entry)[CONF_MODEL] == "generic"
+    assert _stored_trv(entry)["integration"] == "generic_thermostat"
+
+
+async def test_options_flow_swaps_the_thermostat_to_a_device_less_entity(hass):
+    """Swapping onto an entity the entry never saw resolves its model afresh.
+
+    The new thermostat is not in the stored bundle, so the options flow takes
+    its "new device" branch and resolves integration and model from scratch —
+    against a registry that knows nothing about a device-less entity. The
+    flow has to come out the other side with a model, and the entry that
+    reloads has to drive the new device.
+    """
+    set_room_sensor(hass, 19.0)
+    trv, spare = await build_devices(hass, GENERIC_HEAT_TRV, SPARE_HEAT_TRV)
+    await _run_create_flow(hass, _user_step_input(trv.entity_id))
+    entry = _only_entry(hass)
+    await wait_for_startup(hass, entry)
+
+    await _run_options_flow(hass, entry, _user_step_input(SPARE_TRV_ID))
+
+    assert _stored_trv(entry)["trv"] == SPARE_TRV_ID
+    assert _stored_trv(entry)[CONF_MODEL] == "generic"
+    assert _stored_trv(entry)["integration"] == "generic_thermostat"
+
+    bt = await wait_for_startup(hass, entry)
+    assert list(bt.real_trvs) == [SPARE_TRV_ID]
+    assert_profile_adopted(bt, SPARE_HEAT_TRV)
+
+
+async def test_options_flow_keeps_the_settings_of_a_thermostat_left_alone(hass):
+    """A device that stays in the entry keeps the options it was given.
+
+    The swap branch and this one sit in the same loop, one per device in the
+    submission. A device already in the entry has to be carried over rather
+    than resolved again, or every unrelated edit silently resets the options
+    of every device the entry controls.
+    """
+    set_room_sensor(hass, 19.0)
+    (trv,) = await build_devices(hass, GENERIC_HEAT_TRV)
+    await _run_create_flow(
+        hass, _user_step_input(trv.entity_id), advanced={CONF_CHILD_LOCK: True}
+    )
+    entry = _only_entry(hass)
+    await wait_for_startup(hass, entry)
+    assert _stored_trv(entry)["advanced"][CONF_CHILD_LOCK] is True
+
+    advanced_form, _ = await _run_options_flow(
+        hass, entry, _user_step_input(trv.entity_id, name="Renamed Room")
+    )
+
+    assert _field_default(advanced_form, CONF_CHILD_LOCK) is True
+    assert _stored_trv(entry)["advanced"][CONF_CHILD_LOCK] is True
+    assert entry.data["name"] == "Renamed Room"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        (CONF_COOLER, COOLER_ID),
+        (CONF_SENSOR_WINDOW, WINDOW_ID),
+        (CONF_OUTDOOR_SENSOR, OUTDOOR_ID),
+    ],
+)
+async def test_options_flow_clears_an_optional_entity_field(hass, field, value):
+    """An optional entity, once set, can be taken back out of the entry.
+
+    An emptied entity selector sends no key at all, so "keep what is stored"
+    and "the user cleared it" arrive as the same submission. The flow has to
+    read the absent key as cleared, which is only observable from here: a
+    handler called directly is handed whatever the test puts in the dict.
+    """
+    set_room_sensor(hass, 19.0)
+    hass.states.async_set(WINDOW_ID, "off")
+    hass.states.async_set(OUTDOOR_ID, "8.0", {"unit_of_measurement": "°C"})
+    await build_devices(hass, GENERIC_HEAT_TRV, ROOM_AC_COOLER)
+    await _run_create_flow(hass, _user_step_input(TRV_ID, **{field: value}))
+    entry = _only_entry(hass)
+    await wait_for_startup(hass, entry)
+    assert entry.data[field] == value
+
+    # The submission the user sends after emptying the field: every other
+    # field unchanged, and this one simply absent.
+    await _run_options_flow(hass, entry, _user_step_input(TRV_ID))
+
+    assert entry.data[field] is None
+
+
+async def test_clearing_the_cooler_stops_the_thermostat_from_driving_it(hass):
+    """A cleared cooler is gone from the thermostat, not just from the entry.
+
+    Storing ``None`` is half the job: the entry reloads on every options
+    change, and what the user asked for is that the cooler stops being
+    driven. This asserts on the thermostat that came back up.
+    """
+    set_room_sensor(hass, 19.0)
+    await build_devices(hass, GENERIC_HEAT_TRV, ROOM_AC_COOLER)
+    await _run_create_flow(hass, _user_step_input(TRV_ID, **{CONF_COOLER: COOLER_ID}))
+    entry = _only_entry(hass)
+    bt = await wait_for_startup(hass, entry)
+    assert bt.cooler_entity_id == COOLER_ID
+    assert COOLER_ID in bt.all_entities
+
+    await _run_options_flow(hass, entry, _user_step_input(TRV_ID))
+
+    bt = await wait_for_startup(hass, entry)
+    assert bt.cooler_entity_id is None
+    assert COOLER_ID not in bt.all_entities
+
+
+async def test_one_thermostat_reload_does_not_wait_on_another(hass):
+    """Two entries reload independently of each other.
+
+    Every options change reloads the entry it belongs to, and a reload runs
+    the full startup, which waits on the devices. Serializing that across
+    entries would let one thermostat whose device is unreachable hold up the
+    settings of every other thermostat in the instance.
+    """
+    set_room_sensor(hass, 19.0)
+    trv, spare = await build_devices(hass, GENERIC_HEAT_TRV, SPARE_HEAT_TRV)
+    await _run_create_flow(hass, _user_step_input(trv.entity_id))
+    await _run_create_flow(hass, _user_step_input(spare.entity_id, name="Other Room"))
+    holding = _entry_named(hass, ENTRY_NAME)
+    waiting = _entry_named(hass, "Other Room")
+    await wait_for_startup(hass, holding)
+    await wait_for_startup(hass, waiting)
+
+    # Reloading is what creates the lock, so drive one options change through
+    # before taking the first entry's reload lock and holding it.
+    await _run_options_flow(hass, holding, _user_step_input(trv.entity_id))
+    before = hass.data[DOMAIN][waiting.entry_id]["climate"]
+    async with hass.data[RELOAD_LOCKS][holding.entry_id]:
+        async with asyncio.timeout(RELOAD_TIMEOUT_S):
+            await _run_options_flow(
+                hass, waiting, _user_step_input(spare.entity_id, name="Renamed Room")
+            )
+        # The stored name is written before the reload is even scheduled, so
+        # the thermostat is what says whether the reload ran: a reloaded
+        # entry has built a new one.
+        after = await wait_for_startup(hass, waiting)
+
+    assert after is not before
+    assert waiting.data["name"] == "Renamed Room"

--- a/tests/unit/test_init_remove_entry.py
+++ b/tests/unit/test_init_remove_entry.py
@@ -6,12 +6,13 @@ Deleting the config entry must remove the associated repair issues so that
 they do not linger after the BT instance is gone.
 """
 
+from asyncio import Lock
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.const import CONF_NAME
 import pytest
 
-from custom_components.better_thermostat import DOMAIN, async_remove_entry
+from custom_components.better_thermostat import DOMAIN, RELOAD_LOCKS, async_remove_entry
 from custom_components.better_thermostat.utils.const import (
     CONF_HEATER,
     CONF_HUMIDITY,
@@ -35,6 +36,18 @@ def _make_entry(**overrides):
     return entry
 
 
+def _make_hass():
+    """Return a Home Assistant double whose ``data`` is a real mapping.
+
+    ``async_remove_entry`` reads ``hass.data`` synchronously. An AsyncMock
+    answers every attribute with a coroutine, so the shared store has to be a
+    real dict for the removal to reach what is in it.
+    """
+    hass = AsyncMock()
+    hass.data = {}
+    return hass
+
+
 @pytest.fixture
 def patched_delete_issue():
     """Patch ``ir.async_delete_issue`` and return the mock for assertions."""
@@ -50,7 +63,7 @@ class TestAsyncRemoveEntryCleansRepairIssues:
     @pytest.mark.asyncio
     async def test_deletes_device_name_keyed_issues(self, patched_delete_issue):
         """Issues keyed by device name are removed."""
-        hass = AsyncMock()
+        hass = _make_hass()
         entry = _make_entry()
 
         await async_remove_entry(hass, entry)
@@ -63,7 +76,7 @@ class TestAsyncRemoveEntryCleansRepairIssues:
     @pytest.mark.asyncio
     async def test_deletes_missing_entity_for_each_trv(self, patched_delete_issue):
         """``missing_entity_*`` issues are removed for every configured TRV."""
-        hass = AsyncMock()
+        hass = _make_hass()
         entry = _make_entry(
             **{
                 CONF_HEATER: [
@@ -84,7 +97,7 @@ class TestAsyncRemoveEntryCleansRepairIssues:
         self, patched_delete_issue
     ):
         """Optional sensors (when configured) also get their issues cleaned up."""
-        hass = AsyncMock()
+        hass = _make_hass()
         entry = _make_entry(
             **{
                 CONF_HUMIDITY: "sensor.humidity",
@@ -104,7 +117,7 @@ class TestAsyncRemoveEntryCleansRepairIssues:
     @pytest.mark.asyncio
     async def test_skips_unconfigured_optional_sensors(self, patched_delete_issue):
         """Sensors not configured on the entry do not trigger spurious deletes."""
-        hass = AsyncMock()
+        hass = _make_hass()
         entry = _make_entry()
 
         await async_remove_entry(hass, entry)
@@ -121,7 +134,7 @@ class TestAsyncRemoveEntryCleansRepairIssues:
     @pytest.mark.asyncio
     async def test_uses_domain_for_every_delete(self, patched_delete_issue):
         """Every cleanup call targets BT's domain."""
-        hass = AsyncMock()
+        hass = _make_hass()
         entry = _make_entry()
 
         await async_remove_entry(hass, entry)
@@ -129,3 +142,21 @@ class TestAsyncRemoveEntryCleansRepairIssues:
         assert patched_delete_issue.call_args_list
         for call in patched_delete_issue.call_args_list:
             assert call.args[1] == DOMAIN
+
+    @pytest.mark.asyncio
+    async def test_drops_the_reload_lock_of_the_removed_entry(
+        self, patched_delete_issue
+    ):
+        """The lock an entry reloads on is dropped with the entry.
+
+        The locks outlive the per-entry data on purpose, so that a reload can
+        hold one across the unload it drives. Removal is therefore the only
+        point at which one can be let go.
+        """
+        hass = _make_hass()
+        entry = _make_entry()
+        hass.data[RELOAD_LOCKS] = {entry.entry_id: Lock(), "other_entry": Lock()}
+
+        await async_remove_entry(hass, entry)
+
+        assert list(hass.data[RELOAD_LOCKS]) == ["other_entry"]

--- a/tests/unit/test_init_remove_entry.py
+++ b/tests/unit/test_init_remove_entry.py
@@ -48,6 +48,22 @@ def _make_hass():
     return hass
 
 
+@pytest.fixture(autouse=True)
+def patched_remove_store():
+    """Keep the state store out of the repair-issue assertions.
+
+    Removing the store is a separate concern that reaches for the config
+    directory; the Home Assistant double here has none, and answers the
+    lookup with a coroutine nobody awaits.
+    """
+    with patch(
+        "custom_components.better_thermostat.utils.state_manager"
+        ".StateManager.async_remove_store",
+        new_callable=AsyncMock,
+    ):
+        yield
+
+
 @pytest.fixture
 def patched_delete_issue():
     """Patch ``ir.async_delete_issue`` and return the mock for assertions."""


### PR DESCRIPTION
## Why

`config_flow.py` is 1121 lines behind a single unit test file, and two of the
flow bugs users reported this summer lived in what that file cannot see: the
unit tests call the handlers directly and hand them mocked registries, so
Home Assistant never validates a submission, never decides which keys reach
the handler when a field is left empty, and never sets the resulting entry up.

New file `tests/integration/test_config_flow.py` submits forms through
`hass.config_entries.flow` / `.options` against a real Home Assistant instance
and the device profiles the integration harness already carries, and ends on
the entry rather than on the dict. `config_flow.py` goes from 53 % to 84 %.

## What it pins

- The advanced step offers exactly the calibration strategies a device's
  channels allow — a device with no calibration channel behind its entity is
  not offered local-offset calibration.
- A full create-flow run ends in a loaded entry whose thermostat has read the
  device's capabilities, for a device-less entity and for one with a
  calibration number entity on its device.
- A thermostat with no device registry entry resolves to the `generic` model,
  in the create flow and when it is swapped in through the options flow.
- A device already in the entry keeps the options it was given when an
  unrelated field is edited.
- An optional entity (`cooler`, `window_sensors`, `outdoor_sensor`), once set,
  can be cleared again — and a cleared cooler is gone from the running
  thermostat, not just from the stored data.

## Reload lock

Writing these tests surfaced a defect the flow tests could not have been
written around: `config_entry_update_listener` serialized every entry's reload
on one module-level `asyncio.Lock`. In production that couples entries — one
thermostat whose device is unreachable holds up the settings of every other
one, because a reload runs the full startup. In tests the same lock binds
itself to the first event loop that touches it, so a second test driving an
options flow cannot run at all. The lock is now per entry and lives on the
Home Assistant instance; it is dropped when the entry is removed.

`tests/unit/test_init_remove_entry.py` stood in an `AsyncMock` for `hass`,
which answers every attribute with a coroutine; `hass.data` is a real mapping
there now, which is what let the removal path be asserted at all. The state
store removal, which reaches for a config directory the double does not have,
is patched out — that removes six leaked-coroutine warnings from the run.

## Verification

Each test was checked by putting the defect back into production and counting
red tests:

| Injected defect | Red |
|---|---|
| both halves of the device-less model fallback reverted | `test_options_flow_swaps_the_thermostat_to_a_device_less_entity` |
| `cooler` back on the get-with-fallback chain | the `cooler` case of `test_options_flow_clears_an_optional_entity_field`, `test_clearing_the_cooler_stops_the_thermostat_from_driving_it` |
| one reload lock shared by all entries | `test_one_thermostat_reload_does_not_wait_on_another` (plus 5 teardown errors) |
| calibration options ignore the discovered channels | `test_create_flow_offers_the_calibration_the_device_can_take[generic_heat_trv]` |
| options flow re-resolves a thermostat it already stored | `test_options_flow_keeps_the_settings_of_a_thermostat_left_alone` |

Two notes on what the table does *not* say. The model fallback has two
independently defensive halves (`self.model = None` on the options flow and
the `getattr` in `get_device_model`); reverting either one alone leaves the
new integration test green, while the existing unit tests catch each half on
its own. And the `window_sensors` / `outdoor_sensor` cases of the clearing
test are not regression pins — those two keys already went through the shared
optional handling — they guard the behaviour going forward.

Full suite: 7060 passed, 1 skipped. `ruff check`, `ruff format --check` and
`pyrefly check` are clean.
