### PR TITLE
fix: rename BT entity ids only when the thermostat was renamed (1.9)

### DIFF
--- a/custom_components/better_thermostat/__init__.py
+++ b/custom_components/better_thermostat/__init__.py
@@ -23,6 +23,7 @@ from .utils.const import (
     CONF_WINDOW_TIMEOUT,
     CONF_WINDOW_TIMEOUT_AFTER,
     DOMAIN,
+    NORMALIZED_ID_NAMES,
     CalibrationMode,
 )
 from .utils.helpers import get_device_model
@@ -106,6 +107,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     be cleaned up here to avoid stale warnings after a config entry is gone.
     """
     hass.data.get(RELOAD_LOCKS, {}).pop(entry.entry_id, None)
+    hass.data.get(NORMALIZED_ID_NAMES, {}).pop(entry.entry_id, None)
 
     device_name = entry.data.get(CONF_NAME, entry.title)
 

--- a/custom_components/better_thermostat/__init__.py
+++ b/custom_components/better_thermostat/__init__.py
@@ -100,11 +100,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Remove repair-registry issues created by this Better Thermostat instance.
+    """Clean up everything this Better Thermostat instance left behind.
 
-    Issues are scoped by ``device_name`` or by individual ``entity_id`` and
-    persist in HA's issue registry until explicitly deleted, so they have to
-    be cleaned up here to avoid stale warnings after a config entry is gone.
+    Repair-registry issues are scoped by ``device_name`` or by individual
+    ``entity_id`` and persist in HA's issue registry until explicitly
+    deleted, so they have to be cleaned up here to avoid stale warnings
+    after a config entry is gone. The reload lock and the recorded
+    entity-id names outlive the entry's unload by design, so removal is
+    where they are dropped.
+
+    Parameters
+    ----------
+    hass : HomeAssistant
+        The running Home Assistant instance.
+    entry : ConfigEntry
+        The config entry being removed.
     """
     hass.data.get(RELOAD_LOCKS, {}).pop(entry.entry_id, None)
     hass.data.get(NORMALIZED_ID_NAMES, {}).pop(entry.entry_id, None)

--- a/custom_components/better_thermostat/utils/const.py
+++ b/custom_components/better_thermostat/utils/const.py
@@ -20,6 +20,11 @@ DOMAIN: Final = "better_thermostat"
 
 DEFAULT_NAME: Final = "Better Thermostat"
 
+# ``hass.data`` key holding, per entry and platform, the thermostat name the
+# entity ids were last built from. It outlives the reload it describes and is
+# dropped when the entry is removed.
+NORMALIZED_ID_NAMES: Final = f"{DOMAIN}_normalized_id_names"
+
 
 class _Manifest(TypedDict):
     version: str

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import logging
 import math
 import re
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
 
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_STEP,
@@ -36,6 +36,7 @@ from custom_components.better_thermostat.utils.const import (
     MAX_REASONABLE_TEMPERATURE,
     MIN_HEATING_POWER,
     MIN_REASONABLE_TEMPERATURE,
+    NORMALIZED_ID_NAMES,
     VALVE_MIN_BASE,
     VALVE_MIN_OPENING_LARGE_DIFF,
     VALVE_MIN_PROPORTIONAL_SLOPE,
@@ -83,11 +84,16 @@ def find_device_entity(
     return None
 
 
+# Sentinel for "this platform has not been set up in this process yet".
+# ``None`` is a name an entry can genuinely carry, so it cannot say this.
+_NO_RECORDED_NAME: Final = object()
+
+
 @callback
 def async_normalize_bt_entity_ids(
     hass: HomeAssistant, entry: ConfigEntry, domain: str
 ) -> None:
-    """Rename stale BT registry entries so their entity_id tracks the name.
+    """Rename BT registry entries after the thermostat itself was renamed.
 
     HA's entity registry reuses the existing entry on reload (unique id ==
     config entry id), so the entity_id is frozen at first creation while only
@@ -96,11 +102,31 @@ def async_normalize_bt_entity_ids(
     would generate from the current name, before the platform re-adds the
     entities (which reuse the now-correct id).
 
+    A rename reaches this function as an in-process reload and nothing else
+    does, which is what separates it from a restart. The name the ids were
+    last built from is held per entry and platform for as long as the Home
+    Assistant instance lives, so a setup that finds no such name is a restart.
+    The ids in the registry are then whoever's they are, the user's included,
+    and an entity_id its owner chose is theirs to keep. Only a name that
+    differs from the recorded one is a rename, and only that renames anything.
+
     For the climate entity the device does not exist yet at this point in
     setup, so the desired id is derived directly from the configured name.
     For the auxiliary platforms the device already exists (climate set it up
     first), so HA's own ``async_regenerate_entity_id`` is used.
     """
