### PR TITLE
fix: reset an MQTT TRV onto its manual preset instead of "none" (1.9)

### DIFF
--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Final
 
-from homeassistant.components.climate.const import PRESET_NONE
 from homeassistant.components.number.const import SERVICE_SET_VALUE
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
@@ -21,6 +21,43 @@ from .generic import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+# The preset a device offers for "the setpoint is whatever was written to me",
+# tried in order. Home Assistant's MQTT climate entity inserts ``none`` into
+# ``preset_modes`` itself and rejects a discovery config that lists it, so
+# every device reached through this adapter offers ``none`` and none of them
+# implements it: publishing it leaves the device on its schedule and the
+# broker rejects the command.
+MANUAL_PRESET_PREFERENCE: Final = ("manual",)
+
+
+def manual_preset(preset_modes: object) -> str | None:
+    """Return the preset that hands the setpoint to BT, or ``None``.
+
+    Parameters
+    ----------
+    preset_modes : object
+        The presets the device reports, as read from its state attributes.
+        Anything that is not a sequence of presets means the device names
+        none, which is the same answer as a sequence holding nothing usable.
+
+    Returns
+    -------
+    str | None
+        The device's own spelling of the first preset in
+        ``MANUAL_PRESET_PREFERENCE`` it offers, or ``None`` when it offers
+        no preset that hands the setpoint over.
+    """
+    if isinstance(preset_modes, str) or not isinstance(
+        preset_modes, (list, tuple, set)
+    ):
+        return None
+    offered = {str(mode).casefold(): str(mode) for mode in preset_modes}
+    for candidate in MANUAL_PRESET_PREFERENCE:
+        if candidate in offered:
+            return offered[candidate]
+    return None
 
 
 async def get_info(self, entity_id):
@@ -76,30 +113,34 @@ async def init(self, entity_id):
         )
 
         state = self.hass.states.get(entity_id)
-        _preset_modes = (
-            state.attributes.get("preset_modes") if state is not None else None
-        )
-        # Only reset the device preset when "none" is actually a supported mode.
-        # Some TRVs (e.g. proportional Tuya models) expose ``preset_modes`` but
-        # do not accept arbitrary values, so calling the service with an
-        # unsupported mode raises ``ServiceValidationError`` and trips the
-        # startup retry loop.
-        if _preset_modes and PRESET_NONE in _preset_modes:
-            await self.hass.services.async_call(
-                "climate",
-                "set_preset_mode",
-                {"entity_id": entity_id, "preset_mode": PRESET_NONE},
-                blocking=True,
-                context=self.context,
-            )
-        elif _preset_modes:
+        attributes = state.attributes if state is not None else {}
+        _preset_modes = attributes.get("preset_modes")
+        # BT owns the setpoint, so a device running its own schedule has to be
+        # taken off it. The device's manual preset is what does that, and it is
+        # the only value here the device is known to accept.
+        _manual = manual_preset(_preset_modes)
+        if _manual is None:
             _LOGGER.debug(
-                "better_thermostat %s: TRV %s supports presets %s but not '%s'; "
-                "skipping preset reset",
+                "better_thermostat %s: TRV %s offers no manual preset among %s, "
+                "leaving its preset alone",
                 self.device_name,
                 entity_id,
                 _preset_modes,
-                PRESET_NONE,
+            )
+        elif attributes.get("preset_mode") == _manual:
+            _LOGGER.debug(
+                "better_thermostat %s: TRV %s already runs preset '%s'",
+                self.device_name,
+                entity_id,
+                _manual,
+            )
+        else:
+            await self.hass.services.async_call(
+                "climate",
+                "set_preset_mode",
+                {"entity_id": entity_id, "preset_mode": _manual},
+                blocking=True,
+                context=self.context,
             )
 
 

