### PR TITLE
fix: give broad exception handlers a trace or a proven boundary

### DIFF
--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -56,7 +56,12 @@ async def init(self, entity_id):
                 valve.get("writable", False)
             )
     except Exception:
-        pass
+        _LOGGER.debug(
+            "better_thermostat %s: valve entity discovery for %s failed",
+            self.device_name,
+            entity_id,
+            exc_info=True,
+        )
 
     if (
         self.real_trvs[entity_id].local_temperature_calibration_entity is None

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2744,7 +2744,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             if control_needed or self.bt_hvac_mode != HVACMode.OFF:
                 try:
                     request_control_cycle(self)
-                except Exception:
+                except AttributeError:
                     # Queue not ready; the periodic tick will catch up.
                     pass
 
@@ -2868,8 +2868,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                         "unit_of_measurement"
                     ),
                 )
-        except Exception:
-            pass
+        except AttributeError:
+            _LOGGER.debug(
+                "better_thermostat %s: outdoor sensor %s could not be read",
+                self.device_name,
+                self.outdoor_sensor,
+                exc_info=True,
+            )
         return None
 
     @property
@@ -2932,28 +2937,19 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         }
 
         # Optional: next scheduled valve maintenance (ISO8601)
-        try:
-            if (
-                hasattr(self, "next_valve_maintenance")
-                and self.next_valve_maintenance is not None
-            ):
-                dev_specific["next_valve_maintenance"] = (
-                    self.next_valve_maintenance.isoformat()
-                )
-        except Exception:
-            pass
+        if self.next_valve_maintenance is not None:
+            dev_specific["next_valve_maintenance"] = (
+                self.next_valve_maintenance.isoformat()
+            )
 
         # Optional: summarize last valve method per TRV (adapter vs override)
-        try:
-            methods = {}
-            for trv_id, info in (self.real_trvs or {}).items():
-                m = info.last_valve_method
-                if m:
-                    methods[trv_id] = m
-            if methods:
-                dev_specific["valve_method"] = methods
-        except Exception:
-            pass
+        methods = {
+            trv_id: info.last_valve_method
+            for trv_id, info in self.real_trvs.items()
+            if info.last_valve_method
+        }
+        if methods:
+            dev_specific["valve_method"] = methods
 
         dev_specific.update(collect_cycle_telemetry(self))
         dev_specific.update(collect_balance_attrs(self))
@@ -3125,10 +3121,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                         str(action_raw).lower() if action_raw is not None else ""
                     )
                     if action_str:
-                        try:
-                            info.hvac_action = action_str
-                        except Exception:
-                            pass
+                        info.hvac_action = action_str
                 except Exception:
                     action_str = ""
 

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2940,7 +2940,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 if self.kernel_state.control_mode.degraded_since is not None
                 else None
             ),
-            # ECO mode attribute removed: eco preset supported via PRESET_ECO
             ATTR_STATE_PRESET_COOL_TEMPERATURES: json.dumps(
                 self._preset_cool_temperatures
             ),

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2747,6 +2747,16 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 except AttributeError:
                     # Queue not ready; the periodic tick will catch up.
                     pass
+                except Exception:
+                    # This is the last statement of the ``finally``: an
+                    # exception leaving here replaces the one the maintenance
+                    # run is propagating, so the kick reports and stops.
+                    _LOGGER.debug(
+                        "better_thermostat %s: control cycle request after "
+                        "maintenance failed",
+                        self.device_name,
+                        exc_info=True,
+                    )
 
     # -- Unified state persistence helpers ------------------------------------
 

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -243,33 +243,28 @@ async def trigger_trv_change(self, event):
         return
 
     # Always cache hvac_action from the TRV state so it stays current
-    try:
-        hvac_action_attr = _org_trv_state.attributes.get("hvac_action")
-        if hvac_action_attr is None:
-            hvac_action_attr = _org_trv_state.attributes.get("action")
-        if hvac_action_attr is not None:
-            val = str(hvac_action_attr).strip().lower()
-            prev = trv.hvac_action
-            trv.hvac_action = val
-            if prev != val:
-                _main_change = True
-                _LOGGER.debug(
-                    "better_thermostat %s: TRV %s hvac_action changed: %s -> %s",
-                    self.device_name,
-                    entity_id,
-                    prev,
-                    val,
-                )
-
-        # valve_position aktualisieren
-        val_pos = _org_trv_state.attributes.get("valve_position")
-        if val_pos is not None:
-            trv.valve_position = convert_to_float(
-                str(val_pos), self.device_name, "trv_event"
+    hvac_action_attr = _org_trv_state.attributes.get("hvac_action")
+    if hvac_action_attr is None:
+        hvac_action_attr = _org_trv_state.attributes.get("action")
+    if hvac_action_attr is not None:
+        val = str(hvac_action_attr).strip().lower()
+        prev = trv.hvac_action
+        trv.hvac_action = val
+        if prev != val:
+            _main_change = True
+            _LOGGER.debug(
+                "better_thermostat %s: TRV %s hvac_action changed: %s -> %s",
+                self.device_name,
+                entity_id,
+                prev,
+                val,
             )
 
-    except Exception:
-        pass
+    val_pos = _org_trv_state.attributes.get("valve_position")
+    if val_pos is not None:
+        trv.valve_position = convert_to_float(
+            str(val_pos), self.device_name, "trv_event"
+        )
 
     if mapped_state in (HVACMode.OFF, HVACMode.HEAT, HVACMode.HEAT_COOL):
         if trv.hvac_mode != _org_trv_state.state and not child_lock:

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -242,7 +242,8 @@ async def trigger_trv_change(self, event):
         )
         return
 
-    # Always cache hvac_action from the TRV state so it stays current
+    # Always cache the reported hvac_action and valve position so both stay
+    # current
     hvac_action_attr = _org_trv_state.attributes.get("hvac_action")
     if hvac_action_attr is None:
         hvac_action_attr = _org_trv_state.attributes.get("action")

--- a/custom_components/better_thermostat/utils/calibration/pid.py
+++ b/custom_components/better_thermostat/utils/calibration/pid.py
@@ -111,7 +111,7 @@ class PIDParams:
     kp: float = DEFAULT_PID_KP
     ki: float = DEFAULT_PID_KI
     kd: float = DEFAULT_PID_KD
-    # Integrator-Klammer (Anti-Windup) in %-Punkten
+    # Integrator clamp (anti-windup) in percentage points
     i_min: float = -100.0
     i_max: float = 100.0
     # Derivative on measurement

