### PR TITLE
fix: re-send the room temperature to mirroring TRVs on a timer

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -230,6 +230,13 @@ from .utils.weather import check_ambient_air_temperature, check_weather
 
 _LOGGER = logging.getLogger(__name__)
 
+# How often the room temperature is re-sent to TRVs that mirror it into an
+# input of their own. Such a device falls back to its own sensor after a fixed
+# silence, two hours on a Sonoff TRVZB, and BT's own writes are driven by
+# sensor changes, which a room holding its temperature does not produce. The
+# interval sits well inside the shortest fallback window rather than near it.
+EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL = timedelta(minutes=30)
+
 # Default temperature when no sensor data is available (last resort fallback)
 DEFAULT_FALLBACK_TEMPERATURE = 20.0
 
@@ -2562,7 +2569,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     self.hass, [self.outdoor_sensor], self._trigger_outdoor_change
                 )
             )
-        # Send an immediate initial keepalive so TRVs don't have to wait for the first 30min tick
+        # One keepalive right away, so a TRV that mirrors the room temperature
+        # has it before the first interval elapses.
         try:
             _LOGGER.debug(
                 "better_thermostat %s: creating keepalive task...", self.device_name
@@ -2577,6 +2585,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 self.device_name,
                 exc,
             )
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass,
+                self._external_temperature_keepalive,
+                EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL,
+            )
+        )
         # Start periodic EMA update (every minute)
         _LOGGER.debug("better_thermostat %s: starting EMA timer...", self.device_name)
         self.async_on_remove(

--- a/custom_components/better_thermostat/model_fixes/TRVZB.py
+++ b/custom_components/better_thermostat/model_fixes/TRVZB.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.better_thermostat.model_fixes.types import (
@@ -413,7 +414,31 @@ def _find_device_entity(
     The translation key is the stable, language-independent handle and is
     tried first; the id fragment is the fallback for a registry entry that
     carries none.
+
+    Parameters
+    ----------
+    entity_registry : er.EntityRegistry
+        The registry to search.
+    device_id : str | None
+        The device the sibling has to belong to. ``None`` is no device and
+        matches nothing: every entity that belongs to no device would
+        otherwise be a candidate.
+    domain : str
+        The entity domain to search, ``number`` or ``select`` here.
+    translation_keys : frozenset[str]
+        The translation keys that name the wanted entity.
+    id_fragment : str
+        Matched against the entity id, unique id and original name of a
+        registry entry that carries no translation key.
+
+    Returns
+    -------
+    str | None
+        The entity id of the first match, or ``None`` when the device has
+        no such entity.
     """
+    if device_id is None:
+        return None
     for ent in entity_registry.entities.values():
         if ent.device_id != device_id or ent.domain != domain:
             continue
@@ -473,7 +498,9 @@ async def maybe_select_external_sensor(self: ModelFixHost, entity_id: str) -> bo
         )
         return False
     state = self.hass.states.get(target)
-    if state is None:
+    if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+        # A selector that is not reporting names no option, and the device
+        # behind it is in no state to take one either.
         return False
     if str(state.state).startswith(_EXTERNAL_SENSOR_OPTION):
         return True

--- a/custom_components/better_thermostat/model_fixes/TRVZB.py
+++ b/custom_components/better_thermostat/model_fixes/TRVZB.py
@@ -511,8 +511,25 @@ async def maybe_set_external_temperature(
     """Set Sonoff TRVZB external temperature input via a number entity on the same device.
 
     Looks for number.* entity matching external_temperature_input and writes the
-    given temperature (clamped to 0..99.9, rounded to one decimal).
-    Returns True on success, False otherwise.
+    given temperature (clamped to 0..99.9, rounded to one decimal). The sensor
+    selector is pointed at that input alongside the write, because a device
+    regulating on its own sensor never reads it.
+
+    Parameters
+    ----------
+    self : ModelFixHost
+        The Better Thermostat instance, supplying ``hass``, the TRV registry
+        and the context the service calls are made under.
+    entity_id : str
+        The TRV whose device carries the input.
+    temperature : float
+        The room temperature to mirror into the device, in degrees Celsius.
+
+    Returns
+    -------
+    bool
+        True when the input was written, False when the device is not a
+        TRVZB, names no such input, or the value is not a number.
     """
     try:
         model = str(self.real_trvs[entity_id].model or "")

--- a/custom_components/better_thermostat/model_fixes/TRVZB.py
+++ b/custom_components/better_thermostat/model_fixes/TRVZB.py
@@ -387,6 +387,124 @@ async def override_set_valve(self: ModelFixHost, entity_id: str, percent: int) -
         return False
 
 
+# Translation keys Zigbee2MQTT uses for the input the room temperature is
+# mirrored into.
+_TK_EXTERNAL_TEMP = frozenset({"external_temperature_input", "external_temperature"})
+
+# Translation keys Zigbee2MQTT uses for the selector that decides which sensor
+# the TRVZB regulates on.
+_TK_SENSOR_SELECT = frozenset({"temperature_sensor_select", "temperature_sensor"})
+
+# The option that hands regulation to the value BT writes. Devices offer more
+# than one option naming an external sensor, so the ones already on such an
+# option are left as their owner set them.
+_EXTERNAL_SENSOR_OPTION = "external"
+
+
+def _find_device_entity(
+    entity_registry: er.EntityRegistry,
+    device_id: str | None,
+    domain: str,
+    translation_keys: frozenset[str],
+    id_fragment: str,
+) -> str | None:
+    """Return a sibling entity of ``device_id`` in ``domain``, or ``None``.
+
+    The translation key is the stable, language-independent handle and is
+    tried first; the id fragment is the fallback for a registry entry that
+    carries none.
+    """
+    for ent in entity_registry.entities.values():
+        if ent.device_id != device_id or ent.domain != domain:
+            continue
+        if getattr(ent, "translation_key", None) in translation_keys:
+            return ent.entity_id
+        haystacks = (
+            (ent.entity_id or "").lower(),
+            (ent.unique_id or "").lower(),
+            (getattr(ent, "original_name", None) or "").lower().replace(" ", "_"),
+        )
+        if any(id_fragment in haystack for haystack in haystacks):
+            return ent.entity_id
+    return None
+
+
+async def maybe_select_external_sensor(self: ModelFixHost, entity_id: str) -> bool:
+    """Point the TRV's sensor selector at the value BT writes.
+
+    Writing the external temperature input achieves nothing while the device
+    regulates on its own sensor, and it lands there on its own: a TRVZB that
+    is re-paired comes back on the internal sensor. So the selector is checked
+    alongside every write of the input it belongs to.
+
+    A device already on an option naming an external sensor is left alone,
+    whichever of them it is: the choice between them is its owner's.
+
+    Parameters
+    ----------
+    self : ModelFixHost
+        The Better Thermostat instance, supplying ``hass`` and the context
+        the service call is made under.
+    entity_id : str
+        The TRV whose device carries the selector.
+
+    Returns
+    -------
+    bool
+        True when the selector is on an external option, whether this call
+        put it there or found it there.
+    """
+    entity_registry = er.async_get(self.hass)
+    reg_entity = entity_registry.async_get(entity_id)
+    if reg_entity is None:
+        return False
+    target = _find_device_entity(
+        entity_registry,
+        reg_entity.device_id,
+        "select",
+        _TK_SENSOR_SELECT,
+        "temperature_sensor_select",
+    )
+    if target is None:
+        _LOGGER.debug(
+            "better_thermostat %s: TRVZB temperature sensor selector not found for %s",
+            self.device_name,
+            entity_id,
+        )
+        return False
+    state = self.hass.states.get(target)
+    if state is None:
+        return False
+    if str(state.state).startswith(_EXTERNAL_SENSOR_OPTION):
+        return True
+    options = state.attributes.get("options")
+    if not isinstance(options, (list, tuple)) or _EXTERNAL_SENSOR_OPTION not in options:
+        _LOGGER.debug(
+            "better_thermostat %s: TRVZB selector %s offers no '%s' option (%s)",
+            self.device_name,
+            target,
+            _EXTERNAL_SENSOR_OPTION,
+            options,
+        )
+        return False
+    await self.hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": target, "option": _EXTERNAL_SENSOR_OPTION},
+        blocking=True,
+        context=self.context,
+    )
+    _LOGGER.debug(
+        "better_thermostat %s: set TRVZB %s from '%s' to '%s' (for %s)",
+        self.device_name,
+        target,
+        state.state,
+        _EXTERNAL_SENSOR_OPTION,
+        entity_id,
+    )
+    return True
+
+
 async def maybe_set_external_temperature(
     self: ModelFixHost, entity_id: str, temperature: float
 ) -> bool:
@@ -416,32 +534,14 @@ async def maybe_set_external_temperature(
                 entity_id,
             )
             return False
-        device_id = reg_entity.device_id
-        target_entities: list[str] = []
-
-        # Known translation_key values for Sonoff TRVZB external temperature input.
-        _TK_EXTERNAL_TEMP = {"external_temperature_input", "external_temperature"}
-
-        for ent in entity_registry.entities.values():
-            if ent.device_id != device_id or ent.domain != "number":
-                continue
-            # Prefer translation_key (stable, language-independent)
-            tk = getattr(ent, "translation_key", None)
-            if tk and tk in _TK_EXTERNAL_TEMP:
-                target_entities.append(ent.entity_id)
-                continue
-            # Fallback: string matching on entity_id / unique_id / original_name
-            en = (ent.entity_id or "").lower()
-            uid = (ent.unique_id or "").lower()
-            name = (getattr(ent, "original_name", None) or "").lower()
-            if (
-                "external_temperature_input" in en
-                or "external_temperature_input" in uid
-                or "external temperature input" in name
-            ):
-                target_entities.append(ent.entity_id)
-
-        if not target_entities:
+        target = _find_device_entity(
+            entity_registry,
+            reg_entity.device_id,
+            "number",
+            _TK_EXTERNAL_TEMP,
+            "external_temperature_input",
+        )
+        if target is None:
             _LOGGER.debug(
                 "better_thermostat %s: TRVZB external_temperature_input number entity not found for %s",
                 self.device_name,
@@ -461,7 +561,6 @@ async def maybe_set_external_temperature(
             return False
         val = max(0.0, min(99.9, round(val, 1)))
 
-        target = target_entities[0]
         await self.hass.services.async_call(
             "number",
             "set_value",
@@ -476,6 +575,9 @@ async def maybe_set_external_temperature(
             target,
             entity_id,
         )
+        # The value just written only reaches the control loop of a device
+        # that is regulating on it.
+        await maybe_select_external_sensor(self, entity_id)
         return True
     except (TypeError, ValueError, KeyError, AttributeError) as ex:
         _LOGGER.debug(

--- a/tests/unit/test_external_temperature_keepalive.py
+++ b/tests/unit/test_external_temperature_keepalive.py
@@ -1,0 +1,133 @@
+"""The periodic re-send of the room temperature to TRVs that mirror it.
+
+Some TRVs regulate on a room temperature written into an input of their
+own and fall back to their internal sensor after a fixed silence, two
+hours on a Sonoff TRVZB. Better Thermostat's own writes are driven by
+room sensor changes, and a room holding its temperature produces none,
+so the periodic re-send is what holds such a device on the external
+value while the room is settled.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.climate import (
+    EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL,
+    BetterThermostat,
+)
+from custom_components.better_thermostat.core.decide import KernelState
+from custom_components.better_thermostat.trv import Trv
+
+_CLIMATE = "custom_components.better_thermostat.climate"
+_NOW = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+TRV_ID = "climate.trv"
+TRV_ID_2 = "climate.trv2"
+
+
+def _startup_bt():
+    """Minimal BetterThermostat stand-in for _finalize_startup."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.is_removed = False
+    mock.kernel_state = KernelState()
+    mock.clock = MagicMock()
+    mock.clock.now.return_value = _NOW
+    mock.clock.monotonic.return_value = 1000.0
+    mock.real_trvs = {TRV_ID: Trv(entity_id=TRV_ID, advanced={})}
+    mock.entity_ids = [TRV_ID]
+    mock.all_trvs = None
+    mock.all_entities = []
+    mock.sensor_entity_id = "sensor.room_temp"
+    mock.humidity_sensor_entity_id = None
+    mock.window_id = None
+    mock.cooler_entity_id = None
+    mock.outdoor_sensor = None
+    mock._async_unsub_state_changed = None
+    mock._trigger_time = AsyncMock()
+    mock._trigger_check_weather = AsyncMock()
+    mock._startup_control_trvs = AsyncMock()
+    mock.async_update_ha_state = AsyncMock()
+    mock.hass = MagicMock()
+    return mock
+
+
+async def _registered_intervals(bt):
+    """The (callback, interval) pairs _finalize_startup registers."""
+    track_interval = MagicMock()
+    with (
+        patch(f"{_CLIMATE}.await_critical_entities", AsyncMock()),
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
+        patch(f"{_CLIMATE}.await_optional_sensors", AsyncMock()),
+        patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
+        patch(f"{_CLIMATE}.async_track_time_interval", track_interval),
+        patch(f"{_CLIMATE}.async_track_state_change_event", MagicMock()),
+        patch(f"{_CLIMATE}.async_track_time_change", MagicMock()),
+        patch(f"{_CLIMATE}.asyncio.sleep", AsyncMock()),
+    ):
+        await BetterThermostat._finalize_startup(bt)
+    return [(call.args[1], call.args[2]) for call in track_interval.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_the_keepalive_is_registered_as_a_periodic_tick():
+    """Startup leaves a repeating timer behind.
+
+    The task created at the end of startup writes once and covers the
+    first interval; every write after that is the timer's, because a
+    settled room produces no sensor change to drive one.
+    """
+    bt = _startup_bt()
+    intervals = await _registered_intervals(bt)
+    assert (
+        bt._external_temperature_keepalive,
+        EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL,
+    ) in intervals
+
+
+@pytest.mark.asyncio
+async def test_the_interval_stays_inside_the_shortest_known_fallback():
+    """Two hours is the TRVZB's silence budget; the interval clears it.
+
+    Pinned as a bound, not as a value: an interval raised past the
+    fallback window would leave the device on its own sensor between
+    writes, which is the state this tick exists to prevent.
+    """
+    assert EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL.total_seconds() > 0
+    assert EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL.total_seconds() <= 3600
+
+
+@pytest.mark.asyncio
+async def test_the_tick_writes_the_room_temperature_to_every_trv():
+    """Each TRV with the quirk gets the temperature BT is regulating on."""
+    bt = MagicMock()
+    bt.device_name = "Test BT"
+    bt.cur_temp = 21.4
+    quirks = MagicMock()
+    quirks.maybe_set_external_temperature = AsyncMock(return_value=True)
+    bt.real_trvs = {
+        TRV_ID: Trv(entity_id=TRV_ID, model_quirks=quirks),
+        TRV_ID_2: Trv(entity_id=TRV_ID_2, model_quirks=quirks),
+    }
+
+    await BetterThermostat._external_temperature_keepalive(bt)
+
+    assert [
+        call.args[1:] for call in quirks.maybe_set_external_temperature.await_args_list
+    ] == [(TRV_ID, 21.4), (TRV_ID_2, 21.4)]
+
+
+@pytest.mark.asyncio
+async def test_the_tick_writes_nothing_without_a_room_temperature():
+    """No reading means no value to keep alive."""
+    bt = MagicMock()
+    bt.device_name = "Test BT"
+    bt.cur_temp = None
+    quirks = MagicMock()
+    quirks.maybe_set_external_temperature = AsyncMock()
+    bt.real_trvs = {TRV_ID: Trv(entity_id=TRV_ID, model_quirks=quirks)}
+
+    await BetterThermostat._external_temperature_keepalive(bt)
+
+    quirks.maybe_set_external_temperature.assert_not_awaited()

--- a/tests/unit/test_trvzb_quirk_overrides.py
+++ b/tests/unit/test_trvzb_quirk_overrides.py
@@ -211,14 +211,19 @@ def _registry_entry(entity_id, *, domain, translation_key=None, device_id="dev1"
     return entry
 
 
-def _make_selector_self(state, options=("internal", "external"), *, entries=None):
+def _make_selector_self(
+    state, options=("internal", "external"), *, entries=None, trv=None
+):
     """A BT stand-in whose TRV device carries a sensor selector.
 
     ``state`` is what the selector currently reports; ``None`` stands for a
-    selector that publishes no state.
+    selector that publishes no state. ``trv`` is the registry entry the
+    lookup starts from, so a test can hand it one that belongs to no
+    device; it is the first of ``entries`` unless given separately.
     """
     mock_self = _make_self()
-    trv = _registry_entry("climate.trv1", domain="climate")
+    if trv is None:
+        trv = _registry_entry("climate.trv1", domain="climate")
     selector = _registry_entry(
         "select.trv1_temperature_sensor_select",
         domain="select",
@@ -294,6 +299,55 @@ class TestMaybeSelectExternalSensor:
     async def test_a_selector_without_the_option_is_not_written(self, monkeypatch):
         """A device that names no external option keeps its selection."""
         mock_self = _make_selector_self("internal", options=("internal",))
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert (
+            await quirk.maybe_select_external_sensor(mock_self, "climate.trv1") is False
+        )
+
+        assert _selector_calls(mock_self) == []
+
+    @pytest.mark.asyncio
+    async def test_a_trv_that_belongs_to_no_device_is_not_written(self, monkeypatch):
+        """No device is no sibling, not "every entity without a device".
+
+        A registry entry carrying no ``device_id`` would otherwise match
+        every other entity that carries none, and the first one answering
+        to the selector's translation key or id fragment would be written
+        as if it sat on this TRV.
+        """
+        trv = _registry_entry("climate.trv1", domain="climate", device_id=None)
+        stray = _registry_entry(
+            "select.somewhere_else_temperature_sensor_select",
+            domain="select",
+            translation_key="temperature_sensor_select",
+            device_id=None,
+        )
+        mock_self = _make_selector_self("internal", entries=[trv, stray], trv=trv)
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert (
+            await quirk.maybe_select_external_sensor(mock_self, "climate.trv1") is False
+        )
+
+        assert _selector_calls(mock_self) == []
+
+    @pytest.mark.parametrize("reported", ["unavailable", "unknown"])
+    @pytest.mark.asyncio
+    async def test_a_selector_that_is_not_reporting_is_not_written(
+        self, monkeypatch, reported
+    ):
+        """A selector naming no option is in no state to be given one.
+
+        The device behind an unavailable or unknown selector is out of
+        reach, so the write would fail; the options the entity still lists
+        are the ones it had when it was last reachable.
+        """
+        mock_self = _make_selector_self(reported)
         monkeypatch.setattr(
             quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
         )

--- a/tests/unit/test_trvzb_quirk_overrides.py
+++ b/tests/unit/test_trvzb_quirk_overrides.py
@@ -197,3 +197,170 @@ class TestOverrideSetValve:
         assert handled is True
         assert writes == [30]
         assert "_trvzb_valve_bump_task" not in trv_state.extra
+
+
+def _registry_entry(entity_id, *, domain, translation_key=None, device_id="dev1"):
+    """A registry entry stand-in with the fields the lookup reads."""
+    entry = MagicMock()
+    entry.entity_id = entity_id
+    entry.domain = domain
+    entry.device_id = device_id
+    entry.unique_id = entity_id
+    entry.translation_key = translation_key
+    entry.original_name = None
+    return entry
+
+
+def _make_selector_self(state, options=("internal", "external"), *, entries=None):
+    """A BT stand-in whose TRV device carries a sensor selector.
+
+    ``state`` is what the selector currently reports; ``None`` stands for a
+    selector that publishes no state.
+    """
+    mock_self = _make_self()
+    trv = _registry_entry("climate.trv1", domain="climate")
+    selector = _registry_entry(
+        "select.trv1_temperature_sensor_select",
+        domain="select",
+        translation_key="temperature_sensor_select",
+    )
+    registry = MagicMock()
+    registry.async_get.return_value = trv
+    registry.entities.values.return_value = (
+        entries if entries is not None else [trv, selector]
+    )
+    mock_self._registry = registry
+
+    selector_state = None
+    if state is not None:
+        selector_state = MagicMock()
+        selector_state.state = state
+        selector_state.attributes = {"options": list(options)}
+    mock_self.hass.states.get.return_value = selector_state
+    return mock_self
+
+
+def _selector_calls(mock_self):
+    """The select_option payloads the quirk dispatched."""
+    return [
+        call.args[2]
+        for call in mock_self.hass.services.async_call.await_args_list
+        if call.args[:2] == ("select", "select_option")
+    ]
+
+
+class TestMaybeSelectExternalSensor:
+    """Which sensor the TRV regulates on while BT writes into its input.
+
+    Writing the room temperature into the external input achieves nothing
+    while the device regulates on its own sensor, and it lands there on its
+    own: a TRVZB that is re-paired comes back on the internal sensor.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_trv_on_its_internal_sensor_is_switched_over(self, monkeypatch):
+        """The selector is moved onto the option BT writes for."""
+        mock_self = _make_selector_self("internal")
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert await quirk.maybe_select_external_sensor(mock_self, "climate.trv1")
+
+        assert _selector_calls(mock_self) == [
+            {"entity_id": "select.trv1_temperature_sensor_select", "option": "external"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_trv_already_on_an_external_option_is_left_alone(self, monkeypatch):
+        """Which external option it is stays its owner's choice.
+
+        Devices offer more than one option naming an external sensor, and
+        rewriting the plain one would take that choice back on every write.
+        """
+        mock_self = _make_selector_self(
+            "external_ignore_internal",
+            options=("internal", "external", "external_ignore_internal"),
+        )
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert await quirk.maybe_select_external_sensor(mock_self, "climate.trv1")
+
+        assert _selector_calls(mock_self) == []
+
+    @pytest.mark.asyncio
+    async def test_a_selector_without_the_option_is_not_written(self, monkeypatch):
+        """A device that names no external option keeps its selection."""
+        mock_self = _make_selector_self("internal", options=("internal",))
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert (
+            await quirk.maybe_select_external_sensor(mock_self, "climate.trv1") is False
+        )
+
+        assert _selector_calls(mock_self) == []
+
+    @pytest.mark.asyncio
+    async def test_a_device_without_a_selector_is_not_written(self, monkeypatch):
+        """Nothing on the device answers for the sensor choice."""
+        trv = _registry_entry("climate.trv1", domain="climate")
+        mock_self = _make_selector_self("internal", entries=[trv])
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert (
+            await quirk.maybe_select_external_sensor(mock_self, "climate.trv1") is False
+        )
+
+        assert _selector_calls(mock_self) == []
+
+
+class TestExternalTemperatureWriteSelectsTheSensor:
+    """The write and the sensor choice belong to the same intent."""
+
+    @pytest.mark.asyncio
+    async def test_writing_the_input_also_points_the_selector_at_it(self, monkeypatch):
+        """A value written into an input the device ignores changes nothing.
+
+        This pins the wiring rather than either half: the selector check
+        has to happen on the path that writes the value, because that is
+        the only path that knows a value was written.
+        """
+        trv = _registry_entry("climate.trv1", domain="climate")
+        number = _registry_entry(
+            "number.trv1_external_temperature_input",
+            domain="number",
+            translation_key="external_temperature_input",
+        )
+        selector = _registry_entry(
+            "select.trv1_temperature_sensor_select",
+            domain="select",
+            translation_key="temperature_sensor_select",
+        )
+        mock_self = _make_selector_self("internal", entries=[trv, number, selector])
+        mock_self.real_trvs = {
+            "climate.trv1": Trv(entity_id="climate.trv1", model="TRVZB")
+        }
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert await quirk.maybe_set_external_temperature(
+            mock_self, "climate.trv1", 21.42
+        )
+
+        payloads = [
+            call.args[2] for call in mock_self.hass.services.async_call.await_args_list
+        ]
+        assert payloads == [
+            {"entity_id": "number.trv1_external_temperature_input", "value": 21.4},
+            {
+                "entity_id": "select.trv1_temperature_sensor_select",
+                "option": "external",
+            },
+        ]


### PR DESCRIPTION
Fixes #2267. Also the cause behind #1962, open since March.

## What happens

The comment above the startup keepalive says:

```python
# Send an immediate initial keepalive so TRVs don't have to wait for the first 30min tick
```

There is no 30-minute tick. `_external_temperature_keepalive` is called exactly once, as a background task at the end of `_finalize_startup`. The intervals actually registered are the weather check (1 h), the control tick (5 min, conditional), valve maintenance (5 min, conditional) and the EMA update (1 min). On `develop` the reconcile tick (5 min) does not help here: it compares commanded against reported control values and the external temperature is not one of them.

So after startup the only writes come from `events/temperature.py`, on accepted room sensor changes. A Sonoff TRVZB falls back to its internal sensor after two hours without an update to its external input, and a room holding its temperature produces no accepted sensor change, so the fallback happens exactly when the room is settled enough for the reading to matter. That is what the reporter's graphs show.

## What this changes

**The tick the comment describes is registered.** Thirty minutes, well inside the two-hour window rather than near it.

**The sensor selector is checked alongside the write.** A value written into the external input reaches the control loop only on a device that is regulating on that input, and a TRVZB that is re-paired comes back on its internal sensor, which is the reporter's second observation. Better Thermostat wrote the input and never the selector, so on such a device it was writing into nothing.

The selector is only ever moved onto `external`, and only from an option that does not already name an external sensor. Devices offer more than one such option and the choice between them stays their owner's.

## One claim from the issue I could not confirm

The report says that re-writing an unchanged value into the entity usually does not reach the device, and suggests publishing the Zigbee payload directly. Home Assistant's `number.set_value` calls the entity's setter on every service call, whether or not the value changed, so a periodic write is enough and no direct publish is needed. If the value still does not reach the device on the reporter's setup, that is worth a separate look.

## Verification

`tests/unit/test_external_temperature_keepalive.py` pins the registration and interval and covers what the tick writes. The selector tests sit with the other TRVZB quirk tests, including one that pins the wiring rather than either half: the selector check has to happen on the path that writes the value, because that is the only path that knows a value was written.

Counter-check by mutation, three separate ones: removing the interval registration, removing the selector call from the write path, and dropping the already-external check each turn exactly the corresponding test red. The full suite is green with the fix.

## Note

The `_find_device_entity` helper is shared by the input lookup and the selector lookup. The input lookup had that loop inline; leaving a second copy of it next to the first would have been mine to answer for, so the two now use one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External temperature updates now remain synchronized with TRVs every 30 minutes.
  * Sonoff TRVZB devices automatically select their external temperature sensor when available.
  * External sensor selection is configured automatically when temperature data is updated.

* **Bug Fixes**
  * Prevented unnecessary temperature updates when no room temperature is available.
  * Improved handling of TRVZB devices already configured to use an external sensor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->