--- a/tests/unit/test_mqtt_adapter_preset_reset.py
+++ b/tests/unit/test_mqtt_adapter_preset_reset.py
@@ -1,0 +1,124 @@
+"""The preset an MQTT TRV is put on when Better Thermostat takes it over.
+
+Better Thermostat owns the setpoint, so a device still running its own
+schedule has to be taken off it. Home Assistant's MQTT climate entity
+contributes ``none`` to every device's ``preset_modes`` and rejects a
+discovery config that lists it, so ``none`` is never the device's own
+answer and never a value it accepts: the reset has to name a preset the
+device brought itself.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.adapters.mqtt import init, manual_preset
+from custom_components.better_thermostat.trv import Trv
+
+ENTITY_ID = "climate.test_trv"
+_MQTT = "custom_components.better_thermostat.adapters.mqtt"
+# init imports the valve lookup at call time, so the patch goes on the source.
+_FIND_VALVE = "custom_components.better_thermostat.utils.helpers.find_valve_entity"
+_FIND_CALIBRATION = f"{_MQTT}.find_local_calibration_entity"
+_WAIT_FOR_CALIBRATION = f"{_MQTT}.wait_for_calibration_entity_or_timeout"
+
+
+def _bt(preset_modes, preset_mode=None) -> MagicMock:
+    """Build a stand-in whose TRV reports ``preset_modes`` and needs a reset.
+
+    ``calibration`` is deliberately not 1: the preset reset sits inside the
+    branch that discovers the local calibration entity, so a TRV that needs
+    no such lookup never reaches it.
+    """
+    bt = MagicMock()
+    bt.device_name = "Test BT"
+    bt.real_trvs = {ENTITY_ID: Trv(entity_id=ENTITY_ID, calibration=0)}
+    bt.hass.states.get.return_value = State(
+        ENTITY_ID, "heat", {"preset_modes": preset_modes, "preset_mode": preset_mode}
+    )
+    bt.hass.services.async_call = AsyncMock()
+    return bt
+
+
+async def _init(bt) -> None:
+    """Run init past the discovery steps the preset reset sits behind."""
+    with (
+        patch(_FIND_VALVE, AsyncMock(return_value=None)),
+        patch(_FIND_CALIBRATION, AsyncMock(return_value=None)),
+        patch(_WAIT_FOR_CALIBRATION, AsyncMock(return_value=None)),
+    ):
+        await init(bt, ENTITY_ID)
+
+
+def _preset_calls(bt) -> list[dict]:
+    """The preset payloads init dispatched at the TRV."""
+    return [
+        call.args[2]
+        for call in bt.hass.services.async_call.call_args_list
+        if call.args[:2] == ("climate", "set_preset_mode")
+    ]
+
+
+@pytest.mark.parametrize(
+    ("preset_modes", "expected"),
+    [
+        # What Home Assistant reports for a Zigbee2MQTT TRV: the device names
+        # its own presets and HA prepends "none" itself.
+        (["none", "auto", "manual", "holiday"], "manual"),
+        (["none", "programming", "manual", "temporary_manual", "holiday"], "manual"),
+        # Spelling is the device's; the match is not.
+        (["none", "Manual"], "Manual"),
+    ],
+)
+def test_manual_preset_picks_the_device_preset_that_hands_the_setpoint_over(
+    preset_modes, expected
+):
+    """The device's manual preset wins over the "none" HA contributes."""
+    assert manual_preset(preset_modes) == expected
+
+
+@pytest.mark.parametrize(
+    "preset_modes",
+    [
+        # Nothing the device offers takes it off its own schedule.
+        ["none", "eco", "comfort"],
+        # "none" alone is HA's contribution and nothing else, so a device
+        # reporting only it names no preset of its own.
+        ["none"],
+        [],
+        None,
+        # A bare string is not a list of presets; iterating it would match
+        # single characters.
+        "manual",
+    ],
+)
+def test_manual_preset_answers_none_when_the_device_offers_no_manual(preset_modes):
+    """No manual preset means nothing is written, not that "none" is."""
+    assert manual_preset(preset_modes) is None
+
+
+@pytest.mark.asyncio
+async def test_preset_reset_writes_the_device_preset_not_none():
+    """The reset sends "manual"; "none" is what the broker rejects."""
+    bt = _bt(["none", "auto", "manual", "holiday"], preset_mode="auto")
+    await _init(bt)
+    assert _preset_calls(bt) == [{"entity_id": ENTITY_ID, "preset_mode": "manual"}]
+
+
+@pytest.mark.asyncio
+async def test_preset_reset_is_skipped_without_a_manual_preset():
+    """A device with no manual preset keeps the one it is on."""
+    bt = _bt(["none", "eco"], preset_mode="eco")
+    await _init(bt)
+    assert _preset_calls(bt) == []
+
+
+@pytest.mark.asyncio
+async def test_preset_reset_is_skipped_when_the_trv_already_runs_manual():
+    """Nothing is written to a device that is already off its schedule."""
+    bt = _bt(["none", "auto", "manual"], preset_mode="manual")
+    await _init(bt)
+    assert _preset_calls(bt) == []


### PR DESCRIPTION
Fixes #2268.

## What happens

Zigbee2MQTT logs one of these per Better Thermostat TRV, on every setup:

```
error: z2m: Publish 'set' 'preset' to 'Alrum Radiator' failed: 'Error: Unsupported preset 'none''
```

The MQTT adapter resets the device preset to `none` in `init()`, guarded by `if _preset_modes and PRESET_NONE in _preset_modes`. For this adapter that condition is always true, and it is never the device's answer: Home Assistant's MQTT climate entity inserts `none` into `preset_modes` itself (`mqtt/climate.py`, `presets.insert(0, PRESET_NONE)`) and rejects a discovery config that lists it (`preset_modes must not include preset mode 'none'`). Every Zigbee2MQTT TRV therefore passes the guard, and the devices whose converter has no `none` reject the command.

Nothing on the Home Assistant side notices: the publish is fire and forget, so the service call returns cleanly and only the broker log shows it.

## What this changes

What the reset is after is a device that stops running its own schedule and takes the setpoint BT writes. On these devices that is the manual preset, which is also what `model_fixes/TV02-Zigbee.py` already writes for the one model that has a quirk for it.

`manual_preset()` picks the device's own spelling of the first preset in `MANUAL_PRESET_PREFERENCE` that it offers, and answers `None` when it offers none, in which case nothing is written and the device keeps the preset it is on. A device already running that preset is left alone as well.

## Behaviour change worth naming

A device whose converter did accept the literal `none` now gets `manual` instead. Both take the device off its schedule, and `manual` is the one every device here is known to accept.

## Verification

`tests/unit/test_mqtt_adapter_preset_reset.py` covers the picker against the preset lists Home Assistant reports for real Zigbee2MQTT TRVs (Tuya TV02, Moes BRT-100), against a device that offers no manual preset, and against a bare string, which is not a list of presets and whose characters must not match. Three adapter-level tests pin what `init()` dispatches.

Counter-check by mutation: restoring the old call site (write `none`, drop the already-on-it check) turns two of those red. The full suite is green with the fix.

## Not in this PR

The reporter's device is a TV02-Zigbee, but the model reaching BT is `Thermostat radiator valve`, the Zigbee2MQTT description rather than the model. If `get_device_model` resolves the same at runtime, `model_fixes/TV02-Zigbee.py` never loads for them, and that is a separate question best settled from the `get_device_model(...) selected=... via ...` debug line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MQTT thermostat initialization to preserve and select the device’s manual preset instead of resetting it to “none.”
  * Avoids unnecessary preset updates when manual mode is unavailable or already active.
  * Recognizes manual preset names regardless of capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->