### PR TITLE
fix: restore the HVAC mode after maintenance only when it moved (1.9)

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2448,6 +2448,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 set_valve_fn=_set_valve,
                 set_temperature_fn=_set_temp,
                 set_hvac_mode_fn=_set_mode,
+                get_state=self.hass.states.get,
                 device_name=self.device_name,
             )
 

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -329,6 +329,18 @@ async def restore_one(
     moved it, a valve write a device answers by switching itself on among
     them, shows up as a reported mode that is no longer the one the snapshot
     was taken in.
+
+    Parameters
+    ----------
+    info : MaintenanceTrvInfo
+        The snapshot the run started from, carrying the setpoint and mode
+        to restore.
+    set_temperature_fn : SetTemperatureFn
+        Writes the setpoint back.
+    set_hvac_mode_fn : SetHvacModeFn
+        Writes the mode back, when it moved.
+    get_state : Callable[[str], State | None]
+        ``hass.states.get``, supplying the mode the TRV reports now.
     """
     if info.cur_temp is not None:
         try:
@@ -366,6 +378,26 @@ async def run_valve_maintenance(
     This is the pure async orchestrator.  State mutations on
     ``self`` (ignore_states, in_maintenance, control_queue) stay in
     ``climate.py``'s wrapper.
+
+    Parameters
+    ----------
+    infos : list[MaintenanceTrvInfo]
+        The snapshot of each TRV the run drives, taken before it starts.
+    set_valve_fn : SetValveFn
+        Writes a valve percentage; used for the valve-driven TRVs.
+    set_temperature_fn : SetTemperatureFn
+        Writes a setpoint; drives the cycle on the other TRVs and restores
+        the setpoint on all of them.
+    set_hvac_mode_fn : SetHvacModeFn
+        Writes an HVAC mode; wakes a TRV that is off and puts a moved mode
+        back.
+    get_state : Callable[[str], State | None]
+        ``hass.states.get``, read at the restore to tell a mode that moved
+        from one that never did.
+    device_name : str
+        The Better Thermostat instance name, for logging context.
+    cycle_sleep : float
+        Seconds to hold each valve position, so the motor reaches it.
     """
     _LOGGER.info(
         "better_thermostat %s: starting valve maintenance for %d TRV(s)",

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -92,6 +92,34 @@ def pick_wake_mode(
     return None
 
 
+def mode_needs_restoring(
+    info: MaintenanceTrvInfo, get_state: Callable[[str], State | None]
+) -> bool:
+    """Whether the TRV's HVAC mode has to be written back after the run.
+
+    Parameters
+    ----------
+    info : MaintenanceTrvInfo
+        The snapshot the run started from, carrying the mode to restore and
+        the wake mode the run switched into, if any.
+    get_state : Callable[[str], State | None]
+        ``hass.states.get``. A TRV that reports no state is taken to need
+        the restore: nothing then says the mode is where it belongs.
+
+    Returns
+    -------
+    bool
+        True when the run woke the TRV, or when the mode it reports is no
+        longer the one the snapshot was taken in.
+    """
+    if info.wake_mode is not None:
+        return True
+    state = get_state(info.entity_id)
+    if state is None:
+        return True
+    return state.state != info.cur_mode
+
+
 def _get_advanced(info: Trv) -> dict[str, object]:
     """Safely extract the ``advanced`` dict from a Trv entry."""
     adv = info.advanced
@@ -285,13 +313,35 @@ async def restore_one(
     *,
     set_temperature_fn: SetTemperatureFn,
     set_hvac_mode_fn: SetHvacModeFn,
+    get_state: Callable[[str], State | None],
 ) -> None:
-    """Restore a TRV to its pre-maintenance state."""
+    """Restore a TRV to its pre-maintenance state.
+
+    The setpoint is always written back; the mode only when it moved.
+    A device that reports a single mode implements no setter for it, so
+    writing the mode it is already in raises ``NotImplementedError`` inside
+    Home Assistant's climate component and buys nothing in exchange.
+
+    Two things move a mode here, and the guard answers to both. The run
+    itself moves one only through ``wake_step``, which is gated on
+    ``wake_mode``, so that alone says a mode was written and has to go back
+    regardless of what the device has published since. Anything else that
+    moved it, a valve write a device answers by switching itself on among
+    them, shows up as a reported mode that is no longer the one the snapshot
+    was taken in.
+    """
     if info.cur_temp is not None:
         try:
             await set_temperature_fn(info.entity_id, info.cur_temp)
         except Exception:
             pass
+    if not mode_needs_restoring(info, get_state):
+        _LOGGER.debug(
+            "better_thermostat: %s is still in mode %s, leaving it alone",
+            info.entity_id,
+            info.cur_mode,
+        )
+        return
     try:
         await set_hvac_mode_fn(info.entity_id, info.cur_mode)
     except Exception:
@@ -307,6 +357,7 @@ async def run_valve_maintenance(
     set_valve_fn: SetValveFn,
     set_temperature_fn: SetTemperatureFn,
     set_hvac_mode_fn: SetHvacModeFn,
+    get_state: Callable[[str], State | None],
     device_name: str,
     cycle_sleep: float = 30,
 ) -> None:
@@ -398,6 +449,7 @@ async def run_valve_maintenance(
                 info,
                 set_temperature_fn=set_temperature_fn,
                 set_hvac_mode_fn=set_hvac_mode_fn,
+                get_state=get_state,
             )
             for info in infos
         ),

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -93,18 +93,21 @@ def pick_wake_mode(
 
 
 def mode_needs_restoring(
-    info: MaintenanceTrvInfo, get_state: Callable[[str], State | None]
+    info: MaintenanceTrvInfo, get_state: Callable[[str], State | None], *, woken: bool
 ) -> bool:
     """Whether the TRV's HVAC mode has to be written back after the run.
 
     Parameters
     ----------
     info : MaintenanceTrvInfo
-        The snapshot the run started from, carrying the mode to restore and
-        the wake mode the run switched into, if any.
+        The snapshot the run started from, carrying the mode to restore.
     get_state : Callable[[str], State | None]
         ``hass.states.get``. A TRV that reports no state is taken to need
         the restore: nothing then says the mode is where it belongs.
+    woken : bool
+        Whether the wake write for this TRV went out without raising. A
+        wake that was selected but failed left the mode where it was, so
+        only a wake that landed decides on its own.
 
     Returns
     -------
@@ -112,7 +115,7 @@ def mode_needs_restoring(
         True when the run woke the TRV, or when the mode it reports is no
         longer the one the snapshot was taken in.
     """
-    if info.wake_mode is not None:
+    if woken:
         return True
     state = get_state(info.entity_id)
     if state is None:
@@ -314,6 +317,7 @@ async def restore_one(
     set_temperature_fn: SetTemperatureFn,
     set_hvac_mode_fn: SetHvacModeFn,
     get_state: Callable[[str], State | None],
+    woken: bool = False,
 ) -> None:
     """Restore a TRV to its pre-maintenance state.
 
@@ -323,12 +327,11 @@ async def restore_one(
     Home Assistant's climate component and buys nothing in exchange.
 
     Two things move a mode here, and the guard answers to both. The run
-    itself moves one only through ``wake_step``, which is gated on
-    ``wake_mode``, so that alone says a mode was written and has to go back
-    regardless of what the device has published since. Anything else that
-    moved it, a valve write a device answers by switching itself on among
-    them, shows up as a reported mode that is no longer the one the snapshot
-    was taken in.
+    itself moves one only through ``wake_step``, so a wake that went out
+    says a mode was written and has to go back regardless of what the
+    device has published since. Anything else that moved it, a valve write
+    a device answers by switching itself on among them, shows up as a
+    reported mode that is no longer the one the snapshot was taken in.
 
     Parameters
     ----------
@@ -341,13 +344,15 @@ async def restore_one(
         Writes the mode back, when it moved.
     get_state : Callable[[str], State | None]
         ``hass.states.get``, supplying the mode the TRV reports now.
+    woken : bool
+        Whether this TRV's wake write went out without raising.
     """
     if info.cur_temp is not None:
         try:
             await set_temperature_fn(info.entity_id, info.cur_temp)
         except Exception:
             pass
-    if not mode_needs_restoring(info, get_state):
+    if not mode_needs_restoring(info, get_state, woken=woken):
         _LOGGER.debug(
             "better_thermostat: %s is still in mode %s, leaving it alone",
             info.entity_id,
@@ -418,6 +423,7 @@ async def run_valve_maintenance(
     # A TRV that offered no wake mode at all is unreachable for the same
     # reason. Both are still restored below.
     cycled: list[MaintenanceTrvInfo] = []
+    woken: set[str] = set()
     for info, result in zip(infos, wake_results):
         if isinstance(result, BaseException):
             _LOGGER.warning(
@@ -428,6 +434,8 @@ async def run_valve_maintenance(
                 result,
             )
             continue
+        if info.wake_mode is not None:
+            woken.add(info.entity_id)
         if info.use_direct_valve or _temp_cycle_reaches_valve(info):
             cycled.append(info)
 
@@ -482,6 +490,7 @@ async def run_valve_maintenance(
                 set_temperature_fn=set_temperature_fn,
                 set_hvac_mode_fn=set_hvac_mode_fn,
                 get_state=get_state,
+                woken=info.entity_id in woken,
             )
             for info in infos
         ),

--- a/tests/unit/test_valve_maintenance.py
+++ b/tests/unit/test_valve_maintenance.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
 import pytest
 
@@ -29,6 +30,7 @@ from custom_components.better_thermostat.utils.valve_maintenance import (
     collect_maintenance_trvs,
     compute_initial_maintenance,
     compute_next_maintenance,
+    mode_needs_restoring,
     open_step,
     pick_wake_mode,
     restore_one,
@@ -59,6 +61,38 @@ def _trv(
             "valve_position_entity": valve_entity,
         },
     )
+
+
+def _reports(mode: str | None):
+    """A ``hass.states.get`` stand-in reporting every TRV in ``mode``.
+
+    ``None`` stands for a TRV that publishes no state at all.
+    """
+
+    def get_state(entity_id: str) -> State | None:
+        # SimpleNamespace, not State: the ids in this module are bare
+        # names and State rejects anything without a domain.
+        return None if mode is None else SimpleNamespace(state=mode)
+
+    return get_state
+
+
+def _reports_a_moved_mode(infos: list[MaintenanceTrvInfo]):
+    """A state reader answering with a mode no TRV here was started in.
+
+    The restore writes the mode back only when it moved, so this is the
+    reading the tests below assume: they are about what the run does with
+    a TRV whose mode has to go back, not about the guard itself.
+    """
+    moved = {
+        info.entity_id: HVACMode.OFF if info.cur_mode != HVACMode.OFF else "heat"
+        for info in infos
+    }
+
+    def get_state(entity_id: str) -> State | None:
+        return SimpleNamespace(state=moved.get(entity_id, HVACMode.OFF))
+
+    return get_state
 
 
 def _info(
@@ -357,7 +391,12 @@ class TestRestoreOne:
         temp_fn = AsyncMock()
         mode_fn = AsyncMock()
         info = _info(cur_temp=22.5, cur_mode="heat")
-        await restore_one(info, set_temperature_fn=temp_fn, set_hvac_mode_fn=mode_fn)
+        await restore_one(
+            info,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode([info]),
+        )
         temp_fn.assert_awaited_once_with("climate.trv1", 22.5)
         mode_fn.assert_awaited_once_with("climate.trv1", "heat")
 
@@ -367,7 +406,12 @@ class TestRestoreOne:
         temp_fn = AsyncMock()
         mode_fn = AsyncMock()
         info = _info(cur_temp=None)
-        await restore_one(info, set_temperature_fn=temp_fn, set_hvac_mode_fn=mode_fn)
+        await restore_one(
+            info,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode([info]),
+        )
         temp_fn.assert_not_awaited()
         mode_fn.assert_awaited_once()
 
@@ -377,7 +421,12 @@ class TestRestoreOne:
         temp_fn = AsyncMock(side_effect=RuntimeError("fail"))
         mode_fn = AsyncMock()
         info = _info(cur_temp=20.0, cur_mode="heat")
-        await restore_one(info, set_temperature_fn=temp_fn, set_hvac_mode_fn=mode_fn)
+        await restore_one(
+            info,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode([info]),
+        )
         mode_fn.assert_awaited_once_with("climate.trv1", "heat")
 
 
@@ -402,6 +451,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -427,6 +477,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -449,6 +500,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -474,6 +526,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -494,6 +547,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode([]),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -523,6 +577,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -554,6 +609,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -609,6 +665,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_mock,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -657,6 +714,7 @@ class TestRunValveMaintenance:
             set_valve_fn=AsyncMock(),
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_mock,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=30,
         )
@@ -692,6 +750,7 @@ class TestRunValveMaintenance:
             set_valve_fn=AsyncMock(),
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=30,
         )
@@ -716,6 +775,7 @@ class TestRunValveMaintenance:
             set_valve_fn=AsyncMock(),
             set_temperature_fn=AsyncMock(),
             set_hvac_mode_fn=AsyncMock(),
+            get_state=_reports_a_moved_mode([]),
             device_name="Test",
             cycle_sleep=30,
         )
@@ -743,6 +803,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -764,6 +825,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -851,5 +913,89 @@ class TestWakeStep:
         mode_fn = AsyncMock()
         await wake_step(
             _info(entity_id="trv1", wake_mode=None), set_hvac_mode_fn=mode_fn
+        )
+        mode_fn.assert_not_awaited()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# mode_needs_restoring
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestModeNeedsRestoring:
+    """Which TRVs get their HVAC mode written back after a run.
+
+    A device that reports a single HVAC mode implements no setter for it,
+    so Home Assistant's climate component raises ``NotImplementedError`` on
+    a write of the mode the device is already in. The run has no reason to
+    make that write: it never moved the mode of such a device.
+    """
+
+    def test_a_woken_trv_is_restored_whatever_it_reports(self):
+        """The wake mode alone decides; a stale reading cannot undo it.
+
+        ``wake_step`` wrote the mode, so it has to go back. The device may
+        not have published the change yet, and a reading that still shows
+        the mode the run started from would otherwise leave the TRV in the
+        mode it was woken into.
+        """
+        info = _info(cur_mode=HVACMode.OFF, wake_mode="heat")
+        assert mode_needs_restoring(info, _reports(HVACMode.OFF)) is True
+
+    def test_a_trv_still_in_its_own_mode_is_left_alone(self):
+        """Nothing moved the mode, so writing it back buys nothing."""
+        info = _info(cur_mode="heat", wake_mode=None)
+        assert mode_needs_restoring(info, _reports("heat")) is False
+
+    def test_a_mode_that_moved_without_the_wake_step_is_restored(self):
+        """A device that switched itself on is put back.
+
+        A valve-driven TRV is never woken, and a device that answers a
+        valve write by leaving ``off`` moved a mode the run has to undo.
+        """
+        info = _info(cur_mode=HVACMode.OFF, use_direct_valve=True, wake_mode=None)
+        assert mode_needs_restoring(info, _reports("heat")) is True
+
+    def test_a_trv_without_a_state_is_restored(self):
+        """No reading is no evidence that the mode is where it belongs."""
+        info = _info(cur_mode="heat", wake_mode=None)
+        assert mode_needs_restoring(info, _reports(None)) is True
+
+
+class TestRestoreLeavesAnUnmovedModeAlone:
+    """The guard as the restore applies it, setpoint included."""
+
+    @pytest.mark.asyncio
+    async def test_setpoint_is_restored_and_the_mode_is_not_written(self):
+        """A single-mode TRV gets its setpoint back and no mode write."""
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+        info = _info(cur_temp=21.5, cur_mode="heat", wake_mode=None)
+        await restore_one(
+            info,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            get_state=_reports("heat"),
+        )
+        temp_fn.assert_awaited_once_with("climate.trv1", 21.5)
+        mode_fn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_full_run_writes_no_mode_to_a_trv_that_kept_it(self):
+        """End to end: the run leaves such a TRV's mode untouched.
+
+        The valve cycle drives the TRV through a number entity, so nothing
+        in the run asks its mode to move.
+        """
+        mode_fn = AsyncMock()
+        infos = [_info(entity_id="trv1", cur_mode="heat", use_direct_valve=True)]
+        await run_valve_maintenance(
+            infos,
+            set_valve_fn=AsyncMock(return_value=True),
+            set_temperature_fn=AsyncMock(),
+            set_hvac_mode_fn=mode_fn,
+            get_state=_reports("heat"),
+            device_name="Test",
+            cycle_sleep=0,
         )
         mode_fn.assert_not_awaited()

--- a/tests/unit/test_valve_maintenance.py
+++ b/tests/unit/test_valve_maintenance.py
@@ -63,6 +63,16 @@ def _trv(
     )
 
 
+def _state(entity_id: str, mode: str) -> State:
+    """A ``State`` for ``entity_id``, which is a bare name in this module.
+
+    ``State`` splits the id into a domain and an object id and rejects one
+    without a domain, so a bare name is given the climate domain it stands
+    for. Only the reported mode is read back.
+    """
+    return State(entity_id if "." in entity_id else f"climate.{entity_id}", mode)
+
+
 def _reports(mode: str | None):
     """A ``hass.states.get`` stand-in reporting every TRV in ``mode``.
 
@@ -70,9 +80,7 @@ def _reports(mode: str | None):
     """
 
     def get_state(entity_id: str) -> State | None:
-        # SimpleNamespace, not State: the ids in this module are bare
-        # names and State rejects anything without a domain.
-        return None if mode is None else SimpleNamespace(state=mode)
+        return None if mode is None else _state(entity_id, mode)
 
     return get_state
 
@@ -90,7 +98,7 @@ def _reports_a_moved_mode(infos: list[MaintenanceTrvInfo]):
     }
 
     def get_state(entity_id: str) -> State | None:
-        return SimpleNamespace(state=moved.get(entity_id, HVACMode.OFF))
+        return _state(entity_id, moved.get(entity_id, HVACMode.OFF))
 
     return get_state
 
@@ -940,12 +948,12 @@ class TestModeNeedsRestoring:
         mode it was woken into.
         """
         info = _info(cur_mode=HVACMode.OFF, wake_mode="heat")
-        assert mode_needs_restoring(info, _reports(HVACMode.OFF)) is True
+        assert mode_needs_restoring(info, _reports(HVACMode.OFF), woken=True) is True
 
     def test_a_trv_still_in_its_own_mode_is_left_alone(self):
         """Nothing moved the mode, so writing it back buys nothing."""
         info = _info(cur_mode="heat", wake_mode=None)
-        assert mode_needs_restoring(info, _reports("heat")) is False
+        assert mode_needs_restoring(info, _reports("heat"), woken=False) is False
 
     def test_a_mode_that_moved_without_the_wake_step_is_restored(self):
         """A device that switched itself on is put back.
@@ -954,12 +962,22 @@ class TestModeNeedsRestoring:
         valve write by leaving ``off`` moved a mode the run has to undo.
         """
         info = _info(cur_mode=HVACMode.OFF, use_direct_valve=True, wake_mode=None)
-        assert mode_needs_restoring(info, _reports("heat")) is True
+        assert mode_needs_restoring(info, _reports("heat"), woken=False) is True
+
+    def test_a_wake_that_never_landed_decides_nothing(self):
+        """A selected wake mode is an intention, not a write that happened.
+
+        ``wake_step`` can raise, and the orchestrator already drops such a
+        TRV from the cycle. Its mode is then still the one the snapshot was
+        taken in, so repeating the write that just failed buys nothing.
+        """
+        info = _info(cur_mode=HVACMode.OFF, wake_mode="heat")
+        assert mode_needs_restoring(info, _reports(HVACMode.OFF), woken=False) is False
 
     def test_a_trv_without_a_state_is_restored(self):
         """No reading is no evidence that the mode is where it belongs."""
         info = _info(cur_mode="heat", wake_mode=None)
-        assert mode_needs_restoring(info, _reports(None)) is True
+        assert mode_needs_restoring(info, _reports(None), woken=False) is True
 
 
 class TestRestoreLeavesAnUnmovedModeAlone:


### PR DESCRIPTION
Fixes #2244.

## What happens

At the end of every valve maintenance run, `restore_one` writes the TRV's HVAC mode back, unconditionally. A device that reports a single HVAC mode implements no setter for it, so that call passes Home Assistant's `hvac_modes` validation and then reaches `ClimateEntity`'s default implementation, which raises `NotImplementedError`. The result is an ERROR-level traceback per affected TRV per maintenance interval, with no action attached to it.

The reporter's analysis in the issue is accurate down to the line numbers, and I verified all of it against the current tree. Nothing else about the run is affected: the setpoint restore runs first, the exception is caught and not re-raised, and the valve cycle itself comes out correct. It is noise, but it is noise a user cannot act on.

Nothing regressed here either. `restore_one` is unchanged since 1.8.2; what changed in 1.9.0 was that the maintenance tick no longer returns early while the thermostat is off (#2208), which is what put summer instances on this path for the first time.

## What this changes

The mode is written back only when it moved. Two things can move it, and the guard answers to both:

- `wake_step` is the run's only mode write and is already gated on `wake_mode`, so `wake_mode is not None` alone says a mode was written. It decides on its own, without consulting the device: a TRV that was woken has to go back whatever it has published since, and a reading that has not caught up yet would otherwise leave it in the mode it was woken into.
- Anything else that moved the mode shows up as a reported mode that is no longer the one the snapshot was taken in. This is the reporter's own open question, the direct-valve TRV that answers a valve write by switching itself on: it is never woken, so a `wake_mode`-only guard would stop restoring it. Comparing against the reported mode covers it without needing a device to confirm the behaviour first.

`run_valve_maintenance` and `restore_one` take a `get_state` reader for this. The module already receives one that way in `build_trv_snapshots`, so this is the same seam, not a new one.

## Verification

`TestModeNeedsRestoring` covers the four cases of the predicate; `TestRestoreLeavesAnUnmovedModeAlone` covers the restore and one end-to-end run. The existing tests around the restore now say which reading they assume, which is what they were silently relying on before.

Counter-check by mutation: with the guard removed, the two new restore tests fail and the rest of the file stays green. The full suite is green with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved valve maintenance restoration for thermostatic radiator valves.
  * Temperatures are restored reliably after maintenance cycles.
  * HVAC modes are restored when they changed during maintenance, including after a device wakes or reports a different mode.
  * Avoids unnecessary HVAC mode updates when the mode remained unchanged.

* **Tests**
  * Added coverage for mode detection and restoration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->