### PR TITLE
1.9.1: make the device automation surface work on the maintenance line

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -25,6 +25,7 @@ reviews:
     # ("auto reviews disabled on non-default branch").
     base_branches:
       - "develop"
+      - "1.9"
 
     # PRs are opened as draft by default and marked ready later, so review them
     # while still draft — except genuine work-in-progress (see keywords below).
@@ -46,10 +47,17 @@ reviews:
   path_instructions:
     - path: "tests/**"
       instructions: >-
-        Tests run with `uv run pytest -p no:homeassistant`. Every test function
-        and class needs a docstring (ruff pydocstyle "D" rules are enforced).
+        Tests run with `uv run pytest tests/`. Do not suggest
+        `-p no:homeassistant`: that flag removes the plugin providing the
+        `hass` fixture and makes the whole integration suite error.
+        `asyncio_mode = "auto"` is set, so async tests need no marker at all —
+        do not ask for `@pytest.mark.asyncio` to be added, and where a marker
+        is present, match the one the surrounding class already uses.
+        Ruff's pydocstyle "D" rules are switched off for `tests/**` via
+        `per-file-ignores`, so NumPy `Parameters` sections are not required
+        here; what a docstring has to say is what the test pins and why.
         Follow the existing patterns: MagicMock + real dicts for `real_trvs`,
-        `State()` for HA states, `@pytest.mark.asyncio` / `AsyncMock` for async.
+        `State()` for HA states, `AsyncMock` for async collaborators.
     - path: "custom_components/better_thermostat/**"
       instructions: >-
         Home Assistant custom integration. Comments must describe the current

--- a/custom_components/better_thermostat/__init__.py
+++ b/custom_components/better_thermostat/__init__.py
@@ -31,7 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.CLIMATE, Platform.SENSOR, Platform.NUMBER, Platform.SWITCH]
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
-config_entry_update_listener_lock = Lock()
+RELOAD_LOCKS = f"{DOMAIN}_reload_locks"
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -61,9 +61,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+def _reload_lock(hass: HomeAssistant, entry: ConfigEntry) -> Lock:
+    """Return the lock one entry serializes its own reloads on.
+
+    The lock lives on the Home Assistant instance and is keyed by entry, so
+    two thermostats reload independently and a lock never outlives the
+    instance it was created for. It has to survive the reload it guards,
+    which is why it does not live in the per-entry data the unload clears.
+
+    Parameters
+    ----------
+    hass : HomeAssistant
+        The running Home Assistant instance.
+    entry : ConfigEntry
+        The config entry about to reload.
+
+    Returns
+    -------
+    Lock
+        The lock for this entry, created on first use.
+    """
+    return hass.data.setdefault(RELOAD_LOCKS, {}).setdefault(entry.entry_id, Lock())
+
+
 async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
-    async with config_entry_update_listener_lock:
+    async with _reload_lock(hass, entry):
         await hass.config_entries.async_reload(entry.entry_id)
 
 
@@ -82,6 +105,8 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     persist in HA's issue registry until explicitly deleted, so they have to
     be cleaned up here to avoid stale warnings after a config entry is gone.
     """
+    hass.data.get(RELOAD_LOCKS, {}).pop(entry.entry_id, None)
+
     device_name = entry.data.get(CONF_NAME, entry.title)
 
     for issue_id in (

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1190,6 +1190,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
             sensor_state = self.hass.states.get(self.sensor_entity_id)
             if not self._check_entities_ready(sensor_state):
+                # This loop waits for as long as it takes, and nothing
+                # downstream of it runs while it does, so without this call a
+                # TRV that never comes back is never reported at all — while
+                # one that disappears after startup is. The critical check
+                # owns the rule for when waiting turns into reporting and
+                # stays quiet for the length of the grace window.
+                await check_critical_entities(self)
                 await asyncio.sleep(20)
                 if self.is_removed:
                     return

--- a/custom_components/better_thermostat/device_action.py
+++ b/custom_components/better_thermostat/device_action.py
@@ -30,12 +30,30 @@ from .utils.helpers import is_bt_climate_entity
 
 ACTION_TYPES = {"set_hvac_mode", "set_temperature"}
 
-_ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+# One schema per action type, because each type carries its own fields and
+# ``async_call_action_from_config`` reads the hvac mode back without a
+# fallback. Home Assistant looks the schema up by this exact name.
+SET_HVAC_MODE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_TYPE): vol.In(ACTION_TYPES),
+        vol.Required(CONF_TYPE): "set_hvac_mode",
         vol.Required(CONF_ENTITY_ID): cv.entity_domain(CLIMATE_DOMAIN),
+        vol.Required(ATTR_HVAC_MODE): vol.In(
+            [HVACMode.HEAT, HVACMode.OFF, HVACMode.HEAT_COOL]
+        ),
     }
 )
+
+SET_TEMPERATURE_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): "set_temperature",
+        vol.Required(CONF_ENTITY_ID): cv.entity_domain(CLIMATE_DOMAIN),
+        vol.Optional(ATTR_TEMPERATURE): vol.Coerce(float),
+        vol.Optional(ATTR_TARGET_TEMP_HIGH): vol.Coerce(float),
+        vol.Optional(ATTR_TARGET_TEMP_LOW): vol.Coerce(float),
+    }
+)
+
+ACTION_SCHEMA = vol.Any(SET_HVAC_MODE_SCHEMA, SET_TEMPERATURE_SCHEMA)
 
 
 async def async_get_actions(

--- a/custom_components/better_thermostat/device_condition.py
+++ b/custom_components/better_thermostat/device_condition.py
@@ -85,6 +85,12 @@ def async_condition_from_config(
     hass: HomeAssistant, config: ConfigType
 ) -> condition.ConditionCheckerType:
     """Create a function to test a device condition."""
+    # A stored condition may name the entity by its registry id rather than by
+    # its entity id, which the schema accepts and ``hass.states`` does not.
+    entity_id = entity_registry.async_resolve_entity_id(
+        entity_registry.async_get(hass), config[CONF_ENTITY_ID]
+    )
+
     if config[CONF_TYPE] == "is_hvac_mode":
         hvac_mode = config[ATTR_HVAC_MODE]
 
@@ -96,8 +102,9 @@ def async_condition_from_config(
             A climate entity carries its mode as the state, not as an
             attribute; ``hvac_action`` is the one that is an attribute.
             """
