### PR TITLE
fix: read "a head is off" the same way at startup and at runtime (1.9)

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -152,6 +152,7 @@ from .utils.helpers import (
     get_device_model,
     get_hvac_bt_mode,
     is_reasonable_temperature,
+    member_counts_as_off,
     normalize_hvac_mode,
     normalize_step,
     reported_setpoint_step_celsius,
@@ -1772,10 +1773,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # if hvac mode could not be restored, turn heat off
         _LOGGER.debug("better_thermostat %s: checking hvac mode...", self.device_name)
         if self.bt_hvac_mode in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
-            # OFF is filtered out, so a non-empty list means at least one child
-            # is running -> adopt HEAT; otherwise (all OFF or none) stay OFF.
-            current_hvac_modes = [x.state for x in states if x.state != HVACMode.OFF]
-            if current_hvac_modes:
+            # A room is off only when every one of its heads is off, and it
+            # heats as soon as one head heats — the same rule the runtime event
+            # path applies, read through the same predicate so the two cannot
+            # drift apart. A head that never reports "off" is off at its own
+            # minimum setpoint, which is why the bare state is not enough.
+            heating_members = [
+                x for x in states if not member_counts_as_off(self, x.entity_id, x)
+            ]
+            if heating_members:
                 self.bt_hvac_mode = HVACMode.HEAT
             else:
                 self.bt_hvac_mode = HVACMode.OFF

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -552,6 +552,45 @@ def mode_remap(
     return _clamp_to_offered_mode(self, trv, entity_id, hvac_mode, inbound)
 
 
+def member_counts_as_off(self, entity_id: str, state: State) -> bool:
+    """Whether one group member is effectively off.
+
+    This is the single reading of "off" behind the room-level rule that both
+    the startup path and the runtime event path apply: a room is off only when
+    every one of its heads is off, and it heats as soon as one head heats.
+
+    A member counts as off when its reported HVAC state is ``off`` or, for a
+    ``no_off_system_mode`` device (which never reports ``off``), when its
+    current setpoint has dropped to that device's minimum temperature. The
+    setpoint is read via :func:`attr_to_celsius` (with ``target_temp_low`` as
+    fallback attribute) so it is compared in Celsius, like ``min_temp``.
+
+    ``min_temp`` comes from the cached :class:`Trv` and falls back to the
+    reported state, because ``Trv.min_temp`` is filled by ``_initialize_trvs``
+    — which runs after the startup mode is decided, so a caller in the startup
+    path finds the cache still empty.
+    """
+    if state.state == HVACMode.OFF:
+        return True
+
+    member = self.real_trvs.get(entity_id)
+    if member is None or not (member.advanced or {}).get("no_off_system_mode", False):
+        return False
+
+    setpoint_key = (
+        "temperature" if "temperature" in state.attributes else "target_temp_low"
+    )
+    setpoint = attr_to_celsius(
+        self, state, setpoint_key, None, "member_counts_as_off()"
+    )
+    min_temp = member.min_temp
+    if min_temp is None:
+        min_temp = attr_to_celsius(
+            self, state, "min_temp", None, "member_counts_as_off()"
+        )
+    return setpoint is not None and min_temp is not None and setpoint <= min_temp
+
+
 def group_all_members_off(self) -> bool:
     """Whether every available group member is effectively off.
 
@@ -560,11 +599,8 @@ def group_all_members_off(self) -> bool:
     valve dropping to its minimum temperature cannot turn the whole room off.
     Single-TRV instances always agree, preserving historical behavior.
 
-    A member counts as off when its reported HVAC state is ``off`` or, for a
-    ``no_off_system_mode`` device (which never reports ``off``), when its
-    current setpoint has dropped to that device's minimum temperature. The
-    setpoint is read via :func:`attr_to_celsius` (with ``target_temp_low`` as
-    fallback attribute) so it is compared in Celsius, like ``min_temp``.
+    What makes one member count as off is :func:`member_counts_as_off`, which
+    the startup path reads too so the two cannot drift apart.
     """
     trv_ids = list(self.real_trvs.keys())
     if len(trv_ids) <= 1:
@@ -576,27 +612,8 @@ def group_all_members_off(self) -> bool:
         if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
             continue
         saw_member = True
-        if state.state == HVACMode.OFF:
-            continue
-        member = self.real_trvs.get(entity_id)
-        if member is not None and (member.advanced or {}).get(
-            "no_off_system_mode", False
-        ):
-            setpoint_key = (
-                "temperature"
-                if "temperature" in state.attributes
-                else "target_temp_low"
-            )
-            setpoint = attr_to_celsius(
-                self, state, setpoint_key, None, "group_all_members_off()"
-            )
-            if (
-                setpoint is not None
-                and member.min_temp is not None
-                and setpoint <= member.min_temp
-            ):
-                continue
-        return False
+        if not member_counts_as_off(self, entity_id, state):
+            return False
     return saw_member
 
 

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -562,13 +562,34 @@ def member_counts_as_off(self, entity_id: str, state: State) -> bool:
     A member counts as off when its reported HVAC state is ``off`` or, for a
     ``no_off_system_mode`` device (which never reports ``off``), when its
     current setpoint has dropped to that device's minimum temperature. The
-    setpoint is read via :func:`attr_to_celsius` (with ``target_temp_low`` as
-    fallback attribute) so it is compared in Celsius, like ``min_temp``.
+    setpoint is read via :func:`attr_to_celsius` so it is compared in Celsius,
+    like ``min_temp``. ``target_temp_low`` carries the setpoint whenever
+    ``temperature`` yields nothing: a device that supports both a single target
+    and a target range publishes ``temperature`` as ``None`` while it runs on
+    the range.
 
     ``min_temp`` comes from the cached :class:`Trv` and falls back to the
     reported state, because ``Trv.min_temp`` is filled by ``_initialize_trvs``
     — which runs after the startup mode is decided, so a caller in the startup
     path finds the cache still empty.
+
+    Parameters
+    ----------
+    self :
+            the Better Thermostat instance, supplying ``hass`` and ``real_trvs``
+    entity_id : str
+            entity id of the group member to judge
+    state : State
+            the member's reported state
+
+    Returns
+    -------
+    bool
+            True when the member is off, False when it heats
+
+    See Also
+    --------
+    group_all_members_off : applies this reading to the whole room
     """
     if state.state == HVACMode.OFF:
         return True
@@ -577,12 +598,13 @@ def member_counts_as_off(self, entity_id: str, state: State) -> bool:
     if member is None or not (member.advanced or {}).get("no_off_system_mode", False):
         return False
 
-    setpoint_key = (
-        "temperature" if "temperature" in state.attributes else "target_temp_low"
-    )
     setpoint = attr_to_celsius(
-        self, state, setpoint_key, None, "member_counts_as_off()"
+        self, state, "temperature", None, "member_counts_as_off()"
     )
+    if setpoint is None:
+        setpoint = attr_to_celsius(
+            self, state, "target_temp_low", None, "member_counts_as_off()"
+        )
     min_temp = member.min_temp
     if min_temp is None:
         min_temp = attr_to_celsius(

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -58,7 +58,20 @@ def bt():
     mock.hass = MagicMock()
     mock.device_name = "Test BT"
     mock.sensor_entity_id = SENSOR_ID
-    mock.real_trvs = {TRV_ID: {"calibration": 1}}
+    # Production holds Trv objects here, not raw dicts: a fixture that maps to
+    # a dict passes attribute reads straight through MagicMock and hides
+    # whatever the code under test asks of a member.
+    mock.real_trvs = {
+        TRV_ID: Trv(
+            entity_id=TRV_ID,
+            calibration=1,
+            integration="generic_thermostat",
+            adapter=None,
+            model_quirks=None,
+            model="SomeModel",
+            advanced={},
+        )
+    }
     mock.cooler_entity_id = None
     mock.humidity_sensor_entity_id = None
     mock.window_id = None
@@ -118,6 +131,24 @@ def _make_trv_state(entity_id=TRV_ID, state="heat", attrs=None):
     if attrs:
         default_attrs.update(attrs)
     return State(entity_id, state, attributes=default_attrs)
+
+
+def _make_no_off_trv(entity_id):
+    """Build a Trv for a device that never reports "off".
+
+    ``min_temp`` is left empty on purpose: ``_initialize_trvs`` fills it only
+    after the startup mode is decided, so this is the shape the startup path
+    actually sees.
+    """
+    return Trv(
+        entity_id=entity_id,
+        calibration=None,
+        integration="generic_thermostat",
+        adapter=None,
+        model_quirks=None,
+        model="SomeModel",
+        advanced={"no_off_system_mode": True, "child_lock": False},
+    )
 
 
 def _make_sensor_state(temp="21.5", state_val=None):
@@ -1549,13 +1580,67 @@ class TestValidateHvacMode:
         BetterThermostat._validate_hvac_mode(bt, states)
         assert bt.bt_hvac_mode == HVACMode.OFF
 
-    def test_none_mode_most_heat_sets_heat(self, bt):
-        """Test None mode most heat sets heat."""
+    def test_none_mode_every_head_heating_sets_heat(self, bt):
+        """A room whose heads all heat comes up heating."""
         bt.bt_hvac_mode = None
         bt.humidity_sensor_entity_id = None
         states = [
             _make_trv_state(TRV_ID, state="heat"),
             _make_trv_state(TRV_ID_2, state="heat"),
+        ]
+        BetterThermostat._validate_hvac_mode(bt, states)
+        assert bt.bt_hvac_mode == HVACMode.HEAT
+
+    def test_none_mode_one_head_heating_sets_heat(self, bt):
+        """One head still heating is enough to bring the room up heating.
+
+        The counterpart of the runtime rule: the room follows its heads off
+        only once all of them are off, so a single one that is not carries it.
+        """
+        bt.bt_hvac_mode = None
+        bt.humidity_sensor_entity_id = None
+        states = [
+            _make_trv_state(TRV_ID, state="off"),
+            _make_trv_state(TRV_ID_2, state="heat"),
+        ]
+        BetterThermostat._validate_hvac_mode(bt, states)
+        assert bt.bt_hvac_mode == HVACMode.HEAT
+
+    def test_none_mode_heads_parked_at_their_minimum_set_off(self, bt):
+        """Heads that never report "off" are off at their own minimum.
+
+        A ``no_off_system_mode`` valve expresses "off" as its minimum setpoint,
+        so a room of them parked there is off — the reading the runtime path
+        has always used, and which the startup path used to miss because it
+        judged the reported state alone.
+        """
+        bt.bt_hvac_mode = None
+        bt.humidity_sensor_entity_id = None
+        parked = {"temperature": 5.0, "min_temp": 5.0}
+        bt.real_trvs = {
+            trv_id: _make_no_off_trv(trv_id) for trv_id in (TRV_ID, TRV_ID_2)
+        }
+        states = [
+            _make_trv_state(TRV_ID, state="heat", attrs=parked),
+            _make_trv_state(TRV_ID_2, state="heat", attrs=parked),
+        ]
+        BetterThermostat._validate_hvac_mode(bt, states)
+        assert bt.bt_hvac_mode == HVACMode.OFF
+
+    def test_none_mode_one_head_above_its_minimum_sets_heat(self, bt):
+        """One head lifted off its minimum brings the whole room up heating."""
+        bt.bt_hvac_mode = None
+        bt.humidity_sensor_entity_id = None
+        bt.real_trvs = {
+            trv_id: _make_no_off_trv(trv_id) for trv_id in (TRV_ID, TRV_ID_2)
+        }
+        states = [
+            _make_trv_state(
+                TRV_ID, state="heat", attrs={"temperature": 5.0, "min_temp": 5.0}
+            ),
+            _make_trv_state(
+                TRV_ID_2, state="heat", attrs={"temperature": 21.0, "min_temp": 5.0}
+            ),
         ]
         BetterThermostat._validate_hvac_mode(bt, states)
         assert bt.bt_hvac_mode == HVACMode.HEAT

--- a/tests/unit/test_helpers_group_off.py
+++ b/tests/unit/test_helpers_group_off.py
@@ -113,6 +113,26 @@ def test_no_off_target_temp_low_at_min_true():
     assert group_all_members_off(_fake_self(members, states)) is True
 
 
+def test_no_off_null_temperature_falls_back_to_target_temp_low():
+    """A device on a target range publishes ``temperature`` as None.
+
+    Home Assistant emits both attributes for a device that supports a single
+    target and a range, and leaves ``temperature`` empty while the range is in
+    use. Reading only that key makes a head sitting at its minimum look like it
+    is heating, and the room comes back from a restart in HEAT.
+    """
+    members = {"climate.a": _member(no_off=True), "climate.b": _member(no_off=True)}
+    states = {
+        "climate.a": _state("climate.a", "heat", temperature=5.0),
+        "climate.b": State(
+            "climate.b",
+            "heat",
+            attributes={"temperature": None, "target_temp_low": 5.0, "min_temp": 5.0},
+        ),
+    }
+    assert group_all_members_off(_fake_self(members, states)) is True
+
+
 def test_unavailable_members_skipped():
     """An unavailable member is ignored; the rest still decide the outcome."""
     members = {f"climate.{n}": _member() for n in ("a", "b", "c")}


### PR DESCRIPTION
The 1.9 twin of #2284 — same defect, same fix, same tests.

## What

A room is off only when every one of its heads is off, and it heats as soon as one head heats. Both the startup path and the runtime event path apply that rule, but each spelled its own reading of when a *single* head counts as off:

- Runtime (`group_all_members_off`) counts a `no_off_system_mode` valve parked at its minimum setpoint as off. Such a device never reports `off`; its minimum *is* its off.
- Startup (`_validate_hvac_mode`) judged the reported state alone.

A room of those valves parked at their minimum is off at runtime and comes up **heating** after a restart that found no mode to restore. Measured on 1.9 before the change:

```
runtime  group_all_members_off = True    (room counts as off)
startup  _validate_hvac_mode    = HVACMode.HEAT
```

## How

`member_counts_as_off()` becomes the single reading, called by both paths. The minimum comes from the cached `Trv` first and falls back to the reported state — `_initialize_trvs()` fills `Trv.min_temp` only *after* `_validate_hvac_mode()` runs, so a cache-only predicate would be a silent no-op in the path this fixes. Cache-first leaves the runtime reading unchanged.

## Note on #2063

The quorum guard #2063 asks for is already on this line (`events/trv.py`, `and (mapped_state != HVACMode.OFF or group_all_members_off(self))`) and has been since #2095 — a commit both lines share, so there was never anything to backport. `TestGroupedModeAdoption` pins both directions here already.

What #2063 additionally proposes — a majority rule for `heat`/`heat_cool` — argues from a startup majority vote that no longer exists on either line. See #2284 for the reasoning against adding it.

## Tests

Three new cases in `TestValidateHvacMode`, one rename (`test_none_mode_most_heat_sets_heat` still carried the majority rule the code dropped), and the `bt` fixture now holds a `Trv` where it held a raw `dict` — production holds `Trv` objects, and a dict inside a `MagicMock` passes attribute reads straight through, hiding what the code asks of a member.

Counter-checked by mutation: reverting the startup path to `x.state != HVACMode.OFF`, and dropping the `min_temp` fallback, each turn `test_none_mode_heads_parked_at_their_minimum_set_off` red. Removing the runtime guard turns `TestGroupedModeAdoption::test_group_off_not_adopted_when_others_heat` red.

Suite: 5111 passed, 1 skipped. `ruff` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thermostat startup heating detection when connected valves do not report an explicit “off” state.
  - Devices without an “off” mode are now correctly treated as off when positioned at their minimum temperature.
  - Heating starts correctly when any valve is set above its minimum temperature.
  - Startup and runtime off-state handling are now consistent across thermostat members.
  - Improved off-state detection when a device’s current temperature is unavailable but its minimum target temperature is reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->