### PR TITLE
chore(review): correct the test-review instructions for CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -46,10 +46,17 @@ reviews:
   path_instructions:
     - path: "tests/**"
       instructions: >-
-        Tests run with `uv run pytest -p no:homeassistant`. Every test function
-        and class needs a docstring (ruff pydocstyle "D" rules are enforced).
+        Tests run with `uv run pytest tests/`. Do not suggest
+        `-p no:homeassistant`: that flag removes the plugin providing the
+        `hass` fixture and makes the whole integration suite error.
+        `asyncio_mode = "auto"` is set, so async tests need no marker at all —
+        do not ask for `@pytest.mark.asyncio` to be added, and where a marker
+        is present, match the one the surrounding class already uses.
+        Ruff's pydocstyle "D" rules are switched off for `tests/**` via
+        `per-file-ignores`, so NumPy `Parameters` sections are not required
+        here; what a docstring has to say is what the test pins and why.
         Follow the existing patterns: MagicMock + real dicts for `real_trvs`,
-        `State()` for HA states, `@pytest.mark.asyncio` / `AsyncMock` for async.
+        `State()` for HA states, `AsyncMock` for async collaborators.
     - path: "custom_components/better_thermostat/**"
       instructions: >-
         Home Assistant custom integration. Comments must describe the current


### PR DESCRIPTION
## Why

The `tests/**` entry in `.coderabbit.yaml` states three things that do not hold
for this repository. Because CodeRabbit derives findings from these
instructions, each wrong statement manufactures findings that are wrong by
construction — and it does so on every pull request, indefinitely.

All three were measured on `develop`.

### `-p no:homeassistant`

The instruction says tests run with that flag. They do not:

```
$ uv run pytest tests/integration -q -p no:homeassistant
4 warnings, 60 errors in 0.06s
```

The flag removes `pytest-homeassistant-custom-component`, which is where the
`hass` fixture comes from, so the entire integration suite errors at collection.
The suite runs with plain `uv run pytest tests/`.

### `@pytest.mark.asyncio`

`pyproject.toml` sets `asyncio_mode = "auto"`, so pytest-asyncio collects async
tests with no marker at all. Every integration test file except
`test_preset_migration_contract.py` carries none. `tests/unit/test_watcher.py`
is mixed (26 `anyio` markers vs 8 `asyncio`), and the marker to use there
follows the surrounding class.

### pydocstyle for tests

```toml
[tool.ruff.lint.per-file-ignores]
# Test code does not need docstrings on every function/class/method.
"tests/**" = ["D"]
```

The `D` rules — including D417, which is what would require a NumPy
`Parameters` section — are switched off for `tests/**`. The instruction claimed
they are enforced. No method in `tests/integration/conftest.py` carries a
`Parameters` section, including ones with several arguments.

## What changed

Only the `tests/**` path instruction. The corrected text states how the suite
is actually run, that async tests need no marker, and that a test docstring's
job is to say what the test pins and why rather than to enumerate arguments.

Found while working through the CodeRabbit review on #2238, where both findings
traced back to these instructions rather than to the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test review guidance to use the standard pytest setup.
  * Clarified automatic asyncio handling, mocking expectations, and state-management patterns.
  * Removed unnecessary docstring requirements from test guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->