-            state = hass.states.get(config[CONF_ENTITY_ID])
-            return state is not None and state.state == hvac_mode
+            if entity_id is None or (state := hass.states.get(entity_id)) is None:
+                return False
+            return state.state == hvac_mode
 
         return test_is_hvac_mode
 
@@ -108,11 +115,9 @@ def async_condition_from_config(
             hass: HomeAssistant, variables: Mapping[str, object] | None
         ) -> bool:
             """Test if an HVAC action condition is met."""
-            state = hass.states.get(config[CONF_ENTITY_ID])
-            return (
-                state is not None
-                and state.attributes.get(ATTR_HVAC_ACTION) == hvac_action
-            )
+            if entity_id is None or (state := hass.states.get(entity_id)) is None:
+                return False
+            return state.attributes.get(ATTR_HVAC_ACTION) == hvac_action
 
         return test_is_hvac_action
 

--- a/custom_components/better_thermostat/device_condition.py
+++ b/custom_components/better_thermostat/device_condition.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import condition, config_validation as cv, entity_registry
+from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
 from homeassistant.helpers.typing import ConfigType
 import voluptuous as vol
 
@@ -27,9 +28,12 @@ from .utils.helpers import is_bt_climate_entity
 
 CONDITION_TYPES = {"is_hvac_mode", "is_hvac_action"}
 
