### PR TITLE
chore: ignore Playwright MCP session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ node_modules
 .mcp.json
 .memory/
 .opencode/
+.playwright-mcp/
 AGENTS.md
 CLAUDE.md
 STACK.md


### PR DESCRIPTION
The Playwright MCP server writes console logs and page snapshots into `.playwright-mcp/` in the working tree while a browser session is driven from an editor. Those files belong to one local session, so they show up as untracked noise in `git status` and can be committed by accident.

The entry goes into the existing `#AI` block, next to `.claude/`, `.mcp.json` and `.opencode/`, which cover the same class of local tooling state.

Documentation-only change to `.gitignore`; no code, no configuration, no CI surface is touched.