### PR TITLE
test(integration): drive startup and availability over time

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1415,6 +1415,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 return
             sensor_state = self.hass.states.get(self.sensor_entity_id)
             if not self._check_entities_ready(sensor_state):
+                # This loop waits for as long as it takes, and nothing
+                # downstream of it runs while it does, so without this call a
+                # TRV that never comes back is never reported at all — while
+                # one that disappears after startup is. The critical check
+                # owns the rule for when waiting turns into reporting and
+                # stays quiet for the length of the grace window.
+                await check_critical_entities(self)
                 await asyncio.sleep(20)
                 if self.is_removed:
                     return

--- a/custom_components/better_thermostat/utils/watcher.py
+++ b/custom_components/better_thermostat/utils/watcher.py
@@ -273,29 +273,33 @@ async def check_critical_entities(self) -> bool:
                     self.device_name,
                     entity,
                 )
-            else:
+            elif entity not in self.devices_errors:
+                # Both the log line and the repair announce the outage, so
+                # both follow the transition into it. The check runs on every
+                # trigger and on every pass of the startup wait loop, and an
+                # entity that stays away would otherwise be announced for as
+                # long as it is gone.
                 _LOGGER.warning(
                     "better_thermostat %s: Critical entity %s is unavailable",
                     self.device_name,
                     entity,
                 )
-                if entity not in self.devices_errors:
-                    self.devices_errors.append(entity)
-                    self.async_write_ha_state()
-                    ir.async_create_issue(
-                        hass=self.hass,
-                        domain=DOMAIN,
-                        issue_id=f"missing_entity_{entity}",
-                        is_fixable=True,
-                        is_persistent=False,
-                        learn_more_url="https://better-thermostat.org/faq/missing-entity",
-                        severity=ir.IssueSeverity.ERROR,
-                        translation_key="missing_entity",
-                        translation_placeholders={
-                            "entity": str(entity),
-                            "name": str(self.device_name),
-                        },
-                    )
+                self.devices_errors.append(entity)
+                self.async_write_ha_state()
+                ir.async_create_issue(
+                    hass=self.hass,
+                    domain=DOMAIN,
+                    issue_id=f"missing_entity_{entity}",
+                    is_fixable=True,
+                    is_persistent=False,
+                    learn_more_url="https://better-thermostat.org/faq/missing-entity",
+                    severity=ir.IssueSeverity.ERROR,
+                    translation_key="missing_entity",
+                    translation_placeholders={
+                        "entity": str(entity),
+                        "name": str(self.device_name),
+                    },
+                )
             all_available = False
         else:
             recovered = entity in self.devices_errors

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -83,6 +83,16 @@ COOLER_RESEND = (
     "custom_components.better_thermostat.utils.controlling.COOLER_RESEND_INTERVAL_S"
 )
 
+# The two startup grace windows, during which an unavailable entity is waited
+# for instead of reported. Both are minutes long, so a test that wants to see
+# what happens after one has closed shortens it here rather than waiting.
+CRITICAL_GRACE = (
+    "custom_components.better_thermostat.climate.STARTUP_CRITICAL_GRACE_PERIOD"
+)
+DEGRADED_GRACE = (
+    "custom_components.better_thermostat.climate.STARTUP_DEGRADED_GRACE_PERIOD"
+)
+
 
 @pytest.fixture(autouse=True)
 async def _recorder(recorder_mock):
@@ -169,6 +179,18 @@ class SimulatedClimate(ClimateEntity):
         self.set_temperature_calls: list[float | dict[str, float]] = []
         self.set_hvac_mode_calls: list[str] = []
         self.drop_next_setpoint_write = False