-HVAC_MODE_CONDITION = vol.Schema(
+# Both extend the device-condition base schema, which carries the `condition`,
+# `device_id` and `domain` keys every condition this platform offers is built
+# with; a bare schema rejects its own output.
+HVAC_MODE_CONDITION = DEVICE_CONDITION_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(CONF_TYPE): "is_hvac_mode",
         vol.Required(ATTR_HVAC_MODE): vol.In(
             [HVACMode.OFF, HVACMode.HEAT, HVACMode.HEAT_COOL]
@@ -37,9 +41,9 @@ HVAC_MODE_CONDITION = vol.Schema(
     }
 )
 
-HVAC_ACTION_CONDITION = vol.Schema(
+HVAC_ACTION_CONDITION = DEVICE_CONDITION_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         vol.Required(CONF_TYPE): "is_hvac_action",
         vol.Required(ATTR_HVAC_ACTION): vol.In(
             [HVACAction.OFF, HVACAction.HEATING, HVACAction.IDLE]
@@ -87,11 +91,13 @@ def async_condition_from_config(
         def test_is_hvac_mode(
             hass: HomeAssistant, variables: Mapping[str, object] | None
         ) -> bool:
-            """Test if an HVAC mode condition is met."""
+            """Test if an HVAC mode condition is met.
+
+            A climate entity carries its mode as the state, not as an
+            attribute; ``hvac_action`` is the one that is an attribute.
+            """
             state = hass.states.get(config[CONF_ENTITY_ID])
-            return (
-                state is not None and state.attributes.get(ATTR_HVAC_MODE) == hvac_mode
-            )
+            return state is not None and state.state == hvac_mode
 
         return test_is_hvac_mode
 

--- a/custom_components/better_thermostat/device_trigger.py
+++ b/custom_components/better_thermostat/device_trigger.py
@@ -24,6 +24,9 @@ from __future__ import annotations
 
 from homeassistant.components.climate.const import HVAC_MODES
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
 from homeassistant.components.homeassistant.triggers import (
     numeric_state as numeric_state_trigger,
     state as state_trigger,
@@ -78,6 +81,11 @@ TRIGGER_TYPES = _PURPOSE_TRIGGER_TYPES | _CLASSIC_TRIGGER_TYPES
 TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+        # The automation editor stores the entity alongside the device, and
+        # the base schema does not carry the key, so without it every trigger
+        # this platform offers fails validation. It stays optional because the
+        # blueprints shipped with the integration pick a device only.
+        vol.Optional(CONF_ENTITY_ID): cv.entity_id_or_uuid,
         # Fields used by classic triggers
         vol.Optional(CONF_TO): vol.Any(str, [str]),
         # Fields used by numeric triggers
@@ -161,6 +169,38 @@ async def async_get_triggers(
     return triggers
 
 
+def _resolve_entity_id(hass: HomeAssistant, config: ConfigType) -> str | None:
+    """Return the thermostat entity a trigger config watches.
+
+    The automation editor stores the entity next to the device, and a stored
+    automation may hold the registry id rather than the entity id. The
+    blueprints shipped with the integration pick a device only, so the entity
+    has to be recoverable from the device alone as well.
+
+    Parameters
+    ----------
+    hass : HomeAssistant
+        The running Home Assistant instance.
+    config : ConfigType
+        A validated trigger configuration.
+
+    Returns
+    -------
+    str or None
+        The entity id to watch, or None when the device carries no Better
+        Thermostat climate entity.
+    """
+    registry = entity_registry.async_get(hass)
+    if configured := config.get(CONF_ENTITY_ID):
+        return entity_registry.async_resolve_entity_id(registry, configured)
+    for entry in entity_registry.async_entries_for_device(
+        registry, config[CONF_DEVICE_ID]
+    ):
+        if is_bt_climate_entity(entry):
+            return entry.entity_id
+    return None
+
+
 async def async_attach_trigger(
     hass: HomeAssistant,
     config: ConfigType,
@@ -169,7 +209,12 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Attach a trigger and return an unsubscribe callback."""
     trigger_type: str = config[CONF_TYPE]
-    entity_id: str = config[CONF_ENTITY_ID]
+    entity_id = _resolve_entity_id(hass, config)
+    if entity_id is None:
+        raise InvalidDeviceAutomationConfig(
+            f"No Better Thermostat climate entity found for device "
+            f"{config[CONF_DEVICE_ID]}"
+        )
 
     # Helpers
     def _build_state(
@@ -270,7 +315,7 @@ async def async_attach_trigger(
     #   Threshold is configurable (CONF_ABOVE); default is DEFAULT_HUMIDITY_THRESHOLD.
     if trigger_type == "humidity_high":
         numeric_config = _build_numeric(
-            "{{ state.attributes.get('humidity', 0) | float(0) }}"
+            "{{ state.attributes.get('current_humidity', 0) | float(0) }}"
         )
         if CONF_ABOVE not in numeric_config:
             numeric_config[CONF_ABOVE] = DEFAULT_HUMIDITY_THRESHOLD

--- a/custom_components/better_thermostat/device_trigger.py
+++ b/custom_components/better_thermostat/device_trigger.py
@@ -172,10 +172,13 @@ async def async_get_triggers(
 def _resolve_entity_id(hass: HomeAssistant, config: ConfigType) -> str | None:
     """Return the thermostat entity a trigger config watches.
 
-    The automation editor stores the entity next to the device, and a stored
-    automation may hold the registry id rather than the entity id. The
-    blueprints shipped with the integration pick a device only, so the entity
-    has to be recoverable from the device alone as well.
+    The automation editor stores the entity next to the device; the blueprints
+    shipped with the integration pick a device only, so the entity has to be
+    recoverable from the device alone as well.
+
+    A configured value is passed through as it stands, including a registry id:
+    every branch below hands it to a state or numeric-state trigger, and those
+    resolve a registry id to an entity id themselves.
 
     Parameters
     ----------
@@ -187,12 +190,12 @@ def _resolve_entity_id(hass: HomeAssistant, config: ConfigType) -> str | None:
     Returns
     -------
     str or None
-        The entity id to watch, or None when the device carries no Better
-        Thermostat climate entity.
+        The entity or registry id to watch, or None when the device carries no
+        Better Thermostat climate entity.
     """
-    registry = entity_registry.async_get(hass)
     if configured := config.get(CONF_ENTITY_ID):
-        return entity_registry.async_resolve_entity_id(registry, configured)
+        return configured
+    registry = entity_registry.async_get(hass)
     for entry in entity_registry.async_entries_for_device(
         registry, config[CONF_DEVICE_ID]
     ):

--- a/custom_components/better_thermostat/manifest.json
+++ b/custom_components/better_thermostat/manifest.json
@@ -20,5 +20,5 @@
   "requirements": [
     "numpy>=2"
   ],
-  "version": "1.9.0"
+  "version": "1.9.1"
 }

--- a/custom_components/better_thermostat/utils/watcher.py
+++ b/custom_components/better_thermostat/utils/watcher.py
@@ -261,29 +261,33 @@ async def check_critical_entities(self) -> bool:
                     self.device_name,
                     entity,
                 )
-            else:
+            elif entity not in self.devices_errors:
+                # Both the log line and the repair announce the outage, so
+                # both follow the transition into it. The check runs on every
+                # trigger and on every pass of the startup wait loop, and an
+                # entity that stays away would otherwise be announced for as
+                # long as it is gone.
                 _LOGGER.warning(
                     "better_thermostat %s: Critical entity %s is unavailable",
                     self.device_name,
                     entity,
                 )
-                if entity not in self.devices_errors:
-                    self.devices_errors.append(entity)
-                    self.async_write_ha_state()
-                    ir.async_create_issue(
-                        hass=self.hass,
-                        domain=DOMAIN,
-                        issue_id=f"missing_entity_{entity}",
-                        is_fixable=True,
-                        is_persistent=False,
-                        learn_more_url="https://better-thermostat.org/faq/missing-entity",
-                        severity=ir.IssueSeverity.ERROR,
-                        translation_key="missing_entity",
-                        translation_placeholders={
-                            "entity": str(entity),
-                            "name": str(self.device_name),
-                        },
-                    )
+                self.devices_errors.append(entity)
+                self.async_write_ha_state()
+                ir.async_create_issue(
+                    hass=self.hass,
+                    domain=DOMAIN,
+                    issue_id=f"missing_entity_{entity}",
+                    is_fixable=True,
+                    is_persistent=False,
+                    learn_more_url="https://better-thermostat.org/faq/missing-entity",
+                    severity=ir.IssueSeverity.ERROR,
+                    translation_key="missing_entity",
+                    translation_placeholders={
+                        "entity": str(entity),
+                        "name": str(self.device_name),
+                    },
+                )
             all_available = False
         else:
             recovered = entity in self.devices_errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "better-thermostat"
-version = "1.9.0"  # keep in sync with manifest.json
+version = "1.9.1"  # keep in sync with manifest.json
 description = "Better Thermostat — Home Assistant custom integration for smart TRV control"
 requires-python = ">=3.14.2"  # floor inherited from Home Assistant 2026.7.x
 dependencies = ["homeassistant>=2026.7.2"]

--- a/tests/integration/test_device_automation.py
+++ b/tests/integration/test_device_automation.py
@@ -1,0 +1,393 @@
+"""The automation surface Home Assistant offers for a Better Thermostat device.
+
+Triggers, conditions and actions are the one surface the integration never
+uses itself — users build automations on it, Home Assistant calls into it, and
+nothing inside this repository does. A broken entry here is therefore
+invisible to every other test: the code still imports, the lists still render
+in the automation editor, and the automation the user saves simply never runs.
+
+So these tests go the way a user's automation goes: ask Home Assistant what
+the device offers, put each offered entry into a real automation, and drive
+the change it claims to watch.
+"""
+
+import json
+
+from homeassistant.components import automation
+from homeassistant.components.climate.const import ATTR_HVAC_ACTION, ATTR_HVAC_MODE
+from homeassistant.components.device_automation import DeviceAutomationType
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_TEMPERATURE,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_TYPE,
+)
+from homeassistant.core import State
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+import pytest
+from pytest_homeassistant_custom_component.common import (
+    async_get_device_automations,
+    async_mock_service,
+)
+
+from custom_components.better_thermostat.device_action import ACTION_TYPES
+from custom_components.better_thermostat.device_condition import CONDITION_TYPES
+from custom_components.better_thermostat.device_trigger import TRIGGER_TYPES
+
+from .conftest import (
+    DOMAIN,
+    SENSOR_ID,
+    TRV_ID,
+    make_entry,
+    setup_entry,
+    wait_for,
+    wait_for_startup,
+)
+
+BT_ENTITY = "climate.bt_test"
+
+# The state change each trigger claims to watch, written as the attributes the
+# thermostat itself publishes. Every key is checked against the live entity
+# before it is used: a trigger that names an attribute Better Thermostat does
+# not expose can only be caught if the test refuses to invent that attribute.
+TRIGGER_CASES = {
+    "heating_active": {ATTR_HVAC_ACTION: "heating"},
+    "heating_stopped": {ATTR_HVAC_ACTION: "idle"},
+    "window_opened": {"window_open": True},
+    "window_closed": {"window_open": False},
+    "target_temp_reached": {"current_temperature": 24.0, ATTR_TEMPERATURE: 20.0},
+    "device_error": {"errors": json.dumps([TRV_ID])},
+    "humidity_high": {"current_humidity": 85.0},
+    "battery_low": {"batteries": json.dumps({TRV_ID: {"battery": 5}})},
+    "hvac_mode_changed": {},
+    "current_temperature_changed": {"current_temperature": 26.0},
+    "current_humidity_changed": {"current_humidity": 70.0},
+}
+
+# What each trigger has to be sitting on before the change above is a change.
+# A threshold trigger fires on the crossing, not on the value, so the ones
+# whose quantity already sits on the far side have to be moved back first.
+TRIGGER_PRECONDITIONS = {
+    "heating_stopped": {ATTR_HVAC_ACTION: "heating"},
+    "window_closed": {"window_open": True},
+    "target_temp_reached": {"current_temperature": 18.0, ATTR_TEMPERATURE: 22.0},
+    "current_temperature_changed": {"current_temperature": 20.0},
+    "current_humidity_changed": {"current_humidity": 50.0},
+}
+
+# Extra fields a trigger requires beyond the entry the device offers. The two
+# classic value triggers carry no threshold of their own — the automation
+# editor asks the user for one, and without it there is nothing to cross.
+TRIGGER_EXTRA_FIELDS = {
+    "hvac_mode_changed": {"to": "off"},
+    "current_temperature_changed": {"above": 25.0},
+    "current_humidity_changed": {"above": 65.0},
+}
+
+CONDITION_CASES = {
+    "is_hvac_mode": ({ATTR_HVAC_MODE: "heat"}, "heat", {}),
+    "is_hvac_action": ({ATTR_HVAC_ACTION: "idle"}, None, {ATTR_HVAC_ACTION: "idle"}),
+}
+
+
+def _room_sensor(hass, value="19.0"):
+    """Set the external room temperature sensor to ``value`` (°C)."""
+    hass.states.async_set(SENSOR_ID, value, {"unit_of_measurement": "°C"})
+
+
+async def _entry_with_device(hass):
+    """Set a thermostat up and return its config entry and device id."""
+    _room_sensor(hass)
+    entry = make_entry()
+    await setup_entry(hass, entry)
+    await wait_for_startup(hass, entry)
+    registry_entry = er.async_get(hass).async_get(BT_ENTITY)
+    assert registry_entry is not None
+    assert registry_entry.device_id is not None
+    return entry, registry_entry.device_id
+
+
+def _offered(automations, wanted_type):
+    """Return the entry Home Assistant offers for ``wanted_type``."""
+    matches = [
+        item
+        for item in automations
+        if item.get(CONF_DOMAIN) == DOMAIN and item[CONF_TYPE] == wanted_type
+    ]
+    assert matches, f"the device offers no {wanted_type}"
+    # The offered entries carry editor metadata that is not part of the config.
+    return {k: v for k, v in matches[0].items() if k != "metadata"}
+
+
+def _republish(hass, **changes) -> State:
+    """Republish the thermostat's own state with some attributes changed.
+
+    Every key has to be one the entity already publishes. That is the point of
+    going through the live state instead of writing a state from scratch: an
+    automation entry that watches an attribute the thermostat does not have
+    would otherwise be tested against an attribute this test invented.
+    """
+    state = hass.states.get(BT_ENTITY)
+    assert state is not None
+    missing = sorted(key for key in changes if key not in state.attributes)
+    assert not missing, f"the thermostat publishes no {missing}"
+    hass.states.async_set(BT_ENTITY, state.state, {**state.attributes, **changes})
+    return state
+
+
+async def _run_automation(hass, config) -> None:
+    """Set one automation up and assert it survived validation."""
+    assert await async_setup_component(
+        hass, automation.DOMAIN, {automation.DOMAIN: [config]}
+    )
+    await hass.async_block_till_done()
+    assert hass.states.async_entity_ids("automation"), (
+        f"{config['alias']} did not survive automation setup"
+    )
+
+
+async def test_the_device_offers_every_declared_trigger(hass, fake_trv):
+    """Home Assistant is offered each trigger type the platform declares."""
+    _entry, device_id = await _entry_with_device(hass)
+
+    offered = await async_get_device_automations(
+        hass, DeviceAutomationType.TRIGGER, device_id
+    )
+    ours = {item[CONF_TYPE] for item in offered if item.get(CONF_DOMAIN) == DOMAIN}
+
+    assert ours == TRIGGER_TYPES
+
+
+@pytest.mark.parametrize("trigger_type", sorted(TRIGGER_CASES), ids=str)
+async def test_each_trigger_fires_on_the_change_it_names(hass, fake_trv, trigger_type):
+    """An automation built on each offered trigger runs when its change happens.
+
+    This is the whole contract: the entry the device offers has to be a valid
+    automation trigger, and it has to watch something the thermostat actually
+    publishes. Both halves fail silently — the first at automation setup, the
+    second never.
+    """
+    _entry, device_id = await _entry_with_device(hass)
+    trigger = _offered(
+        await async_get_device_automations(
+            hass, DeviceAutomationType.TRIGGER, device_id
+        ),
+        trigger_type,
+    )
+    trigger.update(TRIGGER_EXTRA_FIELDS.get(trigger_type, {}))
+    calls = async_mock_service(hass, "test", "automation")
+
+    await _run_automation(
+        hass,
+        {
+            "alias": trigger_type,
+            "trigger": trigger,
+            "action": {"service": "test.automation"},
+        },
+    )
+
+    if trigger_type in TRIGGER_PRECONDITIONS:
+        _republish(hass, **TRIGGER_PRECONDITIONS[trigger_type])
+        await hass.async_block_till_done()
+
+    if trigger_type == "hvac_mode_changed":
+        # The mode is the entity state, so this one is driven through the
+        # service the user would call rather than through the attributes.
+        await hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {ATTR_ENTITY_ID: BT_ENTITY, ATTR_HVAC_MODE: "off"},
+            blocking=True,
+        )
+    else:
+        _republish(hass, **TRIGGER_CASES[trigger_type])
+
+    assert await wait_for(hass, lambda: calls), f"{trigger_type} never fired"
+
+
+async def test_a_trigger_that_names_only_a_device_finds_the_entity(hass, fake_trv):
+    """A device-only trigger watches the thermostat on that device.
+
+    This is the shape the bundled blueprints are written in: they let the user
+    pick a device, and nothing in the blueprint knows an entity id. The
+    automation editor writes the entity alongside the device, so both shapes
+    reach the platform and both have to work.
+    """
+    _entry, device_id = await _entry_with_device(hass)
+    calls = async_mock_service(hass, "test", "automation")
+
+    await _run_automation(
+        hass,
+        {
+            "alias": "device_only",
+            "trigger": {
+                "platform": "device",
+                CONF_DOMAIN: DOMAIN,
+                CONF_DEVICE_ID: device_id,
+                CONF_TYPE: "heating_active",
+            },
+            "action": {"service": "test.automation"},
+        },
+    )
+
+    _republish(hass, **{ATTR_HVAC_ACTION: "heating"})
+
+    assert await wait_for(hass, lambda: calls)
+
+
+async def test_the_device_offers_every_declared_condition(hass, fake_trv):
+    """Home Assistant is offered each condition type the platform declares."""
+    _entry, device_id = await _entry_with_device(hass)
+
+    offered = await async_get_device_automations(
+        hass, DeviceAutomationType.CONDITION, device_id
+    )
+    ours = {item[CONF_TYPE] for item in offered if item.get(CONF_DOMAIN) == DOMAIN}
+
+    assert ours == CONDITION_TYPES
+
+
+@pytest.mark.parametrize("condition_type", sorted(CONDITION_CASES), ids=str)
+async def test_each_condition_passes_on_the_state_it_names(
+    hass, fake_trv, condition_type
+):
+    """A condition built on each offered entry passes for the state it names.
+
+    A condition that can never be true is worse than a missing one: the
+    automation runs, the condition blocks it, and nothing anywhere says why.
+    """
+    _entry, device_id = await _entry_with_device(hass)
+    extra_fields, expected_state, attributes = CONDITION_CASES[condition_type]
+    condition = _offered(
+        await async_get_device_automations(
+            hass, DeviceAutomationType.CONDITION, device_id
+        ),
+        condition_type,
+    )
+    condition.update(extra_fields)
+    calls = async_mock_service(hass, "test", "automation")
+
+    await _run_automation(
+        hass,
+        {
+            "alias": condition_type,
+            "trigger": {"platform": "event", "event_type": "run_condition"},
+            "condition": [condition],
+            "action": {"service": "test.automation"},
+        },
+    )
+
+    state = _republish(hass, **attributes) if attributes else hass.states.get(BT_ENTITY)
+    if expected_state is not None:
+        assert state.state == expected_state, (
+            f"the thermostat is not in {expected_state}, so this proves nothing"
+        )
+
+    hass.bus.async_fire("run_condition")
+    await hass.async_block_till_done()
+
+    assert calls, f"{condition_type} blocked the state it names"
+
+
+async def test_a_condition_that_names_the_registry_id_reads_the_state(hass, fake_trv):
+    """A condition naming the entity by registry id still reads its state.
+
+    A stored automation may hold the registry id instead of the entity id —
+    that is the point of the id, it survives a rename. The schema accepts both
+    and ``hass.states`` accepts only one, so the registry id has to be resolved
+    before the state is read, or the condition is silently always false.
+    """
+    _entry, device_id = await _entry_with_device(hass)
+    registry_entry = er.async_get(hass).async_get(BT_ENTITY)
+    condition = _offered(
+        await async_get_device_automations(
+            hass, DeviceAutomationType.CONDITION, device_id
+        ),
+        "is_hvac_mode",
+    )
+    condition[CONF_ENTITY_ID] = registry_entry.id
+    condition[ATTR_HVAC_MODE] = "heat"
+    calls = async_mock_service(hass, "test", "automation")
+
+    await _run_automation(
+        hass,
+        {
+            "alias": "by_registry_id",
+            "trigger": {"platform": "event", "event_type": "run_condition"},
+            "condition": [condition],
+            "action": {"service": "test.automation"},
+        },
+    )
+    assert hass.states.get(BT_ENTITY).state == "heat"
+
+    hass.bus.async_fire("run_condition")
+    await hass.async_block_till_done()
+
+    assert calls, "the condition did not resolve the registry id"
+
+
+async def test_the_device_offers_every_declared_action(hass, fake_trv):
+    """Home Assistant is offered each action type the platform declares."""
+    _entry, device_id = await _entry_with_device(hass)
+
+    offered = await async_get_device_automations(
+        hass, DeviceAutomationType.ACTION, device_id
+    )
+    ours = {item[CONF_TYPE] for item in offered if item.get(CONF_DOMAIN) == DOMAIN}
+
+    assert ours == ACTION_TYPES
+
+
+async def test_the_set_hvac_mode_action_reaches_the_thermostat(hass, fake_trv):
+    """The offered mode action turns the thermostat off when it runs."""
+    _entry, device_id = await _entry_with_device(hass)
+    action = _offered(
+        await async_get_device_automations(
+            hass, DeviceAutomationType.ACTION, device_id
+        ),
+        "set_hvac_mode",
+    )
+    action[ATTR_HVAC_MODE] = "off"
+    assert hass.states.get(BT_ENTITY).state == "heat"
+
+    await _run_automation(
+        hass,
+        {
+            "alias": "set_hvac_mode",
+            "trigger": {"platform": "event", "event_type": "run_action"},
+            "action": action,
+        },
+    )
+    hass.bus.async_fire("run_action")
+
+    assert await wait_for(hass, lambda: hass.states.get(BT_ENTITY).state == "off")
+
+
+async def test_the_set_temperature_action_reaches_the_thermostat(hass, fake_trv):
+    """The offered setpoint action moves the thermostat's target when it runs."""
+    _entry, device_id = await _entry_with_device(hass)
+    action = _offered(
+        await async_get_device_automations(
+            hass, DeviceAutomationType.ACTION, device_id
+        ),
+        "set_temperature",
+    )
+    action[ATTR_TEMPERATURE] = 23.5
+    assert hass.states.get(BT_ENTITY).attributes[ATTR_TEMPERATURE] != 23.5
+
+    await _run_automation(
+        hass,
+        {
+            "alias": "set_temperature",
+            "trigger": {"platform": "event", "event_type": "run_action"},
+            "action": action,
+        },
+    )
+    hass.bus.async_fire("run_action")
+
+    assert await wait_for(
+        hass, lambda: hass.states.get(BT_ENTITY).attributes[ATTR_TEMPERATURE] == 23.5
+    )

--- a/tests/integration/test_device_automation.py
+++ b/tests/integration/test_device_automation.py
@@ -25,10 +25,11 @@ from homeassistant.const import (
     CONF_TYPE,
 )
 from homeassistant.core import State
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 import pytest
 from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
     async_get_device_automations,
     async_mock_service,
 )
@@ -391,3 +392,56 @@ async def test_the_set_temperature_action_reaches_the_thermostat(hass, fake_trv)
     assert await wait_for(
         hass, lambda: hass.states.get(BT_ENTITY).attributes[ATTR_TEMPERATURE] == 23.5
     )
+
+
+async def test_a_trigger_on_a_device_without_a_thermostat_is_refused(
+    hass, fake_trv, caplog
+):
+    """A device carrying no thermostat is refused by name, and watches nothing.
+
+    Resolving the entity from the device is what makes the device-only shape
+    work, and it has exactly one way to come up empty. Home Assistant leaves
+    such an automation switched on either way, so the log line naming the
+    device is the only thing that separates "armed" from "attached to
+    nothing".
+    """
+    await _entry_with_device(hass)
+    calls = async_mock_service(hass, "test", "automation")
+    other = MockConfigEntry(domain="other_integration")
+    other.add_to_hass(hass)
+    stranger = dr.async_get(hass).async_get_or_create(
+        config_entry_id=other.entry_id,
+        identifiers={("other_integration", "no_thermostat_here")},
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "alias": "stranger",
+                    "trigger": {
+                        "platform": "device",
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_DEVICE_ID: stranger.id,
+                        CONF_TYPE: "heating_active",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert any(
+        stranger.id in record.message
+        and "Better Thermostat climate entity" in record.message
+        for record in caplog.records
+    ), "the refusal did not name the device"
+
+    # The thermostat that does exist changes; nothing is watching for it.
+    _republish(hass, **{ATTR_HVAC_ACTION: "heating"})
+    await hass.async_block_till_done()
+
+    assert not calls

--- a/tests/unit/test_blueprints.py
+++ b/tests/unit/test_blueprints.py
@@ -32,6 +32,9 @@ import pytest
 import voluptuous as vol
 import yaml
 
+from custom_components.better_thermostat.device_trigger import TRIGGER_SCHEMA
+from custom_components.better_thermostat.utils.const import DOMAIN
+
 BLUEPRINTS_DIR = Path(__file__).resolve().parents[2] / "blueprints"
 BLUEPRINT_FILES = sorted(BLUEPRINTS_DIR.glob("*.yaml"))
 
@@ -518,3 +521,59 @@ def test_pause_off_does_not_resume_while_another_switch_holds_the_pause(
     )
 
     assert still_paused is True
+
+
+# ── The device triggers the bundled blueprints are built on ──────────────────
+#
+# The checks above validate service names and entity ids by hand. That says
+# nothing about whether Better Thermostat's own trigger platform accepts the
+# trigger a blueprint writes: the blueprint picks a device and a trigger type,
+# and the platform's schema is the thing that decides whether the automation
+# saves at all.
+
+
+def _bt_device_triggers(blueprint: dict) -> list[dict]:
+    """Return the Better Thermostat device triggers a blueprint declares."""
+    triggers = blueprint.get("trigger") or blueprint.get("triggers") or []
+    if isinstance(triggers, dict):
+        triggers = [triggers]
+    return [
+        trigger
+        for trigger in triggers
+        if isinstance(trigger, dict)
+        and trigger.get("platform") == "device"
+        and trigger.get("domain") == DOMAIN
+    ]
+
+
+BLUEPRINTS_WITH_DEVICE_TRIGGERS = [
+    path for path in BLUEPRINT_FILES if _bt_device_triggers(_load(path))
+]
+
+
+def test_some_blueprint_uses_a_device_trigger():
+    """Sanity check: the schema test below has blueprints to run against."""
+    assert BLUEPRINTS_WITH_DEVICE_TRIGGERS
+
+
+@pytest.mark.parametrize("path", BLUEPRINTS_WITH_DEVICE_TRIGGERS, ids=lambda p: p.name)
+def test_bundled_device_triggers_pass_the_trigger_schema(path):
+    """Every device trigger a blueprint declares validates against the platform.
+
+    A blueprint that picks a device but no entity is the shape these are all
+    written in, and it has to be a shape the trigger schema accepts — a
+    rejected trigger takes the whole automation down at save time, with the
+    blueprint itself looking perfectly fine.
+    """
+    blueprint = _load(path)
+    inputs = _resolve_inputs(blueprint)
+
+    for trigger in _bt_device_triggers(blueprint):
+        resolved = _substitute(trigger, inputs)
+        try:
+            TRIGGER_SCHEMA(resolved)
+        except vol.Invalid as err:
+            raise AssertionError(
+                f"{path.name}: trigger {resolved.get('type')} is rejected "
+                f"by the platform schema: {err}"
+            ) from err

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -152,10 +152,19 @@ class TestStartupUnloadBailout:
         async def fake_sleep(_seconds):
             bt.is_removed = True
 
-        with patch(
-            "custom_components.better_thermostat.climate.asyncio.sleep",
-            side_effect=fake_sleep,
-        ) as mock_sleep:
+        with (
+            # Each pass of the wait branch reports on the critical entities;
+            # against a mocked thermostat that check has nothing to read, and
+            # this test is about the bail-out, not about the reporting.
+            patch(
+                "custom_components.better_thermostat.climate.check_critical_entities",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "custom_components.better_thermostat.climate.asyncio.sleep",
+                side_effect=fake_sleep,
+            ) as mock_sleep,
+        ):
             await asyncio.wait_for(BetterThermostat.startup(bt), timeout=1)
 
         mock_sleep.assert_awaited_once()

--- a/tests/unit/test_init_remove_entry.py
+++ b/tests/unit/test_init_remove_entry.py
@@ -6,12 +6,13 @@ Deleting the config entry must remove the associated repair issues so that
 they do not linger after the BT instance is gone.
 """
 
+from asyncio import Lock
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.const import CONF_NAME
 import pytest
 
-from custom_components.better_thermostat import DOMAIN, async_remove_entry
+from custom_components.better_thermostat import DOMAIN, RELOAD_LOCKS, async_remove_entry
 from custom_components.better_thermostat.utils.const import (
     CONF_HEATER,
     CONF_HUMIDITY,
@@ -35,6 +36,18 @@ def _make_entry(**overrides):
     return entry
 
 
+def _make_hass():
+    """Return a Home Assistant double whose ``data`` is a real mapping.
+
+    ``async_remove_entry`` reads ``hass.data`` synchronously. An AsyncMock
+    answers every attribute with a coroutine, so the shared store has to be a
+    real dict for the removal to reach what is in it.
+    """
+    hass = AsyncMock()
+    hass.data = {}
+    return hass
+
+
 @pytest.fixture
 def patched_delete_issue():
     """Patch ``ir.async_delete_issue`` and return the mock for assertions."""
@@ -50,7 +63,7 @@ class TestAsyncRemoveEntryCleansRepairIssues:
     @pytest.mark.asyncio
     async def test_deletes_device_name_keyed_issues(self, patched_delete_issue):
         """Issues keyed by device name are removed."""
-        hass = AsyncMock()
+        hass = _make_hass()
         entry = _make_entry()
 
         await async_remove_entry(hass, entry)
@@ -63,7 +76,7 @@ class TestAsyncRemoveEntryCleansRepairIssues:
     @pytest.mark.asyncio
     async def test_deletes_missing_entity_for_each_trv(self, patched_delete_issue):
         """``missing_entity_*`` issues are removed for every configured TRV."""
-        hass = AsyncMock()
+        hass = _make_hass()
         entry = _make_entry(
             **{
                 CONF_HEATER: [
@@ -84,7 +97,7 @@ class TestAsyncRemoveEntryCleansRepairIssues:
         self, patched_delete_issue
     ):
         """Optional sensors (when configured) also get their issues cleaned up."""
-        hass = AsyncMock()
+        hass = _make_hass()
         entry = _make_entry(
             **{
                 CONF_HUMIDITY: "sensor.humidity",
@@ -104,7 +117,7 @@ class TestAsyncRemoveEntryCleansRepairIssues:
     @pytest.mark.asyncio
     async def test_skips_unconfigured_optional_sensors(self, patched_delete_issue):
         """Sensors not configured on the entry do not trigger spurious deletes."""
-        hass = AsyncMock()
+        hass = _make_hass()
         entry = _make_entry()
 
         await async_remove_entry(hass, entry)
@@ -121,7 +134,7 @@ class TestAsyncRemoveEntryCleansRepairIssues:
     @pytest.mark.asyncio
     async def test_uses_domain_for_every_delete(self, patched_delete_issue):
         """Every cleanup call targets BT's domain."""
-        hass = AsyncMock()
+        hass = _make_hass()
         entry = _make_entry()
 
         await async_remove_entry(hass, entry)
@@ -129,3 +142,21 @@ class TestAsyncRemoveEntryCleansRepairIssues:
         assert patched_delete_issue.call_args_list
         for call in patched_delete_issue.call_args_list:
             assert call.args[1] == DOMAIN
+
+    @pytest.mark.asyncio
+    async def test_drops_the_reload_lock_of_the_removed_entry(
+        self, patched_delete_issue
+    ):
+        """The lock an entry reloads on is dropped with the entry.
+
+        The locks outlive the per-entry data on purpose, so that a reload can
+        hold one across the unload it drives. Removal is therefore the only
+        point at which one can be let go.
+        """
+        hass = _make_hass()
+        entry = _make_entry()
+        hass.data[RELOAD_LOCKS] = {entry.entry_id: Lock(), "other_entry": Lock()}
+
+        await async_remove_entry(hass, entry)
+
+        assert list(hass.data[RELOAD_LOCKS]) == ["other_entry"]

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -359,6 +359,45 @@ class TestCheckCriticalEntities:
         assert mock_ir.async_create_issue.called
 
     @pytest.mark.anyio
+    async def test_warns_once_while_a_trv_stays_unavailable(
+        self, mock_bt_instance, caplog
+    ):
+        """A continuing outage is announced when it starts, not while it lasts.
+
+        The check runs on every trigger and on every pass of the startup wait
+        loop, so an entity that stays away is seen over and over. The repair
+        issue is raised once; the log line has to follow the same transition
+        or it repeats for as long as the device is gone.
+        """
+        from datetime import timedelta
+
+        from custom_components.better_thermostat.utils.watcher import (
+            check_critical_entities,
+        )
+
+        mock_state = MagicMock()
+        mock_state.state = "unavailable"
+        mock_bt_instance.hass.states.get.return_value = mock_state
+        mock_bt_instance._critical_grace_until = (
+            mock_bt_instance.clock.now() - timedelta(minutes=1)
+        )
+
+        with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
+            with caplog.at_level("WARNING"):
+                await check_critical_entities(mock_bt_instance)
+                await check_critical_entities(mock_bt_instance)
+                await check_critical_entities(mock_bt_instance)
+
+        announced = [
+            r.getMessage() for r in caplog.records if "is unavailable" in r.message
+        ]
+        # Three passes over the fixture's devices: one line per device that is
+        # gone, not one per pass.
+        trv_count = len(mock_bt_instance.real_trvs)
+        assert len(announced) == len(set(announced)) == trv_count
+        assert mock_ir.async_create_issue.call_count == trv_count
+
+    @pytest.mark.anyio
     async def test_auto_clear_issue_on_recovery(self, mock_bt_instance):
         """Issue is cleared when a previously-unavailable TRV becomes available."""
         from custom_components.better_thermostat.utils.watcher import (

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -371,6 +371,8 @@ class TestCheckCriticalEntities:
         """
         from datetime import timedelta
 
+        from homeassistant.util import dt as dt_util
+
         from custom_components.better_thermostat.utils.watcher import (
             check_critical_entities,
         )
@@ -378,9 +380,7 @@ class TestCheckCriticalEntities:
         mock_state = MagicMock()
         mock_state.state = "unavailable"
         mock_bt_instance.hass.states.get.return_value = mock_state
-        mock_bt_instance._critical_grace_until = (
-            mock_bt_instance.clock.now() - timedelta(minutes=1)
-        )
+        mock_bt_instance._critical_grace_until = dt_util.now() - timedelta(minutes=1)
 
         with patch("custom_components.better_thermostat.utils.watcher.ir") as mock_ir:
             with caplog.at_level("WARNING"):

--- a/uv.lock
+++ b/uv.lock
@@ -392,7 +392,7 @@ wheels = [
 
 [[package]]
 name = "better-thermostat"
-version = "1.9.0"
+version = "1.9.1"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION
## Why this exists

The whole of Better Thermostat's device automation surface — every trigger,
condition and action a user builds an automation on in the Home Assistant UI —
**does not work in 1.9.0**. It was found on `develop` and fixed there (#2240),
but 1.9.0 is what users install today, so the fixes need to reach this line.

Checked against `1.9` before this branch: eight defects, none of them present.
The three automation modules are byte-identical between `1.9` and the `develop`
commit the fixes were written against, so the backport is the same change, not
a re-implementation.

## What was broken

| Surface | What happens in 1.9.0 |
|---|---|
| **Triggers** (11 types) | `Automation ... failed to setup triggers and has been disabled: extra keys not allowed @ data['entity_id']` — the schema rejects the entries `async_get_triggers` itself lists |
| **Conditions** (2 types) | `... failed to setup conditions ...: extra keys not allowed @ data['condition']` — the schemas are bare `vol.Schema`, missing the device-condition base |
| **Actions** (2 types) | `Unknown error calling automation config validator - module '...device_action' has no attribute 'ACTION_SCHEMA'` — validation raises and takes the whole automation config down |

Two more sit underneath the schema failures, and would have applied even if the
schemas had been right:

- `humidity_high` reads the `humidity` attribute. That is the climate *target*
  humidity, which Better Thermostat does not publish; the measured value is
  `current_humidity`. The trigger read a missing attribute as zero and could
  never cross its threshold.
- `is_hvac_mode` compares against an `hvac_mode` attribute. A climate entity
  carries its mode as the state — only `hvac_action` is an attribute — so the
  condition was never true.

And three outside that surface:

- A registry id in a condition was handed straight to `hass.states.get`, where
  only an entity id resolves. A stored automation holds the registry id after a
  rename, so the condition was silently always false.
- A TRV that never becomes available was **never reported**: the startup loop
  waits without end and nothing downstream of it runs, so the thermostat sat
  `unavailable` with no repair issue naming the entity — while the same valve
  dropping out *after* a successful startup did raise one.
- Every config entry reload serialized on one module-level lock, so one
  thermostat whose device is unreachable held up the settings of every other
  entry in the instance (a reload runs the full startup).

## What came across, and what did not

All eight production fixes, plus the end-to-end tests for the automation
surface, adapted to this line's simpler integration harness (no device-profile
matrix here), and the blueprint schema check.

The availability scenarios from the `develop` work did not come across: they
need a fake TRV that can be taken off the air mid-test, which is a harness
change this line does not otherwise call for. The startup fix is covered by the
unit test for the announcement cadence instead.

`tests/unit/test_init_remove_entry.py` stood in an `AsyncMock` for `hass`, which
answers every attribute with a coroutine; `hass.data` is a real mapping there
now, which is what let the removal path be asserted at all.

## Verification

Each fix was checked by putting the defect back and counting red tests — on
*this* branch, not by trusting the `develop` run:

| Injected defect | Red |
|---|---|
| trigger schema rejects `entity_id` again | all 11 trigger cases |
| trigger requires `entity_id` instead of resolving it from the device | `test_a_trigger_that_names_only_a_device_finds_the_entity` |
| humidity reads the target attribute | `...[humidity_high]` |
| condition schemas drop the base schema | both condition cases + the registry-id case |
| mode condition reads an attribute | `...[is_hvac_mode]` + the registry-id case |
| action schema goes back to being private | both action tests |

Full suite on this branch: **5057 passed, 1 skipped**. `ruff check` and
`ruff format --check` clean. Version bumped to 1.9.1 in `manifest.json`,
`pyproject.toml` and `uv.lock`; the release-metadata test passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved device automations with support for entity IDs and device registry references.
  * Added clearer validation for HVAC mode and temperature actions.
  * Improved trigger and condition handling, including humidity and HVAC state checks.

* **Bug Fixes**
  * Prevented repeated warnings and duplicate repair notifications for unavailable equipment.
  * Improved startup reporting when required sensors or thermostats remain unavailable.
  * Made configuration reloads more reliable when multiple entries are updated.
  * Improved handling of invalid device automation configurations.

* **Maintenance**
  * Updated the integration version to 1.9.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->