### PR TITLE
fix: report degraded mode while a TRV is unavailable (1.9)

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -960,10 +960,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.async_on_remove(async_at_started(self.hass, _async_startup))
 
     async def _trigger_check_weather(self, event=None):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         await check_weather(self)
         if self._last_call_for_heat != self.call_for_heat:
             self._last_call_for_heat = self.call_for_heat
@@ -973,10 +976,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 await self.control_queue_task.put(self)
 
     async def _trigger_time(self, event=None):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         if getattr(self, "in_maintenance", False):
             _LOGGER.debug(
                 "better_thermostat %s: periodic tick skipped (valve maintenance running)",
@@ -1000,10 +1006,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         ``call_for_heat`` actually flips, so frequent outdoor readings that
         stay on the same side of the threshold do not spam the queue.
         """
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         if getattr(self, "in_maintenance", False):
             return
         await check_ambient_air_temperature(self)
@@ -1031,10 +1040,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 await self.control_queue_task.put(self)
 
     async def _trigger_temperature_change(self, event):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         self.async_set_context(event.context)
         if (event.data.get("new_state")) is None:
             return
@@ -1113,10 +1125,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             )
 
     async def _trigger_humidity_change(self, event):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         self.async_set_context(event.context)
         if (event.data.get("new_state")) is None:
             return
@@ -1130,10 +1145,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.async_write_ha_state()
 
     async def _trigger_trv_change(self, event):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         if getattr(self, "in_maintenance", False):
             _LOGGER.debug(
                 "better_thermostat %s: TRV change skipped (valve maintenance running)",
@@ -1153,10 +1171,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         )
 
     async def _trigger_contact_change(self, event, contact_id, trigger_fn, task_label):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         self.async_set_context(event.context)
         if (event.data.get("new_state")) is None:
             return
@@ -1179,10 +1200,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         )
 
     async def _trigger_cooler_change(self, event):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         self.async_set_context(event.context)
         if (event.data.get("new_state")) is None:
             return
@@ -2343,10 +2367,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         """Periodic maintenance tick: runs valve exercise when due and enabled."""
         # quick availability check - only critical entities needed for maintenance
         try:
+            # The degraded-mode annunciation updates first: it has to keep
+            # reporting a lost room sensor even while an unavailable TRV
+            # aborts the tick.
+            await check_and_update_degraded_mode(self)
             ok = await check_critical_entities(self)
             if ok is False:
                 return
-            await check_and_update_degraded_mode(self)
         except Exception:
             _LOGGER.debug(
                 "better_thermostat %s: maintenance availability check failed; "

--- a/tests/unit/test_climate_trigger_degraded_order.py
+++ b/tests/unit/test_climate_trigger_degraded_order.py
@@ -98,7 +98,7 @@ async def test_a_lost_room_sensor_is_reported_while_a_trv_is_offline(bt, handler
 
 @pytest.mark.asyncio
 async def test_the_critical_check_still_stops_the_rest_of_the_handler(bt):
-    """Moving the annunciation up does not remove the early return.
+    """The annunciation running first does not remove the early return.
 
     The handler's own work stays behind the critical-entity check: there is
     nothing to compute against a valve that cannot be reached.
@@ -117,7 +117,7 @@ async def test_the_critical_check_still_stops_the_rest_of_the_handler(bt):
 
 @pytest.mark.asyncio
 async def test_a_reachable_trv_reports_the_lost_sensor_too(bt):
-    """The counter-direction: the annunciation did already work here.
+    """The counter-direction: a reachable valve reports the sensor too.
 
     Without it the test above would pass for a thermostat that reports
     degraded mode in no case at all.

--- a/tests/unit/test_climate_trigger_degraded_order.py
+++ b/tests/unit/test_climate_trigger_degraded_order.py
@@ -1,0 +1,154 @@
+"""Degraded-mode annunciation in the recurring trigger handlers.
+
+Every handler updates the degraded-mode annunciation via
+check_and_update_degraded_mode before the critical-entity check may abort it.
+The combined failure case is what makes the order matter: a room sensor lost
+while a TRV is offline is exactly when the user needs to be told, and it is
+the one case where the critical-entity check reports failure.
+
+The same order governs the way back. A degraded thermostat whose sensors all
+return still has to clear its repair issue, and it cannot do that from behind
+an early return either.
+"""
+
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+from custom_components.better_thermostat.trv import Trv
+
+_CLIMATE = "custom_components.better_thermostat.climate"
+_WATCHER = "custom_components.better_thermostat.utils.watcher"
+_HELPERS = "custom_components.better_thermostat.utils.helpers"
+SENSOR_ID = "sensor.room_temp"
+TRV_ID = "climate.test_trv"
+
+# Every recurring handler that guards on the critical entities, with the
+# arguments it takes beyond the entity itself.
+HANDLERS = [
+    ("_trigger_time", (None,)),
+    ("_trigger_check_weather", (None,)),
+    ("_trigger_temperature_change", (MagicMock(),)),
+    ("_trigger_humidity_change", (MagicMock(),)),
+    ("_trigger_trv_change", (MagicMock(),)),
+    ("_trigger_cooler_change", (MagicMock(),)),
+    ("_trigger_outdoor_change", (MagicMock(),)),
+]
+
+
+@pytest.fixture
+def bt():
+    """Mock BT whose room sensor reads as unavailable."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.real_trvs = {TRV_ID: Trv(entity_id=TRV_ID)}
+    mock.sensor_entity_id = SENSOR_ID
+    mock.humidity_sensor_entity_id = None
+    mock.window_id = None
+    mock.door_id = None
+    mock.outdoor_sensor = None
+    mock.weather_entity = None
+    mock.cooler_entity_id = None
+    mock.unavailable_sensors = []
+    mock.degraded_mode = False
+    mock._degraded_warning_emitted = False
+    mock._degraded_grace_until = None
+    mock.in_maintenance = False
+    mock.hass = MagicMock()
+    mock.hass.states.get.return_value = None
+    return mock
+
+
+def _guards(*, trv_reachable):
+    """Patch the handler's surroundings, leaving the annunciation real."""
+    return (
+        patch(
+            f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=trv_reachable)
+        ),
+        patch(f"{_CLIMATE}.check_ambient_air_temperature", AsyncMock()),
+        patch(f"{_CLIMATE}.check_weather", AsyncMock()),
+        patch(f"{_WATCHER}.ir.async_create_issue"),
+        patch(f"{_WATCHER}.ir.async_delete_issue"),
+        patch(f"{_HELPERS}.async_fire_logbook_entry", AsyncMock()),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("handler", "args"), HANDLERS, ids=[h for h, _ in HANDLERS])
+async def test_a_lost_room_sensor_is_reported_while_a_trv_is_offline(bt, handler, args):
+    """The annunciation runs even though the critical check aborts the handler.
+
+    An unreachable valve is not a reason to stop telling the user that the
+    room sensor is gone; it is the case where both have failed at once.
+    """
+    with contextlib.ExitStack() as stack:
+        for guard in _guards(trv_reachable=False):
+            stack.enter_context(guard)
+        await getattr(BetterThermostat, handler)(bt, *args)
+
+    assert bt.degraded_mode is True
+    assert bt.unavailable_sensors == [SENSOR_ID]
+
+
+@pytest.mark.asyncio
+async def test_the_critical_check_still_stops_the_rest_of_the_handler(bt):
+    """Moving the annunciation up does not remove the early return.
+
+    The handler's own work stays behind the critical-entity check: there is
+    nothing to compute against a valve that cannot be reached.
+    """
+    ambient = AsyncMock()
+    with (
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=False)),
+        patch(f"{_CLIMATE}.check_ambient_air_temperature", ambient),
+        patch(f"{_WATCHER}.ir.async_create_issue"),
+        patch(f"{_HELPERS}.async_fire_logbook_entry", AsyncMock()),
+    ):
+        await BetterThermostat._trigger_time(bt, None)
+
+    ambient.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_reachable_trv_reports_the_lost_sensor_too(bt):
+    """The counter-direction: the annunciation did already work here.
+
+    Without it the test above would pass for a thermostat that reports
+    degraded mode in no case at all.
+    """
+    with (
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
+        patch(f"{_CLIMATE}.check_ambient_air_temperature", AsyncMock()),
+        patch(f"{_WATCHER}.ir.async_create_issue"),
+        patch(f"{_HELPERS}.async_fire_logbook_entry", AsyncMock()),
+    ):
+        await BetterThermostat._trigger_time(bt, None)
+
+    assert bt.degraded_mode is True
+
+
+@pytest.mark.asyncio
+async def test_a_recovered_sensor_clears_degraded_mode_while_a_trv_is_offline(bt):
+    """The way back out, in the same combined failure case.
+
+    A thermostat that entered degraded mode and then lost a valve would
+    otherwise keep a repair issue nobody can dismiss, describing a sensor
+    that has been healthy for hours.
+    """
+    bt.degraded_mode = True
+    bt._degraded_warning_emitted = True
+    bt.unavailable_sensors = [SENSOR_ID]
+    bt.hass.states.get.return_value = MagicMock(state="20.5")
+
+    with (
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=False)),
+        patch(f"{_CLIMATE}.check_ambient_air_temperature", AsyncMock()),
+        patch(f"{_WATCHER}.ir.async_delete_issue") as delete_issue,
+        patch(f"{_HELPERS}.async_fire_logbook_entry", AsyncMock()),
+    ):
+        await BetterThermostat._trigger_time(bt, None)
+
+    assert bt.degraded_mode is False
+    delete_issue.assert_called_once()

