### PR TITLE
docs: close a device-specific bug with a matrix row, not just a test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,43 @@ Translations can also be edited with the [INLANG Editor](https://inlang.com/edit
 ### Reporting Bugs
 
 You can create an issue if you have any kind of bug or error but please use the issue template.
+
+## Closing a device- or configuration-specific bug
+
+Most bugs reported here are not calculation errors. They are a device that
+speaks a slightly different dialect, or a combination of configuration options
+nobody had put together before. Such a bug is closed with **two** artefacts,
+not one:
+
+1. **A regression test at the level the bug sat.** A wrong number gets a unit
+   test; a write that never reached the device gets an integration test.
+2. **A row in the device matrix** — a `DeviceProfile` or `RoleScenario` in
+   `tests/integration/device_profiles.py` describing the shape the report came
+   from.
+
+The first artefact proves this bug is gone. The second is what catches the
+next one: every test parametrized over the matrix runs against that shape from
+then on, so what the report taught us is not confined to the single test
+written for it.
+
+A profile states a whole device — its integration, its calibration strategy,
+its mode vocabulary, its setpoint grid, whether its entity carries a device
+registry entry — because those are inseparable in the field. A Zigbee2MQTT
+head *is* the mqtt integration plus local calibration, and pairing one with
+the other integration describes a device that does not exist. Reuse the
+profile that already matches; add a row only when the shape is genuinely new.
+
+`SHAPES_FROM_REPORTS` in the same file names the shapes that reached us this
+way, and a test asserts each of them is still part of the matrix the
+integration suite runs over — a profile that quietly drops out of the matrix
+stops covering anything.
+
+Not every report has a device shape. A bug in the config flow, or in what
+happens while entities are still coming up, belongs in
+`tests/integration/test_config_flow.py` or
+`tests/integration/test_startup_scenarios.py` instead; those drive
+configurations and timelines rather than devices.
+
 ## Docstring type
 
 We use numpy type docstrings. Documentation can be found here:

--- a/tests/integration/device_profiles.py
+++ b/tests/integration/device_profiles.py
@@ -335,3 +335,22 @@ SINGLE_ROLE_PROFILES = (
 """Every profile a test can drive as the single controlled device."""
 
 ROLE_SCENARIOS = (HEAT_ONLY, SEPARATE_COOLER, RANGED_COOLER, DUAL_ROLE)
+"""Every wiring of a room a test can drive."""
+
+SHAPES_FROM_REPORTS: dict[str, DeviceProfile | RoleScenario] = {
+    "a head that offers no heating mode at all": AUTO_COOL_AC,
+    "a head whose calibration is a number entity on its device": MQTT_OFFSET_TRV,
+    "one entity wired as thermostat and as cooler": DUAL_ROLE,
+    "a thermostat entity with no device registry entry": GENERIC_HEAT_TRV,
+}
+"""The device shapes users have reported a bug against, by what they are.
+
+A report teaches the project a shape of device or wiring it did not have. The
+regression test that closes the report covers the one path the bug sat on; the
+entry here is what makes the whole integration suite run against that shape
+from then on. Adding to this table is half of closing such a report — see
+CONTRIBUTING.md.
+
+A report about the config flow or about entity startup has no device shape and
+does not belong here; those live in their own scenario files.
+"""

--- a/tests/integration/test_device_matrix.py
+++ b/tests/integration/test_device_matrix.py
@@ -49,7 +49,9 @@ from .device_profiles import (
     MQTT_OFFSET_TRV,
     OFFSET_NUMBER_ID,
     RANGED_COOLER,
+    ROLE_SCENARIOS,
     SEPARATE_COOLER,
+    SHAPES_FROM_REPORTS,
     SINGLE_ROLE_PROFILES,
     SPARE_HEAT_TRV,
     SPARE_TRV_ID,
@@ -58,6 +60,7 @@ from .device_profiles import (
     VALVE_NUMBER_ID,
     VALVE_TRV,
     DeviceProfile,
+    RoleScenario,
 )
 
 
@@ -494,3 +497,23 @@ async def test_cooling_demand_reaches_the_cooler(hass, device_role):
         cooler.profile.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE
     )
     assert isinstance(written, dict) is not takes_a_setpoint
+
+
+@pytest.mark.parametrize(
+    ("description", "shape"),
+    [
+        pytest.param(description, shape, id=description)
+        for description, shape in sorted(SHAPES_FROM_REPORTS.items())
+    ],
+)
+def test_every_reported_shape_is_still_in_the_matrix(description, shape):
+    """A shape a user reported stays in the matrix the suite runs over.
+
+    The regression test written for a report covers the one path the bug sat
+    on. What keeps the shape covered afterwards is its membership here: drop a
+    profile from the matrix and every parametrized test quietly stops running
+    against it, with nothing failing to say so.
+    """
+    matrix = ROLE_SCENARIOS if isinstance(shape, RoleScenario) else SINGLE_ROLE_PROFILES
+
+    assert shape in matrix, f"{description} is no longer part of the matrix"


### PR DESCRIPTION
## Why

The fix pull requests here are well covered — the four August ones brought
roughly 3600 lines of tests between them. The knowledge still stays local: the
test knows the new device shape, the rest of the suite does not. The next bug
on the same shape is found by a user again.

Most bugs reported against this integration are not calculation errors. They
are a device speaking a slightly different dialect, or a combination of
configuration options nobody had put together. For those, the regression test
is only half of what closes the report.

## The rule

CONTRIBUTING now states it: a bug that hangs on a device or configuration
variant is closed with **two** artefacts.

1. A regression test at the level the bug sat.
2. A row in the device matrix — a `DeviceProfile` or `RoleScenario` in
   `tests/integration/device_profiles.py` describing the shape the report came
   from.

The first proves this bug is gone. The second is what catches the next one:
every test parametrized over the matrix runs against that shape from then on.

## The executable half

`SHAPES_FROM_REPORTS` in `device_profiles.py` names the shapes that reached
the project this way, keyed by what they are rather than by where they came
from. A test asserts each is still part of the matrix the integration suite
runs over — dropping a profile from `SINGLE_ROLE_PROFILES` or `ROLE_SCENARIOS`
otherwise silently stops every parametrized test from running against it, and
nothing fails to say so. Verified by removing one: the test turns red naming
the shape that lost its coverage.

## What the ticket assumed, and what is actually there

The plan called for all eight reported issues to become matrix rows. Only four
of them have a device or wiring shape at all:

| Shape | Profile |
|---|---|
| a head that offers no heating mode at all | `AUTO_COOL_AC` |
| a head whose calibration is a number entity on its device | `MQTT_OFFSET_TRV` |
| one entity wired as thermostat and as cooler | `DUAL_ROLE` |
| a thermostat entity with no device registry entry | `GENERIC_HEAT_TRV` |

The other four are a config-flow bug, an options-flow bug, and two lifecycle
bugs. They have no device shape and cannot be matrix rows; they are covered by
`test_config_flow.py` and `test_startup_scenarios.py`, which drive
configurations and timelines instead. CONTRIBUTING says where each kind
belongs, so the rule does not send someone looking for a profile that cannot
exist.

Full suite: 7073 passed, 1 skipped. `ruff check` and `ruff format --check` are
clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for handling device- and configuration-specific bug reports, including required regression tests and device-matrix coverage.

* **Tests**
  * Added representative device shapes from reported issues.
  * Added regression coverage to ensure every reported device shape remains included in the device test matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->