--- a/custom_components/better_thermostat/utils/calibration/pid.py
+++ b/custom_components/better_thermostat/utils/calibration/pid.py
@@ -338,8 +338,10 @@ def compute_pid(
                 st.ema_slope = s_in
             else:
                 st.ema_slope = 0.6 * st.ema_slope + 0.4 * s_in
-    except Exception:
-        pass
+    except TypeError:
+        _LOGGER.debug(
+            "better_thermostat PID: slope EMA update skipped for %s", key, exc_info=True
+        )
 
     # Proportional term
     p_term = float(st.pid_kp) * e
@@ -381,8 +383,12 @@ def compute_pid(
             decay = 0.8  # 20% relief
             i_term *= decay
             i_relief = True
-    except Exception:
-        pass
+    except TypeError:
+        _LOGGER.debug(
+            "better_thermostat PID: integrator relief skipped for %s",
+            key,
+            exc_info=True,
+        )
 
     # Final control output
     u = p_term + i_term + d_term  # PID
@@ -462,10 +468,7 @@ def compute_pid(
     st.pid_last_time = now
 
     # Remember the error sign for the next cycle
-    try:
-        st.last_error_sign = 1 if e > 0 else (-1 if e < 0 else 0)
-    except Exception:
-        pass
+    st.last_error_sign = 1 if e > 0 else (-1 if e < 0 else 0)
 
     # Optional auto-tuning (conservative)
     if params.auto_tune:

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -2041,18 +2041,15 @@ async def get_device_model(self, entity_id: str) -> str:
         except Exception:
             device = None
         # Selection exclusively via Device-Registry
-        try:
-            _LOGGER.debug(
-                "better_thermostat %s: device registry -> manufacturer=%s model=%s model_id=%s name=%s identifiers=%s",
-                self.device_name,
-                getattr(device, "manufacturer", None),
-                getattr(device, "model", None),
-                getattr(device, "model_id", None),
-                getattr(device, "name", None),
-                list(getattr(device, "identifiers", []) or []),
-            )
-        except Exception:
-            pass
+        _LOGGER.debug(
+            "better_thermostat %s: device registry -> manufacturer=%s model=%s model_id=%s name=%s identifiers=%s",
+            self.device_name,
+            getattr(device, "manufacturer", None),
+            getattr(device, "model", None),
+            getattr(device, "model_id", None),
+            getattr(device, "name", None),
+            list(getattr(device, "identifiers", []) or []),
+        )
 
         dev_model_id = getattr(device, "model_id", None)
         if isinstance(dev_model_id, str) and len(dev_model_id.strip()) >= 2:
@@ -2075,8 +2072,14 @@ async def get_device_model(self, entity_id: str) -> str:
                     selected = model_str.strip()
                     source = "devreg.model"
     except Exception:
-        # swallow registry access issues and continue to fallback
-        pass
+        # Registry access is best effort; the fallback chain below still
+        # yields a model name.
+        _LOGGER.debug(
+            "better_thermostat %s: device registry lookup for %s failed",
+            self.device_name,
+            entity_id,
+            exc_info=True,
+        )
 
     # Final fallback: configured model, then generic
     configured_model = getattr(self, "model", None)
@@ -2120,7 +2123,11 @@ async def async_fire_logbook_entry(self, key: str, default_msg: str) -> None:
                 f"component.{DOMAIN}.entity.sensor.logbook.state.{key}", default_msg
             )
         except Exception:
-            pass
+            _LOGGER.debug(
+                "better_thermostat: logbook translation for %s unavailable",
+                key,
+                exc_info=True,
+            )
 
         entity_id = getattr(self, "entity_id", None)
         if not entity_id:

--- a/custom_components/better_thermostat/utils/migrate_v0_stores.py
+++ b/custom_components/better_thermostat/utils/migrate_v0_stores.py
@@ -145,7 +145,11 @@ async def migrate_v0_stores(
                 _import_legacy_data(state_mgr, mpc_data=entity_entries)
                 any_imported = True
     except Exception:
-        pass
+        _LOGGER.debug(
+            "better_thermostat [%s]: legacy MPC store not imported",
+            config_entry_id,
+            exc_info=True,
+        )
 
     # PID legacy
     try:
@@ -157,7 +161,11 @@ async def migrate_v0_stores(
                 _import_legacy_data(state_mgr, pid_data=entity_entries)
                 any_imported = True
     except Exception:
-        pass
+        _LOGGER.debug(
+            "better_thermostat [%s]: legacy PID store not imported",
+            config_entry_id,
+            exc_info=True,
+        )
 
     # TPI legacy
     try:
@@ -169,7 +177,11 @@ async def migrate_v0_stores(
                 _import_legacy_data(state_mgr, tpi_data=entity_entries)
                 any_imported = True
     except Exception:
-        pass
+        _LOGGER.debug(
+            "better_thermostat [%s]: legacy TPI store not imported",
+            config_entry_id,
+            exc_info=True,
+        )
 
     # Thermal legacy
     try:
@@ -181,7 +193,11 @@ async def migrate_v0_stores(
                 _import_legacy_data(state_mgr, thermal_data=thermal_entry)
                 any_imported = True
     except Exception:
-        pass
+        _LOGGER.debug(
+            "better_thermostat [%s]: legacy thermal store not imported",
+            config_entry_id,
+            exc_info=True,
+        )
 
     if any_imported:
         await state_mgr.save()

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -287,11 +287,19 @@ async def restore_one(
         try:
             await set_temperature_fn(info.entity_id, info.cur_temp)
         except Exception:
-            pass
+            _LOGGER.debug(
+                "better_thermostat: restoring the setpoint of %s failed",
+                info.entity_id,
+                exc_info=True,
+            )
     try:
         await set_hvac_mode_fn(info.entity_id, info.cur_mode)
     except Exception:
-        pass
+        _LOGGER.debug(
+            "better_thermostat: restoring the HVAC mode of %s failed",
+            info.entity_id,
+            exc_info=True,
+        )
 
 
 # Main orchestrator

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,9 +1,10 @@
 """Shared builders for unit-test fixtures.
 
 The canonical home of the recurring mock shapes: kernel inputs
-(``make_snapshot``/``make_state``) and the entity mock (``make_bt``).
-Tests import from here instead of re-declaring the MagicMock shape per
-file.
+(``make_snapshot``/``make_state``), the entity mock for the control path
+(``make_bt``) and the one for the reported state attributes
+(``make_state_attributes_bt``). Tests import from here instead of
+re-declaring the MagicMock shape per file.
 """
 
 from __future__ import annotations
@@ -163,4 +164,52 @@ def make_bt(
     bt.real_trvs = {
         entity_id: make_trv(entity_id, **trv_fields) for entity_id in trv_ids
     }
+    return bt
+
+
+def make_state_attributes_bt(**overrides) -> MagicMock:
+    """Return the entity mock ``extra_state_attributes`` can be read from.
+
+    The property reads roughly forty attributes and JSON-encodes four of
+    them, so the collections it serialises have to be real containers
+    rather than MagicMock children.
+
+    Parameters
+    ----------
+    **overrides
+        Attribute values applied on top of the defaults.
+
+    Returns
+    -------
+    MagicMock
+        The entity mock with every attribute the property touches.
+    """
+    bt = MagicMock()
+    bt.window_open = False
+    bt.call_for_heat = True
+    bt.last_change = datetime(2026, 5, 18, tzinfo=UTC)
+    bt._saved_temperature = None
+    bt._preset_temperature = None
+    bt._current_humidity = None
+    bt.humidity_sensor_entity_id = None
+    bt.last_main_hvac_mode = HVACMode.HEAT
+    bt.off_temperature = None
+    bt.tolerance = 0.5
+    bt.bt_target_temp_step = 0.5
+    bt.heating_power = 0.1
+    bt.heat_loss_rate = 0.0
+    bt.devices_errors = []
+    bt.devices_states = {}
+    bt.cur_temp_filtered = 20.5
+    bt.degraded_mode = False
+    bt.unavailable_sensors = []
+    bt.real_trvs = {}
+    bt.heating_cycles = []
+    bt.loss_cycles = []
+    bt.last_heating_power_stats = {}
+    bt.last_heat_loss_stats = {}
+    bt.next_valve_maintenance = None
+    bt._preset_cool_temperatures = {}
+    for name, value in overrides.items():
+        setattr(bt, name, value)
     return bt

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -170,9 +170,9 @@ def make_bt(
 def make_state_attributes_bt(**overrides) -> MagicMock:
     """Return the entity mock ``extra_state_attributes`` can be read from.
 
-    The property reads roughly forty attributes and JSON-encodes four of
-    them, so the collections it serialises have to be real containers
-    rather than MagicMock children.
+    The property JSON-encodes several of the values it reads, so the
+    collections it serialises have to be real containers rather than
+    MagicMock children.
 
     Parameters
     ----------

--- a/tests/unit/test_climate_optional_attributes.py
+++ b/tests/unit/test_climate_optional_attributes.py
@@ -1,0 +1,89 @@
+"""Optional entries of BetterThermostat.extra_state_attributes.
+
+``next_valve_maintenance`` and ``valve_method`` are published only when the
+entity actually holds the data behind them: a scheduled maintenance run, and
+at least one TRV that has recorded how its valve was last written.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+from homeassistant.components.climate.const import HVACMode
+
+from custom_components.better_thermostat.climate import BetterThermostat
+from custom_components.better_thermostat.trv import Trv
+
+
+def _make_mock_bt(**overrides):
+    """Construct a mock_bt sufficient for the ``extra_state_attributes`` property."""
+    bt = MagicMock()
+    bt.window_open = False
+    bt.call_for_heat = True
+    bt.last_change = datetime(2026, 5, 18, tzinfo=UTC)
+    bt._saved_temperature = None
+    bt._preset_temperature = None
+    bt._current_humidity = None
+    bt.humidity_sensor_entity_id = None
+    bt.last_main_hvac_mode = HVACMode.HEAT
+    bt.off_temperature = None
+    bt.tolerance = 0.5
+    bt.bt_target_temp_step = 0.5
+    bt.heating_power = 0.1
+    bt.heat_loss_rate = 0.0
+    bt.devices_errors = []
+    bt.devices_states = {}
+    bt.cur_temp_filtered = 20.5
+    bt.degraded_mode = False
+    bt.unavailable_sensors = []
+    bt.real_trvs = {}
+    bt.heating_cycles = []
+    bt.loss_cycles = []
+    bt.last_heating_power_stats = {}
+    bt.last_heat_loss_stats = {}
+    bt.next_valve_maintenance = None
+    bt._preset_cool_temperatures = {}
+    for k, v in overrides.items():
+        setattr(bt, k, v)
+    return bt
+
+
+class TestNextValveMaintenance:
+    """The schedule stamp is published as ISO8601 when it is a timestamp."""
+
+    def test_absent_without_a_schedule(self):
+        """No schedule means no key."""
+        bt = _make_mock_bt(next_valve_maintenance=None)
+        attrs = BetterThermostat.extra_state_attributes.fget(bt)
+        assert "next_valve_maintenance" not in attrs
+
+    def test_timestamp_is_published_as_iso8601(self):
+        """A datetime schedule is rendered in ISO8601."""
+        due = datetime(2026, 1, 8, 12, 0, tzinfo=UTC)
+        bt = _make_mock_bt(next_valve_maintenance=due)
+        attrs = BetterThermostat.extra_state_attributes.fget(bt)
+        assert attrs["next_valve_maintenance"] == due.isoformat()
+
+
+class TestValveMethod:
+    """The per-TRV valve-method summary is published when a TRV reports one."""
+
+    def test_absent_without_reported_methods(self):
+        """No TRV reported a method, so no key."""
+        bt = _make_mock_bt(real_trvs={"climate.trv": Trv(entity_id="climate.trv")})
+        attrs = BetterThermostat.extra_state_attributes.fget(bt)
+        assert "valve_method" not in attrs
+
+    def test_reported_methods_are_summarized(self):
+        """Each TRV that reports a method appears in the summary."""
+        trv = Trv(entity_id="climate.trv", last_valve_method="adapter")
+        bt = _make_mock_bt(real_trvs={"climate.trv": trv})
+        attrs = BetterThermostat.extra_state_attributes.fget(bt)
+        assert attrs["valve_method"] == {"climate.trv": "adapter"}
+
+    def test_only_reporting_trvs_appear(self):
+        """A TRV without a recorded method is left out of the summary."""
+        reporting = Trv(entity_id="climate.a", last_valve_method="adapter")
+        silent = Trv(entity_id="climate.b")
+        bt = _make_mock_bt(real_trvs={"climate.a": reporting, "climate.b": silent})
+        attrs = BetterThermostat.extra_state_attributes.fget(bt)
+        assert attrs["valve_method"] == {"climate.a": "adapter"}

--- a/tests/unit/test_climate_optional_attributes.py
+++ b/tests/unit/test_climate_optional_attributes.py
@@ -2,49 +2,18 @@
 
 ``next_valve_maintenance`` and ``valve_method`` are published only when the
 entity actually holds the data behind them: a scheduled maintenance run, and
-at least one TRV that has recorded how its valve was last written.
+at least one TRV that has recorded how its valve was last written. A schedule
+stamp that is not a timestamp surfaces as an error rather than as a silently
+missing attribute.
 """
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock
 
-from homeassistant.components.climate.const import HVACMode
+import pytest
 
 from custom_components.better_thermostat.climate import BetterThermostat
 from custom_components.better_thermostat.trv import Trv
-
-
-def _make_mock_bt(**overrides):
-    """Construct a mock_bt sufficient for the ``extra_state_attributes`` property."""
-    bt = MagicMock()
-    bt.window_open = False
-    bt.call_for_heat = True
-    bt.last_change = datetime(2026, 5, 18, tzinfo=UTC)
-    bt._saved_temperature = None
-    bt._preset_temperature = None
-    bt._current_humidity = None
-    bt.humidity_sensor_entity_id = None
-    bt.last_main_hvac_mode = HVACMode.HEAT
-    bt.off_temperature = None
-    bt.tolerance = 0.5
-    bt.bt_target_temp_step = 0.5
-    bt.heating_power = 0.1
-    bt.heat_loss_rate = 0.0
-    bt.devices_errors = []
-    bt.devices_states = {}
-    bt.cur_temp_filtered = 20.5
-    bt.degraded_mode = False
-    bt.unavailable_sensors = []
-    bt.real_trvs = {}
-    bt.heating_cycles = []
-    bt.loss_cycles = []
-    bt.last_heating_power_stats = {}
-    bt.last_heat_loss_stats = {}
-    bt.next_valve_maintenance = None
-    bt._preset_cool_temperatures = {}
-    for k, v in overrides.items():
-        setattr(bt, k, v)
-    return bt
+from tests.factories import make_state_attributes_bt
 
 
 class TestNextValveMaintenance:
@@ -52,16 +21,22 @@ class TestNextValveMaintenance:
 
     def test_absent_without_a_schedule(self):
         """No schedule means no key."""
-        bt = _make_mock_bt(next_valve_maintenance=None)
+        bt = make_state_attributes_bt(next_valve_maintenance=None)
         attrs = BetterThermostat.extra_state_attributes.fget(bt)
         assert "next_valve_maintenance" not in attrs
 
     def test_timestamp_is_published_as_iso8601(self):
         """A datetime schedule is rendered in ISO8601."""
         due = datetime(2026, 1, 8, 12, 0, tzinfo=UTC)
-        bt = _make_mock_bt(next_valve_maintenance=due)
+        bt = make_state_attributes_bt(next_valve_maintenance=due)
         attrs = BetterThermostat.extra_state_attributes.fget(bt)
         assert attrs["next_valve_maintenance"] == due.isoformat()
+
+    def test_a_schedule_that_is_not_a_timestamp_surfaces(self):
+        """A stamp without ``isoformat`` raises rather than dropping the key."""
+        bt = make_state_attributes_bt(next_valve_maintenance="2026-01-08T12:00:00")
+        with pytest.raises(AttributeError):
+            BetterThermostat.extra_state_attributes.fget(bt)
 
 
 class TestValveMethod:
@@ -69,14 +44,16 @@ class TestValveMethod:
 
     def test_absent_without_reported_methods(self):
         """No TRV reported a method, so no key."""
-        bt = _make_mock_bt(real_trvs={"climate.trv": Trv(entity_id="climate.trv")})
+        bt = make_state_attributes_bt(
+            real_trvs={"climate.trv": Trv(entity_id="climate.trv")}
+        )
         attrs = BetterThermostat.extra_state_attributes.fget(bt)
         assert "valve_method" not in attrs
 
     def test_reported_methods_are_summarized(self):
         """Each TRV that reports a method appears in the summary."""
         trv = Trv(entity_id="climate.trv", last_valve_method="adapter")
-        bt = _make_mock_bt(real_trvs={"climate.trv": trv})
+        bt = make_state_attributes_bt(real_trvs={"climate.trv": trv})
         attrs = BetterThermostat.extra_state_attributes.fget(bt)
         assert attrs["valve_method"] == {"climate.trv": "adapter"}
 
@@ -84,6 +61,8 @@ class TestValveMethod:
         """A TRV without a recorded method is left out of the summary."""
         reporting = Trv(entity_id="climate.a", last_valve_method="adapter")
         silent = Trv(entity_id="climate.b")
-        bt = _make_mock_bt(real_trvs={"climate.a": reporting, "climate.b": silent})
+        bt = make_state_attributes_bt(
+            real_trvs={"climate.a": reporting, "climate.b": silent}
+        )
         attrs = BetterThermostat.extra_state_attributes.fget(bt)
         assert attrs["valve_method"] == {"climate.a": "adapter"}

--- a/tests/unit/test_climate_properties.py
+++ b/tests/unit/test_climate_properties.py
@@ -167,7 +167,7 @@ def test_outdoor_temp_read_from_sensor_state(bt):
     assert BetterThermostat._get_outdoor_temp(bt) == 7.5
 
 
-def test_outdoor_temp_unreadable_state_object_is_logged(bt, caplog):
+def test_outdoor_temp_missing_attribute_is_logged(bt, caplog):
     """An outdoor read that hits a missing attribute yields None and a trace."""
     bt.outdoor_sensor = "sensor.outdoor"
     bt.hass = None

--- a/tests/unit/test_climate_properties.py
+++ b/tests/unit/test_climate_properties.py
@@ -1,15 +1,20 @@
 """Branch coverage for BetterThermostat temperature/feature properties.
 
 Covers the clamping in target_temperature, the cooler-gated low/high targets,
-the configured min/max bounds, and the cooler-dependent supported_features.
+the configured min/max bounds, the cooler-dependent supported_features, and
+the outdoor-temperature read.
 """
 
+import logging
 from unittest.mock import MagicMock
 
 from homeassistant.components.climate.const import ClimateEntityFeature
+from homeassistant.core import State
 import pytest
 
 from custom_components.better_thermostat.climate import BetterThermostat
+
+_CLIMATE_LOGGER = "custom_components.better_thermostat.climate"
 
 
 @pytest.fixture
@@ -141,3 +146,40 @@ def test_contact_open_combines_window_and_door(bt, window_open, door_open, expec
     bt.window_open = window_open
     bt.door_open = door_open
     assert _prop("contact_open", bt) is expected
+
+
+# --- _get_outdoor_temp ------------------------------------------------------
+
+
+def test_outdoor_temp_none_without_sensor(bt):
+    """Without a configured outdoor sensor there is nothing to read."""
+    bt.outdoor_sensor = None
+    assert BetterThermostat._get_outdoor_temp(bt) is None
+
+
+def test_outdoor_temp_read_from_sensor_state(bt):
+    """A numeric sensor state is returned in Celsius."""
+    bt.outdoor_sensor = "sensor.outdoor"
+    bt.hass = MagicMock()
+    bt.hass.states.get.return_value = State(
+        "sensor.outdoor", "7.5", attributes={"unit_of_measurement": "°C"}
+    )
+    assert BetterThermostat._get_outdoor_temp(bt) == 7.5
+
+
+def test_outdoor_temp_unreadable_state_object_is_logged(bt, caplog):
+    """An outdoor read that hits a missing attribute yields None and a trace."""
+    bt.outdoor_sensor = "sensor.outdoor"
+    bt.hass = None
+    with caplog.at_level(logging.DEBUG, logger=_CLIMATE_LOGGER):
+        assert BetterThermostat._get_outdoor_temp(bt) is None
+    assert "outdoor sensor sensor.outdoor could not be read" in caplog.text
+
+
+def test_outdoor_temp_other_failure_propagates(bt):
+    """A failure that is not a missing attribute reaches the caller."""
+    bt.outdoor_sensor = "sensor.outdoor"
+    bt.hass = MagicMock()
+    bt.hass.states.get.side_effect = RuntimeError("boom")
+    with pytest.raises(RuntimeError):
+        BetterThermostat._get_outdoor_temp(bt)

--- a/tests/unit/test_climate_run_maintenance.py
+++ b/tests/unit/test_climate_run_maintenance.py
@@ -7,6 +7,7 @@ loop can stall.  Also covers the re-entry guard, reschedule, and control kick.
 
 from dataclasses import replace
 from datetime import UTC, datetime
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -138,9 +139,10 @@ async def test_control_kick_skipped_without_a_queue(bt):
 
 
 @pytest.mark.asyncio
-async def test_failing_control_kick_propagates(bt):
-    """A control-kick failure other than a missing queue reaches the caller."""
+async def test_failing_control_kick_is_traced(bt, caplog):
+    """A control-kick failure other than a missing queue is recorded."""
     with (
+        caplog.at_level(logging.DEBUG, logger=_CLIMATE),
         patch(f"{_CLIMATE}.build_trv_snapshots", _snapshots()),
         patch(f"{_CLIMATE}.run_valve_maintenance", AsyncMock()),
         patch(f"{_CLIMATE}.compute_next_maintenance", MagicMock(return_value=_NEXT)),
@@ -148,6 +150,26 @@ async def test_failing_control_kick_propagates(bt):
             f"{_CLIMATE}.request_control_cycle",
             MagicMock(side_effect=RuntimeError("boom")),
         ),
-        pytest.raises(RuntimeError),
+    ):
+        await BetterThermostat._run_valve_maintenance(bt, ["climate.trv"])
+    assert "control cycle request after maintenance failed" in caplog.text
+    assert any(record.exc_info for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_failing_control_kick_does_not_mask_the_run(bt):
+    """The run's own failure is what the caller sees, not the kick's."""
+    with (
+        patch(f"{_CLIMATE}.build_trv_snapshots", _snapshots()),
+        patch(
+            f"{_CLIMATE}.run_valve_maintenance",
+            AsyncMock(side_effect=ValueError("unreachable TRV")),
+        ),
+        patch(f"{_CLIMATE}.compute_next_maintenance", MagicMock(return_value=_NEXT)),
+        patch(
+            f"{_CLIMATE}.request_control_cycle",
+            MagicMock(side_effect=RuntimeError("boom")),
+        ),
+        pytest.raises(ValueError, match="unreachable TRV"),
     ):
         await BetterThermostat._run_valve_maintenance(bt, ["climate.trv"])

--- a/tests/unit/test_climate_run_maintenance.py
+++ b/tests/unit/test_climate_run_maintenance.py
@@ -121,3 +121,33 @@ async def test_deferred_control_kicks_even_when_off(bt):
         await BetterThermostat._run_valve_maintenance(bt, ["climate.trv"])
     bt.control_queue_task.put_nowait.assert_called_once_with(bt)
     assert bt._control_needed_after_maintenance is False
+
+
+@pytest.mark.asyncio
+async def test_control_kick_skipped_without_a_queue(bt):
+    """Without a control queue the run finishes; the periodic tick catches up."""
+    bt.control_queue_task = None
+    with (
+        patch(f"{_CLIMATE}.build_trv_snapshots", _snapshots()),
+        patch(f"{_CLIMATE}.run_valve_maintenance", AsyncMock()),
+        patch(f"{_CLIMATE}.compute_next_maintenance", MagicMock(return_value=_NEXT)),
+    ):
+        await BetterThermostat._run_valve_maintenance(bt, ["climate.trv"])
+    assert bt.in_maintenance is False
+    assert bt.ignore_states is False
+
+
+@pytest.mark.asyncio
+async def test_failing_control_kick_propagates(bt):
+    """A control-kick failure other than a missing queue reaches the caller."""
+    with (
+        patch(f"{_CLIMATE}.build_trv_snapshots", _snapshots()),
+        patch(f"{_CLIMATE}.run_valve_maintenance", AsyncMock()),
+        patch(f"{_CLIMATE}.compute_next_maintenance", MagicMock(return_value=_NEXT)),
+        patch(
+            f"{_CLIMATE}.request_control_cycle",
+            MagicMock(side_effect=RuntimeError("boom")),
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        await BetterThermostat._run_valve_maintenance(bt, ["climate.trv"])

--- a/tests/unit/test_helpers_device_model.py
+++ b/tests/unit/test_helpers_device_model.py
@@ -1,0 +1,99 @@
+"""Model detection through the device registry (helpers.get_device_model).
+
+Priority is ``model_id`` > ``model`` before parentheses > ``model`` > the
+configured model > ``"generic"``. The registry lookup is best effort: when it
+cannot be performed the fallback chain still yields a name, and the reason is
+recorded at debug level.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.utils.helpers import get_device_model
+
+_HELPERS = "custom_components.better_thermostat.utils.helpers"
+
+
+def _bt(model: str | None = None) -> MagicMock:
+    """Build the caller surface get_device_model reads."""
+    bt = MagicMock()
+    bt.hass = MagicMock()
+    bt.device_name = "Test BT"
+    bt.model = model
+    return bt
+
+
+def _registries(device: object | None):
+    """Patch the entity and device registries to resolve to *device*."""
+    entity_reg = MagicMock()
+    entity_reg.async_get.return_value = SimpleNamespace(device_id="dev1")
+    dev_reg = MagicMock()
+    dev_reg.async_get.return_value = device
+    return (
+        patch(f"{_HELPERS}.er.async_get", return_value=entity_reg),
+        patch(f"{_HELPERS}.dr.async_get", return_value=dev_reg),
+    )
+
+
+def _device(**kwargs) -> SimpleNamespace:
+    """Build a device-registry entry with the fields the lookup reads."""
+    fields = {
+        "manufacturer": "Sonoff",
+        "model": None,
+        "model_id": None,
+        "name": "Valve",
+        "identifiers": {("mqtt", "0x1234")},
+    }
+    fields.update(kwargs)
+    return SimpleNamespace(**fields)
+
+
+@pytest.mark.asyncio
+async def test_model_id_wins():
+    """A device that reports model_id is identified by it."""
+    er_patch, dr_patch = _registries(_device(model_id="TRVZB", model="TRV (Sonoff)"))
+    with er_patch, dr_patch:
+        assert await get_device_model(_bt(), "climate.trv") == "TRVZB"
+
+
+@pytest.mark.asyncio
+async def test_model_before_parentheses():
+    """Without model_id the model up to the description is used."""
+    er_patch, dr_patch = _registries(_device(model="TS0601 _TZE284 (Beok)"))
+    with er_patch, dr_patch:
+        assert await get_device_model(_bt(), "climate.trv") == "TS0601 _TZE284"
+
+
+@pytest.mark.asyncio
+async def test_unknown_device_falls_back_to_configured_model():
+    """An unresolvable device falls back to the configured model."""
+    er_patch, dr_patch = _registries(None)
+    with er_patch, dr_patch:
+        assert await get_device_model(_bt(model="TRVZB"), "climate.trv") == "TRVZB"
+
+
+@pytest.mark.asyncio
+async def test_registry_failure_is_traced_and_falls_back(caplog):
+    """An unreachable registry yields "generic" and names the entity."""
+    with (
+        caplog.at_level(logging.DEBUG, logger=_HELPERS),
+        patch(f"{_HELPERS}.er.async_get", side_effect=RuntimeError("no registry")),
+    ):
+        assert await get_device_model(_bt(), "climate.trv") == "generic"
+    assert "device registry lookup for climate.trv failed" in caplog.text
+    assert any(record.exc_info for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_successful_lookup_is_not_traced_as_a_failure(caplog):
+    """A registry hit reports the device it found, not a failure."""
+    er_patch, dr_patch = _registries(_device(model_id="TRVZB"))
+    with caplog.at_level(logging.DEBUG, logger=_HELPERS), er_patch, dr_patch:
+        assert await get_device_model(_bt(), "climate.trv") == "TRVZB"
+    assert "failed" not in caplog.text
+    assert "identifiers=[('mqtt', '0x1234')]" in caplog.text

--- a/tests/unit/test_helpers_logbook_entry.py
+++ b/tests/unit/test_helpers_logbook_entry.py
@@ -1,0 +1,68 @@
+"""Logbook annunciation (helpers.async_fire_logbook_entry).
+
+The entry carries the translated message for *key* when the translation
+catalogue can be read, and the caller-supplied default otherwise. Either way
+the event is fired, and a catalogue that cannot be read is recorded at debug
+level.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.utils.helpers import async_fire_logbook_entry
+
+_HELPERS = "custom_components.better_thermostat.utils.helpers"
+_TRANSLATIONS = "homeassistant.helpers.translation.async_get_translations"
+_KEY = "component.better_thermostat.entity.sensor.logbook.state.window_open"
+
+
+def _bt() -> MagicMock:
+    """Build the caller surface async_fire_logbook_entry reads."""
+    bt = MagicMock()
+    bt.hass = MagicMock()
+    bt.hass.config.language = "de"
+    bt.entity_id = "climate.test_bt"
+    bt.name = "Test BT"
+    return bt
+
+
+def _fired(bt: MagicMock) -> dict:
+    """Return the payload of the single fired logbook event."""
+    bt.hass.bus.async_fire.assert_called_once()
+    return bt.hass.bus.async_fire.call_args[0][1]
+
+
+@pytest.mark.asyncio
+async def test_translated_message_is_used():
+    """A catalogue hit replaces the default message."""
+    bt = _bt()
+    with patch(_TRANSLATIONS, AsyncMock(return_value={_KEY: "Fenster offen"})):
+        await async_fire_logbook_entry(bt, "window_open", "Window open")
+    assert _fired(bt)["message"] == "Fenster offen"
+
+
+@pytest.mark.asyncio
+async def test_missing_translation_keeps_the_default():
+    """A catalogue without the key keeps the default message."""
+    bt = _bt()
+    with patch(_TRANSLATIONS, AsyncMock(return_value={})):
+        await async_fire_logbook_entry(bt, "window_open", "Window open")
+    assert _fired(bt)["message"] == "Window open"
+
+
+@pytest.mark.asyncio
+async def test_unreadable_catalogue_is_traced_and_entry_still_fires(caplog):
+    """A catalogue that raises still yields an entry with the default message."""
+    bt = _bt()
+    with (
+        caplog.at_level(logging.DEBUG, logger=_HELPERS),
+        patch(_TRANSLATIONS, AsyncMock(side_effect=RuntimeError("no catalogue"))),
+    ):
+        await async_fire_logbook_entry(bt, "window_open", "Window open")
+    assert _fired(bt)["message"] == "Window open"
+    assert "logbook translation for window_open unavailable" in caplog.text
+    assert any(record.exc_info for record in caplog.records)

--- a/tests/unit/test_humidity_attribute_exposure.py
+++ b/tests/unit/test_humidity_attribute_exposure.py
@@ -6,45 +6,12 @@ exposing the current-humidity reading under that key triggers the scene
 reproduce-state path to call an unsupported action.
 """
 
-from datetime import UTC, datetime
 import json
-from unittest.mock import MagicMock
 
-from homeassistant.components.climate.const import ClimateEntityFeature, HVACMode
+from homeassistant.components.climate.const import ClimateEntityFeature
 
 from custom_components.better_thermostat.climate import BetterThermostat
-
-
-def _make_mock_bt(**overrides):
-    """Construct a mock_bt sufficient for the ``extra_state_attributes`` property."""
-    bt = MagicMock()
-    bt.window_open = False
-    bt.call_for_heat = True
-    bt.last_change = datetime(2026, 5, 18, tzinfo=UTC)
-    bt._saved_temperature = None
-    bt._preset_temperature = None
-    bt._current_humidity = None
-    bt.last_main_hvac_mode = HVACMode.HEAT
-    bt.off_temperature = None
-    bt.tolerance = 0.5
-    bt.bt_target_temp_step = 0.5
-    bt.heating_power = 0.1
-    bt.heat_loss_rate = 0.0
-    bt.devices_errors = []
-    bt.devices_states = {}
-    bt.cur_temp_filtered = 20.5
-    bt.degraded_mode = False
-    bt.unavailable_sensors = []
-    bt.real_trvs = {}
-    bt.heating_cycles = []
-    bt.loss_cycles = []
-    bt.last_heating_power_stats = {}
-    bt.last_heat_loss_stats = {}
-    bt.next_valve_maintenance = None
-    bt._preset_cool_temperatures = {}
-    for k, v in overrides.items():
-        setattr(bt, k, v)
-    return bt
+from tests.factories import make_state_attributes_bt
 
 
 class TestHumidityAttributeExposure:
@@ -52,7 +19,9 @@ class TestHumidityAttributeExposure:
 
     def test_no_humidity_key_in_attributes_without_sensor(self):
         """Without a configured humidity sensor, no ``humidity`` key is exposed."""
-        bt = _make_mock_bt(humidity_sensor_entity_id=None, _current_humidity=None)
+        bt = make_state_attributes_bt(
+            humidity_sensor_entity_id=None, _current_humidity=None
+        )
         attrs = BetterThermostat.extra_state_attributes.fget(bt)
         assert "humidity" not in attrs
 
@@ -63,7 +32,7 @@ class TestHumidityAttributeExposure:
         property — using the reserved key collides with the climate target
         humidity attribute that drives ``climate.set_humidity``.
         """
-        bt = _make_mock_bt(
+        bt = make_state_attributes_bt(
             humidity_sensor_entity_id="sensor.room_humidity", _current_humidity=42.5
         )
         attrs = BetterThermostat.extra_state_attributes.fget(bt)
@@ -71,7 +40,7 @@ class TestHumidityAttributeExposure:
 
     def test_target_humidity_feature_not_advertised(self):
         """BT must not advertise ``TARGET_HUMIDITY`` in its supported feature set."""
-        bt = _make_mock_bt(cooler_entity_id=None)
+        bt = make_state_attributes_bt(cooler_entity_id=None)
         bt._support_flags = (
             ClimateEntityFeature.TARGET_TEMPERATURE
             | ClimateEntityFeature.PRESET_MODE
@@ -89,7 +58,7 @@ class TestExtraStateAttributesSmoke:
 
     def test_returns_dict_with_expected_keys(self):
         """The property returns a dict with the documented top-level keys."""
-        bt = _make_mock_bt()
+        bt = make_state_attributes_bt()
         attrs = BetterThermostat.extra_state_attributes.fget(bt)
         assert isinstance(attrs, dict)
         for required in (

--- a/tests/unit/test_migrate_v0_stores.py
+++ b/tests/unit/test_migrate_v0_stores.py
@@ -12,6 +12,7 @@ Covers:
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -28,6 +29,8 @@ from custom_components.better_thermostat.utils.state_manager import (
     StateManager,
     ThermalStats,
 )
+
+_MIGRATE_LOGGER = "custom_components.better_thermostat.utils.migrate_v0_stores"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -619,3 +622,60 @@ class TestMigrateV0Stores:
 
         # No data imported, no save
         mgr.save.assert_not_called()
+
+
+class TestUnreadableLegacyStoreIsTraced:
+    """A legacy store that cannot be read leaves a debug trace naming it."""
+
+    @pytest.mark.asyncio
+    async def test_every_failing_store_is_named(self, caplog) -> None:
+        """All four store names and the config entry appear in the trace."""
+        mgr = _make_state_manager()
+        mgr.save = AsyncMock()  # type: ignore[method-assign]
+
+        failing_store = MagicMock()
+        failing_store.async_load = AsyncMock(side_effect=OSError("boom"))
+        store_iter = iter([failing_store] * 4)
+
+        with (
+            caplog.at_level(logging.DEBUG, logger=_MIGRATE_LOGGER),
+            patch(
+                "custom_components.better_thermostat.utils.migrate_v0_stores.Store",
+                side_effect=lambda _hass, _ver, _key: next(store_iter),
+            ),
+        ):
+            await migrate_v0_stores(
+                AsyncMock(), mgr, entity_prefix="uid1:", config_entry_id="entry1"
+            )
+
+        for store_name in ("MPC", "PID", "TPI", "thermal"):
+            assert f"legacy {store_name} store not imported" in caplog.text
+        assert "entry1" in caplog.text
+        assert all(record.exc_info for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_readable_stores_leave_no_trace(self, caplog) -> None:
+        """Stores that read cleanly report nothing."""
+        mgr = _make_state_manager()
+        mgr.save = AsyncMock()  # type: ignore[method-assign]
+
+        stores = [
+            _make_mock_store({"uid1:trv_a": {"gain_est": 0.5}}),
+            _make_mock_store(None),
+            _make_mock_store(None),
+            _make_mock_store(None),
+        ]
+        store_iter = iter(stores)
+
+        with (
+            caplog.at_level(logging.DEBUG, logger=_MIGRATE_LOGGER),
+            patch(
+                "custom_components.better_thermostat.utils.migrate_v0_stores.Store",
+                side_effect=lambda _hass, _ver, _key: next(store_iter),
+            ),
+        ):
+            await migrate_v0_stores(
+                AsyncMock(), mgr, entity_prefix="uid1:", config_entry_id="entry1"
+            )
+
+        assert "not imported" not in caplog.text

--- a/tests/unit/test_mqtt_adapter_init.py
+++ b/tests/unit/test_mqtt_adapter_init.py
@@ -1,0 +1,86 @@
+"""Early valve discovery in the MQTT adapter's init.
+
+Zigbee2MQTT exposes the valve position as a separate number entity, which the
+adapter looks up once at startup. The lookup walks the entity and device
+registries, so it is best effort: a lookup that fails leaves the TRV without a
+valve entity and records why, and startup continues.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.adapters.mqtt import init
+from custom_components.better_thermostat.trv import Trv
+
+ENTITY_ID = "climate.test_trv"
+_MQTT_LOGGER = "custom_components.better_thermostat.adapters.mqtt"
+_FIND_VALVE = "custom_components.better_thermostat.utils.helpers.find_valve_entity"
+
+
+def _bt() -> MagicMock:
+    """Build a BetterThermostat stand-in whose calibration needs no lookup."""
+    bt = MagicMock()
+    bt.device_name = "Test BT"
+    bt.real_trvs = {ENTITY_ID: Trv(entity_id=ENTITY_ID, calibration=1)}
+    return bt
+
+
+@pytest.mark.asyncio
+async def test_writable_valve_entity_is_adopted():
+    """A writable valve entity is stored together with its writability."""
+    bt = _bt()
+    valve = {"entity_id": "number.valve_position", "writable": True}
+    with patch(_FIND_VALVE, AsyncMock(return_value=valve)):
+        await init(bt, ENTITY_ID)
+    assert bt.real_trvs[ENTITY_ID].valve_position_entity == "number.valve_position"
+    assert bt.real_trvs[ENTITY_ID].valve_position_writable is True
+
+
+@pytest.mark.asyncio
+async def test_read_only_valve_entity_is_marked_unwritable():
+    """A valve entity without write support is stored as read-only."""
+    bt = _bt()
+    valve = {"entity_id": "sensor.valve_position", "writable": False}
+    with patch(_FIND_VALVE, AsyncMock(return_value=valve)):
+        await init(bt, ENTITY_ID)
+    assert bt.real_trvs[ENTITY_ID].valve_position_writable is False
+
+
+@pytest.mark.asyncio
+async def test_no_valve_entity_leaves_the_trv_untouched():
+    """Without a discovered entity the TRV keeps its defaults."""
+    bt = _bt()
+    with patch(_FIND_VALVE, AsyncMock(return_value=None)):
+        await init(bt, ENTITY_ID)
+    assert bt.real_trvs[ENTITY_ID].valve_position_entity is None
+
+
+@pytest.mark.asyncio
+async def test_failed_discovery_is_traced_and_init_continues(caplog):
+    """A discovery failure names the TRV and leaves the entity unset."""
+    bt = _bt()
+    with (
+        caplog.at_level(logging.DEBUG, logger=_MQTT_LOGGER),
+        patch(_FIND_VALVE, AsyncMock(side_effect=RuntimeError("no registry"))),
+    ):
+        await init(bt, ENTITY_ID)
+    assert bt.real_trvs[ENTITY_ID].valve_position_entity is None
+    assert f"valve entity discovery for {ENTITY_ID} failed" in caplog.text
+    assert any(record.exc_info for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_successful_discovery_is_not_traced_as_a_failure(caplog):
+    """A discovery that lands reports nothing."""
+    bt = _bt()
+    valve = {"entity_id": "number.valve_position", "writable": True}
+    with (
+        caplog.at_level(logging.DEBUG, logger=_MQTT_LOGGER),
+        patch(_FIND_VALVE, AsyncMock(return_value=valve)),
+    ):
+        await init(bt, ENTITY_ID)
+    assert "failed" not in caplog.text

--- a/tests/unit/test_pid_state_updates.py
+++ b/tests/unit/test_pid_state_updates.py
@@ -1,0 +1,146 @@
+"""Per-cycle state updates inside compute_pid.
+
+Three writes happen alongside the control output: the slope EMA, the
+integrator relief on a sign flip, and the error sign kept for the next cycle.
+The first two are arithmetic on caller-owned state, so a non-numeric value
+skips that single update and is recorded; the error sign is written on every
+cycle.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from custom_components.better_thermostat.utils.calibration.pid import (
+    PIDParams,
+    PIDState,
+    compute_pid,
+)
+
+_PID_LOGGER = "custom_components.better_thermostat.utils.calibration.pid"
+_PARAMS = PIDParams(auto_tune=False, min_hold_time_s=0.0)
+
+
+class _RefusesComparison:
+    """A band that cannot be compared to a temperature difference."""
+
+    def __ge__(self, other):
+        return NotImplemented
+
+
+class _FailsComparison:
+    """A band whose comparison fails for a reason other than its type."""
+
+    def __ge__(self, other):
+        raise ValueError("boom")
+
+
+class _RefusesSlopeWrite(PIDState):
+    """A state whose slope EMA cannot be written."""
+
+    def __setattr__(self, name, value):
+        if name == "ema_slope" and value is not None:
+            raise ValueError("boom")
+        super().__setattr__(name, value)
+
+
+def _compute(params: PIDParams, state: PIDState, **overrides):
+    """Run one cycle with a fixed clock and a rising-temperature default."""
+    kwargs = {
+        "inp_target_temp_C": 21.0,
+        "inp_current_temp_C": 20.0,
+        "inp_trv_temp_C": 20.0,
+        "inp_temp_slope_K_per_min": 0.02,
+        "key": "bt:climate.trv",
+    }
+    kwargs.update(overrides)
+    return compute_pid(params=params, state=state, now=1000.0, **kwargs)
+
+
+class TestSlopeEma:
+    """The slope EMA blends the new reading into the stored one."""
+
+    def test_first_reading_seeds_the_ema(self):
+        """Without a stored value the reading is adopted as is."""
+        _, _, state = _compute(_PARAMS, PIDState())
+        assert state.ema_slope == pytest.approx(0.02)
+
+    def test_further_readings_are_blended(self):
+        """A stored value is blended 60/40 with the new reading."""
+        _, _, state = _compute(_PARAMS, PIDState(ema_slope=0.07))
+        assert state.ema_slope == pytest.approx(0.6 * 0.07 + 0.4 * 0.02)
+
+    def test_non_numeric_stored_value_is_traced(self, caplog):
+        """A stored value that is not a number skips the blend and is recorded."""
+        state = PIDState()
+        state.ema_slope = "warm"  # type: ignore[assignment]
+        with caplog.at_level(logging.DEBUG, logger=_PID_LOGGER):
+            percent, _, out = _compute(_PARAMS, state)
+        assert percent >= 0.0
+        assert out.ema_slope == "warm"
+        assert "slope EMA update skipped for bt:climate.trv" in caplog.text
+
+    def test_unexpected_write_failure_propagates(self):
+        """A failure that is not a type mismatch reaches the caller."""
+        with pytest.raises(ValueError):
+            _compute(_PARAMS, _RefusesSlopeWrite())
+
+
+class TestIntegratorRelief:
+    """A sign flip inside the steady-state band relieves the integrator."""
+
+    @staticmethod
+    def _flipped_state() -> PIDState:
+        """State whose previous error had the opposite sign."""
+        return PIDState(last_error_sign=1, pid_integral=40.0, pid_last_time=990.0)
+
+    def _flip_cycle(self, params: PIDParams, state: PIDState, **overrides):
+        """Run a cycle whose error is small and negative."""
+        return _compute(
+            params, state, inp_target_temp_C=20.0, inp_current_temp_C=20.05, **overrides
+        )
+
+    def test_relief_applies_on_a_sign_flip(self):
+        """The relief flag is reported and the integrator shrinks."""
+        _, debug, state = self._flip_cycle(_PARAMS, self._flipped_state())
+        assert debug["i_relief"] is True
+        assert state.pid_integral < 40.0
+
+    def test_no_relief_without_a_sign_flip(self):
+        """A same-sign error leaves the integrator alone."""
+        state = PIDState(last_error_sign=-1, pid_integral=40.0, pid_last_time=990.0)
+        _, debug, _ = self._flip_cycle(_PARAMS, state)
+        assert debug["i_relief"] is False
+
+    def test_non_numeric_band_is_traced(self, caplog):
+        """A band that is not a number skips the relief and is recorded."""
+        params = PIDParams(auto_tune=False, min_hold_time_s=0.0)
+        params.steady_state_band_K = _RefusesComparison()  # type: ignore[assignment]
+        with caplog.at_level(logging.DEBUG, logger=_PID_LOGGER):
+            _, debug, _ = self._flip_cycle(params, self._flipped_state())
+        assert debug["i_relief"] is False
+        assert "integrator relief skipped for bt:climate.trv" in caplog.text
+
+    def test_unexpected_band_failure_propagates(self):
+        """A failure that is not a type mismatch reaches the caller."""
+        params = PIDParams(auto_tune=False, min_hold_time_s=0.0)
+        params.steady_state_band_K = _FailsComparison()  # type: ignore[assignment]
+        with pytest.raises(ValueError):
+            self._flip_cycle(params, self._flipped_state())
+
+
+class TestErrorSign:
+    """The error sign is recorded on every cycle."""
+
+    @pytest.mark.parametrize(
+        ("target", "current", "expected"),
+        [(21.0, 20.0, 1), (20.0, 21.0, -1), (20.0, 20.0, 0)],
+    )
+    def test_sign_recorded(self, target, current, expected):
+        """A positive, negative, and zero error each store their sign."""
+        _, _, state = _compute(
+            _PARAMS, PIDState(), inp_target_temp_C=target, inp_current_temp_C=current
+        )
+        assert state.last_error_sign == expected

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -545,8 +545,58 @@ class TestInternalTemperatureChange:
 # ---------------------------------------------------------------------------
 
 
+class _UnprintableValvePosition:
+    """A valve reading that cannot be rendered as text."""
+
+    def __str__(self):
+        raise RuntimeError("boom")
+
+
 class TestHvacActionAndValvePosition:
     """Tests for hvac_action / valve_position cache updates."""
+
+    @pytest.mark.asyncio
+    async def test_unreadable_valve_position_propagates(self, mock_bt):
+        """A valve reading that cannot be parsed reaches the caller."""
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "valve_position": _UnprintableValvePosition(),
+            }
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with (
+            patch(
+                "custom_components.better_thermostat.events.trv.convert_inbound_states",
+                return_value=HVACMode.HEAT,
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+    @pytest.mark.asyncio
+    async def test_valve_position_cached_from_attribute(self, mock_bt):
+        """A numeric valve reading is cached on the TRV."""
+        trv_state = _make_state(
+            attributes={
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "valve_position": "42",
+            }
+        )
+        mock_bt.hass.states.get.return_value = trv_state
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].valve_position == 42.0
 
     @pytest.mark.asyncio
     async def test_hvac_action_updated_from_attribute(self, mock_bt):

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -557,7 +557,7 @@ class TestHvacActionAndValvePosition:
 
     @pytest.mark.asyncio
     async def test_unreadable_valve_position_propagates(self, mock_bt):
-        """A valve reading that cannot be parsed reaches the caller."""
+        """A valve reading that cannot be rendered as text reaches the caller."""
         trv_state = _make_state(
             attributes={
                 "current_temperature": 18.0,

--- a/tests/unit/test_trv_object.py
+++ b/tests/unit/test_trv_object.py
@@ -31,8 +31,10 @@ class TestTypedAccess:
         trv = _make()
         trv.current_temperature = 21.5
         trv.ignore_trv_states = True
+        trv.hvac_action = "heating"
         assert trv.current_temperature == 21.5
         assert trv.ignore_trv_states is True
+        assert trv.hvac_action == "heating"
 
 
 class TestExtraScratchpad:

--- a/tests/unit/test_valve_maintenance.py
+++ b/tests/unit/test_valve_maintenance.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -35,6 +36,8 @@ from custom_components.better_thermostat.utils.valve_maintenance import (
     run_valve_maintenance,
     wake_step,
 )
+
+_MAINTENANCE_LOGGER = "custom_components.better_thermostat.utils.valve_maintenance"
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -381,6 +384,30 @@ class TestRestoreOne:
         info = _info(cur_temp=20.0, cur_mode="heat")
         await restore_one(info, set_temperature_fn=temp_fn, set_hvac_mode_fn=mode_fn)
         mode_fn.assert_awaited_once_with("climate.trv1", "heat")
+
+    @pytest.mark.asyncio
+    async def test_failed_restores_are_traced(self, caplog):
+        """Both restore writes report the TRV they could not reach."""
+        temp_fn = AsyncMock(side_effect=RuntimeError("fail"))
+        mode_fn = AsyncMock(side_effect=HomeAssistantError("fail"))
+        info = _info(cur_temp=20.0, cur_mode="heat")
+        with caplog.at_level(logging.DEBUG, logger=_MAINTENANCE_LOGGER):
+            await restore_one(
+                info, set_temperature_fn=temp_fn, set_hvac_mode_fn=mode_fn
+            )
+        assert "restoring the setpoint of climate.trv1 failed" in caplog.text
+        assert "restoring the HVAC mode of climate.trv1 failed" in caplog.text
+        assert all(record.exc_info for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_successful_restore_is_not_traced(self, caplog):
+        """A restore that lands reports nothing."""
+        info = _info(cur_temp=20.0, cur_mode="heat")
+        with caplog.at_level(logging.DEBUG, logger=_MAINTENANCE_LOGGER):
+            await restore_one(
+                info, set_temperature_fn=AsyncMock(), set_hvac_mode_fn=AsyncMock()
+            )
+        assert "failed" not in caplog.text
 
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What changes

Every exception handler under `custom_components/` whose entire body was a bare `pass` behind a blind `except Exception` now does one of three things, chosen from what the guarded code can actually raise.

### Narrowed to the type the call can raise

| Site | Catches | Why |
|---|---|---|
| `climate.py` post-maintenance control kick | `AttributeError` silently, the rest traced | `request_control_cycle` reads `self.control_queue_task`; a queue that is not there yet is the only failure it has, and `asyncio.QueueFull` is already handled inside the scheduler. The kick is the last statement of the maintenance `finally` block, so anything it does let escape would replace whichever failure the run is propagating — the residual `except Exception` keeps that from happening and records what it caught. |
| `climate.py` `_get_outdoor_temp` | `AttributeError` + debug trace | `convert_to_float_celsius` absorbs every parse failure itself and returns `None`; what remains is attribute access on the state object. |
| `calibration/pid.py` slope-EMA blend | `TypeError` + debug trace | Arithmetic on `ema_slope` and the slope reading, both typed `float \| None`. |
| `calibration/pid.py` integrator relief | `TypeError` + debug trace | Comparison against `params.steady_state_band_K` and a multiplication of the integrator. |

### Dissolved, because the statement cannot raise

| Site | Proof |
|---|---|
| `climate.py` `next_valve_maintenance` attribute | Every write site assigns `datetime` (`clock.now()`, `compute_initial_maintenance`, `compute_next_maintenance`, `MaintenanceState.next_due`), the `is not None` check covers the rest, and `self.last_change.isoformat()` runs unguarded in the same dict literal. `__init__` sets the attribute unconditionally, so the `hasattr` probe went with it. This is the one dissolution with a reachable behaviour change, and it is pinned. |
| `climate.py` `valve_method` summary | The property reads `self.real_trvs` unguarded on both sides of the removed guard: the same dict literal iterates `self.real_trvs.items()` twenty lines above, and `collect_balance_attrs` reads `info.calibration_balance` off every entry a few lines below. A `real_trvs` shape that trips the removed guard raises outside it either way. |
| `climate.py` TRV `hvac_action` cache write | `info` is `isinstance`-checked as `Trv`, and `Trv` is a plain `@dataclass` — not frozen, no `__slots__`, no property. A field assignment cannot raise. |
| `events/trv.py` `hvac_action` / `valve_position` cache | `_org_trv_state.attributes.get(...)` runs unguarded thirteen lines above in `adopt_reported_hvac_modes`, and `convert_to_float` absorbs unparseable readings. |
| `calibration/pid.py` error-sign write | `e` is `inp_target_temp_C - current_temp`; if either were non-numeric the subtraction would already have raised outside the guard. Comparing a float to `0` cannot raise, and `PIDState` is a plain `@dataclass`. |
| `helpers.py` guard around a `_LOGGER.debug` call | `device` is `DeviceEntry \| None` and `identifiers` is a `set`, so the eager `list(...)` argument cannot raise. The enclosing registry handler still covers the unforeseen. |

### Breadth kept, trace added

These reach into the Home Assistant entity and device registries, the translation catalogue, climate services, and on-disk store files, so the set of things they can see is genuinely open. Each now logs at debug with `exc_info=True`, using the module's own logger and message style.

- `utils/migrate_v0_stores.py` (four handlers). **This is deliberate swallowing, so it stays a log and not a narrowing.** The four v0 store files are external on-disk artifacts. A file that is corrupt, unreadable, or holds a shape `deserialize_*` chokes on must not abort startup and must not stop the other three imports from running. Narrowing would put a user's whole integration into a retry loop over one bad file. Each handler now names which store it could not import and the config entry it belongs to.
- `utils/valve_maintenance.py` `restore_one` (two handlers). The restore writes go through adapter service calls; one TRV that will not take its setpoint must not abort the mode restore or the restore of the next TRV. Each now names the TRV.
- `utils/helpers.py` `get_device_model` — registry access is best effort and the fallback chain still yields a name.
- `utils/helpers.py` `async_fire_logbook_entry` — a catalogue that cannot be read leaves the default message in place, and the entry still fires.
- `adapters/mqtt.py` `init` — valve discovery walks both registries; a failure leaves the TRV without a valve entity and startup continues.

## Behaviour

Two kinds of change are observable, and each is pinned by a test:

1. A failure other than the narrowed type no longer vanishes: it propagates (`_get_outdoor_temp`, both PID blocks, the `events/trv.py` cache), or it is recorded (the control kick, where escaping would mask the maintenance run's own error).
2. `next_valve_maintenance` no longer drops its attribute when the stored stamp is not a timestamp; the `AttributeError` surfaces.
3. Fourteen sites emit a debug record they did not emit before.

Everything else is neutral. Four of the five remaining dissolutions sit on statements the type analysis above shows cannot raise, so the attribute dict and the cached TRV fields are identical for every input the code can be reached with.

## Not in scope

The ticket's search was handlers whose body is `pass` or `continue`. That set is now empty under `custom_components/`. An AST scan finds **15** further broad `except Exception` handlers that are equally silent but store a value or return instead — `adapters/delegate.py` (2), `adapters/zwave_js.py`, `climate.py` (4), `sensor.py`, `calibration/mpc.py`, `calibration/pid.py` (2), `utils/helpers.py` (3), `utils/valve_maintenance.py`. One of them, `climate.py` `except Exception: action_str = ""`, is the outer half of the pair whose inner guard this PR dissolved.

For anyone lining up a `BLE001` gate: `ruff check --isolated --select BLE001 custom_components/` reports **69** findings on this branch against **79** on `develop`. `BLE001` does not exempt a handler that logs with `exc_info=True` — only one that re-raises or calls `logging.exception` — so the nine handlers this PR deliberately keeps blind are still in that count. Enabling the rule is a separate decision from this ticket, and it would need per-site `noqa` for the deliberate ones.

## Verification

|  | Base `d0a2be6b` | This branch |
|---|---|---|
| `pytest tests/ -q` | 7115 passed, 1 skipped | **7158 passed, 1 skipped** |
| `ruff check .` | All checks passed | All checks passed |
| `ruff format --check .` | 313 files already formatted | 318 files already formatted |
| `pyrefly check` | 0 errors (3 suppressed) | 0 errors (3 suppressed) |

The added tests were checked by mutation, not by reading: reverting the whole `custom_components/` diff and re-running turns **14 of them red** — every narrowing in both directions (the narrowed type still caught, the unexpected one surfacing), every new log line, the `events/trv.py` dissolution and the `next_valve_maintenance` one. The one behaviour change mutation cannot see is the control kick no longer masking the maintenance run — the handler it replaces swallowed too — so that one has its own regression test. The remaining new tests pin contracts that are neutral by construction plus negative controls asserting the success paths log no failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat maintenance, valve discovery, temperature reading, and state restoration reliability.
  * Prevented unexpected errors from being silently suppressed, allowing them to surface appropriately while preserving normal fallback behavior.
  * Improved handling of PID updates, TRV readings, device details, logbook translations, and legacy data migration.

* **Tests**
  * Expanded coverage for optional attributes, maintenance workflows, MQTT discovery, PID updates, TRV behavior, migrations, and error logging.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->