### PR TITLE
fix: treat a missing child lock flag as unlocked (1.9)

### DIFF
--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -101,10 +101,10 @@ async def trigger_trv_change(self, event):
         return
 
     advanced = trv.advanced or {}
-    # Absent means unlocked. An entry written before the option existed carries
-    # no flag at all and no migration adds one, so the key is missing rather
-    # than false for those — which is the same thing the config flow normalises
-    # an unset flag to, and what the child lock switch reports for it.
+    # A missing flag counts as unlocked, and it can be missing: nothing
+    # backfills the key, so an entry that has not been through the options flow
+    # carries none. The config flow, the child lock switch and both guards
+    # below read an absent flag the same way.
     child_lock = advanced.get("child_lock")
 
     # Dynamic model detection: only once (e.g. at startup), not on every event

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -101,6 +101,10 @@ async def trigger_trv_change(self, event):
         return
 
     advanced = trv.advanced or {}
+    # Absent means unlocked. An entry written before the option existed carries
+    # no flag at all and no migration adds one, so the key is missing rather
+    # than false for those — which is the same thing the config flow normalises
+    # an unset flag to, and what the child lock switch reports for it.
     child_lock = advanced.get("child_lock")
 
     # Dynamic model detection: only once (e.g. at startup), not on every event
@@ -257,7 +261,7 @@ async def trigger_trv_change(self, event):
             trv.hvac_mode = _org_trv_state.state
             _main_change = True
             if (
-                child_lock is False
+                not child_lock
                 and trv.system_mode_received is True
                 and trv.last_hvac_mode != _org_trv_state.state
                 and (mapped_state != HVACMode.OFF or group_all_members_off(self))

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -868,8 +868,16 @@ class TestHvacModeUpdate:
         assert mock_bt.real_trvs[ENTITY_ID].hvac_mode == "heat"
 
     @pytest.mark.asyncio
-    async def test_child_lock_none_blocks_mode_propagation(self, mock_bt):
-        """Mode cache updates but bt_hvac_mode does not propagate when child_lock is None."""
+    async def test_a_missing_child_lock_flag_counts_as_unlocked(self, mock_bt):
+        """A TRV whose config carries no child lock flag is not locked.
+
+        A config entry written before the option existed has no flag at all,
+        and no migration adds one, so ``advanced`` is missing the key rather
+        than holding ``False``. Everything else that reads the flag — the
+        mode cache in this same handler, the setpoint adoption below it, the
+        child lock switch — takes that as unlocked, so a dial turned on such
+        a device has to reach Better Thermostat like on any other.
+        """
         mock_bt.real_trvs[ENTITY_ID].advanced.pop("child_lock", None)
         trv_state = _make_state(
             state_str="off",
@@ -891,7 +899,44 @@ class TestHvacModeUpdate:
             await trigger_trv_change(mock_bt, event)
 
         assert mock_bt.real_trvs[ENTITY_ID].hvac_mode == "off"
-        assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+        assert mock_bt.bt_hvac_mode == HVACMode.OFF
+
+    @pytest.mark.asyncio
+    async def test_a_missing_and_a_false_child_lock_flag_behave_alike(self, mock_bt):
+        """The two ways of not being locked are one behaviour, not two.
+
+        The guard is asked three times in this handler, and a flag that is
+        absent rather than ``False`` used to answer one of them differently:
+        the device's new mode was recorded but never adopted, while a
+        setpoint turned on the same device was. What that looks like from
+        the outside is a dial that works for temperature and not for mode.
+        """
+        outcomes = []
+        for flag in ({}, {"child_lock": False}):
+            trv = mock_bt.real_trvs[ENTITY_ID]
+            trv.advanced.pop("child_lock", None)
+            trv.advanced.update(flag)
+            trv.hvac_mode = "heat"
+            trv.system_mode_received = True
+            trv.last_hvac_mode = "heat"
+            mock_bt.bt_hvac_mode = HVACMode.HEAT
+            trv_state = _make_state(
+                state_str="off",
+                attributes={"current_temperature": 18.0, "temperature": 19.0},
+            )
+            mock_bt.hass.states.get.return_value = trv_state
+
+            event = _make_event(
+                mock_bt, new_state=trv_state, old_state=_make_state(state_str="heat")
+            )
+            with patch(
+                "custom_components.better_thermostat.events.trv.convert_inbound_states",
+                return_value=HVACMode.OFF,
+            ):
+                await trigger_trv_change(mock_bt, event)
+            outcomes.append((trv.hvac_mode, mock_bt.bt_hvac_mode))
+
+        assert outcomes[0] == outcomes[1]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Backport of #2246 onto the maintenance line. The production diff is
byte-identical to the one there; the two unit tests were lifted verbatim.

## Why this line needs it too

The defect is present here unchanged, and every supporting read site is as
well — I checked rather than assumed:

| | `1.9` |
|---|---|
| `events/trv.py:260` | `child_lock is False` — the odd one out |
| `events/trv.py:247`, `:321` | `not child_lock` |
| `__init__.py` migration | no `child_lock` backfill |
| `config_flow.py:341` | `_as_bool(..., False)` |
| `switch.py:194` | `.get("child_lock", False)` |
| `tests/unit/test_trv_events.py:871` | same characterisation test |

If anything this line is the one that matters more: it is what users on the
stable release run, so it holds the entries most likely to predate the
option and to have never been through the options flow since.

## The defect

`trigger_trv_change` asks about the same flag three times and answers one of
them differently. An entry with no `child_lock` key hands the guard `None`,
and `is False` then simply never takes the branch.

**Symptom:** turning the dial on the TRV changes the temperature Better
Thermostat holds, but never the mode it runs in. The device's new mode *is*
recorded — only the adoption is skipped — so nothing logs an error.

## Blast radius

For every entry the config flow has written, `child_lock` is a bool, where
`child_lock is False` and `not child_lock` are the same test — nothing
changes there. Of 5030 tests exactly one depended on the old behaviour, the
characterisation test named above; it now pins the intended behaviour, next
to a new test that the two ways of not being locked stay one behaviour. Both
were checked by reverting the production change: both go red.

TG11 (#2245), where this was found, is **not** proposed for this line — its
harness (`device_profiles.py`, the device matrix) does not exist here, and
test work lands on the maintenance line only on demand.

## Checks

- `uv run pytest tests/` — 5031 passed, 1 skipped
- `uv run ruff check` / `format --check` — clean
- `uv run pyrefly check` — 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Thermostat HVAC mode updates now work correctly when the child lock setting is omitted or disabled.
  * Missing child-lock configuration is treated as unlocked, consistent with an explicit unlocked setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->