+    name = entry.data.get(CONF_NAME)
+    normalized = hass.data.setdefault(NORMALIZED_ID_NAMES, {}).setdefault(
+        entry.entry_id, {}
+    )
+    # Recorded per platform: the four calls run in one setup pass, so a single
+    # record per entry would let the first of them mark the name as handled
+    # and leave the other three looking at a rename that already happened.
+    previous = normalized.get(domain, _NO_RECORDED_NAME)
+    normalized[domain] = name
+    if previous is _NO_RECORDED_NAME or previous == name:
+        return
+
     registry = er.async_get(hass)
     # The registry is populated lazily on first load; with a mocked hass
     # (unit tests) it is an unloaded shell without ``.entities``, so there is
@@ -124,7 +150,7 @@ def async_normalize_bt_entity_ids(
         except ValueError as err:
             _LOGGER.warning(
                 "better_thermostat %s: could not rename %s to %s: %s",
-                entry.data.get(CONF_NAME),
+                name,
                 reg_entry.entity_id,
                 desired,
                 err,

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -93,7 +93,7 @@ _NO_RECORDED_NAME: Final = object()
 def async_normalize_bt_entity_ids(
     hass: HomeAssistant, entry: ConfigEntry, domain: str
 ) -> None:
-    """Rename BT registry entries after the thermostat itself was renamed.
+    """Rename BT registry entries to follow a change of the thermostat name.
 
     HA's entity registry reuses the existing entry on reload (unique id ==
     config entry id), so the entity_id is frozen at first creation while only
@@ -114,6 +114,17 @@ def async_normalize_bt_entity_ids(
     setup, so the desired id is derived directly from the configured name.
     For the auxiliary platforms the device already exists (climate set it up
     first), so HA's own ``async_regenerate_entity_id`` is used.
+
+    Parameters
+    ----------
+    hass : HomeAssistant
+        The running Home Assistant instance, supplying the entity registry
+        and the runtime data the recorded names live in.
+    entry : ConfigEntry
+        The config entry whose entities are named after it.
+    domain : str
+        The entity platform being set up; only its registry entries are
+        considered, and each platform carries its own recorded name.
     """
     name = entry.data.get(CONF_NAME)
     normalized = hass.data.setdefault(NORMALIZED_ID_NAMES, {}).setdefault(

--- a/tests/integration/test_entry_lifecycle.py
+++ b/tests/integration/test_entry_lifecycle.py
@@ -151,3 +151,51 @@ async def test_climate_entity_id_follows_device_name_after_rename(hass, fake_trv
         == "sensor.bt_livingroom_temperature_ema"
     )
     assert hass.states.get("climate.bt_livingroom") is not None
+
+
+async def test_entity_ids_the_user_chose_survive_a_restart(hass, fake_trv):
+    """A restart leaves the ids in the registry alone, whoever wrote them.
+
+    An entity_id is the user's to set, and the ones seeded here are the
+    form somebody who named BT's entities themselves holds. Setting the
+    entry up finds them already in the registry, which is what a restart
+    looks like from the integration's side.
+
+    Both platforms are seeded: the climate entity derives its id from the
+    entry, the auxiliary ones from the device, and those are two different
+    code paths.
+    """
+    _room_sensor(hass)
+    entry = make_entry(name="Livingroom")
+    entry.add_to_hass(hass)
+
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "climate",
+        DOMAIN,
+        entry.entry_id,
+        config_entry=entry,
+        suggested_object_id="livingroom_thermostat",
+    )
+    registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        entry.entry_id + "_external_temp_ema",
+        config_entry=entry,
+        suggested_object_id="livingroom_thermostat_ema",
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    await wait_for_startup(hass, entry)
+
+    assert (
+        registry.async_get_entity_id("climate", DOMAIN, entry.entry_id)
+        == "climate.livingroom_thermostat"
+    )
+    assert (
+        registry.async_get_entity_id(
+            "sensor", DOMAIN, entry.entry_id + "_external_temp_ema"
+        )
+        == "sensor.livingroom_thermostat_ema"
+    )

--- a/tests/unit/test_helpers_entity_id_rename.py
+++ b/tests/unit/test_helpers_entity_id_rename.py
@@ -1,0 +1,138 @@
+"""Tests for the entity-id rename that follows a thermostat rename.
+
+``async_normalize_bt_entity_ids`` decides, per config entry and platform,
+whether the registry ids have to be rebuilt. The decision rests on a name
+recorded in ``hass.data``: absent means this process has not set the
+platform up before, which is a restart and leaves the ids alone. These
+tests drive that decision directly and cover what the registry does to a
+rename once the decision has been made in its favour.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.const import Platform
+
+from custom_components.better_thermostat.utils.const import DOMAIN
+from custom_components.better_thermostat.utils.helpers import (
+    async_normalize_bt_entity_ids,
+)
+
+
+def _entry(name):
+    """Build a config entry stub carrying ``name``."""
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.data = {"name": name}
+    return entry
+
+
+def _registry_entry(entity_id, domain):
+    """Build a registry entry stub this integration owns."""
+    reg_entry = MagicMock()
+    reg_entry.entity_id = entity_id
+    reg_entry.platform = DOMAIN
+    reg_entry.domain = domain
+    return reg_entry
+
+
+def _registry(entries):
+    """Build an entity registry stub holding ``entries``."""
+    registry = MagicMock()
+    registry.entities.get_entries_for_config_entry_id.return_value = entries
+    return registry
+
+
+def _rename(hass, entry, registry, domain=Platform.SENSOR):
+    """Run a rename of ``entry`` against ``registry`` and return the calls.
+
+    The first call records the name, so it is the second one -- the entry
+    now carrying a different name -- that is the rename under test.
+    """
+    with patch(
+        "custom_components.better_thermostat.utils.helpers.er.async_get",
+        return_value=registry,
+    ):
+        async_normalize_bt_entity_ids(hass, entry, domain)
+        entry.data = {**entry.data, "name": entry.data["name"] + " renamed"}
+        async_normalize_bt_entity_ids(hass, entry, domain)
+    return registry.async_update_entity.call_args_list
+
+
+def test_a_registry_without_entities_is_left_alone():
+    """An unloaded registry shell is not walked.
+
+    The registry is populated lazily, so before the first load it carries
+    no ``entities`` at all. Reaching for them would raise, and there is
+    nothing to rename in an empty registry either way.
+    """
+    hass = MagicMock()
+    hass.data = {}
+    # A shell carrying everything but the ``entities`` it has not loaded yet.
+    registry = MagicMock(spec=["async_update_entity", "async_regenerate_entity_id"])
+
+    calls = _rename(hass, _entry("Livingroom"), registry)
+
+    assert calls == []
+
+
+def test_an_id_that_already_matches_is_not_rewritten():
+    """A rename that leaves an id unchanged writes nothing.
+
+    Renaming "Livingroom" to "livingroom" changes the name the entry
+    carries but not the slug the ids are built from, and rewriting an
+    entity_id to itself is a registry error rather than a no-op.
+    """
+    hass = MagicMock()
+    hass.data = {}
+    reg_entry = _registry_entry("sensor.livingroom_temperature_ema", Platform.SENSOR)
+    registry = _registry([reg_entry])
+    registry.async_regenerate_entity_id.return_value = reg_entry.entity_id
+
+    calls = _rename(hass, _entry("Livingroom"), registry)
+
+    assert calls == []
+
+
+def test_a_rejected_rename_is_reported_and_the_others_still_run(caplog):
+    """One id the registry refuses does not cost the remaining ones.
+
+    ``async_update_entity`` raises when the target id is taken. The loop
+    walks every entity of the platform, so swallowing the rejection is
+    what keeps a single collision from stopping the rename half-done.
+    """
+    hass = MagicMock()
+    hass.data = {}
+    blocked = _registry_entry("sensor.livingroom_temperature_ema", Platform.SENSOR)
+    following = _registry_entry("sensor.livingroom_valve", Platform.SENSOR)
+    registry = _registry([blocked, following])
+    registry.async_regenerate_entity_id.side_effect = [
+        "sensor.bedroom_temperature_ema",
+        "sensor.bedroom_valve",
+    ]
+    registry.async_update_entity.side_effect = [
+        ValueError("Entity id already exists"),
+        None,
+    ]
+
+    calls = _rename(hass, _entry("Livingroom"), registry)
+
+    assert [call.args[0] for call in calls] == [blocked.entity_id, following.entity_id]
+    assert "could not rename sensor.livingroom_temperature_ema" in caplog.text
+
+
+def test_an_entity_of_another_platform_is_skipped():
+    """Only the platform being set up is renamed.
+
+    Each platform records its own name and is walked on its own pass, so
+    a pass must leave the entries of the other three alone -- they are in
+    the registry under the same config entry.
+    """
+    hass = MagicMock()
+    hass.data = {}
+    other = _registry_entry("switch.livingroom_child_lock", Platform.SWITCH)
+    registry = _registry([other])
+    registry.async_regenerate_entity_id.return_value = "switch.bedroom_child_lock"
+
+    calls = _rename(hass, _entry("Livingroom"), registry, domain=Platform.SENSOR)
+
+    assert calls == []

--- a/tests/unit/test_helpers_entity_id_rename.py
+++ b/tests/unit/test_helpers_entity_id_rename.py
@@ -42,18 +42,19 @@ def _registry(entries):
     return registry
 
 
-def _rename(hass, entry, registry, domain=Platform.SENSOR):
-    """Run a rename of ``entry`` against ``registry`` and return the calls.
+def _rename(hass, entry, registry, new_name, domain=Platform.SENSOR):
+    """Rename ``entry`` to ``new_name`` against ``registry``; return the calls.
 
-    The first call records the name, so it is the second one -- the entry
-    now carrying a different name -- that is the rename under test.
+    The first call records the name the entry arrives with, so it is the
+    second one -- the entry now carrying ``new_name`` -- that is the rename
+    under test.
     """
     with patch(
         "custom_components.better_thermostat.utils.helpers.er.async_get",
         return_value=registry,
     ):
         async_normalize_bt_entity_ids(hass, entry, domain)
-        entry.data = {**entry.data, "name": entry.data["name"] + " renamed"}
+        entry.data = {**entry.data, "name": new_name}
         async_normalize_bt_entity_ids(hass, entry, domain)
     return registry.async_update_entity.call_args_list
 
@@ -70,7 +71,7 @@ def test_a_registry_without_entities_is_left_alone():
     # A shell carrying everything but the ``entities`` it has not loaded yet.
     registry = MagicMock(spec=["async_update_entity", "async_regenerate_entity_id"])
 
-    calls = _rename(hass, _entry("Livingroom"), registry)
+    calls = _rename(hass, _entry("Livingroom"), registry, "Bedroom")
 
     assert calls == []
 
@@ -88,7 +89,7 @@ def test_an_id_that_already_matches_is_not_rewritten():
     registry = _registry([reg_entry])
     registry.async_regenerate_entity_id.return_value = reg_entry.entity_id
 
-    calls = _rename(hass, _entry("Livingroom"), registry)
+    calls = _rename(hass, _entry("Livingroom"), registry, "livingroom")
 
     assert calls == []
 
@@ -114,7 +115,7 @@ def test_a_rejected_rename_is_reported_and_the_others_still_run(caplog):
         None,
     ]
 
-    calls = _rename(hass, _entry("Livingroom"), registry)
+    calls = _rename(hass, _entry("Livingroom"), registry, "Bedroom")
 
     assert [call.args[0] for call in calls] == [blocked.entity_id, following.entity_id]
     assert "could not rename sensor.livingroom_temperature_ema" in caplog.text
@@ -133,6 +134,8 @@ def test_an_entity_of_another_platform_is_skipped():
     registry = _registry([other])
     registry.async_regenerate_entity_id.return_value = "switch.bedroom_child_lock"
 
-    calls = _rename(hass, _entry("Livingroom"), registry, domain=Platform.SENSOR)
+    calls = _rename(
+        hass, _entry("Livingroom"), registry, "Bedroom", domain=Platform.SENSOR
+    )
 
     assert calls == []


### PR DESCRIPTION
Fixes #2271.

## What happens

`async_normalize_bt_entity_ids` rebuilds every Better Thermostat entity id from the configured name, and it runs in `async_setup_entry` of all four platforms (`climate.py`, `number.py`, `sensor.py`, `switch.py`), so it runs on every restart and every reload. An entity id the user set themselves is rebuilt along with the rest, and the automations naming it stop working. Correcting it by hand does not hold either, which is what the reporters ran into: renamed on the update to 1.9.0, renamed back by hand, renamed again on the update to 1.9.1.

When the generated id is already taken, `async_get_available_entity_id` appends a suffix, so a user who named their physical thermostat `climate.<room>` and Better Thermostat's `climate.<room>_better_thermostat` ends up with `climate.<room>_2`.

## What this changes

The rename itself is worth keeping: an entity id that no longer matches the thermostat's name is the reason it exists, and `test_climate_entity_id_follows_device_name_after_rename` pins that. What it could not do is tell a rename from a restart.

A rename of the thermostat reaches the integration as an in-process reload and nothing else does. So the name the ids were last built from is now recorded per entry and per platform, in `hass.data`, for as long as the Home Assistant instance lives, next to the reload locks and dropped by `async_remove_entry` the same way. A setup that finds no such name is a restart, and it leaves the registry alone. Only a name that differs from the recorded one is a rename, and only that renames anything.

Per platform rather than per entry: the four calls happen in one setup pass, and a single record would let the first of them mark the name as handled and leave the other three looking at a rename that already happened.

## Verification

`tests/integration/test_entry_lifecycle.py::test_entity_ids_the_user_chose_survive_a_restart` seeds the registry with the ids somebody who renamed BT's entities is left holding, one climate and one sensor because the two derive their id along different paths, then sets the entry up and asserts both survive.

Counter-check by mutation: with the guard removed, that test fails (`climate.livingroom_thermostat` becomes `climate.livingroom`) and the four existing tests in the file stay green, so the new test pins the fix and not something else. With the guard in place, the whole suite is green.

## Note for existing installs

This stops the renaming; it does not undo it. An entity that 1.9.0 or 1.9.1 already renamed keeps that id until the user changes it, and from then on the change sticks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved user-selected entity IDs when configurations are reloaded or the system restarts.
  * Updated entity IDs only when thermostat names actually change.
  * Prevented unintended renaming of climate and auxiliary sensor entities.
  * Ensured entities remain available when an ID change is rejected.
  * Improved cleanup when a thermostat configuration is removed.
  * Skipped unrelated entity platforms during ID normalization.
  * Improved reliability when setting up configurations again.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->