+
+    def set_available(self, available: bool) -> None:
+        """Take the device off the air, or put it back on.
+
+        An entity that publishes ``unavailable`` is what a battery device out
+        of radio range, a cloud integration that has not reconnected, and an
+        integration that has not finished loading all look like from the
+        outside. Nothing else about the device changes, which is the point:
+        the same entity is expected back.
+        """
+        self._attr_available = available
+        self.async_write_ha_state()
 
     async def async_set_temperature(self, **kwargs) -> None:
         """Apply and confirm a setpoint write.

--- a/tests/integration/test_startup_scenarios.py
+++ b/tests/integration/test_startup_scenarios.py
@@ -1,0 +1,271 @@
+"""Startup and availability as a course of events, not as an end state.
+
+The rest of the suite sets a device up ready and drives it. These tests drive
+the timeline the device actually arrives on: an entity that is not there yet,
+one that never turns up, one that disappears after startup and comes back,
+and an entity id that is already taken.
+
+What they pin is one line — the one between waiting and reporting. A device
+that is merely late must be waited for silently, because a repair issue that
+resolves itself teaches users to ignore repair issues. A device that is gone
+must be named, because the thermostat that depends on it is doing nothing and
+the only other symptom is silence.
+"""
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
+import pytest
+
+from .conftest import (
+    BT_ENTITY,
+    CRITICAL_GRACE,
+    DEGRADED_GRACE,
+    DOMAIN,
+    WINDOW_ID,
+    assert_profile_adopted,
+    make_entry,
+    profile_id,
+    set_room_sensor,
+    setup_entry,
+    wait_for,
+    wait_for_startup,
+)
+from .device_profiles import GENERIC_HEAT_TRV, MQTT_OFFSET_TRV, TRV_ID
+
+# A grace window that is already over by the time the first check runs, for
+# the tests that are about what happens once waiting has to stop.
+NO_GRACE = timedelta(seconds=0)
+
+
+def bt_issues(hass) -> list[str]:
+    """Return the repair issues Better Thermostat currently holds open."""
+    return sorted(
+        issue_id for (domain, issue_id) in ir.async_get(hass).issues if domain == DOMAIN
+    )
+
+
+def missing_entity_issue(entity_id: str) -> str:
+    """Return the id of the repair issue that names ``entity_id`` as missing."""
+    return f"missing_entity_{entity_id}"
+
+
+async def let_the_wait_loop_run(hass, rounds: int = 20) -> None:
+    """Give the startup wait loop room to go round many times.
+
+    Its own sleep is compressed by the harness, so a handful of passes
+    through the event loop is a large number of iterations of the loop —
+    enough that anything running once per iteration has run repeatedly.
+    Used before asserting that something did *not* happen.
+    """
+    for _ in range(rounds):
+        await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize(
+    "fake_trv", [GENERIC_HEAT_TRV, MQTT_OFFSET_TRV], indirect=True, ids=profile_id
+)
+async def test_a_late_trv_is_waited_for_and_never_reported(hass, fake_trv):
+    """A device that is still booting is waited for, not announced.
+
+    This is the case that produced false repair issues: a cloud-backed valve
+    is routinely still unavailable when Home Assistant has finished starting.
+    The thermostat holds in startup, says nothing, and comes up as soon as
+    the device does — with the device's own capabilities read, which is the
+    proof that it waited for the real thing rather than guessing.
+    """
+    set_room_sensor(hass, 19.0)
+    fake_trv.set_available(False)
+    entry = make_entry(fake_trv.profile)
+    await setup_entry(hass, entry)
+
+    await let_the_wait_loop_run(hass)
+    bt = hass.data[DOMAIN][entry.entry_id]["climate"]
+    assert bt.startup_running
+    assert hass.states.get(BT_ENTITY).state == "unavailable"
+    assert bt_issues(hass) == []
+
+    fake_trv.set_available(True)
+
+    bt = await wait_for_startup(hass, entry)
+    assert bt_issues(hass) == []
+    assert hass.states.get(BT_ENTITY).state == "heat"
+    assert_profile_adopted(bt, fake_trv.profile)
+    assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
+
+
+async def test_a_trv_that_never_arrives_is_reported_once_the_grace_window_closes(
+    hass, fake_trv
+):
+    """A device that stays away is named, and the thermostat keeps waiting.
+
+    The wait loop has no end of its own, so the grace window is what decides
+    when a device is late and when it is gone. Past that window the missing
+    entity is named — while the loop carries on, because the device may still
+    turn up and nothing here is worth giving up on.
+    """
+    set_room_sensor(hass, 19.0)
+    fake_trv.set_available(False)
+    entry = make_entry(fake_trv.profile)
+
+    with patch(CRITICAL_GRACE, NO_GRACE):
+        await setup_entry(hass, entry)
+        assert await wait_for(hass, lambda: bt_issues(hass))
+
+    bt = hass.data[DOMAIN][entry.entry_id]["climate"]
+    assert bt_issues(hass) == [missing_entity_issue(TRV_ID)]
+    assert bt.devices_errors == [TRV_ID]
+    assert bt.startup_running
+    assert hass.states.get(BT_ENTITY).state == "unavailable"
+
+
+async def test_the_report_for_a_missing_trv_clears_when_it_finally_arrives(
+    hass, fake_trv
+):
+    """A device that turns up after being reported takes its report with it.
+
+    Announcing an outage is only half of it; a repair issue that outlives the
+    outage is the thing the grace window exists to avoid, one step later.
+    """
+    set_room_sensor(hass, 19.0)
+    fake_trv.set_available(False)
+    entry = make_entry(fake_trv.profile)
+
+    with patch(CRITICAL_GRACE, NO_GRACE):
+        await setup_entry(hass, entry)
+        assert await wait_for(hass, lambda: bt_issues(hass))
+
+        fake_trv.set_available(True)
+        bt = await wait_for_startup(hass, entry)
+
+    assert bt_issues(hass) == []
+    assert bt.devices_errors == []
+    assert hass.states.get(BT_ENTITY).state == "heat"
+
+
+async def test_a_trv_lost_after_startup_is_reported_and_cleared_on_return(
+    hass, fake_trv
+):
+    """An outage after a good start is announced and withdrawn again.
+
+    The thermostat is up and controlling when the device drops out, so this
+    runs through the state-change path rather than the wait loop — the other
+    of the two ways a device can go missing, and the one whose repair issue
+    the user sees while the entity still reads ``heat``.
+    """
+    set_room_sensor(hass, 19.0)
+    entry = make_entry(fake_trv.profile)
+
+    with patch(CRITICAL_GRACE, NO_GRACE):
+        await setup_entry(hass, entry)
+        bt = await wait_for_startup(hass, entry)
+        assert bt_issues(hass) == []
+
+        fake_trv.set_available(False)
+        assert await wait_for(hass, lambda: bt_issues(hass))
+        assert bt_issues(hass) == [missing_entity_issue(TRV_ID)]
+        assert bt.devices_errors == [TRV_ID]
+
+        fake_trv.set_available(True)
+        assert await wait_for(hass, lambda: not bt_issues(hass))
+
+    assert bt.devices_errors == []
+
+
+async def test_an_optional_sensor_outage_annunciates_degraded_mode_and_recovers(
+    hass, fake_trv
+):
+    """Losing a window sensor degrades the thermostat instead of stopping it.
+
+    An optional sensor is optional because heating continues without it — so
+    the outage has no other symptom, and degraded mode is the whole of what
+    the user gets to see. It has to arrive and to leave again.
+    """
+    set_room_sensor(hass, 19.0)
+    hass.states.async_set(WINDOW_ID, "off")
+    entry = make_entry(fake_trv.profile, with_window=True)
+
+    with patch(DEGRADED_GRACE, NO_GRACE):
+        await setup_entry(hass, entry)
+        bt = await wait_for_startup(hass, entry)
+        assert bt.degraded_mode is False
+        assert bt_issues(hass) == []
+
+        hass.states.async_set(WINDOW_ID, "unavailable")
+        assert await wait_for(hass, lambda: bt.degraded_mode)
+        assert bt.unavailable_sensors == [WINDOW_ID]
+        assert bt_issues(hass) == [f"degraded_mode_{bt.device_name}"]
+        assert hass.states.get(BT_ENTITY).attributes["degraded_mode"] is True
+
+        hass.states.async_set(WINDOW_ID, "off")
+        assert await wait_for(hass, lambda: not bt.degraded_mode)
+
+    assert bt_issues(hass) == []
+    assert bt.unavailable_sensors == []
+    assert hass.states.get(BT_ENTITY).attributes["degraded_mode"] is False
+
+
+async def test_a_rename_into_a_taken_id_lands_on_a_free_one(hass, fake_trv):
+    """Renaming towards an id somebody else holds still moves the entity.
+
+    The entity id is rebuilt from the configured name on every reload, so a
+    rename can aim at an id another integration already occupies. Asking the
+    registry for that id outright fails there, and the failure is quiet: the
+    entity keeps its old id, and every automation written against the new
+    name misses. Asking for the next free one instead is what makes the
+    rename land at all.
+    """
+    set_room_sensor(hass, 19.0)
+    entry = make_entry(fake_trv.profile, name="Livingroom")
+    await setup_entry(hass, entry)
+    await wait_for_startup(hass, entry)
+    registry = er.async_get(hass)
+    climate_key = ("climate", DOMAIN, entry.entry_id)
+    assert registry.async_get_entity_id(*climate_key) == "climate.livingroom"
+
+    squatter = registry.async_get_or_create(
+        "climate", "other_integration", "squatter", suggested_object_id="bt_livingroom"
+    )
+    assert squatter.entity_id == "climate.bt_livingroom"
+
+    hass.config_entries.async_update_entry(
+        entry, data={**entry.data, "name": "BT Livingroom"}
+    )
+    await hass.async_block_till_done()
+    bt = await wait_for_startup(hass, entry)
+
+    assert bt.entity_id not in ("climate.livingroom", squatter.entity_id)
+    assert bt.entity_id.startswith("climate.bt_livingroom")
+    assert registry.async_get_entity_id(*climate_key) == bt.entity_id
+    assert hass.states.get(bt.entity_id).state == "heat"
+
+
+async def test_a_taken_id_does_not_cost_the_thermostat_its_entity(hass, fake_trv):
+    """Setting up against an occupied id still yields a working thermostat.
+
+    This is the shape the outage was reported in: an id that looks like Better
+    Thermostat's is already in the registry, and no ``climate.bt_*`` entity
+    appears. Home Assistant's registry resolves that collision on its own, so
+    no change in this repository can turn this test red today — it guards
+    against Better Thermostat ever taking the choice away from the registry,
+    because having no climate entity at all is indistinguishable from a setup
+    that failed outright.
+    """
+    set_room_sensor(hass, 19.0)
+    registry = er.async_get(hass)
+    squatter = registry.async_get_or_create(
+        "climate", "other_integration", "squatter", suggested_object_id="bt_test"
+    )
+    assert squatter.entity_id == BT_ENTITY
+
+    entry = make_entry(fake_trv.profile)
+    await setup_entry(hass, entry)
+    bt = await wait_for_startup(hass, entry)
+
+    assert bt.entity_id != BT_ENTITY
+    assert registry.async_get_entity_id("climate", DOMAIN, entry.entry_id) == (
+        bt.entity_id
+    )
+    assert hass.states.get(bt.entity_id).state == "heat"
+    assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)

--- a/tests/integration/test_startup_scenarios.py
+++ b/tests/integration/test_startup_scenarios.py
@@ -69,10 +69,10 @@ async def let_the_wait_loop_run(hass, rounds: int = 20) -> None:
 async def test_a_late_trv_is_waited_for_and_never_reported(hass, fake_trv):
     """A device that is still booting is waited for, not announced.
 