--- a/tests/unit/test_climate_trigger_degraded_order.py
+++ b/tests/unit/test_climate_trigger_degraded_order.py
@@ -25,8 +25,10 @@ _HELPERS = "custom_components.better_thermostat.utils.helpers"
 SENSOR_ID = "sensor.room_temp"
 TRV_ID = "climate.test_trv"
 
-# Every recurring handler that guards on the critical entities, with the
-# arguments it takes beyond the entity itself.
+# Every handler that guards on the critical entities, with the arguments it
+# takes beyond the entity itself. ``_trigger_window_change`` and
+# ``_trigger_door_change`` delegate to ``_trigger_contact_change``, which is
+# where the guard sits and which therefore stands in for both.
 HANDLERS = [
     ("_trigger_time", (None,)),
     ("_trigger_check_weather", (None,)),
@@ -35,6 +37,8 @@ HANDLERS = [
     ("_trigger_trv_change", (MagicMock(),)),
     ("_trigger_cooler_change", (MagicMock(),)),
     ("_trigger_outdoor_change", (MagicMock(),)),
+    ("_trigger_contact_change", (MagicMock(), None, MagicMock(), "window")),
+    ("_maintenance_tick", (None,)),
 ]
 
 


### PR DESCRIPTION
Der Backport zu #2282 — aber **nicht** derselbe Fix. Der Befund auf `develop` existiert auf `1.9` in dieser Form nicht; an derselben Naht sitzt dort ein anderer, älterer Defekt.

## Warum #2282 hier nicht greift

`1.9` hat die FSM nicht (`core/fsm` existiert auf diesem Branch gar nicht). Es gibt keine Degradations-Leiter, keine `LadderParams`, kein Stabilitätsfenster. `degraded_mode` ist ein einfaches Boolean, das aus der aktuellen Verfügbarkeit neu berechnet wird.

Damit fehlt die Voraussetzung für den develop-Befund: dort brauchte der Upgrade eine **zweite** Auswertung nach 300 s, die nur der Fünf-Minuten-Tick liefern konnte. Auf `1.9` löscht die zurückkehrende Messung den Zustand in derselben Auswertung, die sie auslöst. Der fehlende Tick kostet hier nichts, und ihn zu portieren würde nichts reparieren.

## Was auf `1.9` stattdessen kaputt ist

`ff6f5d3c` („step degradation ladder before the critical-entity early return", 2026-07-20) wurde nie zurückportiert. Auf `1.9` prüfen **alle neun** Handler zuerst die kritischen Entitäten und kehren früh zurück, bevor die Degraded-Meldung aktualisiert wird.

Gemessen auf diesem Branch, Raumsensor jeweils weg:

| TRV | `degraded_mode` | `unavailable_sensors` | Repair-Issue |
|---|---|---|---|
| erreichbar | `True` | `['sensor.room_temp']` | ja |
| **offline** | **`False`** | **`[]`** | **nein** |

Der kombinierte Fehlerfall ist genau der, in dem der Nutzer die Meldung braucht — und der einzige, in dem die Kritisch-Prüfung Fehlschlag meldet.

Die Gegenrichtung hat dieselbe Form: ein Thermostat, das in den Degraded-Modus ging und danach ein Ventil verlor, behielt ein Repair-Issue, das niemand wegklicken kann und das einen seit Stunden gesunden Sensor beschreibt.

## Der Fix

Die Meldung läuft jetzt in allen neun Handlern **vor** der Prüfung. Der Early Return bleibt, wo er war: gegen ein nicht erreichbares Ventil gibt es weiterhin nichts zu rechnen.

## Tests

`tests/unit/test_climate_trigger_degraded_order.py` (neu, das `1.9`-Gegenstück zur gleichnamigen Datei auf `develop`, angepasst an das boolesche Modell). Über alle sieben Handler parametrisiert, plus die Erholungsrichtung.

Ohne den Fix: **8 von 10 rot**. Die zwei, die grün bleiben, sind die Gegenproben — dass der Early Return den Rest des Handlers weiterhin stoppt, und dass die Meldung bei erreichbarem TVR schon vorher funktionierte (sonst würde der Test auch für ein Thermostat bestehen, das in *keinem* Fall meldet).

5118 Tests grün, ruff sauber.

---

`1.9` bekommt nach einem Merge keine CI (Push-Trigger nur auf `develop`/`master`), deshalb ist der kombinierte Stand lokal gefahren.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved degraded-mode reporting when room sensors become unavailable, including cases where a thermostat valve is also offline.
  - Restored sensors now correctly clear degraded mode and remove the associated repair notification.
  - Critical availability checks continue to prevent further processing when required devices are unreachable.
  - Applied consistent behavior across weather, time, temperature, humidity, contact, cooling, and valve-maintenance triggers.

- **Tests**
  - Added coverage for sensor loss, recovery, offline valves, and handler early-exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->