### PR TITLE
chore: gate type strictness globally and exempt named files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,51 +113,154 @@ pythonVersion = "3.14"
 python-version = "3.14"
 project-includes = ["custom_components/better_thermostat"]
 min-severity = "error"
+errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+
+# Every file under project-includes is checked at the strictness declared above.
+# The entries below name the files that do not meet it yet and list exactly the
+# rules each one is exempt from; a rule not listed applies to that file too.
+# The list only ever shrinks: an entry is removed once its file is annotated,
+# and no new entry is added — a new file is strict from the start.
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/__init__.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/adapters/base.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/adapters/deconz.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/adapters/delegate.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/adapters/generic.py"
+errors = { implicit-any-parameter = false, implicit-any-empty-container = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/adapters/mqtt.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/adapters/tado.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/adapters/zwave_js.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/calibration.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/climate.py"
+errors = { implicit-any-parameter = false, implicit-any-attribute = false, implicit-any-type-argument = false, implicit-any-empty-container = false, missing-override-decorator = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/config_flow.py"
+errors = { implicit-any-parameter = false, implicit-any-attribute = false, implicit-any-type-argument = false, implicit-any-empty-container = false, missing-override-decorator = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/device_trigger.py"
+errors = { implicit-any-type-argument = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/diagnostics.py"
+errors = { implicit-any-type-argument = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/events/cooler.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/events/door.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/events/temperature.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/events/trv.py"
+errors = { implicit-any-parameter = false, implicit-any-type-argument = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/events/window.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/BTH-RM.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/BTH-RM230Z.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/SPZB0001.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/TRVZB.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/TV02-Zigbee.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/ZWA021.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/default.py"
+errors = { implicit-any-parameter = false }
+
+[[tool.pyrefly.sub-config]]
+matches = "custom_components/better_thermostat/model_fixes/model_quirks.py"
+errors = { implicit-any-parameter = false }
 
 [[tool.pyrefly.sub-config]]
 matches = "custom_components/better_thermostat/number.py"
-errors = { bad-override-mutable-attribute = false }
+errors = { implicit-any-parameter = false, missing-override-decorator = false, bad-override-mutable-attribute = false }
 
 [[tool.pyrefly.sub-config]]
-matches = "custom_components/better_thermostat/utils/calibration/*.py"
-errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+matches = "custom_components/better_thermostat/sensor.py"
+errors = { missing-override-decorator = false }
 
 [[tool.pyrefly.sub-config]]
-matches = "custom_components/better_thermostat/model_fixes/types.py"
-errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+matches = "custom_components/better_thermostat/switch.py"
+errors = { implicit-any-parameter = false, implicit-any-empty-container = false, missing-override-decorator = false }
 
 [[tool.pyrefly.sub-config]]
-matches = "custom_components/better_thermostat/model_fixes/TS0601.py"
-errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+matches = "custom_components/better_thermostat/utils/controlling.py"
+errors = { implicit-any-parameter = false, implicit-any-type-argument = false }
 
 [[tool.pyrefly.sub-config]]
-matches = "custom_components/better_thermostat/model_fixes/TS0601_thermostat.py"
-errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+matches = "custom_components/better_thermostat/utils/helpers.py"
+errors = { implicit-any-parameter = false, implicit-any-type-argument = false, implicit-any-empty-container = false }
 
 [[tool.pyrefly.sub-config]]
-matches = "custom_components/better_thermostat/model_fixes/ME167.py"
-errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+matches = "custom_components/better_thermostat/utils/scheduler.py"
+errors = { implicit-any-parameter = false, implicit-any-type-argument = false }
 
 [[tool.pyrefly.sub-config]]
-matches = "custom_components/better_thermostat/model_fixes/COZB0001.py"
-errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+matches = "custom_components/better_thermostat/utils/snapshot.py"
+errors = { implicit-any-parameter = false }
 
 [[tool.pyrefly.sub-config]]
-matches = "custom_components/better_thermostat/model_fixes/BHT-002-GCLZB.py"
-errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+matches = "custom_components/better_thermostat/utils/state_manager.py"
+errors = { implicit-any-parameter = false }
 
 [[tool.pyrefly.sub-config]]
-matches = "custom_components/better_thermostat/model_fixes/SEA801-Zigbee_SEA802-Zigbee.py"
-errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+matches = "custom_components/better_thermostat/utils/watcher.py"
+errors = { implicit-any-parameter = false, implicit-any-type-argument = false, implicit-any-empty-container = false }
 
 [[tool.pyrefly.sub-config]]
-matches = "custom_components/better_thermostat/trv.py"
-errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
-
-[[tool.pyrefly.sub-config]]
-matches = "custom_components/better_thermostat/utils/telemetry.py"
-errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
-
-[[tool.pyrefly.sub-config]]
-matches = "custom_components/better_thermostat/utils/retry.py"
-errors = { implicit-any-parameter = true, implicit-any-attribute = true, implicit-any-type-argument = true, implicit-any-empty-container = true, missing-override-decorator = true }
+matches = "custom_components/better_thermostat/utils/weather.py"
+errors = { implicit-any-parameter = false, implicit-any-attribute = false, implicit-any-empty-container = false }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,8 @@ errors = { implicit-any-parameter = true, implicit-any-attribute = true, implici
 # The entries below name the files that do not meet it yet and list exactly the
 # rules each one is exempt from; a rule not listed applies to that file too.
 # The list only ever shrinks: an entry is removed once its file is annotated,
-# and no new entry is added — a new file is strict from the start.
+# and no new entry is added — a new file is strict from the start. That shape is
+# held by tests/unit/test_type_strictness_exemptions.py.
 
 [[tool.pyrefly.sub-config]]
 matches = "custom_components/better_thermostat/__init__.py"

--- a/tests/unit/test_type_strictness_exemptions.py
+++ b/tests/unit/test_type_strictness_exemptions.py
@@ -10,9 +10,10 @@ Three ways of widening it leave a reviewer nothing to see. An entry whose file
 is gone still matches a file created at that path later, which would start out
 exempt. A wildcard covers files nobody measured, including files that are
 strict today. A sub-config that sets a rule to ``true`` makes the list an
-enumeration of the clean files instead of the backlog, which puts every file
-outside the list back to lax. The fourth way — appending an entry — is visible
-in the diff but still has to raise the recorded ceiling.
+enumeration of the clean files instead of the backlog, and settles strictness
+per entry rather than on ``[tool.pyrefly]``, where one declaration reaches
+every file. The fourth way — appending an entry — is visible in the diff but
+still has to raise the recorded ceiling.
 """
 
 from pathlib import Path

--- a/tests/unit/test_type_strictness_exemptions.py
+++ b/tests/unit/test_type_strictness_exemptions.py
@@ -1,0 +1,86 @@
+"""Tests for the pyrefly type-strictness exemption list in pyproject.toml.
+
+``[tool.pyrefly]`` declares the strictness every file under
+``project-includes`` is checked at. Each ``[[tool.pyrefly.sub-config]]`` block
+names one file that does not meet it yet, together with the rules that file is
+exempt from. The list is the remaining backlog: it shrinks as files get
+annotated, and a file nobody listed is strict from the start.
+
+Three ways of widening it leave a reviewer nothing to see. An entry whose file
+is gone still matches a file created at that path later, which would start out
+exempt. A wildcard covers files nobody measured, including files that are
+strict today. A sub-config that sets a rule to ``true`` makes the list an
+enumeration of the clean files instead of the backlog, which puts every file
+outside the list back to lax. The fourth way — appending an entry — is visible
+in the diff but still has to raise the recorded ceiling.
+"""
+
+from pathlib import Path
+import tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+# How many (file, rule) exemptions the list may hold. Lower it as entries
+# leave; raising it is the one way the backlog grows, and says so in the diff.
+EXEMPTION_CEILING = 58
+
+GLOB_CHARACTERS = "*?["
+
+
+def _exemptions():
+    """Return the pyrefly sub-config blocks as parsed from pyproject.toml."""
+    config = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    return config["tool"]["pyrefly"]["sub-config"]
+
+
+def test_every_exemption_names_a_file_that_exists():
+    gone = sorted(
+        entry["matches"]
+        for entry in _exemptions()
+        if not (REPO_ROOT / entry["matches"]).is_file()
+    )
+
+    assert not gone, f"exempted files that are no longer in the repository: {gone}"
+
+
+def test_every_exemption_names_one_exact_file():
+    wildcards = sorted(
+        entry["matches"]
+        for entry in _exemptions()
+        if any(char in entry["matches"] for char in GLOB_CHARACTERS)
+    )
+
+    assert not wildcards, f"exemptions that match more than one file: {wildcards}"
+
+
+def test_no_file_is_exempted_twice():
+    paths = [entry["matches"] for entry in _exemptions()]
+
+    repeated = sorted({path for path in paths if paths.count(path) > 1})
+
+    assert not repeated, f"files with more than one exemption block: {repeated}"
+
+
+def test_no_entry_tightens():
+    tightenings = sorted(
+        f"{entry['matches']} ({rule})"
+        for entry in _exemptions()
+        for rule, enabled in entry["errors"].items()
+        if enabled
+    )
+
+    assert not tightenings, (
+        f"sub-configs that tighten rather than exempt: {tightenings}. "
+        "Strictness belongs on [tool.pyrefly], where it reaches every file."
+    )
+
+
+def test_the_backlog_is_the_size_it_records():
+    recorded = sum(len(entry["errors"]) for entry in _exemptions())
+
+    assert recorded == EXEMPTION_CEILING, (
+        f"the list holds {recorded} exemptions, EXEMPTION_CEILING says "
+        f"{EXEMPTION_CEILING}. Lower it once entries leave; raising it means a "
+        "file was exempted instead of annotated."
+    )


### PR DESCRIPTION
## What changes

The five implicit-`Any` / override rules move from eleven hand-listed
`[[tool.pyrefly.sub-config]]` tightenings up to the top-level `[tool.pyrefly]`
table, so they apply to everything under `project-includes`. Files that do not
meet that bar carry a sub-config naming exactly the rules they are exempt
from. No production code is touched: `pyproject.toml` plus one unit test that
holds the list to its shape.

The old list enumerated the files that met the bar, so a file was lax unless
someone added it. The new list enumerates the exemptions, so a file is strict
unless someone removes it. Entries leave the list as files get annotated; the
list has no reason to grow.

## Reach

**Files gated on all five rules: 31 → 63 of 99.** The other 36 are still gated
on every rule they do not name:

| rule | files gated |
|---|---:|
| `implicit-any-parameter` | 66 / 99 |
| `implicit-any-type-argument` | 90 / 99 |
| `implicit-any-empty-container` | 92 / 99 |
| `missing-override-decorator` | 94 / 99 |
| `implicit-any-attribute` | 96 / 99 |

The old 31 were the 21 files under `utils/calibration/` reached by the
`utils/calibration/*.py` glob, plus ten files named one by one. The whole
`core/` tree — 18 files including `decide.py`, `safety.py`, `watchdog.py` and
the `fsm/` package — was outside the list entirely, and is clean under full
strictness.

Note for anyone editing the list: a pyrefly `matches` glob is recursive, `*`
crosses `/`. `utils/calibration/*.py` reached `mpc_v2/` and
`mpc_v2_internals/` as well, and a hypothetical `utils/*.py` would sweep all
21 of those files into whatever that block declares. That is why every entry
here is an exact file path and why the test below rejects wildcards.

## Exemption granularity

Each entry lists only the rules that actually fire in that file, measured, not
guessed. `sensor.py` is exempt from `missing-override-decorator` alone and is
still gated on the other four; `adapters/base.py` is exempt from
`implicit-any-parameter` alone. Sub-config `errors` tables merge with the
top-level one rather than replacing it, which is what makes a one-rule
exemption possible.

`number.py` keeps `bad-override-mutable-attribute = false`. Deleting that key
reproduces the error it suppresses, so the exemption is still load-bearing:

```
ERROR custom_components/better_thermostat/number.py:176:5-23: Class member
`BetterThermostatPresetNumber._attr_device_class` overrides parent class
`RestoreEntity` in an inconsistent manner [bad-override-mutable-attribute]
```

## Proof the gate bites

An unannotated parameter appended to `custom_components/better_thermostat/core/decide.py`,
a file with no exemption:

```python
def _ratchet_probe(value):
    return value
```

With this configuration:

```
ERROR custom_components/better_thermostat/core/decide.py:255:20-25: `_ratchet_probe`
is missing an annotation for parameter `value` [implicit-any-parameter]
 INFO 1 error (3 suppressed, 186 warnings not shown)
```

The identical edit against the configuration on `develop`:

```
 INFO 0 errors (3 suppressed, 186 warnings not shown)
```

The same probe in `sensor.py` — a file that *is* on the exemption list, but
only for `missing-override-decorator` — is also caught, which is what the
per-rule granularity buys:

```
ERROR custom_components/better_thermostat/sensor.py:1040:20-25: `_ratchet_probe`
is missing an annotation for parameter `value` [implicit-any-parameter]
```

## What keeps the list shrinking

`pyrefly check` already fails on a violation in any file that is not exempt.
The list itself is guarded by `tests/unit/test_type_strictness_exemptions.py`,
which closes the four ways it can widen — three of which leave nothing for a
reviewer to see in the diff:

| widening | guard |
|---|---|
| entry for a file that is gone, later re-created at that path and born exempt | every `matches` names a file that exists |
| a wildcard sweeping in files nobody measured | every `matches` is an exact path, no `*?[` |
| two entries covering the same file | no path appears twice |
| an entry setting a rule to `true`, turning the list back into a list of clean files | every entry only relaxes |
| appending an entry | `EXEMPTION_CEILING` records the 58 (file, rule) exemptions; adding one means raising that number in the diff |

Each of the five assertions was checked by mutation: injecting the
corresponding defect into `pyproject.toml` turns exactly the matching test(s)
red, and the file passes again once reverted.

## Verification

| | before | after |
|---|---|---|
| `pyrefly check` | 0 errors (3 suppressed, 186 warnings not shown) | 0 errors (3 suppressed, 186 warnings not shown) |
| `pytest tests/ -q` | 7115 passed, 1 skipped | 7120 passed, 1 skipped |
| `ruff check .` | All checks passed! | All checks passed! |
| `ruff format --check .` | 313 files already formatted | 314 files already formatted |

Behaviour-neutral for the integration: no runtime file changed. Turning the
tightening on with no exemptions at all reports 698 errors — 699 counting the
`bad-override-mutable-attribute` that `number.py` suppresses — which is the
backlog the 36 entries represent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type-checking strictness to identify implicit annotations, missing override markers, and related issues more consistently.
  * Removed broad exemptions and narrowed remaining exceptions to specific integration files and rules.

* **Tests**
  * Added validation to ensure type-checking exemptions reference existing files, avoid duplicates and wildcards, and remain within the tracked backlog limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->