-    This is the case that produced false repair issues: a cloud-backed valve
-    is routinely still unavailable when Home Assistant has finished starting.
-    The thermostat holds in startup, says nothing, and comes up as soon as
-    the device does — with the device's own capabilities read, which is the
+    A cloud-backed valve is routinely still unavailable by the time Home
+    Assistant has finished starting, so a repair issue here would be a false
+    one. The thermostat holds in startup, says nothing, and comes up as soon
+    as the device does — with the device's own capabilities read, which is the
     proof that it waited for the real thing rather than guessing.
     """
     set_room_sensor(hass, 19.0)
@@ -244,13 +244,12 @@ async def test_a_rename_into_a_taken_id_lands_on_a_free_one(hass, fake_trv):
 async def test_a_taken_id_does_not_cost_the_thermostat_its_entity(hass, fake_trv):
     """Setting up against an occupied id still yields a working thermostat.
 
-    This is the shape the outage was reported in: an id that looks like Better
-    Thermostat's is already in the registry, and no ``climate.bt_*`` entity
-    appears. Home Assistant's registry resolves that collision on its own, so
-    no change in this repository can turn this test red today — it guards
-    against Better Thermostat ever taking the choice away from the registry,
-    because having no climate entity at all is indistinguishable from a setup
-    that failed outright.
+    An id that looks like Better Thermostat's can already be in the registry,
+    held by another integration. Home Assistant's registry resolves that
+    collision on its own, so no change in this repository can turn this test
+    red today — it guards against Better Thermostat ever taking the choice
+    away from the registry, because having no climate entity at all is
+    indistinguishable from a setup that failed outright.
     """
     set_room_sensor(hass, 19.0)
     registry = er.async_get(hass)

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -183,10 +183,19 @@ class TestStartupUnloadBailout:
         async def fake_sleep(_seconds):
             bt.is_removed = True
 
-        with patch(
-            "custom_components.better_thermostat.climate.asyncio.sleep",
-            side_effect=fake_sleep,
-        ) as mock_sleep:
+        with (
+            # Each pass of the wait branch reports on the critical entities;
+            # against a mocked thermostat that check has nothing to read, and
+            # this test is about the bail-out, not about the reporting.
+            patch(
+                "custom_components.better_thermostat.climate.check_critical_entities",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "custom_components.better_thermostat.climate.asyncio.sleep",
+                side_effect=fake_sleep,
+            ) as mock_sleep,
+        ):
             await asyncio.wait_for(BetterThermostat.startup(bt), timeout=1)
 
         mock_sleep.assert_awaited_once()

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -375,6 +375,45 @@ class TestCheckCriticalEntities:
         assert mock_ir.async_create_issue.called
 
     @pytest.mark.anyio
+    async def test_warns_once_while_a_trv_stays_unavailable(
+        self, mock_bt_instance, caplog
+    ):
+        """A continuing outage is announced when it starts, not while it lasts.
+
+        The check runs on every trigger and on every pass of the startup wait
+        loop, so an entity that stays away is seen over and over. The repair
+        issue is raised once; the log line has to follow the same transition
+        or it repeats for as long as the device is gone.
+        """
+        from datetime import timedelta
+
+        from custom_components.better_thermostat.utils.watcher import (
+            check_critical_entities,
+        )
+
+        mock_state = MagicMock()
+        mock_state.state = "unavailable"
+        mock_bt_instance.hass.states.get.return_value = mock_state
+        mock_bt_instance._critical_grace_until = (
+            mock_bt_instance.clock.now() - timedelta(minutes=1)
+        )
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("WARNING"):
+                await check_critical_entities(mock_bt_instance)
+                await check_critical_entities(mock_bt_instance)
+                await check_critical_entities(mock_bt_instance)
+
+        announced = [
+            r.getMessage() for r in caplog.records if "is unavailable" in r.message
+        ]
+        # Three passes over the fixture's devices: one line per device that is
+        # gone, not one per pass.
+        trv_count = len(mock_bt_instance.real_trvs)
+        assert len(announced) == len(set(announced)) == trv_count
+        assert mock_ir.async_create_issue.call_count == trv_count
+
+    @pytest.mark.anyio
     async def test_auto_clear_issue_on_recovery(self, mock_bt_instance):
         """Issue is cleared when a previously-unavailable TRV becomes available."""
         from custom_components.better_thermostat.utils.watcher import (


### PR DESCRIPTION
## Why

Every integration test so far sets a device up ready and drives it. The
timeline a device actually arrives on was never run against a real Home
Assistant instance — and that timeline is where the only interesting question
lives: when does waiting for a device turn into reporting it?

New file `tests/integration/test_startup_scenarios.py` (8 tests) drives that
course of events: an entity that is not there yet, one that never turns up,
one that drops out after a good start and comes back, an optional sensor
outage, and an entity id somebody else already holds.

## What it found

**A TRV that never becomes available was never reported.** The startup wait
loop has no end of its own and nothing downstream of it runs while it waits,
so a thermostat whose valve never came back sat `unavailable` with no repair
issue naming the entity — while the very same valve dropping out *after* a
successful startup did raise one. The two paths disagreed, and the quiet one
is the more likely misconfiguration (a renamed or removed entity).

The wait branch now runs the same critical-entity check as every other path.
It stays quiet for the length of the startup grace window, so a device that is
merely late is still waited for silently, and the issue clears again when the
device turns up. The loop keeps waiting either way — giving up would leave the
thermostat dead until a reload.

**A continuing outage was announced for its duration.** The repair issue for a
missing TRV is raised on the transition into the outage; the log line beside it
was written on every pass of the check, which runs on every trigger. Adding a
call in the wait loop would have made that a warning every 20 seconds forever.
Both announce the same event, so both now follow the same transition — the rule
the degraded-mode annunciation already follows.

## Verification

Each test was checked by putting the defect into production and counting red
tests:

| Injected defect | Red |
|---|---|
| wait loop reports nothing | `test_a_trv_that_never_arrives_is_reported_once_the_grace_window_closes`, `test_the_report_for_a_missing_trv_clears_when_it_finally_arrives` |
| grace window ignored | both cases of `test_a_late_trv_is_waited_for_and_never_reported`, plus 1 unit test |
| warning repeats every pass | `test_warns_once_while_a_trv_stays_unavailable` |
| recovery keeps the issue | 2 integration tests, 3 unit tests |
| degraded mode never clears | `test_an_optional_sensor_outage_annunciates_degraded_mode_and_recovers`, plus 2 unit tests |
| entity id ignores collisions | `test_a_rename_into_a_taken_id_lands_on_a_free_one` |

One test in the file is a guard, not a regression pin, and says so in its
docstring: `test_a_taken_id_does_not_cost_the_thermostat_its_entity` covers the
shape the collision was reported in, but Home Assistant's registry resolves it
without any code in this repository, so no mutation here turns it red. It
guards against Better Thermostat ever taking that choice away from the
registry.

## Left open on purpose

The room temperature sensor is semi-critical at runtime by design:
`get_critical_entities` excludes it and the degraded-mode check falls back to
the TRV's internal reading. The startup loop treats it as blocking anyway.
Measured: if the configured sensor entity never exists, the thermostat waits
indefinitely, stays `unavailable`, and reports nothing at all — the same silent
failure this PR fixes for the TRV, one level down.

Fixing that is a product decision rather than a test one (either startup
proceeds without the sensor and uses the fallback the runtime already has, or
it keeps waiting and has to announce the outage), so it is not decided here.

Restart-with-restore, rename and reload are already covered in
`test_entry_lifecycle.py` and are not repeated here.

Full suite: 7056 passed, 1 skipped. `ruff check`, `ruff format --check` and
`pyrefly check` are clean.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Missing thermostatic radiator valves are now reported as repair issues after the startup grace period instead of remaining unreported.
  - Startup continues while devices are temporarily unavailable, allowing late-arriving devices to connect without unnecessary alerts.
  - Repeated checks no longer create duplicate warnings or repair issues.
  - Issues clear automatically when devices return.
  - Optional sensor outages now clearly indicate degraded mode and recover when sensors become available.
  - Entity naming collisions are handled without preventing thermostat setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->