### PR TITLE
chore: gate blind exception handlers with ruff BLE001

### DIFF
--- a/.blind-except-budget.json
+++ b/.blind-except-budget.json
@@ -1,0 +1,21 @@
+{
+  "custom_components/better_thermostat/adapters/base.py": 1,
+  "custom_components/better_thermostat/adapters/delegate.py": 7,
+  "custom_components/better_thermostat/adapters/mqtt.py": 1,
+  "custom_components/better_thermostat/adapters/zwave_js.py": 2,
+  "custom_components/better_thermostat/calibration.py": 2,
+  "custom_components/better_thermostat/climate.py": 28,
+  "custom_components/better_thermostat/events/temperature.py": 1,
+  "custom_components/better_thermostat/events/trv.py": 2,
+  "custom_components/better_thermostat/model_fixes/default.py": 4,
+  "custom_components/better_thermostat/sensor.py": 5,
+  "custom_components/better_thermostat/switch.py": 1,
+  "custom_components/better_thermostat/utils/calibration/mpc.py": 1,
+  "custom_components/better_thermostat/utils/calibration/mpc_v2/state.py": 1,
+  "custom_components/better_thermostat/utils/calibration/pid.py": 5,
+  "custom_components/better_thermostat/utils/controlling.py": 4,
+  "custom_components/better_thermostat/utils/helpers.py": 6,
+  "custom_components/better_thermostat/utils/migrate_v0_stores.py": 4,
+  "custom_components/better_thermostat/utils/state_manager.py": 1,
+  "custom_components/better_thermostat/utils/valve_maintenance.py": 3
+}

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -26,3 +26,7 @@ jobs:
         run: uv run --locked --only-group dev ruff check
       - name: ruff format --check
         run: uv run --locked --only-group dev ruff format --check
