### PR TITLE
fix: make the device automation surface work, and test it end to end

### DIFF
--- a/custom_components/better_thermostat/device_action.py
+++ b/custom_components/better_thermostat/device_action.py
@@ -30,12 +30,30 @@ from .utils.helpers import is_bt_climate_entity
 
 ACTION_TYPES = {"set_hvac_mode", "set_temperature"}
 
-_ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+# One schema per action type, because each type carries its own fields and
+# ``async_call_action_from_config`` reads the hvac mode back without a
+# fallback. Home Assistant looks the schema up by this exact name.
+SET_HVAC_MODE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_TYPE): vol.In(ACTION_TYPES),
+        vol.Required(CONF_TYPE): "set_hvac_mode",
         vol.Required(CONF_ENTITY_ID): cv.entity_domain(CLIMATE_DOMAIN),
+        vol.Required(ATTR_HVAC_MODE): vol.In(
+            [HVACMode.HEAT, HVACMode.OFF, HVACMode.HEAT_COOL]
+        ),
     }
 )
+
+SET_TEMPERATURE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): "set_temperature",
+        vol.Required(CONF_ENTITY_ID): cv.entity_domain(CLIMATE_DOMAIN),
+        vol.Optional(ATTR_TEMPERATURE): vol.Coerce(float),
+        vol.Optional(ATTR_TARGET_TEMP_HIGH): vol.Coerce(float),
+        vol.Optional(ATTR_TARGET_TEMP_LOW): vol.Coerce(float),
+    }
+)
+
+ACTION_SCHEMA = vol.Any(SET_HVAC_MODE_SCHEMA, SET_TEMPERATURE_SCHEMA)
 
 
 async def async_get_actions(

--- a/custom_components/better_thermostat/device_condition.py
+++ b/custom_components/better_thermostat/device_condition.py
@@ -85,6 +85,12 @@ def async_condition_from_config(
     hass: HomeAssistant, config: ConfigType
 ) -> condition.ConditionCheckerType:
     """Create a function to test a device condition."""
+    # A stored condition may name the entity by its registry id rather than by
+    # its entity id, which the schema accepts and ``hass.states`` does not.
+    entity_id = entity_registry.async_resolve_entity_id(
+        entity_registry.async_get(hass), config[CONF_ENTITY_ID]
+    )
+
     if config[CONF_TYPE] == "is_hvac_mode":
         hvac_mode = config[ATTR_HVAC_MODE]
 
@@ -96,8 +102,9 @@ def async_condition_from_config(
             A climate entity carries its mode as the state, not as an
             attribute; ``hvac_action`` is the one that is an attribute.
             """
-            state = hass.states.get(config[CONF_ENTITY_ID])
-            return state is not None and state.state == hvac_mode
+            if entity_id is None or (state := hass.states.get(entity_id)) is None:
+                return False
+            return state.state == hvac_mode
 
         return test_is_hvac_mode
 
@@ -108,11 +115,9 @@ def async_condition_from_config(
             hass: HomeAssistant, variables: Mapping[str, object] | None
         ) -> bool:
             """Test if an HVAC action condition is met."""
-            state = hass.states.get(config[CONF_ENTITY_ID])
-            return (
-                state is not None
-                and state.attributes.get(ATTR_HVAC_ACTION) == hvac_action
-            )
+            if entity_id is None or (state := hass.states.get(entity_id)) is None:
+                return False
+            return state.attributes.get(ATTR_HVAC_ACTION) == hvac_action
 
         return test_is_hvac_action
 

--- a/custom_components/better_thermostat/device_condition.py
+++ b/custom_components/better_thermostat/device_condition.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import condition, config_validation as cv, entity_registry
+from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
 from homeassistant.helpers.typing import ConfigType
 import voluptuous as vol
 
@@ -27,9 +28,12 @@ from .utils.helpers import is_bt_climate_entity
 
 CONDITION_TYPES = {"is_hvac_mode", "is_hvac_action"}
 
-HVAC_MODE_CONDITION = vol.Schema(
+# Both extend the device-condition base schema, which carries the `condition`,
+# `device_id` and `domain` keys every condition this platform offers is built
+# with; a bare schema rejects its own output.
+HVAC_MODE_CONDITION = DEVICE_CONDITION_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(CONF_TYPE): "is_hvac_mode",
         vol.Required(ATTR_HVAC_MODE): vol.In(
             [HVACMode.OFF, HVACMode.HEAT, HVACMode.HEAT_COOL]
@@ -37,9 +41,9 @@ HVAC_MODE_CONDITION = vol.Schema(
     }
 )
 
-HVAC_ACTION_CONDITION = vol.Schema(
+HVAC_ACTION_CONDITION = DEVICE_CONDITION_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(CONF_TYPE): "is_hvac_action",
         vol.Required(ATTR_HVAC_ACTION): vol.In(
             [HVACAction.OFF, HVACAction.HEATING, HVACAction.IDLE]
@@ -87,11 +91,13 @@ def async_condition_from_config(
         def test_is_hvac_mode(
             hass: HomeAssistant, variables: Mapping[str, object] | None
         ) -> bool:
-            """Test if an HVAC mode condition is met."""
+            """Test if an HVAC mode condition is met.
+
+            A climate entity carries its mode as the state, not as an
+            attribute; ``hvac_action`` is the one that is an attribute.
+            """
             state = hass.states.get(config[CONF_ENTITY_ID])
-            return (
-                state is not None and state.attributes.get(ATTR_HVAC_MODE) == hvac_mode
-            )
+            return state is not None and state.state == hvac_mode
 
         return test_is_hvac_mode
 

--- a/custom_components/better_thermostat/device_trigger.py
+++ b/custom_components/better_thermostat/device_trigger.py
@@ -24,6 +24,9 @@ from __future__ import annotations
 
 from homeassistant.components.climate.const import HVAC_MODES
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
 from homeassistant.components.homeassistant.triggers import (
     numeric_state as numeric_state_trigger,
     state as state_trigger,
@@ -78,6 +81,11 @@ TRIGGER_TYPES = _PURPOSE_TRIGGER_TYPES | _CLASSIC_TRIGGER_TYPES
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+        # The automation editor stores the entity alongside the device, and
+        # the base schema does not carry the key, so without it every trigger
+        # this platform offers fails validation. It stays optional because the
+        # blueprints shipped with the integration pick a device only.
+        vol.Optional(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         # Fields used by classic triggers
         vol.Optional(CONF_TO): vol.Any(str, [str]),
         # Fields used by numeric triggers
@@ -161,6 +169,38 @@ async def async_get_triggers(
     return triggers
 
 
+def _resolve_entity_id(hass: HomeAssistant, config: ConfigType) -> str | None:
+    """Return the thermostat entity a trigger config watches.
+
+    The automation editor stores the entity next to the device, and a stored
+    automation may hold the registry id rather than the entity id. The
+    blueprints shipped with the integration pick a device only, so the entity
+    has to be recoverable from the device alone as well.
+
+    Parameters
+    ----------
+    hass : HomeAssistant
+        The running Home Assistant instance.
+    config : ConfigType
+        A validated trigger configuration.
+
+    Returns
+    -------
+    str or None
+        The entity id to watch, or None when the device carries no Better
+        Thermostat climate entity.
+    """
+    registry = entity_registry.async_get(hass)
+    if configured := config.get(CONF_ENTITY_ID):
+        return entity_registry.async_resolve_entity_id(registry, configured)
+    for entry in entity_registry.async_entries_for_device(
+        registry, config[CONF_DEVICE_ID]
+    ):
+        if is_bt_climate_entity(entry):
+            return entry.entity_id
+    return None
+
+
 async def async_attach_trigger(
     hass: HomeAssistant,
     config: ConfigType,
@@ -169,7 +209,12 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Attach a trigger and return an unsubscribe callback."""
     trigger_type: str = config[CONF_TYPE]
-    entity_id: str = config[CONF_ENTITY_ID]
+    entity_id = _resolve_entity_id(hass, config)
+    if entity_id is None:
+        raise InvalidDeviceAutomationConfig(
+            f"No Better Thermostat climate entity found for device "
+            f"{config[CONF_DEVICE_ID]}"
+        )
 
     # Helpers
     def _build_state(
@@ -270,7 +315,7 @@ async def async_attach_trigger(
     #   Threshold is configurable (CONF_ABOVE); default is DEFAULT_HUMIDITY_THRESHOLD.
     if trigger_type == "humidity_high":
         numeric_config = _build_numeric(
-            "{{ state.attributes.get('humidity', 0) | float(0) }}"
+            "{{ state.attributes.get('current_humidity', 0) | float(0) }}"
         )
         if CONF_ABOVE not in numeric_config:
             numeric_config[CONF_ABOVE] = DEFAULT_HUMIDITY_THRESHOLD

--- a/custom_components/better_thermostat/device_trigger.py
+++ b/custom_components/better_thermostat/device_trigger.py
@@ -172,10 +172,13 @@ async def async_get_triggers(
 def _resolve_entity_id(hass: HomeAssistant, config: ConfigType) -> str | None:
     """Return the thermostat entity a trigger config watches.
 
-    The automation editor stores the entity next to the device, and a stored
-    automation may hold the registry id rather than the entity id. The
-    blueprints shipped with the integration pick a device only, so the entity
-    has to be recoverable from the device alone as well.
+    The automation editor stores the entity next to the device; the blueprints
+    shipped with the integration pick a device only, so the entity has to be
+    recoverable from the device alone as well.
+
+    A configured value is passed through as it stands, including a registry id:
+    every branch below hands it to a state or numeric-state trigger, and those
+    resolve a registry id to an entity id themselves.
 
     Parameters
     ----------
@@ -187,12 +190,12 @@ def _resolve_entity_id(hass: HomeAssistant, config: ConfigType) -> str | None:
     Returns
     -------
     str or None
-        The entity id to watch, or None when the device carries no Better
-        Thermostat climate entity.
+        The entity or registry id to watch, or None when the device carries no
+        Better Thermostat climate entity.
     """
-    registry = entity_registry.async_get(hass)
     if configured := config.get(CONF_ENTITY_ID):
-        return entity_registry.async_resolve_entity_id(registry, configured)
+        return configured
+    registry = entity_registry.async_get(hass)
     for entry in entity_registry.async_entries_for_device(
         registry, config[CONF_DEVICE_ID]
     ):

--- a/tests/integration/test_device_automation.py
+++ b/tests/integration/test_device_automation.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_DEVICE_ID,
     CONF_DOMAIN,
+    CONF_ENTITY_ID,
     CONF_TYPE,
 )
 from homeassistant.core import State
@@ -366,6 +367,84 @@ async def test_a_trigger_that_names_only_a_device_finds_the_entity(hass, fake_tr
                         CONF_DEVICE_ID: device_id,
                         CONF_TYPE: "heating_active",
                     },
+                    "action": {"service": "test.automation"},
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.async_entity_ids("automation")
+
+    _republish(hass, **{ATTR_HVAC_ACTION: "heating"})
+
+    assert await wait_for(hass, lambda: calls)
+
+
+async def test_a_condition_that_names_the_registry_id_reads_the_state(hass, fake_trv):
+    """A condition naming the entity by registry id still reads its state.
+
+    A stored automation may hold the registry id instead of the entity id —
+    that is the point of the id, it survives a rename. The schema accepts both
+    and ``hass.states`` accepts only one, so the registry id has to be resolved
+    before the state is read, or the condition is silently always false.
+    """
+    _entry, device_id = await _entry_with_device(hass)
+    registry_entry = er.async_get(hass).async_get(BT_ENTITY)
+    condition = _offered(
+        await async_get_device_automations(
+            hass, DeviceAutomationType.CONDITION, device_id
+        ),
+        "is_hvac_mode",
+    )
+    condition[CONF_ENTITY_ID] = registry_entry.id
+    condition[ATTR_HVAC_MODE] = "heat"
+    calls = async_mock_service(hass, "test", "automation")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "alias": "by_registry_id",
+                    "trigger": {"platform": "event", "event_type": "run_condition"},
+                    "condition": [condition],
+                    "action": {"service": "test.automation"},
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.async_entity_ids("automation")
+    assert hass.states.get(BT_ENTITY).state == "heat"
+
+    hass.bus.async_fire("run_condition")
+    await hass.async_block_till_done()
+
+    assert calls, "the condition did not resolve the registry id"
+
+
+async def test_a_trigger_that_names_the_registry_id_watches_the_entity(hass, fake_trv):
+    """A trigger naming the entity by registry id still watches that entity."""
+    _entry, device_id = await _entry_with_device(hass)
+    registry_entry = er.async_get(hass).async_get(BT_ENTITY)
+    trigger = _offered(
+        await async_get_device_automations(
+            hass, DeviceAutomationType.TRIGGER, device_id
+        ),
+        "heating_active",
+    )
+    trigger[CONF_ENTITY_ID] = registry_entry.id
+    calls = async_mock_service(hass, "test", "automation")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "alias": "by_registry_id",
+                    "trigger": trigger,
                     "action": {"service": "test.automation"},
                 }
             ]

--- a/tests/integration/test_device_automation.py
+++ b/tests/integration/test_device_automation.py
@@ -1,0 +1,379 @@
+"""The automation surface Home Assistant offers for a Better Thermostat device.
+
+Triggers, conditions and actions are the one surface the integration never
+uses itself — users build automations on it, Home Assistant calls into it, and
+nothing inside this repository does. A broken entry here is therefore
+invisible to every other test: the code still imports, the lists still render
+in the automation editor, and the automation the user saves simply never runs.
+
+So these tests go the way a user's automation goes: ask Home Assistant what
+the device offers, put each offered entry into a real automation, and drive
+the change it claims to watch.
+"""
+
+import json
+
+from homeassistant.components import automation
+from homeassistant.components.climate.const import ATTR_HVAC_ACTION, ATTR_HVAC_MODE
+from homeassistant.components.device_automation import DeviceAutomationType
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_TEMPERATURE,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_TYPE,
+)
+from homeassistant.core import State
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+import pytest
+from pytest_homeassistant_custom_component.common import (
+    async_get_device_automations,
+    async_mock_service,
+)
+
+from custom_components.better_thermostat.device_action import ACTION_TYPES
+from custom_components.better_thermostat.device_condition import CONDITION_TYPES
+from custom_components.better_thermostat.device_trigger import TRIGGER_TYPES
+
+from .conftest import (
+    BT_ENTITY,
+    DOMAIN,
+    make_entry,
+    set_room_sensor,
+    setup_entry,
+    wait_for,
+    wait_for_startup,
+)
+from .device_profiles import GENERIC_HEAT_TRV, TRV_ID
+
+# The state change each trigger claims to watch, written as the attributes the
+# thermostat itself publishes. Every key is checked against the live entity
+# before it is used: a trigger that names an attribute Better Thermostat does
+# not expose can only be caught if the test refuses to invent that attribute.
+TRIGGER_CASES = {
+    "heating_active": {ATTR_HVAC_ACTION: "heating"},
+    "heating_stopped": {ATTR_HVAC_ACTION: "idle"},
+    "window_opened": {"window_open": True},
+    "window_closed": {"window_open": False},
+    "target_temp_reached": {"current_temperature": 24.0, ATTR_TEMPERATURE: 20.0},
+    "device_error": {"errors": json.dumps([TRV_ID])},
+    "humidity_high": {"current_humidity": 85.0},
+    "battery_low": {"batteries": json.dumps({TRV_ID: {"battery": 5}})},
+    "hvac_mode_changed": {},
+    "current_temperature_changed": {"current_temperature": 26.0},
+    "current_humidity_changed": {"current_humidity": 70.0},
+}
+
+# What each trigger has to be sitting on before the change above is a change.
+# A threshold trigger fires on the crossing, not on the value, so the ones
+# whose quantity already sits on the far side have to be moved back first.
+TRIGGER_PRECONDITIONS = {
+    "heating_stopped": {ATTR_HVAC_ACTION: "heating"},
+    "window_closed": {"window_open": True},
+    "target_temp_reached": {"current_temperature": 18.0, ATTR_TEMPERATURE: 22.0},
+    "current_temperature_changed": {"current_temperature": 20.0},
+    "current_humidity_changed": {"current_humidity": 50.0},
+}
+
+# Extra fields a trigger requires beyond the entry the device offers. The two
+# classic value triggers carry no threshold of their own — the automation
+# editor asks the user for one, and without it there is nothing to cross.
+TRIGGER_EXTRA_FIELDS = {
+    "hvac_mode_changed": {"to": "off"},
+    "current_temperature_changed": {"above": 25.0},
+    "current_humidity_changed": {"above": 65.0},
+}
+
+CONDITION_CASES = {
+    "is_hvac_mode": ({ATTR_HVAC_MODE: "heat"}, "heat", {}),
+    "is_hvac_action": ({ATTR_HVAC_ACTION: "idle"}, None, {ATTR_HVAC_ACTION: "idle"}),
+}
+
+
+async def _entry_with_device(hass):
+    """Set a thermostat up and return its config entry and device id."""
+    set_room_sensor(hass, 19.0)
+    entry = make_entry(GENERIC_HEAT_TRV)
+    await setup_entry(hass, entry)
+    await wait_for_startup(hass, entry)
+    registry_entry = er.async_get(hass).async_get(BT_ENTITY)
+    assert registry_entry is not None
+    assert registry_entry.device_id is not None
+    return entry, registry_entry.device_id
+
+
+def _offered(automations, wanted_type):
+    """Return the entry Home Assistant offers for ``wanted_type``."""
+    matches = [
+        item
+        for item in automations
+        if item.get(CONF_DOMAIN) == DOMAIN and item[CONF_TYPE] == wanted_type
+    ]
+    assert matches, f"the device offers no {wanted_type}"
+    # The offered entries carry editor metadata that is not part of the config.
+    return {k: v for k, v in matches[0].items() if k != "metadata"}
+
+
+def _republish(hass, **changes) -> State:
+    """Republish the thermostat's own state with some attributes changed.
+
+    Every key has to be one the entity already publishes. That is the point of
+    going through the live state instead of writing a state from scratch: an
+    automation entry that watches an attribute the thermostat does not have
+    would otherwise be tested against an attribute this test invented.
+    """
+    state = hass.states.get(BT_ENTITY)
+    assert state is not None
+    missing = sorted(key for key in changes if key not in state.attributes)
+    assert not missing, f"the thermostat publishes no {missing}"
+    hass.states.async_set(BT_ENTITY, state.state, {**state.attributes, **changes})
+    return state
+
+
+async def test_the_device_offers_every_declared_trigger(hass, fake_trv):
+    """Home Assistant is offered each trigger type the platform declares.
+
+    The declaration and the listing are two separate places, so a type added
+    to one and not the other never reaches an automation editor.
+    """
+    _entry, device_id = await _entry_with_device(hass)
+
+    offered = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_id
+    )
+    ours = {item[CONF_TYPE] for item in offered if item.get(CONF_DOMAIN) == DOMAIN}
+
+    assert ours == TRIGGER_TYPES
+
+
+@pytest.mark.parametrize("trigger_type", sorted(TRIGGER_CASES), ids=str)
+async def test_each_trigger_fires_on_the_change_it_names(hass, fake_trv, trigger_type):
+    """An automation built on each offered trigger runs when its change happens.
+
+    This is the whole contract: the entry the device offers has to be a valid
+    automation trigger, and it has to watch something the thermostat actually
+    publishes. Both halves fail silently — the first at automation setup, the
+    second never.
+    """
+    _entry, device_id = await _entry_with_device(hass)
+    trigger = _offered(
+        await async_get_device_automations(
+            hass, DeviceAutomationType.TRIGGER, device_id
+        ),
+        trigger_type,
+    )
+    trigger.update(TRIGGER_EXTRA_FIELDS.get(trigger_type, {}))
+    calls = async_mock_service(hass, "test", "automation")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "alias": trigger_type,
+                    "trigger": trigger,
+                    "action": {"service": "test.automation"},
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.async_entity_ids("automation"), (
+        f"{trigger_type} did not survive automation setup"
+    )
+
+    if trigger_type in TRIGGER_PRECONDITIONS:
+        _republish(hass, **TRIGGER_PRECONDITIONS[trigger_type])
+        await hass.async_block_till_done()
+
+    if trigger_type == "hvac_mode_changed":
+        # The mode is the entity state, so this one is driven through the
+        # service the user would call rather than through the attributes.
+        await hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {ATTR_ENTITY_ID: BT_ENTITY, ATTR_HVAC_MODE: "off"},
+            blocking=True,
+        )
+    else:
+        _republish(hass, **TRIGGER_CASES[trigger_type])
+
+    assert await wait_for(hass, lambda: calls), f"{trigger_type} never fired"
+
+
+async def test_the_device_offers_every_declared_condition(hass, fake_trv):
+    """Home Assistant is offered each condition type the platform declares."""
+    _entry, device_id = await _entry_with_device(hass)
+
+    offered = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_id
+    )
+    ours = {item[CONF_TYPE] for item in offered if item.get(CONF_DOMAIN) == DOMAIN}
+
+    assert ours == CONDITION_TYPES
+
+
+@pytest.mark.parametrize("condition_type", sorted(CONDITION_CASES), ids=str)
+async def test_each_condition_passes_on_the_state_it_names(
+    hass, fake_trv, condition_type
+):
+    """A condition built on each offered entry passes for the state it names.
+
+    A condition that can never be true is worse than a missing one: the
+    automation runs, the condition blocks it, and nothing anywhere says why.
+    """
+    _entry, device_id = await _entry_with_device(hass)
+    extra_fields, expected_state, attributes = CONDITION_CASES[condition_type]
+    condition = _offered(
+        await async_get_device_automations(
+            hass, DeviceAutomationType.CONDITION, device_id
+        ),
+        condition_type,
+    )
+    condition.update(extra_fields)
+    calls = async_mock_service(hass, "test", "automation")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "alias": condition_type,
+                    "trigger": {"platform": "event", "event_type": "run_condition"},
+                    "condition": [condition],
+                    "action": {"service": "test.automation"},
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.async_entity_ids("automation"), (
+        f"{condition_type} did not survive automation setup"
+    )
+
+    state = _republish(hass, **attributes) if attributes else hass.states.get(BT_ENTITY)
+    if expected_state is not None:
+        assert state.state == expected_state, (
+            f"the thermostat is not in {expected_state}, so this proves nothing"
+        )
+
+    hass.bus.async_fire("run_condition")
+    await hass.async_block_till_done()
+
+    assert calls, f"{condition_type} blocked the state it names"
+
+
+async def test_the_device_offers_every_declared_action(hass, fake_trv):
+    """Home Assistant is offered each action type the platform declares."""
+    _entry, device_id = await _entry_with_device(hass)
+
+    offered = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_id
+    )
+    ours = {item[CONF_TYPE] for item in offered if item.get(CONF_DOMAIN) == DOMAIN}
+
+    assert ours == ACTION_TYPES
+
+
+async def test_the_set_hvac_mode_action_reaches_the_thermostat(hass, fake_trv):
+    """The offered mode action turns the thermostat off when it runs."""
+    _entry, device_id = await _entry_with_device(hass)
+    action = _offered(
+        await async_get_device_automations(
+            hass, DeviceAutomationType.ACTION, device_id
+        ),
+        "set_hvac_mode",
+    )
+    action[ATTR_HVAC_MODE] = "off"
+    assert hass.states.get(BT_ENTITY).state == "heat"
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "alias": "set_hvac_mode",
+                    "trigger": {"platform": "event", "event_type": "run_action"},
+                    "action": action,
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    hass.bus.async_fire("run_action")
+
+    assert await wait_for(hass, lambda: hass.states.get(BT_ENTITY).state == "off")
+
+
+async def test_the_set_temperature_action_reaches_the_thermostat(hass, fake_trv):
+    """The offered setpoint action moves the thermostat's target when it runs."""
+    _entry, device_id = await _entry_with_device(hass)
+    action = _offered(
+        await async_get_device_automations(
+            hass, DeviceAutomationType.ACTION, device_id
+        ),
+        "set_temperature",
+    )
+    action[ATTR_TEMPERATURE] = 23.5
+    assert hass.states.get(BT_ENTITY).attributes[ATTR_TEMPERATURE] != 23.5
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "alias": "set_temperature",
+                    "trigger": {"platform": "event", "event_type": "run_action"},
+                    "action": action,
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    hass.bus.async_fire("run_action")
+
+    assert await wait_for(
+        hass, lambda: hass.states.get(BT_ENTITY).attributes[ATTR_TEMPERATURE] == 23.5
+    )
+
+
+async def test_a_trigger_that_names_only_a_device_finds_the_entity(hass, fake_trv):
+    """A device-only trigger watches the thermostat on that device.
+
+    This is the shape the bundled blueprints are written in: they let the user
+    pick a device, and nothing in the blueprint knows an entity id. The
+    automation editor writes the entity alongside the device, so both shapes
+    reach the platform and both have to work.
+    """
+    _entry, device_id = await _entry_with_device(hass)
+    calls = async_mock_service(hass, "test", "automation")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "alias": "device_only",
+                    "trigger": {
+                        "platform": "device",
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_DEVICE_ID: device_id,
+                        CONF_TYPE: "heating_active",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.async_entity_ids("automation")
+
+    _republish(hass, **{ATTR_HVAC_ACTION: "heating"})
+
+    assert await wait_for(hass, lambda: calls)

--- a/tests/unit/test_blueprints.py
+++ b/tests/unit/test_blueprints.py
@@ -32,6 +32,9 @@ import pytest
 import voluptuous as vol
 import yaml
 
+from custom_components.better_thermostat.device_trigger import TRIGGER_SCHEMA
+from custom_components.better_thermostat.utils.const import DOMAIN
+
 BLUEPRINTS_DIR = Path(__file__).resolve().parents[2] / "blueprints"
 BLUEPRINT_FILES = sorted(BLUEPRINTS_DIR.glob("*.yaml"))
 
@@ -518,3 +521,59 @@ def test_pause_off_does_not_resume_while_another_switch_holds_the_pause(
     )
 
     assert still_paused is True
+
+
+# ── The device triggers the bundled blueprints are built on ──────────────────
+#
+# The checks above validate service names and entity ids by hand. That says
+# nothing about whether Better Thermostat's own trigger platform accepts the
+# trigger a blueprint writes: the blueprint picks a device and a trigger type,
+# and the platform's schema is the thing that decides whether the automation
+# saves at all.
+
+
+def _bt_device_triggers(blueprint: dict) -> list[dict]:
+    """Return the Better Thermostat device triggers a blueprint declares."""
+    triggers = blueprint.get("trigger") or blueprint.get("triggers") or []
+    if isinstance(triggers, dict):
+        triggers = [triggers]
+    return [
+        trigger
+        for trigger in triggers
+        if isinstance(trigger, dict)
+        and trigger.get("platform") == "device"
+        and trigger.get("domain") == DOMAIN
+    ]
+
+
+BLUEPRINTS_WITH_DEVICE_TRIGGERS = [
+    path for path in BLUEPRINT_FILES if _bt_device_triggers(_load(path))
+]
+
+
+def test_some_blueprint_uses_a_device_trigger():
+    """Sanity check: the schema test below has blueprints to run against."""
+    assert BLUEPRINTS_WITH_DEVICE_TRIGGERS
+
+
+@pytest.mark.parametrize("path", BLUEPRINTS_WITH_DEVICE_TRIGGERS, ids=lambda p: p.name)
+def test_bundled_device_triggers_pass_the_trigger_schema(path):
+    """Every device trigger a blueprint declares validates against the platform.
+
+    A blueprint that picks a device but no entity is the shape these are all
+    written in, and it has to be a shape the trigger schema accepts — a
+    rejected trigger takes the whole automation down at save time, with the
+    blueprint itself looking perfectly fine.
+    """
+    blueprint = _load(path)
+    inputs = _resolve_inputs(blueprint)
+
+    for trigger in _bt_device_triggers(blueprint):
+        resolved = _substitute(trigger, inputs)
+        try:
+            TRIGGER_SCHEMA(resolved)
+        except vol.Invalid as err:
+            raise AssertionError(
+                f"{path.name}: trigger {resolved.get('type')} is rejected "
+                f"by the platform schema: {err}"
+            ) from err


### PR DESCRIPTION
## What this found

Better Thermostat's device automation surface — every trigger, condition and
action a user builds an automation on in the Home Assistant UI — **does not
work at all**. Each of the three platforms fails for its own reason, and all
three fail the same way from outside: the entries render in the automation
editor, the automation saves, and then it is silently disabled or never fires.

Measured against a real Home Assistant instance and a real config entry:

| Surface | What happens today |
|---|---|
| **Triggers** (11 types) | `Automation ... failed to setup triggers and has been disabled: extra keys not allowed @ data['entity_id']` — the schema rejects the very entries `async_get_triggers` lists |
| **Conditions** (2 types) | `... failed to setup conditions ...: extra keys not allowed @ data['condition']` — the schemas are bare `vol.Schema`, missing the device-condition base |
| **Actions** (2 types) | `Unknown error calling automation config validator - module '...device_action' has no attribute 'ACTION_SCHEMA'` — the schema is private, so validation raises and takes the whole automation config down |

Underneath the schema failures sit two more:

- The `humidity_high` trigger reads the `humidity` attribute. That is the
  climate *target* humidity, which Better Thermostat does not publish; the
  measured value is `current_humidity`. The trigger read a missing attribute
  as zero and could never cross its threshold.
- The `is_hvac_mode` condition compares against an `hvac_mode` attribute. A
  climate entity carries its mode as the state — only `hvac_action` is an
  attribute — so the condition was never true.

This is the mechanism the surface was picked for: the integration never calls
any of it, so nothing in the test suite ever did either. `device_trigger.py`
sat at 30 % line coverage because its attach path is unreachable through the
real flow.

## The fixes

All four follow Home Assistant's own `climate` device automation platform:

- `TRIGGER_SCHEMA` accepts `entity_id`, **optionally** — the automation editor
  writes it, the bundled blueprints pick a device only, and both shapes have
  to work. When it is absent the entity is resolved from the device; a stored
  registry id is resolved to an entity id.
- Both condition schemas extend `DEVICE_CONDITION_BASE_SCHEMA`.
- The action schema is exported as `ACTION_SCHEMA`, split per action type
  because the call path reads the hvac mode back without a fallback.
- The humidity template and the mode comparison read what the entity publishes.

## The tests

New `tests/integration/test_device_automation.py` (19 tests) asks Home
Assistant what the device offers, puts each offered entry into a real
automation, and drives the change it claims to watch. Attribute changes are
made on the thermostat's own published state, and every key is checked against
that state first — so a trigger naming an attribute the thermostat does not
expose cannot be tested against an attribute the test invented. That check is
what catches the humidity defect.

`tests/unit/test_blueprints.py` gains a schema check for the four bundled
blueprints that use device triggers. The existing blueprint checks validate
service names and entity ids by hand and were green throughout all of the
above.

## Verification

| Injected defect | Red |
|---|---|
| trigger schema rejects `entity_id` again | all 11 trigger cases |
| trigger requires `entity_id` instead of resolving it | `test_a_trigger_that_names_only_a_device_finds_the_entity` |
| humidity reads the target attribute | `...[humidity_high]` |
| condition schemas drop the base schema | both condition cases |
| mode condition reads an attribute | `...[is_hvac_mode]` |
| action schema goes back to being private | both action tests |

Full suite: 7093 passed, 1 skipped. `ruff check`, `ruff format --check` and
`pyrefly check` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved Better Thermostat device automation support for triggers, conditions, and actions.
  - HVAC mode conditions now evaluate the climate entity’s current state more accurately.
  - HVAC mode and temperature actions now provide stronger validation for supported values.
  - Device automations can resolve thermostats from configured entities or registered devices.
  - Humidity triggers now use the thermostat’s current humidity reading.
  - Added clearer configuration errors when no compatible Better Thermostat entity is available.
  - Device conditions now support entity IDs and unique IDs for more flexible configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->