### PR TITLE
fix: patch find_valve_entity where the mqtt adapter binds it

### DIFF
--- a/tests/unit/test_mqtt_adapter_init.py
+++ b/tests/unit/test_mqtt_adapter_init.py
@@ -18,7 +18,7 @@ from custom_components.better_thermostat.trv import Trv
 
 ENTITY_ID = "climate.test_trv"
 _MQTT_LOGGER = "custom_components.better_thermostat.adapters.mqtt"
-_FIND_VALVE = "custom_components.better_thermostat.utils.helpers.find_valve_entity"
+_FIND_VALVE = "custom_components.better_thermostat.adapters.mqtt.find_valve_entity"
 
 
 def _bt() -> MagicMock:


### PR DESCRIPTION
`develop` is red: `tests/unit/test_mqtt_adapter_init.py` fails three tests at `19de90df`.

Neither #2255 nor #2256 fails on its own, which is why both went green through CI and merged:

- #2256 added `test_mqtt_adapter_init.py`. At the time, `adapters/mqtt.py` imported `find_valve_entity` **inside** `init()`, so the lookup happened at call time and patching `utils.helpers.find_valve_entity` reached it.
- #2255 hoisted that import to module level. The name is now bound in `adapters.mqtt` when the module loads, so patching the source module rebinds something `init()` never consults — the real lookup runs, finds no entity, and the three assertions fail.

The fix moves the patch target to the binding the call actually uses:

```python
-_FIND_VALVE = "custom_components.better_thermostat.utils.helpers.find_valve_entity"
+_FIND_VALVE = "custom_components.better_thermostat.adapters.mqtt.find_valve_entity"
```

Test-only; `adapters/mqtt.py` is unchanged.

**Verified**

- `pytest tests/` — 7177 passed, 1 skipped (was 3 failed / 7174 passed on `develop`)
- `ruff check`, `ruff format --check` clean
- Counter-check by mutation: setting `valve_position_entity = None` in `init()` makes `test_writable_valve_entity_is_adopted` fail again, so the patched test still pins the behaviour rather than passing vacuously.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated valve discovery test mocking to reflect the MQTT adapter’s current behavior.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->