+      # BLE001 is silenced per file in pyproject.toml, so `ruff check` above
+      # says nothing about those files. This is what caps them.
+      - name: Check the blind exception handler budget
+        run: uv run --locked --only-group dev python scripts/blind_except_budget.py check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ select = [
     "D",      # pydocstyle (docstrings)
     "D417",   # Require documented args to match the signature (numpy convention disables this by default)
     "C4",     # flake8-comprehensions
+    "BLE001", # flake8-blind-except: broad `except Exception` that neither re-raises nor logs the exception
     "PL",     # pylint
     "RUF100", # unused noqa directives
     "I",      # isort
@@ -72,6 +73,36 @@ convention = "numpy"
 [tool.ruff.lint.per-file-ignores]
 # Test code does not need docstrings on every function/class/method.
 "tests/**" = ["D"]
+
+# BLE001 ratchet: these files hold the remaining blind broad exception
+# handlers — `except Exception` that neither re-raises nor logs the exception
+# with its traceback. Modules whose broad handlers all log that way are absent
+# from this list and are gated like every other module, so the list is not an
+# inventory of `except Exception` in the package.
+# Entries are only ever removed — once a file's handlers name the exceptions
+# they expect (or re-raise, or log via `_LOGGER.exception`), drop its line.
+# Never add a file: every other module is gated, so a new blind `except
+# Exception` fails the lint. BLE001 does not reach
+# `contextlib.suppress(Exception)`, which stays a review concern.
+"custom_components/better_thermostat/adapters/base.py" = ["BLE001"]
+"custom_components/better_thermostat/adapters/delegate.py" = ["BLE001"]
+"custom_components/better_thermostat/adapters/mqtt.py" = ["BLE001"]
+"custom_components/better_thermostat/adapters/zwave_js.py" = ["BLE001"]
+"custom_components/better_thermostat/calibration.py" = ["BLE001"]
+"custom_components/better_thermostat/climate.py" = ["BLE001"]
+"custom_components/better_thermostat/events/temperature.py" = ["BLE001"]
+"custom_components/better_thermostat/events/trv.py" = ["BLE001"]
+"custom_components/better_thermostat/model_fixes/default.py" = ["BLE001"]
+"custom_components/better_thermostat/sensor.py" = ["BLE001"]
+"custom_components/better_thermostat/switch.py" = ["BLE001"]
+"custom_components/better_thermostat/utils/calibration/mpc.py" = ["BLE001"]
+"custom_components/better_thermostat/utils/calibration/mpc_v2/state.py" = ["BLE001"]
+"custom_components/better_thermostat/utils/calibration/pid.py" = ["BLE001"]
+"custom_components/better_thermostat/utils/controlling.py" = ["BLE001"]
+"custom_components/better_thermostat/utils/helpers.py" = ["BLE001"]
+"custom_components/better_thermostat/utils/migrate_v0_stores.py" = ["BLE001"]
+"custom_components/better_thermostat/utils/state_manager.py" = ["BLE001"]
+"custom_components/better_thermostat/utils/valve_maintenance.py" = ["BLE001"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["custom_components.better_thermostat", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,15 +74,15 @@ convention = "numpy"
 # Test code does not need docstrings on every function/class/method.
 "tests/**" = ["D"]
 
-# BLE001 ratchet: these files hold the remaining blind broad exception
-# handlers — `except Exception` that neither re-raises nor logs the exception
-# with its traceback. Modules whose broad handlers all log that way are absent
-# from this list and are gated like every other module, so the list is not an
-# inventory of `except Exception` in the package.
-# Entries are only ever removed — once a file's handlers name the exceptions
-# they expect (or re-raise, or log via `_LOGGER.exception`), drop its line.
-# Never add a file: every other module is gated, so a new blind `except
-# Exception` fails the lint. BLE001 does not reach
+# BLE001 is silenced outright in the files below: ruff reports none of their
+# blind broad exception handlers — `except Exception` that neither re-raises
+# nor logs the exception with its traceback — not even ones added later.
+# What caps those files is `.blind-except-budget.json`, a per-file count that
+# `scripts/blind_except_budget.py check` enforces: a listed file may not exceed
+# its recorded number, and a file absent from the budget may not have a single
+# finding. Only that script writes the budget.
+# Drop a line here once a file's handlers name the exceptions they expect, or
+# re-raise, or log via `_LOGGER.exception`. BLE001 does not reach
 # `contextlib.suppress(Exception)`, which stays a review concern.
 "custom_components/better_thermostat/adapters/base.py" = ["BLE001"]
 "custom_components/better_thermostat/adapters/delegate.py" = ["BLE001"]

--- a/scripts/blind_except_budget.py
+++ b/scripts/blind_except_budget.py
@@ -149,7 +149,12 @@ def _load_budget() -> dict[str, int]:
 
 
 def check() -> int:
-    """Report every file over its budget. Return an exit code."""
+    """Report the files over budget and the files with no budget at all.
+
+    Files that came in under budget are named too, with a prompt to re-record.
+    Return 1 when any file is over or unbudgeted, 0 otherwise; exit outright
+    when no budget has been recorded yet.
+    """
     counts = _measure()
     budget = _load_budget()
     if not budget:

--- a/scripts/blind_except_budget.py
+++ b/scripts/blind_except_budget.py
@@ -1,0 +1,170 @@
+"""Per-file budget for blind exception handlers: freeze the backlog, refuse growth.
+
+Ruff's BLE001 flags an `except Exception` that neither re-raises nor logs the
+exception with its traceback. A handler that calls `_LOGGER.exception(...)`, or
+passes `exc_info=True`, is not flagged. So what this budget counts is broad
+handlers that swallow the failure silently, not broad handlers as such.
+
+Silencing the rule per file — which `pyproject.toml` does for the files that
+carry the backlog — exempts the handlers written tomorrow along with the ones
+written yesterday, and the file holding the largest backlog is exactly where
+the next one lands. So the budget is per file and it counts: a file may not
+exceed the number it has today, and a file that is not in the budget may not
+have a single finding.
+
+The count is taken with every in-repository suppression overridden — the
+`per-file-ignores` entries in `pyproject.toml` and `# noqa` comments alike — so
+the budget file is the one place where a blind handler is recorded.
+
+Two modes:
+
+``check``
+    Count today's findings and exit non-zero when a file is over its budget, or
+    when a file with no budget has a finding at all.
+
+``update``
+    Rewrite the budget from today's counts. Run this after converting handlers,
+    so the lower number is the one that has to be held.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BUDGET_FILE = REPO_ROOT / ".blind-except-budget.json"
+
+# `--config` overrides `per-file-ignores` and `--ignore-noqa` overrides the
+# inline directives, so the scan sees the handlers the committed lint settings
+# hide from `ruff check`.
+RUFF_SCAN = (
+    sys.executable,
+    "-m",
+    "ruff",
+    "check",
+    "--select",
+    "BLE001",
+    "--ignore-noqa",
+    "--config",
+    "lint.per-file-ignores = {}",
+    "--output-format",
+    "json",
+    ".",
+)
+
+
+def _normalise(name: str) -> str:
+    """Return a ruff filename as a repository-relative POSIX path."""
+    path = Path(name)
+    if path.is_absolute():
+        try:
+            path = path.relative_to(REPO_ROOT)
+        except ValueError:
+            pass
+    return path.as_posix()
+
+
+def _measure() -> dict[str, int]:
+    """Return the number of blind exception handlers per file."""
+    scan = subprocess.run(
+        RUFF_SCAN, cwd=REPO_ROOT, capture_output=True, text=True, check=False
+    )
+    # Ruff exits 1 when it found something and 2 or above when it could not
+    # scan, which is the only case that says nothing about the code.
+    if scan.returncode > 1:
+        sys.exit(f"ruff could not scan the repository:\n{scan.stderr.strip()}")
+    try:
+        findings = json.loads(scan.stdout)
+    except json.JSONDecodeError as err:
+        sys.exit(f"ruff did not report JSON: {err}\n{scan.stderr.strip()}")
+
+    counts: dict[str, int] = {}
+    for finding in findings:
+        name = _normalise(finding["filename"])
+        counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+def _load_budget() -> dict[str, int]:
+    """Return the stored budget, or an empty mapping when there is none yet."""
+    if not BUDGET_FILE.exists():
+        return {}
+    return json.loads(BUDGET_FILE.read_text(encoding="utf-8"))
+
+
+def check() -> int:
+    """Report every file over its budget. Return an exit code."""
+    counts = _measure()
+    budget = _load_budget()
+    if not budget:
+        sys.exit(f"no budget recorded — run '{Path(__file__).name} update' first")
+
+    over = [
+        (name, budget[name], counts[name])
+        for name in sorted(counts)
+        if name in budget and counts[name] > budget[name]
+    ]
+    unbudgeted = sorted(name for name in counts if name not in budget)
+    improved = [
+        (name, allowed, counts.get(name, 0))
+        for name, allowed in sorted(budget.items())
+        if counts.get(name, 0) < allowed
+    ]
+
+    for name, allowed, now in improved:
+        print(f"below budget: {name} at {now} of {allowed}")
+    if improved:
+        print(
+            f"re-record with '{Path(__file__).name} update' to hold the lower numbers"
+        )
+
+    if not over and not unbudgeted:
+        print(f"all {len(budget)} files stay within their budget")
+        return 0
+
+    if over:
+        print("\nmore blind exception handlers than the budget allows:")
+        for name, allowed, now in over:
+            print(f"  {name}: {now} > {allowed}")
+    if unbudgeted:
+        print("\nblind exception handlers in files with no budget:")
+        for name in unbudgeted:
+            print(f"  {name}: {counts[name]}")
+    print(
+        "\nName the exceptions the handler expects, re-raise, or log the "
+        "traceback with `_LOGGER.exception`. The budget only ever falls."
+    )
+    return 1
+
+
+def update() -> int:
+    """Rewrite the budget from today's counts. Return an exit code."""
+    counts = _measure()
+    previous = _load_budget()
+    BUDGET_FILE.write_text(
+        json.dumps(counts, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+    raised = sorted(
+        name for name, count in counts.items() if count > previous.get(name, 0)
+    )
+    for name in raised:
+        print(f"raised: {name} {previous.get(name, 0)} -> {counts[name]}")
+    print(f"recorded {len(counts)} files in {BUDGET_FILE.name}")
+    return 0
+
+
+def main() -> int:
+    """Parse arguments and run the requested mode."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("mode", choices=("check", "update"))
+    args = parser.parse_args()
+    return check() if args.mode == "check" else update()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/blind_except_budget.py
+++ b/scripts/blind_except_budget.py
@@ -12,9 +12,12 @@ the next one lands. So the budget is per file and it counts: a file may not
 exceed the number it has today, and a file that is not in the budget may not
 have a single finding.
 
-The count is taken with every in-repository suppression overridden — the
-`per-file-ignores` entries in `pyproject.toml` and `# noqa` comments alike — so
-the budget file is the one place where a blind handler is recorded.
+The count therefore does not come from `ruff check`. It comes from a scan that
+runs with ruff's own configuration ignored, with inline `noqa` directives
+overridden, and over the file list git reports rather than over a directory
+walk. No `per-file-ignores` entry, no `exclude` entry, no `noqa` comment and no
+`.gitignore` line moves the number: the budget file is the one place where a
+blind handler is recorded.
 
 Two modes:
 
@@ -34,26 +37,30 @@ import json
 from pathlib import Path
 import subprocess
 import sys
+import tomllib
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BUDGET_FILE = REPO_ROOT / ".blind-except-budget.json"
 
-# `--config` overrides `per-file-ignores` and `--ignore-noqa` overrides the
-# inline directives, so the scan sees the handlers the committed lint settings
-# hide from `ruff check`.
+RULE = "BLE001"
+
+# `--isolated` drops every lint setting the repository carries, which is the
+# point: `per-file-ignores`, `extend-per-file-ignores`, `ignore`, `exclude` and
+# `extend-exclude` each silence BLE001, and the scan has to see past every one
+# of them. `--ignore-noqa` does the same for the inline directives. The files
+# are passed explicitly, so no directory walk and no `.gitignore` line decides
+# what is looked at.
 RUFF_SCAN = (
     sys.executable,
     "-m",
     "ruff",
     "check",
+    "--isolated",
     "--select",
-    "BLE001",
+    RULE,
     "--ignore-noqa",
-    "--config",
-    "lint.per-file-ignores = {}",
     "--output-format",
     "json",
-    ".",
 )
 
 
@@ -68,10 +75,45 @@ def _normalise(name: str) -> str:
     return path.as_posix()
 
 
+def _target_version() -> str | None:
+    """Return the Python version ruff parses against, or None when unset.
+
+    An isolated scan has no `target-version`, and a grammar older than the
+    sources turns a file into a syntax error, which reports no findings at all.
+    The setting selects a grammar and cannot silence a rule, so reading this one
+    value back out of `pyproject.toml` does not reopen what `--isolated` closes.
+    """
+    config = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    version = config.get("tool", {}).get("ruff", {}).get("target-version")
+    return str(version) if version else None
+
+
+def _python_files() -> list[str]:
+    """Return the repository's Python files, as git records them."""
+    listing = subprocess.run(
+        ("git", "ls-files", "-z", "--", "*.py"),
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if listing.returncode != 0:
+        sys.exit(f"git could not list the Python files:\n{listing.stderr.strip()}")
+    return [name for name in listing.stdout.split("\0") if name]
+
+
 def _measure() -> dict[str, int]:
     """Return the number of blind exception handlers per file."""
+    target = _target_version()
+    command = [*RUFF_SCAN]
+    if target is not None:
+        command += ["--target-version", target]
     scan = subprocess.run(
-        RUFF_SCAN, cwd=REPO_ROOT, capture_output=True, text=True, check=False
+        [*command, *_python_files()],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
     )
     # Ruff exits 1 when it found something and 2 or above when it could not
     # scan, which is the only case that says nothing about the code.
@@ -81,6 +123,16 @@ def _measure() -> dict[str, int]:
         findings = json.loads(scan.stdout)
     except json.JSONDecodeError as err:
         sys.exit(f"ruff did not report JSON: {err}\n{scan.stderr.strip()}")
+
+    # Only BLE001 was selected, so anything else is a file ruff could not parse.
+    # Such a file reports no findings, which would read as a count of zero.
+    unparsed = sorted(
+        {_normalise(f["filename"]) for f in findings if f["code"] != RULE}
+    )
+    if unparsed:
+        sys.exit(
+            "ruff could not parse, so it counted nothing in: " + ", ".join(unparsed)
+        )
 
     counts: dict[str, int] = {}
     for finding in findings:

--- a/tests/unit/test_blind_except_budget.py
+++ b/tests/unit/test_blind_except_budget.py
@@ -4,11 +4,16 @@ The budget is the thing that notices when a change adds a handler that swallows
 a failure silently, so the check itself has to be right about three cases: a
 file that stayed level passes, a file that gained one fails, and a file nobody
 has budgeted fails on its first finding rather than on its second.
+
+The count underneath those cases has to be right about one more thing: it is
+taken with the repository's lint settings ignored, so the suppressions that
+silence `ruff check` do not lower it.
 """
 
 import importlib.util
 import json
 from pathlib import Path
+import textwrap
 
 import pytest
 
@@ -17,6 +22,59 @@ SCRIPT = REPO_ROOT / "scripts" / "blind_except_budget.py"
 
 FILE = "custom_components/better_thermostat/climate.py"
 OTHER = "custom_components/better_thermostat/sensor.py"
+
+# Every route the lint settings offer to silence BLE001 for one file, at once.
+SUPPRESSING_CONFIG = textwrap.dedent(
+    """
+    [tool.ruff]
+    target-version = "py314"
+    exclude = ["hidden.py"]
+    extend-exclude = ["hidden.py"]
+
+    [tool.ruff.lint]
+    ignore = ["BLE001"]
+
+    [tool.ruff.lint.per-file-ignores]
+    "hidden.py" = ["BLE001"]
+
+    [tool.ruff.lint.extend-per-file-ignores]
+    "hidden.py" = ["BLE001"]
+    """
+)
+
+BLIND_HANDLER = textwrap.dedent(
+    '''
+    """A module its own lint settings report nothing about."""
+
+
+    def swallow() -> None:
+        """Swallow whatever goes wrong."""
+        try:
+            pass
+        except Exception:  # noqa: BLE001
+            pass
+    '''
+)
+
+# `except X, Y:` without parentheses is Python 3.14 syntax, so an older grammar
+# makes this module a syntax error instead of the one handler it holds.
+NEWER_GRAMMAR = textwrap.dedent(
+    '''
+    """A module in the grammar the repository targets."""
+
+
+    def swallow() -> None:
+        """Swallow whatever goes wrong."""
+        try:
+            pass
+        except ValueError, TypeError:
+            pass
+        try:
+            pass
+        except Exception:
+            pass
+    '''
+)
 
 
 def _load_script():
@@ -77,8 +135,8 @@ def test_check_fails_on_the_first_handler_in_an_unbudgeted_file(
 ):
     """A file with no budget has no allowance, so its first finding fails.
 
-    Adding a file to `per-file-ignores` silences `ruff check` for it but not
-    this, so a blind handler cannot be hidden by editing the lint settings.
+    The alternative reading — no entry means no limit — would let a file nobody
+    has budgeted collect handlers until someone thought to budget it.
     """
     _counts(budget, monkeypatch, **{FILE: 28})
     budget.update()
@@ -116,6 +174,63 @@ def test_update_names_the_budgets_it_raises(budget, monkeypatch, capsys):
     budget.update()
 
     assert f"raised: {FILE} 28 -> 30" in capsys.readouterr().out
+
+
+def test_the_scan_counts_a_handler_the_lint_settings_hide(
+    budget, monkeypatch, tmp_path
+):
+    """No lint setting lowers the count: that is what the budget rests on.
+
+    The module below is silenced by `per-file-ignores`, by
+    `extend-per-file-ignores`, by the `ignore` list, by `exclude`, by
+    `extend-exclude` and by a `noqa` comment, all at once, and is still counted.
+    """
+    (tmp_path / "pyproject.toml").write_text(SUPPRESSING_CONFIG, encoding="utf-8")
+    (tmp_path / ".gitignore").write_text("hidden.py\n", encoding="utf-8")
+    (tmp_path / "hidden.py").write_text(BLIND_HANDLER, encoding="utf-8")
+    monkeypatch.setattr(budget, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(budget, "_python_files", lambda: ["hidden.py"])
+
+    assert budget._measure() == {"hidden.py": 1}
+
+
+def test_the_scan_refuses_a_file_it_could_not_parse(budget, monkeypatch, tmp_path):
+    """A file ruff cannot read reports nothing, which must not pass as zero.
+
+    The grammar is the one `pyproject.toml` names, so aiming the scan at an
+    older `target-version` than the sources are written in is what makes ruff
+    report nothing about a module that does hold a blind handler.
+    """
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.ruff]\ntarget-version = "py310"\n', encoding="utf-8"
+    )
+    (tmp_path / "newer.py").write_text(NEWER_GRAMMAR, encoding="utf-8")
+    monkeypatch.setattr(budget, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(budget, "_python_files", lambda: ["newer.py"])
+
+    with pytest.raises(SystemExit) as refused:
+        budget._measure()
+
+    assert "newer.py" in str(refused.value)
+
+
+def test_the_scan_reads_the_files_it_was_given(budget, monkeypatch, tmp_path):
+    """The scan reads a list, not a directory, so no walk decides what it sees."""
+    (tmp_path / "pyproject.toml").write_text(SUPPRESSING_CONFIG, encoding="utf-8")
+    (tmp_path / "listed.py").write_text(BLIND_HANDLER, encoding="utf-8")
+    (tmp_path / "unlisted.py").write_text(BLIND_HANDLER, encoding="utf-8")
+    monkeypatch.setattr(budget, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(budget, "_python_files", lambda: ["listed.py"])
+
+    assert budget._measure() == {"listed.py": 1}
+
+
+def test_the_listed_files_are_the_ones_git_tracks(budget):
+    """That list is the repository's Python files as git records them."""
+    files = budget._python_files()
+
+    assert "scripts/blind_except_budget.py" in files
+    assert [name for name in files if not name.endswith(".py")] == []
 
 
 def test_the_recorded_budget_names_files_that_exist(budget):

--- a/tests/unit/test_blind_except_budget.py
+++ b/tests/unit/test_blind_except_budget.py
@@ -1,0 +1,134 @@
+"""Tests for the per-file budget of blind exception handlers.
+
+The budget is the thing that notices when a change adds a handler that swallows
+a failure silently, so the check itself has to be right about three cases: a
+file that stayed level passes, a file that gained one fails, and a file nobody
+has budgeted fails on its first finding rather than on its second.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "blind_except_budget.py"
+
+FILE = "custom_components/better_thermostat/climate.py"
+OTHER = "custom_components/better_thermostat/sensor.py"
+
+
+def _load_script():
+    """Import the budget script as a module."""
+    spec = importlib.util.spec_from_file_location("blind_except_budget", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def budget(tmp_path, monkeypatch):
+    """Point the script at a budget file inside the test's own directory."""
+    script = _load_script()
+    monkeypatch.setattr(script, "BUDGET_FILE", tmp_path / "budget.json")
+    return script
+
+
+def _counts(script, monkeypatch, **files):
+    """Make the script see the given per-file counts instead of scanning."""
+    monkeypatch.setattr(script, "_measure", lambda: dict(files))
+
+
+def test_update_records_the_counts_it_measured(budget, monkeypatch):
+    """The budget is today's count, so it is reached but never exceeded."""
+    _counts(budget, monkeypatch, **{FILE: 28, OTHER: 5})
+
+    assert budget.update() == 0
+
+    recorded = json.loads(budget.BUDGET_FILE.read_text(encoding="utf-8"))
+    assert recorded == {FILE: 28, OTHER: 5}
+
+
+def test_check_passes_when_every_file_stays_within_its_budget(budget, monkeypatch):
+    """Counts at the recorded level are what the check is for."""
+    _counts(budget, monkeypatch, **{FILE: 28, OTHER: 5})
+    budget.update()
+
+    assert budget.check() == 0
+
+
+def test_check_fails_when_a_file_gains_a_handler(budget, monkeypatch, capsys):
+    """One more blind handler in a budgeted file fails the check and is named."""
+    _counts(budget, monkeypatch, **{FILE: 28, OTHER: 5})
+    budget.update()
+    capsys.readouterr()
+
+    _counts(budget, monkeypatch, **{FILE: 29, OTHER: 5})
+
+    assert budget.check() == 1
+    output = capsys.readouterr().out
+    assert f"{FILE}: 29 > 28" in output
+    assert OTHER not in output
+
+
+def test_check_fails_on_the_first_handler_in_an_unbudgeted_file(
+    budget, monkeypatch, capsys
+):
+    """A file with no budget has no allowance, so its first finding fails.
+
+    Adding a file to `per-file-ignores` silences `ruff check` for it but not
+    this, so a blind handler cannot be hidden by editing the lint settings.
+    """
+    _counts(budget, monkeypatch, **{FILE: 28})
+    budget.update()
+    capsys.readouterr()
+
+    _counts(budget, monkeypatch, **{FILE: 28, OTHER: 1})
+
+    assert budget.check() == 1
+    output = capsys.readouterr().out
+    assert "no budget" in output
+    assert f"{OTHER}: 1" in output
+
+
+def test_check_passes_when_a_count_falls(budget, monkeypatch, capsys):
+    """Converting handlers is the direction the budget exists to allow."""
+    _counts(budget, monkeypatch, **{FILE: 28, OTHER: 5})
+    budget.update()
+    capsys.readouterr()
+
+    _counts(budget, monkeypatch, **{FILE: 24, OTHER: 0})
+
+    assert budget.check() == 0
+    output = capsys.readouterr().out
+    assert f"below budget: {FILE} at 24 of 28" in output
+    assert f"below budget: {OTHER} at 0 of 5" in output
+
+
+def test_update_names_the_budgets_it_raises(budget, monkeypatch, capsys):
+    """Re-recording a higher number says so, so it cannot pass unnoticed."""
+    _counts(budget, monkeypatch, **{FILE: 28})
+    budget.update()
+    capsys.readouterr()
+
+    _counts(budget, monkeypatch, **{FILE: 30})
+    budget.update()
+
+    assert f"raised: {FILE} 28 -> 30" in capsys.readouterr().out
+
+
+def test_the_recorded_budget_names_files_that_exist(budget):
+    """Every recorded budget names a file that is still in the repository."""
+    recorded = json.loads(
+        (REPO_ROOT / ".blind-except-budget.json").read_text(encoding="utf-8")
+    )
+
+    missing = sorted(name for name in recorded if not (REPO_ROOT / name).exists())
+
+    assert not missing, f"budget recorded for files that are gone: {missing}"
+
+
+def test_the_repository_stays_within_its_recorded_budget():
+    """The committed counts hold against a real scan of the working tree."""
+    assert _load_script().check() == 0

--- a/tests/unit/test_blind_except_budget.py
+++ b/tests/unit/test_blind_except_budget.py
@@ -1,9 +1,9 @@
 """Tests for the per-file budget of blind exception handlers.
 
 The budget is the thing that notices when a change adds a handler that swallows
-a failure silently, so the check itself has to be right about three cases: a
-file that stayed level passes, a file that gained one fails, and a file nobody
-has budgeted fails on its first finding rather than on its second.
+a failure silently, so the check itself has to be right about a file that
+stayed level, a file that gained one, a file that fell, and a file nobody has
+budgeted — which fails on its first finding rather than on its second.
 
 The count underneath those cases has to be right about one more thing: it is
 taken with the repository's lint settings ignored, so the suppressions that


### PR DESCRIPTION
## What changes

Lint configuration, one new script, its data file and its tests. No production code.

1. `BLE001` (flake8-blind-except) is added to `[tool.ruff.lint] select`. It fires on `except Exception` whose handler neither re-raises nor logs the exception (`logging.exception`, or `logging.error(..., exc_info=True)`).
2. The 19 files that still contain such a handler get a `BLE001` per-file exception, listed individually rather than by glob so that a directory's already-clean modules stay gated.
3. `.blind-except-budget.json` records how many blind handlers each of those 19 files holds. `scripts/blind_except_budget.py check` fails when a file exceeds its number, and when a file with no budget has a finding at all. `update` re-records, so a file that improves freezes at the better number.
4. The Lint workflow runs `check` after `ruff check` and `ruff format --check`.

The budget is modelled on `scripts/coverage_floors.py` / `.coverage-floors.json`, down to the `check` / `update` split, the exit codes and the message style.

## Why the budget is needed on top of the ignores

A `per-file-ignores` entry suppresses **every** `BLE001` finding in that file, including handlers written later. `climate.py` holds 28 of the 79 findings and is the likeliest place for the next one, so the ignore list alone would leave the largest backlog the least protected: the backlog could still grow, just not into new files.

The budget closes that. It counts, per file, and only ever falls.

## Why the ignores stay

Three options were on the table.

| option | `ruff check` on the backlog | what gates a new handler |
|---|---|---|
| drop the ignores, budget only | **red**, 79 findings | nothing — the red is permanent noise |
| 79 inline `# noqa: BLE001` | green | ruff, per line |
| ignores + budget (**chosen**) | green | ruff outside the 19 files, the budget inside them |

Dropping the ignores makes `ruff check` red for every contributor until the entire backlog is converted, which trains people to ignore the linter. Rejected.

Inline `# noqa` would work as a ratchet, but it scatters 79 suppressions across production source, one per site, each of which a reader has to interpret locally, and each of which is one copy-paste away from silencing the next handler. The budget puts the same information in one data file where a rising number is visible in the diff as a number going up.

So the ignores stay and the budget is what actually gates those files. The comment above the ignore list says exactly that and claims nothing more.

## How the count is taken

The lint settings silence `BLE001` for the 19 files, so a plain `ruff check --select BLE001` reports nothing about them. The scan therefore runs with the repository's lint configuration ignored altogether, and takes its file list from git rather than from a directory walk:

```
$ uv run python -m ruff check --isolated --select BLE001 --ignore-noqa \
    --target-version py314 --output-format json $(git ls-files '*.py')
```

`--isolated` is what makes the number independent of the settings, and that matters because `per-file-ignores` is not the only way to silence the rule. Each row below was probed against the pinned ruff 0.15.22 by appending `try: pass / except Exception: pass` to `adapters/generic.py` — a file with no budget, so its first finding has to fail — and then adding the suppression:

| suppression | `ruff check` | budget `check` |
|---|---|---|
| none | red | red |
| `[tool.ruff.lint.per-file-ignores]` entry | green | **red** |
| `[tool.ruff.lint.extend-per-file-ignores]` entry | green | **red** |
| `"BLE001"` in `[tool.ruff.lint] ignore` | green | **red** |
| the file added to `[tool.ruff] exclude` | green | **red** |
| the file added to `.gitignore` | green | **red** |
| inline `# noqa: BLE001` | green | **red** |
| file-level `# ruff: noqa: BLE001` | green | **red** |

`extend-per-file-ignores` is why the scan cannot just clear `per-file-ignores` on the command line: `extend-*` settings are additive, so assigning them an empty table adds nothing and removes nothing — the count comes back unchanged and the handler stays hidden. Passing the files explicitly instead of `.` is what takes `exclude` and `.gitignore` out of the decision.

`--target-version` is read from `pyproject.toml`. An isolated scan carries none, and a grammar older than the sources turns a file into a syntax error; a file ruff cannot parse reports no findings, which would read as a count of zero. The scan refuses that case rather than recording it.

On the clean tree the scan reports 79 findings across 19 files, exit code 1, parseable JSON with absolute `filename` keys, and the counts equal `.blind-except-budget.json` entry for entry.

79 findings across 19 files:

| count | file |
|------:|------|
| 28 | `custom_components/better_thermostat/climate.py` |
| 7 | `custom_components/better_thermostat/adapters/delegate.py` |
| 6 | `custom_components/better_thermostat/utils/helpers.py` |
| 5 | `custom_components/better_thermostat/utils/calibration/pid.py` |
| 5 | `custom_components/better_thermostat/sensor.py` |
| 4 | `custom_components/better_thermostat/utils/migrate_v0_stores.py` |
| 4 | `custom_components/better_thermostat/utils/controlling.py` |
| 4 | `custom_components/better_thermostat/model_fixes/default.py` |
| 3 | `custom_components/better_thermostat/utils/valve_maintenance.py` |
| 2 | `custom_components/better_thermostat/events/trv.py` |
| 2 | `custom_components/better_thermostat/calibration.py` |
| 2 | `custom_components/better_thermostat/adapters/zwave_js.py` |
| 1 | `custom_components/better_thermostat/utils/state_manager.py` |
| 1 | `custom_components/better_thermostat/utils/calibration/mpc.py` |
| 1 | `custom_components/better_thermostat/utils/calibration/mpc_v2/state.py` |
| 1 | `custom_components/better_thermostat/switch.py` |
| 1 | `custom_components/better_thermostat/events/temperature.py` |
| 1 | `custom_components/better_thermostat/adapters/mqtt.py` |
| 1 | `custom_components/better_thermostat/adapters/base.py` |

The budgeted set and the ignored set are the same 19 files, which is the invariant that makes the two halves meet exactly.

`custom_components/` contains 94 `except Exception` in 22 files, no bare `except:` and no `except BaseException`. BLE001 flags 79 of the 94, because a handler that re-raises or calls `_LOGGER.exception(...)` is not blind. Three of the 22 files — `__init__.py`, `config_flow.py`, `adapters/generic.py` — are therefore already clean and are deliberately **not** on the exception list, so they are gated twice: by `ruff check` and by the budget. `tests/`, `scripts/` and the benchmark tree produce no BLE001 findings and are gated the same way.

## The gate bites, in both directions

**(a) A handler added to a file that IS in the budget.** `try: pass / except Exception: pass` appended to `climate.py`:

```
$ uv run ruff check .
All checks passed!

$ uv run python scripts/blind_except_budget.py check
more blind exception handlers than the budget allows:
  custom_components/better_thermostat/climate.py: 29 > 28

Name the exceptions the handler expects, re-raise, or log the traceback with `_LOGGER.exception`. The budget only ever falls.
$ echo $?
1
```

This is the hole, shown open and shut in one run: `ruff check` is green on the added handler, the budget is not. `pytest tests/unit/test_blind_except_budget.py` fails at the same time, on `test_the_repository_stays_within_its_recorded_budget`.

**(b) A handler added to a file that is NOT in the budget.** The same block appended to `adapters/generic.py`:

```
$ uv run ruff check .
Found 1 error.

$ uv run python scripts/blind_except_budget.py check
blind exception handlers in files with no budget:
  custom_components/better_thermostat/adapters/generic.py: 1

Name the exceptions the handler expects, re-raise, or log the traceback with `_LOGGER.exception`. The budget only ever falls.
$ echo $?
1
```

**(c) A handler removed.** `_LOGGER.debug` changed to `_LOGGER.exception` in the handler at `climate.py:649`, which is exactly what makes BLE001 stop flagging it:

```
$ uv run python scripts/blind_except_budget.py check
below budget: custom_components/better_thermostat/climate.py at 27 of 28
re-record with 'blind_except_budget.py update' to hold the lower numbers
all 19 files stay within their budget
$ echo $?
0
```

A falling count passes and is named, so converting handlers never needs coordination with this branch.

All three probes were reverted; `git status --porcelain` was empty before committing.

## Verification

| check | before | after |
|---|---|---|
| `pytest tests/ -q` | 7115 passed, 1 skipped | 7127 passed, 1 skipped |
| `ruff check .` | All checks passed! | All checks passed! |
| `ruff format --check .` | 313 files already formatted | 315 files already formatted |
| `pyrefly check` | 0 errors (3 suppressed) | 0 errors (3 suppressed) |
| `scripts/coverage_floors.py check` | all 99 modules hold their floor | all 99 modules hold their floor |

The twelve new tests are `tests/unit/test_blind_except_budget.py`. No coverage floor moved: `--cov` is scoped to `custom_components/better_thermostat`, so `scripts/` is not measured.

Behaviour-neutral: the diff touches lint configuration, a build script and tests.

## What the gate does not cover

BLE001 targets *blind* catches, not broad ones. Two limits are recorded in the `per-file-ignores` comment and in the script docstring so neither the ignore list nor the budget is misread as an inventory of `except Exception`:

- A handler that logs via `_LOGGER.exception(...)` or `_LOGGER.error(..., exc_info=True)` passes, so the rule will not force narrow exception types on a handler that reports properly.
- `with contextlib.suppress(Exception):` produces no finding at all. Probed against ruff 0.15.22: `except Exception: pass` flags, `_LOGGER.error(...)` and `_LOGGER.debug(...)` handlers flag, while `contextlib.suppress(Exception)`, `_LOGGER.exception(...)` and a bare `raise` do not. `utils/weather.py` already imports `suppress`, so that idiom is one import away and stays a review concern rather than a lint-enforced one.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Added automated checks to identify and track broad exception handling across the codebase.
  * Established safeguards to prevent new unhandled error patterns from being introduced.
  * Existing exception-handling allowances are monitored against defined limits.

* **Tests**
  * Added comprehensive validation for exception-handling checks, including increases, decreases, missing entries, and parsing failures.
  * Added repository-wide verification to ensure quality limits remain satisfied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->