### PR TITLE
1.9.2

### DIFF
--- a/custom_components/better_thermostat/__init__.py
+++ b/custom_components/better_thermostat/__init__.py
@@ -23,6 +23,7 @@ from .utils.const import (
     CONF_WINDOW_TIMEOUT,
     CONF_WINDOW_TIMEOUT_AFTER,
     DOMAIN,
+    NORMALIZED_ID_NAMES,
     CalibrationMode,
 )
 from .utils.helpers import get_device_model
@@ -106,6 +107,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     be cleaned up here to avoid stale warnings after a config entry is gone.
     """
     hass.data.get(RELOAD_LOCKS, {}).pop(entry.entry_id, None)
+    hass.data.get(NORMALIZED_ID_NAMES, {}).pop(entry.entry_id, None)
 
     device_name = entry.data.get(CONF_NAME, entry.title)
 

--- a/custom_components/better_thermostat/__init__.py
+++ b/custom_components/better_thermostat/__init__.py
@@ -100,11 +100,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Remove repair-registry issues created by this Better Thermostat instance.
+    """Clean up everything this Better Thermostat instance left behind.
 
-    Issues are scoped by ``device_name`` or by individual ``entity_id`` and
-    persist in HA's issue registry until explicitly deleted, so they have to
-    be cleaned up here to avoid stale warnings after a config entry is gone.
+    Repair-registry issues are scoped by ``device_name`` or by individual
+    ``entity_id`` and persist in HA's issue registry until explicitly
+    deleted, so they have to be cleaned up here to avoid stale warnings
+    after a config entry is gone. The reload lock and the recorded
+    entity-id names outlive the entry's unload by design, so removal is
+    where they are dropped.
+
+    Parameters
+    ----------
+    hass : HomeAssistant
+        The running Home Assistant instance.
+    entry : ConfigEntry
+        The config entry being removed.
     """
     hass.data.get(RELOAD_LOCKS, {}).pop(entry.entry_id, None)
     hass.data.get(NORMALIZED_ID_NAMES, {}).pop(entry.entry_id, None)

--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -8,8 +8,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Final
 
-from homeassistant.components.climate.const import PRESET_NONE
 from homeassistant.components.number.const import SERVICE_SET_VALUE
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
@@ -21,6 +21,43 @@ from .generic import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+# The preset a device offers for "the setpoint is whatever was written to me",
+# tried in order. Home Assistant's MQTT climate entity inserts ``none`` into
+# ``preset_modes`` itself and rejects a discovery config that lists it, so
+# every device reached through this adapter offers ``none`` and none of them
+# implements it: publishing it leaves the device on its schedule and the
+# broker rejects the command.
+MANUAL_PRESET_PREFERENCE: Final = ("manual",)
+
+
+def manual_preset(preset_modes: object) -> str | None:
+    """Return the preset that hands the setpoint to BT, or ``None``.
+
+    Parameters
+    ----------
+    preset_modes : object
+        The presets the device reports, as read from its state attributes.
+        Anything that is not a sequence of presets means the device names
+        none, which is the same answer as a sequence holding nothing usable.
+
+    Returns
+    -------
+    str | None
+        The device's own spelling of the first preset in
+        ``MANUAL_PRESET_PREFERENCE`` it offers, or ``None`` when it offers
+        no preset that hands the setpoint over.
+    """
+    if isinstance(preset_modes, str) or not isinstance(
+        preset_modes, (list, tuple, set)
+    ):
+        return None
+    offered = {str(mode).casefold(): str(mode) for mode in preset_modes}
+    for candidate in MANUAL_PRESET_PREFERENCE:
+        if candidate in offered:
+            return offered[candidate]
+    return None
 
 
 async def get_info(self, entity_id):
@@ -76,30 +113,34 @@ async def init(self, entity_id):
         )
 
         state = self.hass.states.get(entity_id)
-        _preset_modes = (
-            state.attributes.get("preset_modes") if state is not None else None
-        )
-        # Only reset the device preset when "none" is actually a supported mode.
-        # Some TRVs (e.g. proportional Tuya models) expose ``preset_modes`` but
-        # do not accept arbitrary values, so calling the service with an
-        # unsupported mode raises ``ServiceValidationError`` and trips the
-        # startup retry loop.
-        if _preset_modes and PRESET_NONE in _preset_modes:
-            await self.hass.services.async_call(
-                "climate",
-                "set_preset_mode",
-                {"entity_id": entity_id, "preset_mode": PRESET_NONE},
-                blocking=True,
-                context=self.context,
-            )
-        elif _preset_modes:
+        attributes = state.attributes if state is not None else {}
+        _preset_modes = attributes.get("preset_modes")
+        # BT owns the setpoint, so a device running its own schedule has to be
+        # taken off it. The device's manual preset is what does that, and it is
+        # the only value here the device is known to accept.
+        _manual = manual_preset(_preset_modes)
+        if _manual is None:
             _LOGGER.debug(
-                "better_thermostat %s: TRV %s supports presets %s but not '%s'; "
-                "skipping preset reset",
+                "better_thermostat %s: TRV %s offers no manual preset among %s, "
+                "leaving its preset alone",
                 self.device_name,
                 entity_id,
                 _preset_modes,
-                PRESET_NONE,
+            )
+        elif attributes.get("preset_mode") == _manual:
+            _LOGGER.debug(
+                "better_thermostat %s: TRV %s already runs preset '%s'",
+                self.device_name,
+                entity_id,
+                _manual,
+            )
+        else:
+            await self.hass.services.async_call(
+                "climate",
+                "set_preset_mode",
+                {"entity_id": entity_id, "preset_mode": _manual},
+                blocking=True,
+                context=self.context,
             )
 
 

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2448,6 +2448,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 set_valve_fn=_set_valve,
                 set_temperature_fn=_set_temp,
                 set_hvac_mode_fn=_set_mode,
+                get_state=self.hass.states.get,
                 device_name=self.device_name,
             )
 

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -960,10 +960,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.async_on_remove(async_at_started(self.hass, _async_startup))
 
     async def _trigger_check_weather(self, event=None):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         await check_weather(self)
         if self._last_call_for_heat != self.call_for_heat:
             self._last_call_for_heat = self.call_for_heat
@@ -973,10 +976,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 await self.control_queue_task.put(self)
 
     async def _trigger_time(self, event=None):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         if getattr(self, "in_maintenance", False):
             _LOGGER.debug(
                 "better_thermostat %s: periodic tick skipped (valve maintenance running)",
@@ -1000,10 +1006,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         ``call_for_heat`` actually flips, so frequent outdoor readings that
         stay on the same side of the threshold do not spam the queue.
         """
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         if getattr(self, "in_maintenance", False):
             return
         await check_ambient_air_temperature(self)
@@ -1031,10 +1040,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 await self.control_queue_task.put(self)
 
     async def _trigger_temperature_change(self, event):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         self.async_set_context(event.context)
         if (event.data.get("new_state")) is None:
             return
@@ -1113,10 +1125,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             )
 
     async def _trigger_humidity_change(self, event):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         self.async_set_context(event.context)
         if (event.data.get("new_state")) is None:
             return
@@ -1130,10 +1145,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.async_write_ha_state()
 
     async def _trigger_trv_change(self, event):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         if getattr(self, "in_maintenance", False):
             _LOGGER.debug(
                 "better_thermostat %s: TRV change skipped (valve maintenance running)",
@@ -1153,10 +1171,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         )
 
     async def _trigger_contact_change(self, event, contact_id, trigger_fn, task_label):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         self.async_set_context(event.context)
         if (event.data.get("new_state")) is None:
             return
@@ -1179,10 +1200,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         )
 
     async def _trigger_cooler_change(self, event):
+        # The degraded-mode annunciation updates first: it has to keep
+        # reporting a lost room sensor even while an unavailable TRV aborts
+        # the rest of the handler.
+        await check_and_update_degraded_mode(self)
         _check = await check_critical_entities(self)
         if _check is False:
             return
-        await check_and_update_degraded_mode(self)
         self.async_set_context(event.context)
         if (event.data.get("new_state")) is None:
             return
@@ -2343,10 +2367,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         """Periodic maintenance tick: runs valve exercise when due and enabled."""
         # quick availability check - only critical entities needed for maintenance
         try:
+            # The degraded-mode annunciation updates first: it has to keep
+            # reporting a lost room sensor even while an unavailable TRV
+            # aborts the tick.
+            await check_and_update_degraded_mode(self)
             ok = await check_critical_entities(self)
             if ok is False:
                 return
-            await check_and_update_degraded_mode(self)
         except Exception:
             _LOGGER.debug(
                 "better_thermostat %s: maintenance availability check failed; "

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -205,6 +205,13 @@ from .utils.weather import check_ambient_air_temperature, check_weather
 
 _LOGGER = logging.getLogger(__name__)
 
+# How often the room temperature is re-sent to TRVs that mirror it into an
+# input of their own. Such a device falls back to its own sensor after a fixed
+# silence, two hours on a Sonoff TRVZB, and BT's own writes are driven by
+# sensor changes, which a room holding its temperature does not produce. The
+# interval sits well inside the shortest fallback window rather than near it.
+EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL = timedelta(minutes=30)
+
 # Default temperature when no sensor data is available (last resort fallback)
 DEFAULT_FALLBACK_TEMPERATURE = 20.0
 
@@ -2298,7 +2305,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     self.hass, [self.outdoor_sensor], self._trigger_outdoor_change
                 )
             )
-        # Send an immediate initial keepalive so TRVs don't have to wait for the first 30min tick
+        # One keepalive right away, so a TRV that mirrors the room temperature
+        # has it before the first interval elapses.
         try:
             _LOGGER.debug(
                 "better_thermostat %s: creating keepalive task...", self.device_name
@@ -2313,6 +2321,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 self.device_name,
                 exc,
             )
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass,
+                self._external_temperature_keepalive,
+                EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL,
+            )
+        )
         # Start periodic EMA update (every minute)
         _LOGGER.debug("better_thermostat %s: starting EMA timer...", self.device_name)
         self.async_on_remove(

--- a/custom_components/better_thermostat/manifest.json
+++ b/custom_components/better_thermostat/manifest.json
@@ -20,5 +20,5 @@
   "requirements": [
     "numpy>=2"
   ],
-  "version": "1.9.1"
+  "version": "1.9.2"
 }

--- a/custom_components/better_thermostat/model_fixes/TRVZB.py
+++ b/custom_components/better_thermostat/model_fixes/TRVZB.py
@@ -421,16 +421,26 @@ def _find_device_entity(
     Returns
     -------
     str | None
-        The entity id of the first match, or ``None`` when the device has
-        no such entity.
+        The entity id of the translation key match, the first id fragment
+        match when no entry carries one of the keys, or ``None`` when the
+        device has no such entity.
     """
     if device_id is None:
         return None
-    for ent in entity_registry.entities.values():
-        if ent.device_id != device_id or ent.domain != domain:
-            continue
+    siblings = [
+        ent
+        for ent in entity_registry.entities.values()
+        if ent.device_id == device_id and ent.domain == domain
+    ]
+    for ent in siblings:
         if getattr(ent, "translation_key", None) in translation_keys:
             return ent.entity_id
+    # Only now, and only for entries that name themselves nothing: the
+    # registry hands its entities out in insertion order, so a fragment match
+    # tried per entry would beat the canonical key of an entry behind it.
+    for ent in siblings:
+        if getattr(ent, "translation_key", None) is not None:
+            continue
         haystacks = (
             (ent.entity_id or "").lower(),
             (ent.unique_id or "").lower(),

--- a/custom_components/better_thermostat/model_fixes/TRVZB.py
+++ b/custom_components/better_thermostat/model_fixes/TRVZB.py
@@ -374,6 +374,124 @@ async def override_set_valve(self, entity_id, percent: int):
         return False
 
 
+# Translation keys Zigbee2MQTT uses for the input the room temperature is
+# mirrored into.
+_TK_EXTERNAL_TEMP = frozenset({"external_temperature_input", "external_temperature"})
+
+# Translation keys Zigbee2MQTT uses for the selector that decides which sensor
+# the TRVZB regulates on.
+_TK_SENSOR_SELECT = frozenset({"temperature_sensor_select", "temperature_sensor"})
+
+# The option that hands regulation to the value BT writes. Devices offer more
+# than one option naming an external sensor, so the ones already on such an
+# option are left as their owner set them.
+_EXTERNAL_SENSOR_OPTION = "external"
+
+
+def _find_device_entity(
+    entity_registry: er.EntityRegistry,
+    device_id: str | None,
+    domain: str,
+    translation_keys: frozenset[str],
+    id_fragment: str,
+) -> str | None:
+    """Return a sibling entity of ``device_id`` in ``domain``, or ``None``.
+
+    The translation key is the stable, language-independent handle and is
+    tried first; the id fragment is the fallback for a registry entry that
+    carries none.
+    """
+    for ent in entity_registry.entities.values():
+        if ent.device_id != device_id or ent.domain != domain:
+            continue
+        if getattr(ent, "translation_key", None) in translation_keys:
+            return ent.entity_id
+        haystacks = (
+            (ent.entity_id or "").lower(),
+            (ent.unique_id or "").lower(),
+            (getattr(ent, "original_name", None) or "").lower().replace(" ", "_"),
+        )
+        if any(id_fragment in haystack for haystack in haystacks):
+            return ent.entity_id
+    return None
+
+
+async def maybe_select_external_sensor(self, entity_id: str) -> bool:
+    """Point the TRV's sensor selector at the value BT writes.
+
+    Writing the external temperature input achieves nothing while the device
+    regulates on its own sensor, and it lands there on its own: a TRVZB that
+    is re-paired comes back on the internal sensor. So the selector is checked
+    alongside every write of the input it belongs to.
+
+    A device already on an option naming an external sensor is left alone,
+    whichever of them it is: the choice between them is its owner's.
+
+    Parameters
+    ----------
+    self :
+        The Better Thermostat instance, supplying ``hass`` and the context
+        the service call is made under.
+    entity_id : str
+        The TRV whose device carries the selector.
+
+    Returns
+    -------
+    bool
+        True when the selector is on an external option, whether this call
+        put it there or found it there.
+    """
+    entity_registry = er.async_get(self.hass)
+    reg_entity = entity_registry.async_get(entity_id)
+    if reg_entity is None:
+        return False
+    target = _find_device_entity(
+        entity_registry,
+        reg_entity.device_id,
+        "select",
+        _TK_SENSOR_SELECT,
+        "temperature_sensor_select",
+    )
+    if target is None:
+        _LOGGER.debug(
+            "better_thermostat %s: TRVZB temperature sensor selector not found for %s",
+            self.device_name,
+            entity_id,
+        )
+        return False
+    state = self.hass.states.get(target)
+    if state is None:
+        return False
+    if str(state.state).startswith(_EXTERNAL_SENSOR_OPTION):
+        return True
+    options = state.attributes.get("options")
+    if not isinstance(options, (list, tuple)) or _EXTERNAL_SENSOR_OPTION not in options:
+        _LOGGER.debug(
+            "better_thermostat %s: TRVZB selector %s offers no '%s' option (%s)",
+            self.device_name,
+            target,
+            _EXTERNAL_SENSOR_OPTION,
+            options,
+        )
+        return False
+    await self.hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": target, "option": _EXTERNAL_SENSOR_OPTION},
+        blocking=True,
+        context=self.context,
+    )
+    _LOGGER.debug(
+        "better_thermostat %s: set TRVZB %s from '%s' to '%s' (for %s)",
+        self.device_name,
+        target,
+        state.state,
+        _EXTERNAL_SENSOR_OPTION,
+        entity_id,
+    )
+    return True
+
+
 async def maybe_set_external_temperature(self, entity_id, temperature: float) -> bool:
     """Set Sonoff TRVZB external temperature input via a number entity on the same device.
 
@@ -401,32 +519,14 @@ async def maybe_set_external_temperature(self, entity_id, temperature: float) ->
                 entity_id,
             )
             return False
-        device_id = reg_entity.device_id
-        target_entities = []
-
-        # Known translation_key values for Sonoff TRVZB external temperature input.
-        _TK_EXTERNAL_TEMP = {"external_temperature_input", "external_temperature"}
-
-        for ent in entity_registry.entities.values():
-            if ent.device_id != device_id or ent.domain != "number":
-                continue
-            # Prefer translation_key (stable, language-independent)
-            tk = getattr(ent, "translation_key", None)
-            if tk and tk in _TK_EXTERNAL_TEMP:
-                target_entities.append(ent.entity_id)
-                continue
-            # Fallback: string matching on entity_id / unique_id / original_name
-            en = (ent.entity_id or "").lower()
-            uid = (ent.unique_id or "").lower()
-            name = (getattr(ent, "original_name", None) or "").lower()
-            if (
-                "external_temperature_input" in en
-                or "external_temperature_input" in uid
-                or "external temperature input" in name
-            ):
-                target_entities.append(ent.entity_id)
-
-        if not target_entities:
+        target = _find_device_entity(
+            entity_registry,
+            reg_entity.device_id,
+            "number",
+            _TK_EXTERNAL_TEMP,
+            "external_temperature_input",
+        )
+        if target is None:
             _LOGGER.debug(
                 "better_thermostat %s: TRVZB external_temperature_input number entity not found for %s",
                 self.device_name,
@@ -446,7 +546,6 @@ async def maybe_set_external_temperature(self, entity_id, temperature: float) ->
             return False
         val = max(0.0, min(99.9, round(val, 1)))
 
-        target = target_entities[0]
         await self.hass.services.async_call(
             "number",
             "set_value",
@@ -461,6 +560,9 @@ async def maybe_set_external_temperature(self, entity_id, temperature: float) ->
             target,
             entity_id,
         )
+        # The value just written only reaches the control loop of a device
+        # that is regulating on it.
+        await maybe_select_external_sensor(self, entity_id)
         return True
     except (TypeError, ValueError, KeyError, AttributeError) as ex:
         _LOGGER.debug(

--- a/custom_components/better_thermostat/model_fixes/TRVZB.py
+++ b/custom_components/better_thermostat/model_fixes/TRVZB.py
@@ -496,8 +496,25 @@ async def maybe_set_external_temperature(self, entity_id, temperature: float) ->
     """Set Sonoff TRVZB external temperature input via a number entity on the same device.
 
     Looks for number.* entity matching external_temperature_input and writes the
-    given temperature (clamped to 0..99.9, rounded to one decimal).
-    Returns True on success, False otherwise.
+    given temperature (clamped to 0..99.9, rounded to one decimal). The sensor
+    selector is pointed at that input alongside the write, because a device
+    regulating on its own sensor never reads it.
+
+    Parameters
+    ----------
+    self :
+        The Better Thermostat instance, supplying ``hass``, the TRV registry
+        and the context the service calls are made under.
+    entity_id : str
+        The TRV whose device carries the input.
+    temperature : float
+        The room temperature to mirror into the device, in degrees Celsius.
+
+    Returns
+    -------
+    bool
+        True when the input was written, False when the device is not a
+        TRVZB, names no such input, or the value is not a number.
     """
     try:
         model = str(self.real_trvs[entity_id].model or "")

--- a/custom_components/better_thermostat/model_fixes/TRVZB.py
+++ b/custom_components/better_thermostat/model_fixes/TRVZB.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.helpers import entity_registry as er
 
 _LOGGER = logging.getLogger(__name__)
@@ -400,7 +401,31 @@ def _find_device_entity(
     The translation key is the stable, language-independent handle and is
     tried first; the id fragment is the fallback for a registry entry that
     carries none.
+
+    Parameters
+    ----------
+    entity_registry : er.EntityRegistry
+        The registry to search.
+    device_id : str | None
+        The device the sibling has to belong to. ``None`` is no device and
+        matches nothing: every entity that belongs to no device would
+        otherwise be a candidate.
+    domain : str
+        The entity domain to search, ``number`` or ``select`` here.
+    translation_keys : frozenset[str]
+        The translation keys that name the wanted entity.
+    id_fragment : str
+        Matched against the entity id, unique id and original name of a
+        registry entry that carries no translation key.
+
+    Returns
+    -------
+    str | None
+        The entity id of the first match, or ``None`` when the device has
+        no such entity.
     """
+    if device_id is None:
+        return None
     for ent in entity_registry.entities.values():
         if ent.device_id != device_id or ent.domain != domain:
             continue
@@ -460,7 +485,9 @@ async def maybe_select_external_sensor(self, entity_id: str) -> bool:
         )
         return False
     state = self.hass.states.get(target)
-    if state is None:
+    if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+        # A selector that is not reporting names no option, and the device
+        # behind it is in no state to take one either.
         return False
     if str(state.state).startswith(_EXTERNAL_SENSOR_OPTION):
         return True

--- a/custom_components/better_thermostat/utils/const.py
+++ b/custom_components/better_thermostat/utils/const.py
@@ -20,6 +20,11 @@ DOMAIN: Final = "better_thermostat"
 
 DEFAULT_NAME: Final = "Better Thermostat"
 
+# ``hass.data`` key holding, per entry and platform, the thermostat name the
+# entity ids were last built from. It outlives the reload it describes and is
+# dropped when the entry is removed.
+NORMALIZED_ID_NAMES: Final = f"{DOMAIN}_normalized_id_names"
+
 
 class _Manifest(TypedDict):
     version: str

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import logging
 import math
 import re
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
 
 from homeassistant.components.climate.const import (
     ATTR_TARGET_TEMP_STEP,
@@ -36,6 +36,7 @@ from custom_components.better_thermostat.utils.const import (
     MAX_REASONABLE_TEMPERATURE,
     MIN_HEATING_POWER,
     MIN_REASONABLE_TEMPERATURE,
+    NORMALIZED_ID_NAMES,
     VALVE_MIN_BASE,
     VALVE_MIN_OPENING_LARGE_DIFF,
     VALVE_MIN_PROPORTIONAL_SLOPE,
@@ -83,11 +84,16 @@ def find_device_entity(
     return None
 
 
+# Sentinel for "this platform has not been set up in this process yet".
+# ``None`` is a name an entry can genuinely carry, so it cannot say this.
+_NO_RECORDED_NAME: Final = object()
+
+
 @callback
 def async_normalize_bt_entity_ids(
     hass: HomeAssistant, entry: ConfigEntry, domain: str
 ) -> None:
-    """Rename stale BT registry entries so their entity_id tracks the name.
+    """Rename BT registry entries after the thermostat itself was renamed.
 
     HA's entity registry reuses the existing entry on reload (unique id ==
     config entry id), so the entity_id is frozen at first creation while only
@@ -96,11 +102,31 @@ def async_normalize_bt_entity_ids(
     would generate from the current name, before the platform re-adds the
     entities (which reuse the now-correct id).
 
+    A rename reaches this function as an in-process reload and nothing else
+    does, which is what separates it from a restart. The name the ids were
+    last built from is held per entry and platform for as long as the Home
+    Assistant instance lives, so a setup that finds no such name is a restart.
+    The ids in the registry are then whoever's they are, the user's included,
+    and an entity_id its owner chose is theirs to keep. Only a name that
+    differs from the recorded one is a rename, and only that renames anything.
+
     For the climate entity the device does not exist yet at this point in
     setup, so the desired id is derived directly from the configured name.
     For the auxiliary platforms the device already exists (climate set it up
     first), so HA's own ``async_regenerate_entity_id`` is used.
     """
+    name = entry.data.get(CONF_NAME)
+    normalized = hass.data.setdefault(NORMALIZED_ID_NAMES, {}).setdefault(
+        entry.entry_id, {}
+    )
+    # Recorded per platform: the four calls run in one setup pass, so a single
+    # record per entry would let the first of them mark the name as handled
+    # and leave the other three looking at a rename that already happened.
+    previous = normalized.get(domain, _NO_RECORDED_NAME)
+    normalized[domain] = name
+    if previous is _NO_RECORDED_NAME or previous == name:
+        return
+
     registry = er.async_get(hass)
     # The registry is populated lazily on first load; with a mocked hass
     # (unit tests) it is an unloaded shell without ``.entities``, so there is
@@ -124,7 +150,7 @@ def async_normalize_bt_entity_ids(
         except ValueError as err:
             _LOGGER.warning(
                 "better_thermostat %s: could not rename %s to %s: %s",
-                entry.data.get(CONF_NAME),
+                name,
                 reg_entry.entity_id,
                 desired,
                 err,

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -93,7 +93,7 @@ _NO_RECORDED_NAME: Final = object()
 def async_normalize_bt_entity_ids(
     hass: HomeAssistant, entry: ConfigEntry, domain: str
 ) -> None:
-    """Rename BT registry entries after the thermostat itself was renamed.
+    """Rename BT registry entries to follow a change of the thermostat name.
 
     HA's entity registry reuses the existing entry on reload (unique id ==
     config entry id), so the entity_id is frozen at first creation while only
@@ -114,6 +114,17 @@ def async_normalize_bt_entity_ids(
     setup, so the desired id is derived directly from the configured name.
     For the auxiliary platforms the device already exists (climate set it up
     first), so HA's own ``async_regenerate_entity_id`` is used.
+
+    Parameters
+    ----------
+    hass : HomeAssistant
+        The running Home Assistant instance, supplying the entity registry
+        and the runtime data the recorded names live in.
+    entry : ConfigEntry
+        The config entry whose entities are named after it.
+    domain : str
+        The entity platform being set up; only its registry entries are
+        considered, and each platform carries its own recorded name.
     """
     name = entry.data.get(CONF_NAME)
     normalized = hass.data.setdefault(NORMALIZED_ID_NAMES, {}).setdefault(

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -329,6 +329,18 @@ async def restore_one(
     moved it, a valve write a device answers by switching itself on among
     them, shows up as a reported mode that is no longer the one the snapshot
     was taken in.
+
+    Parameters
+    ----------
+    info : MaintenanceTrvInfo
+        The snapshot the run started from, carrying the setpoint and mode
+        to restore.
+    set_temperature_fn : SetTemperatureFn
+        Writes the setpoint back.
+    set_hvac_mode_fn : SetHvacModeFn
+        Writes the mode back, when it moved.
+    get_state : Callable[[str], State | None]
+        ``hass.states.get``, supplying the mode the TRV reports now.
     """
     if info.cur_temp is not None:
         try:
@@ -366,6 +378,26 @@ async def run_valve_maintenance(
     This is the pure async orchestrator.  State mutations on
     ``self`` (ignore_states, in_maintenance, control_queue) stay in
     ``climate.py``'s wrapper.
+
+    Parameters
+    ----------
+    infos : list[MaintenanceTrvInfo]
+        The snapshot of each TRV the run drives, taken before it starts.
+    set_valve_fn : SetValveFn
+        Writes a valve percentage; used for the valve-driven TRVs.
+    set_temperature_fn : SetTemperatureFn
+        Writes a setpoint; drives the cycle on the other TRVs and restores
+        the setpoint on all of them.
+    set_hvac_mode_fn : SetHvacModeFn
+        Writes an HVAC mode; wakes a TRV that is off and puts a moved mode
+        back.
+    get_state : Callable[[str], State | None]
+        ``hass.states.get``, read at the restore to tell a mode that moved
+        from one that never did.
+    device_name : str
+        The Better Thermostat instance name, for logging context.
+    cycle_sleep : float
+        Seconds to hold each valve position, so the motor reaches it.
     """
     _LOGGER.info(
         "better_thermostat %s: starting valve maintenance for %d TRV(s)",

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -92,6 +92,34 @@ def pick_wake_mode(
     return None
 
 
+def mode_needs_restoring(
+    info: MaintenanceTrvInfo, get_state: Callable[[str], State | None]
+) -> bool:
+    """Whether the TRV's HVAC mode has to be written back after the run.
+
+    Parameters
+    ----------
+    info : MaintenanceTrvInfo
+        The snapshot the run started from, carrying the mode to restore and
+        the wake mode the run switched into, if any.
+    get_state : Callable[[str], State | None]
+        ``hass.states.get``. A TRV that reports no state is taken to need
+        the restore: nothing then says the mode is where it belongs.
+
+    Returns
+    -------
+    bool
+        True when the run woke the TRV, or when the mode it reports is no
+        longer the one the snapshot was taken in.
+    """
+    if info.wake_mode is not None:
+        return True
+    state = get_state(info.entity_id)
+    if state is None:
+        return True
+    return state.state != info.cur_mode
+
+
 def _get_advanced(info: Trv) -> dict[str, object]:
     """Safely extract the ``advanced`` dict from a Trv entry."""
     adv = info.advanced
@@ -285,13 +313,35 @@ async def restore_one(
     *,
     set_temperature_fn: SetTemperatureFn,
     set_hvac_mode_fn: SetHvacModeFn,
+    get_state: Callable[[str], State | None],
 ) -> None:
-    """Restore a TRV to its pre-maintenance state."""
+    """Restore a TRV to its pre-maintenance state.
+
+    The setpoint is always written back; the mode only when it moved.
+    A device that reports a single mode implements no setter for it, so
+    writing the mode it is already in raises ``NotImplementedError`` inside
+    Home Assistant's climate component and buys nothing in exchange.
+
+    Two things move a mode here, and the guard answers to both. The run
+    itself moves one only through ``wake_step``, which is gated on
+    ``wake_mode``, so that alone says a mode was written and has to go back
+    regardless of what the device has published since. Anything else that
+    moved it, a valve write a device answers by switching itself on among
+    them, shows up as a reported mode that is no longer the one the snapshot
+    was taken in.
+    """
     if info.cur_temp is not None:
         try:
             await set_temperature_fn(info.entity_id, info.cur_temp)
         except Exception:
             pass
+    if not mode_needs_restoring(info, get_state):
+        _LOGGER.debug(
+            "better_thermostat: %s is still in mode %s, leaving it alone",
+            info.entity_id,
+            info.cur_mode,
+        )
+        return
     try:
         await set_hvac_mode_fn(info.entity_id, info.cur_mode)
     except Exception:
@@ -307,6 +357,7 @@ async def run_valve_maintenance(
     set_valve_fn: SetValveFn,
     set_temperature_fn: SetTemperatureFn,
     set_hvac_mode_fn: SetHvacModeFn,
+    get_state: Callable[[str], State | None],
     device_name: str,
     cycle_sleep: float = 30,
 ) -> None:
@@ -398,6 +449,7 @@ async def run_valve_maintenance(
                 info,
                 set_temperature_fn=set_temperature_fn,
                 set_hvac_mode_fn=set_hvac_mode_fn,
+                get_state=get_state,
             )
             for info in infos
         ),

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -93,18 +93,21 @@ def pick_wake_mode(
 
 
 def mode_needs_restoring(
-    info: MaintenanceTrvInfo, get_state: Callable[[str], State | None]
+    info: MaintenanceTrvInfo, get_state: Callable[[str], State | None], *, woken: bool
 ) -> bool:
     """Whether the TRV's HVAC mode has to be written back after the run.
 
     Parameters
     ----------
     info : MaintenanceTrvInfo
-        The snapshot the run started from, carrying the mode to restore and
-        the wake mode the run switched into, if any.
+        The snapshot the run started from, carrying the mode to restore.
     get_state : Callable[[str], State | None]
         ``hass.states.get``. A TRV that reports no state is taken to need
         the restore: nothing then says the mode is where it belongs.
+    woken : bool
+        Whether the wake write for this TRV went out without raising. A
+        wake that was selected but failed left the mode where it was, so
+        only a wake that landed decides on its own.
 
     Returns
     -------
@@ -112,7 +115,7 @@ def mode_needs_restoring(
         True when the run woke the TRV, or when the mode it reports is no
         longer the one the snapshot was taken in.
     """
-    if info.wake_mode is not None:
+    if woken:
         return True
     state = get_state(info.entity_id)
     if state is None:
@@ -314,6 +317,7 @@ async def restore_one(
     set_temperature_fn: SetTemperatureFn,
     set_hvac_mode_fn: SetHvacModeFn,
     get_state: Callable[[str], State | None],
+    woken: bool = False,
 ) -> None:
     """Restore a TRV to its pre-maintenance state.
 
@@ -323,12 +327,11 @@ async def restore_one(
     Home Assistant's climate component and buys nothing in exchange.
 
     Two things move a mode here, and the guard answers to both. The run
-    itself moves one only through ``wake_step``, which is gated on
-    ``wake_mode``, so that alone says a mode was written and has to go back
-    regardless of what the device has published since. Anything else that
-    moved it, a valve write a device answers by switching itself on among
-    them, shows up as a reported mode that is no longer the one the snapshot
-    was taken in.
+    itself moves one only through ``wake_step``, so a wake that went out
+    says a mode was written and has to go back regardless of what the
+    device has published since. Anything else that moved it, a valve write
+    a device answers by switching itself on among them, shows up as a
+    reported mode that is no longer the one the snapshot was taken in.
 
     Parameters
     ----------
@@ -341,13 +344,15 @@ async def restore_one(
         Writes the mode back, when it moved.
     get_state : Callable[[str], State | None]
         ``hass.states.get``, supplying the mode the TRV reports now.
+    woken : bool
+        Whether this TRV's wake write went out without raising.
     """
     if info.cur_temp is not None:
         try:
             await set_temperature_fn(info.entity_id, info.cur_temp)
         except Exception:
             pass
-    if not mode_needs_restoring(info, get_state):
+    if not mode_needs_restoring(info, get_state, woken=woken):
         _LOGGER.debug(
             "better_thermostat: %s is still in mode %s, leaving it alone",
             info.entity_id,
@@ -418,6 +423,7 @@ async def run_valve_maintenance(
     # A TRV that offered no wake mode at all is unreachable for the same
     # reason. Both are still restored below.
     cycled: list[MaintenanceTrvInfo] = []
+    woken: set[str] = set()
     for info, result in zip(infos, wake_results):
         if isinstance(result, BaseException):
             _LOGGER.warning(
@@ -428,6 +434,8 @@ async def run_valve_maintenance(
                 result,
             )
             continue
+        if info.wake_mode is not None:
+            woken.add(info.entity_id)
         if info.use_direct_valve or _temp_cycle_reaches_valve(info):
             cycled.append(info)
 
@@ -482,6 +490,7 @@ async def run_valve_maintenance(
                 set_temperature_fn=set_temperature_fn,
                 set_hvac_mode_fn=set_hvac_mode_fn,
                 get_state=get_state,
+                woken=info.entity_id in woken,
             )
             for info in infos
         ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "better-thermostat"
-version = "1.9.1"  # keep in sync with manifest.json
+version = "1.9.2"  # keep in sync with manifest.json
 description = "Better Thermostat — Home Assistant custom integration for smart TRV control"
 requires-python = ">=3.14.2"  # floor inherited from Home Assistant 2026.7.x
 dependencies = ["homeassistant>=2026.7.2"]

--- a/tests/integration/test_entry_lifecycle.py
+++ b/tests/integration/test_entry_lifecycle.py
@@ -151,3 +151,51 @@ async def test_climate_entity_id_follows_device_name_after_rename(hass, fake_trv
         == "sensor.bt_livingroom_temperature_ema"
     )
     assert hass.states.get("climate.bt_livingroom") is not None
+
+
+async def test_entity_ids_the_user_chose_survive_a_restart(hass, fake_trv):
+    """A restart leaves the ids in the registry alone, whoever wrote them.
+
+    An entity_id is the user's to set, and the ones seeded here are the
+    form somebody who named BT's entities themselves holds. Setting the
+    entry up finds them already in the registry, which is what a restart
+    looks like from the integration's side.
+
+    Both platforms are seeded: the climate entity derives its id from the
+    entry, the auxiliary ones from the device, and those are two different
+    code paths.
+    """
+    _room_sensor(hass)
+    entry = make_entry(name="Livingroom")
+    entry.add_to_hass(hass)
+
+    registry = er.async_get(hass)
+    registry.async_get_or_create(
+        "climate",
+        DOMAIN,
+        entry.entry_id,
+        config_entry=entry,
+        suggested_object_id="livingroom_thermostat",
+    )
+    registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        entry.entry_id + "_external_temp_ema",
+        config_entry=entry,
+        suggested_object_id="livingroom_thermostat_ema",
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    await wait_for_startup(hass, entry)
+
+    assert (
+        registry.async_get_entity_id("climate", DOMAIN, entry.entry_id)
+        == "climate.livingroom_thermostat"
+    )
+    assert (
+        registry.async_get_entity_id(
+            "sensor", DOMAIN, entry.entry_id + "_external_temp_ema"
+        )
+        == "sensor.livingroom_thermostat_ema"
+    )

--- a/tests/unit/test_climate_trigger_degraded_order.py
+++ b/tests/unit/test_climate_trigger_degraded_order.py
@@ -98,7 +98,7 @@ async def test_a_lost_room_sensor_is_reported_while_a_trv_is_offline(bt, handler
 
 @pytest.mark.asyncio
 async def test_the_critical_check_still_stops_the_rest_of_the_handler(bt):
-    """Moving the annunciation up does not remove the early return.
+    """The annunciation running first does not remove the early return.
 
     The handler's own work stays behind the critical-entity check: there is
     nothing to compute against a valve that cannot be reached.
@@ -117,7 +117,7 @@ async def test_the_critical_check_still_stops_the_rest_of_the_handler(bt):
 
 @pytest.mark.asyncio
 async def test_a_reachable_trv_reports_the_lost_sensor_too(bt):
-    """The counter-direction: the annunciation did already work here.
+    """The counter-direction: a reachable valve reports the sensor too.
 
     Without it the test above would pass for a thermostat that reports
     degraded mode in no case at all.

--- a/tests/unit/test_climate_trigger_degraded_order.py
+++ b/tests/unit/test_climate_trigger_degraded_order.py
@@ -1,0 +1,154 @@
+"""Degraded-mode annunciation in the recurring trigger handlers.
+
+Every handler updates the degraded-mode annunciation via
+check_and_update_degraded_mode before the critical-entity check may abort it.
+The combined failure case is what makes the order matter: a room sensor lost
+while a TRV is offline is exactly when the user needs to be told, and it is
+the one case where the critical-entity check reports failure.
+
+The same order governs the way back. A degraded thermostat whose sensors all
+return still has to clear its repair issue, and it cannot do that from behind
+an early return either.
+"""
+
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+from custom_components.better_thermostat.trv import Trv
+
+_CLIMATE = "custom_components.better_thermostat.climate"
+_WATCHER = "custom_components.better_thermostat.utils.watcher"
+_HELPERS = "custom_components.better_thermostat.utils.helpers"
+SENSOR_ID = "sensor.room_temp"
+TRV_ID = "climate.test_trv"
+
+# Every recurring handler that guards on the critical entities, with the
+# arguments it takes beyond the entity itself.
+HANDLERS = [
+    ("_trigger_time", (None,)),
+    ("_trigger_check_weather", (None,)),
+    ("_trigger_temperature_change", (MagicMock(),)),
+    ("_trigger_humidity_change", (MagicMock(),)),
+    ("_trigger_trv_change", (MagicMock(),)),
+    ("_trigger_cooler_change", (MagicMock(),)),
+    ("_trigger_outdoor_change", (MagicMock(),)),
+]
+
+
+@pytest.fixture
+def bt():
+    """Mock BT whose room sensor reads as unavailable."""
+    mock = MagicMock()
+    mock.device_name = "Test BT"
+    mock.real_trvs = {TRV_ID: Trv(entity_id=TRV_ID)}
+    mock.sensor_entity_id = SENSOR_ID
+    mock.humidity_sensor_entity_id = None
+    mock.window_id = None
+    mock.door_id = None
+    mock.outdoor_sensor = None
+    mock.weather_entity = None
+    mock.cooler_entity_id = None
+    mock.unavailable_sensors = []
+    mock.degraded_mode = False
+    mock._degraded_warning_emitted = False
+    mock._degraded_grace_until = None
+    mock.in_maintenance = False
+    mock.hass = MagicMock()
+    mock.hass.states.get.return_value = None
+    return mock
+
+
+def _guards(*, trv_reachable):
+    """Patch the handler's surroundings, leaving the annunciation real."""
+    return (
+        patch(
+            f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=trv_reachable)
+        ),
+        patch(f"{_CLIMATE}.check_ambient_air_temperature", AsyncMock()),
+        patch(f"{_CLIMATE}.check_weather", AsyncMock()),
+        patch(f"{_WATCHER}.ir.async_create_issue"),
+        patch(f"{_WATCHER}.ir.async_delete_issue"),
+        patch(f"{_HELPERS}.async_fire_logbook_entry", AsyncMock()),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("handler", "args"), HANDLERS, ids=[h for h, _ in HANDLERS])
+async def test_a_lost_room_sensor_is_reported_while_a_trv_is_offline(bt, handler, args):
+    """The annunciation runs even though the critical check aborts the handler.
+
+    An unreachable valve is not a reason to stop telling the user that the
+    room sensor is gone; it is the case where both have failed at once.
+    """
+    with contextlib.ExitStack() as stack:
+        for guard in _guards(trv_reachable=False):
+            stack.enter_context(guard)
+        await getattr(BetterThermostat, handler)(bt, *args)
+
+    assert bt.degraded_mode is True
+    assert bt.unavailable_sensors == [SENSOR_ID]
+
+
+@pytest.mark.asyncio
+async def test_the_critical_check_still_stops_the_rest_of_the_handler(bt):
+    """Moving the annunciation up does not remove the early return.
+
+    The handler's own work stays behind the critical-entity check: there is
+    nothing to compute against a valve that cannot be reached.
+    """
+    ambient = AsyncMock()
+    with (
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=False)),
+        patch(f"{_CLIMATE}.check_ambient_air_temperature", ambient),
+        patch(f"{_WATCHER}.ir.async_create_issue"),
+        patch(f"{_HELPERS}.async_fire_logbook_entry", AsyncMock()),
+    ):
+        await BetterThermostat._trigger_time(bt, None)
+
+    ambient.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_reachable_trv_reports_the_lost_sensor_too(bt):
+    """The counter-direction: the annunciation did already work here.
+
+    Without it the test above would pass for a thermostat that reports
+    degraded mode in no case at all.
+    """
+    with (
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
+        patch(f"{_CLIMATE}.check_ambient_air_temperature", AsyncMock()),
+        patch(f"{_WATCHER}.ir.async_create_issue"),
+        patch(f"{_HELPERS}.async_fire_logbook_entry", AsyncMock()),
+    ):
+        await BetterThermostat._trigger_time(bt, None)
+
+    assert bt.degraded_mode is True
+
+
+@pytest.mark.asyncio
+async def test_a_recovered_sensor_clears_degraded_mode_while_a_trv_is_offline(bt):
+    """The way back out, in the same combined failure case.
+
+    A thermostat that entered degraded mode and then lost a valve would
+    otherwise keep a repair issue nobody can dismiss, describing a sensor
+    that has been healthy for hours.
+    """
+    bt.degraded_mode = True
+    bt._degraded_warning_emitted = True
+    bt.unavailable_sensors = [SENSOR_ID]
+    bt.hass.states.get.return_value = MagicMock(state="20.5")
+
+    with (
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=False)),
+        patch(f"{_CLIMATE}.check_ambient_air_temperature", AsyncMock()),
+        patch(f"{_WATCHER}.ir.async_delete_issue") as delete_issue,
+        patch(f"{_HELPERS}.async_fire_logbook_entry", AsyncMock()),
+    ):
+        await BetterThermostat._trigger_time(bt, None)
+
+    assert bt.degraded_mode is False
+    delete_issue.assert_called_once()

--- a/tests/unit/test_climate_trigger_degraded_order.py
+++ b/tests/unit/test_climate_trigger_degraded_order.py
@@ -25,8 +25,10 @@ _HELPERS = "custom_components.better_thermostat.utils.helpers"
 SENSOR_ID = "sensor.room_temp"
 TRV_ID = "climate.test_trv"
 
-# Every recurring handler that guards on the critical entities, with the
-# arguments it takes beyond the entity itself.
+# Every handler that guards on the critical entities, with the arguments it
+# takes beyond the entity itself. ``_trigger_window_change`` and
+# ``_trigger_door_change`` delegate to ``_trigger_contact_change``, which is
+# where the guard sits and which therefore stands in for both.
 HANDLERS = [
     ("_trigger_time", (None,)),
     ("_trigger_check_weather", (None,)),
@@ -35,6 +37,8 @@ HANDLERS = [
     ("_trigger_trv_change", (MagicMock(),)),
     ("_trigger_cooler_change", (MagicMock(),)),
     ("_trigger_outdoor_change", (MagicMock(),)),
+    ("_trigger_contact_change", (MagicMock(), None, MagicMock(), "window")),
+    ("_maintenance_tick", (None,)),
 ]
 
 

--- a/tests/unit/test_external_temperature_keepalive.py
+++ b/tests/unit/test_external_temperature_keepalive.py
@@ -1,0 +1,126 @@
+"""The periodic re-send of the room temperature to TRVs that mirror it.
+
+Some TRVs regulate on a room temperature written into an input of their
+own and fall back to their internal sensor after a fixed silence, two
+hours on a Sonoff TRVZB. Better Thermostat's own writes are driven by
+room sensor changes, and a room holding its temperature produces none,
+so the periodic re-send is what holds such a device on the external
+value while the room is settled.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.better_thermostat.climate import (
+    EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL,
+    BetterThermostat,
+)
+from custom_components.better_thermostat.trv import Trv
+
+_CLIMATE = "custom_components.better_thermostat.climate"
+TRV_ID = "climate.trv"
+TRV_ID_2 = "climate.trv2"
+
+
+def _startup_bt():
+    """Minimal BetterThermostat stand-in for _finalize_startup."""
+    mock = MagicMock(spec=BetterThermostat)
+    mock.hass = MagicMock()
+    mock.device_name = "Test BT"
+    mock.is_removed = False
+    mock.real_trvs = {TRV_ID: Trv(entity_id=TRV_ID, advanced={})}
+    mock.all_trvs = None
+    mock.all_entities = []
+    mock.entity_ids = [TRV_ID]
+    mock.sensor_entity_id = "sensor.room_temp"
+    mock.humidity_sensor_entity_id = None
+    mock.window_id = None
+    mock.door_id = None
+    mock.cooler_entity_id = None
+    mock.outdoor_sensor = None
+    mock._async_unsub_state_changed = None
+    # Plain MagicMocks so the un-awaited coroutines handed to the background
+    # task mock do not raise "coroutine was never awaited" warnings.
+    mock._post_grace_recheck = MagicMock()
+    mock._external_temperature_keepalive = MagicMock()
+    return mock
+
+
+async def _registered_intervals(bt):
+    """The (callback, interval) pairs _finalize_startup registers."""
+    with (
+        patch(f"{_CLIMATE}.await_critical_entities", AsyncMock()),
+        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=True)),
+        patch(f"{_CLIMATE}.await_optional_sensors", AsyncMock()),
+        patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
+        patch(f"{_CLIMATE}.asyncio.sleep", AsyncMock()),
+        patch(f"{_CLIMATE}.async_track_time_interval") as track_interval,
+        patch(f"{_CLIMATE}.async_track_state_change_event"),
+        patch(f"{_CLIMATE}.async_track_time_change"),
+    ):
+        await BetterThermostat._finalize_startup(bt)
+    return [(call.args[1], call.args[2]) for call in track_interval.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_the_keepalive_is_registered_as_a_periodic_tick():
+    """Startup leaves a repeating timer behind.
+
+    The task created at the end of startup writes once and covers the
+    first interval; every write after that is the timer's, because a
+    settled room produces no sensor change to drive one.
+    """
+    bt = _startup_bt()
+    intervals = await _registered_intervals(bt)
+    assert (
+        bt._external_temperature_keepalive,
+        EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL,
+    ) in intervals
+
+
+@pytest.mark.asyncio
+async def test_the_interval_stays_inside_the_shortest_known_fallback():
+    """Two hours is the TRVZB's silence budget; the interval clears it.
+
+    Pinned as a bound, not as a value: an interval raised past the
+    fallback window would leave the device on its own sensor between
+    writes, which is the state this tick exists to prevent.
+    """
+    assert EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL.total_seconds() > 0
+    assert EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL.total_seconds() <= 3600
+
+
+@pytest.mark.asyncio
+async def test_the_tick_writes_the_room_temperature_to_every_trv():
+    """Each TRV with the quirk gets the temperature BT is regulating on."""
+    bt = MagicMock()
+    bt.device_name = "Test BT"
+    bt.cur_temp = 21.4
+    quirks = MagicMock()
+    quirks.maybe_set_external_temperature = AsyncMock(return_value=True)
+    bt.real_trvs = {
+        TRV_ID: Trv(entity_id=TRV_ID, model_quirks=quirks),
+        TRV_ID_2: Trv(entity_id=TRV_ID_2, model_quirks=quirks),
+    }
+
+    await BetterThermostat._external_temperature_keepalive(bt)
+
+    assert [
+        call.args[1:] for call in quirks.maybe_set_external_temperature.await_args_list
+    ] == [(TRV_ID, 21.4), (TRV_ID_2, 21.4)]
+
+
+@pytest.mark.asyncio
+async def test_the_tick_writes_nothing_without_a_room_temperature():
+    """No reading means no value to keep alive."""
+    bt = MagicMock()
+    bt.device_name = "Test BT"
+    bt.cur_temp = None
+    quirks = MagicMock()
+    quirks.maybe_set_external_temperature = AsyncMock()
+    bt.real_trvs = {TRV_ID: Trv(entity_id=TRV_ID, model_quirks=quirks)}
+
+    await BetterThermostat._external_temperature_keepalive(bt)
+
+    quirks.maybe_set_external_temperature.assert_not_awaited()

--- a/tests/unit/test_helpers_entity_id_rename.py
+++ b/tests/unit/test_helpers_entity_id_rename.py
@@ -1,0 +1,138 @@
+"""Tests for the entity-id rename that follows a thermostat rename.
+
+``async_normalize_bt_entity_ids`` decides, per config entry and platform,
+whether the registry ids have to be rebuilt. The decision rests on a name
+recorded in ``hass.data``: absent means this process has not set the
+platform up before, which is a restart and leaves the ids alone. These
+tests drive that decision directly and cover what the registry does to a
+rename once the decision has been made in its favour.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.const import Platform
+
+from custom_components.better_thermostat.utils.const import DOMAIN
+from custom_components.better_thermostat.utils.helpers import (
+    async_normalize_bt_entity_ids,
+)
+
+
+def _entry(name):
+    """Build a config entry stub carrying ``name``."""
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    entry.data = {"name": name}
+    return entry
+
+
+def _registry_entry(entity_id, domain):
+    """Build a registry entry stub this integration owns."""
+    reg_entry = MagicMock()
+    reg_entry.entity_id = entity_id
+    reg_entry.platform = DOMAIN
+    reg_entry.domain = domain
+    return reg_entry
+
+
+def _registry(entries):
+    """Build an entity registry stub holding ``entries``."""
+    registry = MagicMock()
+    registry.entities.get_entries_for_config_entry_id.return_value = entries
+    return registry
+
+
+def _rename(hass, entry, registry, domain=Platform.SENSOR):
+    """Run a rename of ``entry`` against ``registry`` and return the calls.
+
+    The first call records the name, so it is the second one -- the entry
+    now carrying a different name -- that is the rename under test.
+    """
+    with patch(
+        "custom_components.better_thermostat.utils.helpers.er.async_get",
+        return_value=registry,
+    ):
+        async_normalize_bt_entity_ids(hass, entry, domain)
+        entry.data = {**entry.data, "name": entry.data["name"] + " renamed"}
+        async_normalize_bt_entity_ids(hass, entry, domain)
+    return registry.async_update_entity.call_args_list
+
+
+def test_a_registry_without_entities_is_left_alone():
+    """An unloaded registry shell is not walked.
+
+    The registry is populated lazily, so before the first load it carries
+    no ``entities`` at all. Reaching for them would raise, and there is
+    nothing to rename in an empty registry either way.
+    """
+    hass = MagicMock()
+    hass.data = {}
+    # A shell carrying everything but the ``entities`` it has not loaded yet.
+    registry = MagicMock(spec=["async_update_entity", "async_regenerate_entity_id"])
+
+    calls = _rename(hass, _entry("Livingroom"), registry)
+
+    assert calls == []
+
+
+def test_an_id_that_already_matches_is_not_rewritten():
+    """A rename that leaves an id unchanged writes nothing.
+
+    Renaming "Livingroom" to "livingroom" changes the name the entry
+    carries but not the slug the ids are built from, and rewriting an
+    entity_id to itself is a registry error rather than a no-op.
+    """
+    hass = MagicMock()
+    hass.data = {}
+    reg_entry = _registry_entry("sensor.livingroom_temperature_ema", Platform.SENSOR)
+    registry = _registry([reg_entry])
+    registry.async_regenerate_entity_id.return_value = reg_entry.entity_id
+
+    calls = _rename(hass, _entry("Livingroom"), registry)
+
+    assert calls == []
+
+
+def test_a_rejected_rename_is_reported_and_the_others_still_run(caplog):
+    """One id the registry refuses does not cost the remaining ones.
+
+    ``async_update_entity`` raises when the target id is taken. The loop
+    walks every entity of the platform, so swallowing the rejection is
+    what keeps a single collision from stopping the rename half-done.
+    """
+    hass = MagicMock()
+    hass.data = {}
+    blocked = _registry_entry("sensor.livingroom_temperature_ema", Platform.SENSOR)
+    following = _registry_entry("sensor.livingroom_valve", Platform.SENSOR)
+    registry = _registry([blocked, following])
+    registry.async_regenerate_entity_id.side_effect = [
+        "sensor.bedroom_temperature_ema",
+        "sensor.bedroom_valve",
+    ]
+    registry.async_update_entity.side_effect = [
+        ValueError("Entity id already exists"),
+        None,
+    ]
+
+    calls = _rename(hass, _entry("Livingroom"), registry)
+
+    assert [call.args[0] for call in calls] == [blocked.entity_id, following.entity_id]
+    assert "could not rename sensor.livingroom_temperature_ema" in caplog.text
+
+
+def test_an_entity_of_another_platform_is_skipped():
+    """Only the platform being set up is renamed.
+
+    Each platform records its own name and is walked on its own pass, so
+    a pass must leave the entries of the other three alone -- they are in
+    the registry under the same config entry.
+    """
+    hass = MagicMock()
+    hass.data = {}
+    other = _registry_entry("switch.livingroom_child_lock", Platform.SWITCH)
+    registry = _registry([other])
+    registry.async_regenerate_entity_id.return_value = "switch.bedroom_child_lock"
+
+    calls = _rename(hass, _entry("Livingroom"), registry, domain=Platform.SENSOR)
+
+    assert calls == []

--- a/tests/unit/test_helpers_entity_id_rename.py
+++ b/tests/unit/test_helpers_entity_id_rename.py
@@ -42,18 +42,19 @@ def _registry(entries):
     return registry
 
 
-def _rename(hass, entry, registry, domain=Platform.SENSOR):
-    """Run a rename of ``entry`` against ``registry`` and return the calls.
+def _rename(hass, entry, registry, new_name, domain=Platform.SENSOR):
+    """Rename ``entry`` to ``new_name`` against ``registry``; return the calls.
 
-    The first call records the name, so it is the second one -- the entry
-    now carrying a different name -- that is the rename under test.
+    The first call records the name the entry arrives with, so it is the
+    second one -- the entry now carrying ``new_name`` -- that is the rename
+    under test.
     """
     with patch(
         "custom_components.better_thermostat.utils.helpers.er.async_get",
         return_value=registry,
     ):
         async_normalize_bt_entity_ids(hass, entry, domain)
-        entry.data = {**entry.data, "name": entry.data["name"] + " renamed"}
+        entry.data = {**entry.data, "name": new_name}
         async_normalize_bt_entity_ids(hass, entry, domain)
     return registry.async_update_entity.call_args_list
 
@@ -70,7 +71,7 @@ def test_a_registry_without_entities_is_left_alone():
     # A shell carrying everything but the ``entities`` it has not loaded yet.
     registry = MagicMock(spec=["async_update_entity", "async_regenerate_entity_id"])
 
-    calls = _rename(hass, _entry("Livingroom"), registry)
+    calls = _rename(hass, _entry("Livingroom"), registry, "Bedroom")
 
     assert calls == []
 
@@ -88,7 +89,7 @@ def test_an_id_that_already_matches_is_not_rewritten():
     registry = _registry([reg_entry])
     registry.async_regenerate_entity_id.return_value = reg_entry.entity_id
 
-    calls = _rename(hass, _entry("Livingroom"), registry)
+    calls = _rename(hass, _entry("Livingroom"), registry, "livingroom")
 
     assert calls == []
 
@@ -114,7 +115,7 @@ def test_a_rejected_rename_is_reported_and_the_others_still_run(caplog):
         None,
     ]
 
-    calls = _rename(hass, _entry("Livingroom"), registry)
+    calls = _rename(hass, _entry("Livingroom"), registry, "Bedroom")
 
     assert [call.args[0] for call in calls] == [blocked.entity_id, following.entity_id]
     assert "could not rename sensor.livingroom_temperature_ema" in caplog.text
@@ -133,6 +134,8 @@ def test_an_entity_of_another_platform_is_skipped():
     registry = _registry([other])
     registry.async_regenerate_entity_id.return_value = "switch.bedroom_child_lock"
 
-    calls = _rename(hass, _entry("Livingroom"), registry, domain=Platform.SENSOR)
+    calls = _rename(
+        hass, _entry("Livingroom"), registry, "Bedroom", domain=Platform.SENSOR
+    )
 
     assert calls == []

--- a/tests/unit/test_mqtt_adapter_preset_reset.py
+++ b/tests/unit/test_mqtt_adapter_preset_reset.py
@@ -1,0 +1,124 @@
+"""The preset an MQTT TRV is put on when Better Thermostat takes it over.
+
+Better Thermostat owns the setpoint, so a device still running its own
+schedule has to be taken off it. Home Assistant's MQTT climate entity
+contributes ``none`` to every device's ``preset_modes`` and rejects a
+discovery config that lists it, so ``none`` is never the device's own
+answer and never a value it accepts: the reset has to name a preset the
+device brought itself.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.adapters.mqtt import init, manual_preset
+from custom_components.better_thermostat.trv import Trv
+
+ENTITY_ID = "climate.test_trv"
+_MQTT = "custom_components.better_thermostat.adapters.mqtt"
+# init imports the valve lookup at call time, so the patch goes on the source.
+_FIND_VALVE = "custom_components.better_thermostat.utils.helpers.find_valve_entity"
+_FIND_CALIBRATION = f"{_MQTT}.find_local_calibration_entity"
+_WAIT_FOR_CALIBRATION = f"{_MQTT}.wait_for_calibration_entity_or_timeout"
+
+
+def _bt(preset_modes, preset_mode=None) -> MagicMock:
+    """Build a stand-in whose TRV reports ``preset_modes`` and needs a reset.
+
+    ``calibration`` is deliberately not 1: the preset reset sits inside the
+    branch that discovers the local calibration entity, so a TRV that needs
+    no such lookup never reaches it.
+    """
+    bt = MagicMock()
+    bt.device_name = "Test BT"
+    bt.real_trvs = {ENTITY_ID: Trv(entity_id=ENTITY_ID, calibration=0)}
+    bt.hass.states.get.return_value = State(
+        ENTITY_ID, "heat", {"preset_modes": preset_modes, "preset_mode": preset_mode}
+    )
+    bt.hass.services.async_call = AsyncMock()
+    return bt
+
+
+async def _init(bt) -> None:
+    """Run init past the discovery steps the preset reset sits behind."""
+    with (
+        patch(_FIND_VALVE, AsyncMock(return_value=None)),
+        patch(_FIND_CALIBRATION, AsyncMock(return_value=None)),
+        patch(_WAIT_FOR_CALIBRATION, AsyncMock(return_value=None)),
+    ):
+        await init(bt, ENTITY_ID)
+
+
+def _preset_calls(bt) -> list[dict]:
+    """The preset payloads init dispatched at the TRV."""
+    return [
+        call.args[2]
+        for call in bt.hass.services.async_call.call_args_list
+        if call.args[:2] == ("climate", "set_preset_mode")
+    ]
+
+
+@pytest.mark.parametrize(
+    ("preset_modes", "expected"),
+    [
+        # What Home Assistant reports for a Zigbee2MQTT TRV: the device names
+        # its own presets and HA prepends "none" itself.
+        (["none", "auto", "manual", "holiday"], "manual"),
+        (["none", "programming", "manual", "temporary_manual", "holiday"], "manual"),
+        # Spelling is the device's; the match is not.
+        (["none", "Manual"], "Manual"),
+    ],
+)
+def test_manual_preset_picks_the_device_preset_that_hands_the_setpoint_over(
+    preset_modes, expected
+):
+    """The device's manual preset wins over the "none" HA contributes."""
+    assert manual_preset(preset_modes) == expected
+
+
+@pytest.mark.parametrize(
+    "preset_modes",
+    [
+        # Nothing the device offers takes it off its own schedule.
+        ["none", "eco", "comfort"],
+        # "none" alone is HA's contribution and nothing else, so a device
+        # reporting only it names no preset of its own.
+        ["none"],
+        [],
+        None,
+        # A bare string is not a list of presets; iterating it would match
+        # single characters.
+        "manual",
+    ],
+)
+def test_manual_preset_answers_none_when_the_device_offers_no_manual(preset_modes):
+    """No manual preset means nothing is written, not that "none" is."""
+    assert manual_preset(preset_modes) is None
+
+
+@pytest.mark.asyncio
+async def test_preset_reset_writes_the_device_preset_not_none():
+    """The reset sends "manual"; "none" is what the broker rejects."""
+    bt = _bt(["none", "auto", "manual", "holiday"], preset_mode="auto")
+    await _init(bt)
+    assert _preset_calls(bt) == [{"entity_id": ENTITY_ID, "preset_mode": "manual"}]
+
+
+@pytest.mark.asyncio
+async def test_preset_reset_is_skipped_without_a_manual_preset():
+    """A device with no manual preset keeps the one it is on."""
+    bt = _bt(["none", "eco"], preset_mode="eco")
+    await _init(bt)
+    assert _preset_calls(bt) == []
+
+
+@pytest.mark.asyncio
+async def test_preset_reset_is_skipped_when_the_trv_already_runs_manual():
+    """Nothing is written to a device that is already off its schedule."""
+    bt = _bt(["none", "auto", "manual"], preset_mode="manual")
+    await _init(bt)
+    assert _preset_calls(bt) == []

--- a/tests/unit/test_trvzb_quirk_overrides.py
+++ b/tests/unit/test_trvzb_quirk_overrides.py
@@ -211,14 +211,19 @@ def _registry_entry(entity_id, *, domain, translation_key=None, device_id="dev1"
     return entry
 
 
-def _make_selector_self(state, options=("internal", "external"), *, entries=None):
+def _make_selector_self(
+    state, options=("internal", "external"), *, entries=None, trv=None
+):
     """A BT stand-in whose TRV device carries a sensor selector.
 
     ``state`` is what the selector currently reports; ``None`` stands for a
-    selector that publishes no state.
+    selector that publishes no state. ``trv`` is the registry entry the
+    lookup starts from, so a test can hand it one that belongs to no
+    device; it is the first of ``entries`` unless given separately.
     """
     mock_self = _make_self()
-    trv = _registry_entry("climate.trv1", domain="climate")
+    if trv is None:
+        trv = _registry_entry("climate.trv1", domain="climate")
     selector = _registry_entry(
         "select.trv1_temperature_sensor_select",
         domain="select",
@@ -294,6 +299,55 @@ class TestMaybeSelectExternalSensor:
     async def test_a_selector_without_the_option_is_not_written(self, monkeypatch):
         """A device that names no external option keeps its selection."""
         mock_self = _make_selector_self("internal", options=("internal",))
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert (
+            await quirk.maybe_select_external_sensor(mock_self, "climate.trv1") is False
+        )
+
+        assert _selector_calls(mock_self) == []
+
+    @pytest.mark.asyncio
+    async def test_a_trv_that_belongs_to_no_device_is_not_written(self, monkeypatch):
+        """No device is no sibling, not "every entity without a device".
+
+        A registry entry carrying no ``device_id`` would otherwise match
+        every other entity that carries none, and the first one answering
+        to the selector's translation key or id fragment would be written
+        as if it sat on this TRV.
+        """
+        trv = _registry_entry("climate.trv1", domain="climate", device_id=None)
+        stray = _registry_entry(
+            "select.somewhere_else_temperature_sensor_select",
+            domain="select",
+            translation_key="temperature_sensor_select",
+            device_id=None,
+        )
+        mock_self = _make_selector_self("internal", entries=[trv, stray], trv=trv)
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert (
+            await quirk.maybe_select_external_sensor(mock_self, "climate.trv1") is False
+        )
+
+        assert _selector_calls(mock_self) == []
+
+    @pytest.mark.parametrize("reported", ["unavailable", "unknown"])
+    @pytest.mark.asyncio
+    async def test_a_selector_that_is_not_reporting_is_not_written(
+        self, monkeypatch, reported
+    ):
+        """A selector naming no option is in no state to be given one.
+
+        The device behind an unavailable or unknown selector is out of
+        reach, so the write would fail; the options the entity still lists
+        are the ones it had when it was last reachable.
+        """
+        mock_self = _make_selector_self(reported)
         monkeypatch.setattr(
             quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
         )

--- a/tests/unit/test_trvzb_quirk_overrides.py
+++ b/tests/unit/test_trvzb_quirk_overrides.py
@@ -359,6 +359,35 @@ class TestMaybeSelectExternalSensor:
         assert _selector_calls(mock_self) == []
 
     @pytest.mark.asyncio
+    async def test_the_translation_key_wins_over_an_earlier_id_match(self, monkeypatch):
+        """The key names the selector; the id fragment only guesses at it.
+
+        A device that carries a second select whose id reads like the
+        selector — a leftover from a rename, say — hands it out first, and
+        matching per entry would write to it and never reach the entry that
+        names itself.
+        """
+        trv = _registry_entry("climate.trv1", domain="climate")
+        decoy = _registry_entry(
+            "select.trv1_temperature_sensor_select_old", domain="select"
+        )
+        selector = _registry_entry(
+            "select.trv1_temperature_sensor_select",
+            domain="select",
+            translation_key="temperature_sensor_select",
+        )
+        mock_self = _make_selector_self("internal", entries=[trv, decoy, selector])
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert await quirk.maybe_select_external_sensor(mock_self, "climate.trv1")
+
+        assert _selector_calls(mock_self) == [
+            {"entity_id": "select.trv1_temperature_sensor_select", "option": "external"}
+        ]
+
+    @pytest.mark.asyncio
     async def test_a_device_without_a_selector_is_not_written(self, monkeypatch):
         """Nothing on the device answers for the sensor choice."""
         trv = _registry_entry("climate.trv1", domain="climate")

--- a/tests/unit/test_trvzb_quirk_overrides.py
+++ b/tests/unit/test_trvzb_quirk_overrides.py
@@ -197,3 +197,170 @@ class TestOverrideSetValve:
         assert handled is True
         assert writes == [30]
         assert "_trvzb_valve_bump_task" not in trv_state.extra
+
+
+def _registry_entry(entity_id, *, domain, translation_key=None, device_id="dev1"):
+    """A registry entry stand-in with the fields the lookup reads."""
+    entry = MagicMock()
+    entry.entity_id = entity_id
+    entry.domain = domain
+    entry.device_id = device_id
+    entry.unique_id = entity_id
+    entry.translation_key = translation_key
+    entry.original_name = None
+    return entry
+
+
+def _make_selector_self(state, options=("internal", "external"), *, entries=None):
+    """A BT stand-in whose TRV device carries a sensor selector.
+
+    ``state`` is what the selector currently reports; ``None`` stands for a
+    selector that publishes no state.
+    """
+    mock_self = _make_self()
+    trv = _registry_entry("climate.trv1", domain="climate")
+    selector = _registry_entry(
+        "select.trv1_temperature_sensor_select",
+        domain="select",
+        translation_key="temperature_sensor_select",
+    )
+    registry = MagicMock()
+    registry.async_get.return_value = trv
+    registry.entities.values.return_value = (
+        entries if entries is not None else [trv, selector]
+    )
+    mock_self._registry = registry
+
+    selector_state = None
+    if state is not None:
+        selector_state = MagicMock()
+        selector_state.state = state
+        selector_state.attributes = {"options": list(options)}
+    mock_self.hass.states.get.return_value = selector_state
+    return mock_self
+
+
+def _selector_calls(mock_self):
+    """The select_option payloads the quirk dispatched."""
+    return [
+        call.args[2]
+        for call in mock_self.hass.services.async_call.await_args_list
+        if call.args[:2] == ("select", "select_option")
+    ]
+
+
+class TestMaybeSelectExternalSensor:
+    """Which sensor the TRV regulates on while BT writes into its input.
+
+    Writing the room temperature into the external input achieves nothing
+    while the device regulates on its own sensor, and it lands there on its
+    own: a TRVZB that is re-paired comes back on the internal sensor.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_trv_on_its_internal_sensor_is_switched_over(self, monkeypatch):
+        """The selector is moved onto the option BT writes for."""
+        mock_self = _make_selector_self("internal")
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert await quirk.maybe_select_external_sensor(mock_self, "climate.trv1")
+
+        assert _selector_calls(mock_self) == [
+            {"entity_id": "select.trv1_temperature_sensor_select", "option": "external"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_a_trv_already_on_an_external_option_is_left_alone(self, monkeypatch):
+        """Which external option it is stays its owner's choice.
+
+        Devices offer more than one option naming an external sensor, and
+        rewriting the plain one would take that choice back on every write.
+        """
+        mock_self = _make_selector_self(
+            "external_ignore_internal",
+            options=("internal", "external", "external_ignore_internal"),
+        )
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert await quirk.maybe_select_external_sensor(mock_self, "climate.trv1")
+
+        assert _selector_calls(mock_self) == []
+
+    @pytest.mark.asyncio
+    async def test_a_selector_without_the_option_is_not_written(self, monkeypatch):
+        """A device that names no external option keeps its selection."""
+        mock_self = _make_selector_self("internal", options=("internal",))
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert (
+            await quirk.maybe_select_external_sensor(mock_self, "climate.trv1") is False
+        )
+
+        assert _selector_calls(mock_self) == []
+
+    @pytest.mark.asyncio
+    async def test_a_device_without_a_selector_is_not_written(self, monkeypatch):
+        """Nothing on the device answers for the sensor choice."""
+        trv = _registry_entry("climate.trv1", domain="climate")
+        mock_self = _make_selector_self("internal", entries=[trv])
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert (
+            await quirk.maybe_select_external_sensor(mock_self, "climate.trv1") is False
+        )
+
+        assert _selector_calls(mock_self) == []
+
+
+class TestExternalTemperatureWriteSelectsTheSensor:
+    """The write and the sensor choice belong to the same intent."""
+
+    @pytest.mark.asyncio
+    async def test_writing_the_input_also_points_the_selector_at_it(self, monkeypatch):
+        """A value written into an input the device ignores changes nothing.
+
+        This pins the wiring rather than either half: the selector check
+        has to happen on the path that writes the value, because that is
+        the only path that knows a value was written.
+        """
+        trv = _registry_entry("climate.trv1", domain="climate")
+        number = _registry_entry(
+            "number.trv1_external_temperature_input",
+            domain="number",
+            translation_key="external_temperature_input",
+        )
+        selector = _registry_entry(
+            "select.trv1_temperature_sensor_select",
+            domain="select",
+            translation_key="temperature_sensor_select",
+        )
+        mock_self = _make_selector_self("internal", entries=[trv, number, selector])
+        mock_self.real_trvs = {
+            "climate.trv1": Trv(entity_id="climate.trv1", model="TRVZB")
+        }
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+
+        assert await quirk.maybe_set_external_temperature(
+            mock_self, "climate.trv1", 21.42
+        )
+
+        payloads = [
+            call.args[2] for call in mock_self.hass.services.async_call.await_args_list
+        ]
+        assert payloads == [
+            {"entity_id": "number.trv1_external_temperature_input", "value": 21.4},
+            {
+                "entity_id": "select.trv1_temperature_sensor_select",
+                "option": "external",
+            },
+        ]

--- a/tests/unit/test_valve_maintenance.py
+++ b/tests/unit/test_valve_maintenance.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
 import pytest
 
@@ -29,6 +30,7 @@ from custom_components.better_thermostat.utils.valve_maintenance import (
     collect_maintenance_trvs,
     compute_initial_maintenance,
     compute_next_maintenance,
+    mode_needs_restoring,
     open_step,
     pick_wake_mode,
     restore_one,
@@ -59,6 +61,38 @@ def _trv(
             "valve_position_entity": valve_entity,
         },
     )
+
+
+def _reports(mode: str | None):
+    """A ``hass.states.get`` stand-in reporting every TRV in ``mode``.
+
+    ``None`` stands for a TRV that publishes no state at all.
+    """
+
+    def get_state(entity_id: str) -> State | None:
+        # SimpleNamespace, not State: the ids in this module are bare
+        # names and State rejects anything without a domain.
+        return None if mode is None else SimpleNamespace(state=mode)
+
+    return get_state
+
+
+def _reports_a_moved_mode(infos: list[MaintenanceTrvInfo]):
+    """A state reader answering with a mode no TRV here was started in.
+
+    The restore writes the mode back only when it moved, so this is the
+    reading the tests below assume: they are about what the run does with
+    a TRV whose mode has to go back, not about the guard itself.
+    """
+    moved = {
+        info.entity_id: HVACMode.OFF if info.cur_mode != HVACMode.OFF else "heat"
+        for info in infos
+    }
+
+    def get_state(entity_id: str) -> State | None:
+        return SimpleNamespace(state=moved.get(entity_id, HVACMode.OFF))
+
+    return get_state
 
 
 def _info(
@@ -357,7 +391,12 @@ class TestRestoreOne:
         temp_fn = AsyncMock()
         mode_fn = AsyncMock()
         info = _info(cur_temp=22.5, cur_mode="heat")
-        await restore_one(info, set_temperature_fn=temp_fn, set_hvac_mode_fn=mode_fn)
+        await restore_one(
+            info,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode([info]),
+        )
         temp_fn.assert_awaited_once_with("climate.trv1", 22.5)
         mode_fn.assert_awaited_once_with("climate.trv1", "heat")
 
@@ -367,7 +406,12 @@ class TestRestoreOne:
         temp_fn = AsyncMock()
         mode_fn = AsyncMock()
         info = _info(cur_temp=None)
-        await restore_one(info, set_temperature_fn=temp_fn, set_hvac_mode_fn=mode_fn)
+        await restore_one(
+            info,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode([info]),
+        )
         temp_fn.assert_not_awaited()
         mode_fn.assert_awaited_once()
 
@@ -377,7 +421,12 @@ class TestRestoreOne:
         temp_fn = AsyncMock(side_effect=RuntimeError("fail"))
         mode_fn = AsyncMock()
         info = _info(cur_temp=20.0, cur_mode="heat")
-        await restore_one(info, set_temperature_fn=temp_fn, set_hvac_mode_fn=mode_fn)
+        await restore_one(
+            info,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode([info]),
+        )
         mode_fn.assert_awaited_once_with("climate.trv1", "heat")
 
 
@@ -402,6 +451,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -427,6 +477,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -449,6 +500,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -474,6 +526,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -494,6 +547,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode([]),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -523,6 +577,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -554,6 +609,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -609,6 +665,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_mock,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -657,6 +714,7 @@ class TestRunValveMaintenance:
             set_valve_fn=AsyncMock(),
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_mock,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=30,
         )
@@ -692,6 +750,7 @@ class TestRunValveMaintenance:
             set_valve_fn=AsyncMock(),
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=30,
         )
@@ -716,6 +775,7 @@ class TestRunValveMaintenance:
             set_valve_fn=AsyncMock(),
             set_temperature_fn=AsyncMock(),
             set_hvac_mode_fn=AsyncMock(),
+            get_state=_reports_a_moved_mode([]),
             device_name="Test",
             cycle_sleep=30,
         )
@@ -743,6 +803,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -764,6 +825,7 @@ class TestRunValveMaintenance:
             set_valve_fn=valve_fn,
             set_temperature_fn=temp_fn,
             set_hvac_mode_fn=mode_fn,
+            get_state=_reports_a_moved_mode(infos),
             device_name="Test",
             cycle_sleep=0,
         )
@@ -851,5 +913,89 @@ class TestWakeStep:
         mode_fn = AsyncMock()
         await wake_step(
             _info(entity_id="trv1", wake_mode=None), set_hvac_mode_fn=mode_fn
+        )
+        mode_fn.assert_not_awaited()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# mode_needs_restoring
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestModeNeedsRestoring:
+    """Which TRVs get their HVAC mode written back after a run.
+
+    A device that reports a single HVAC mode implements no setter for it,
+    so Home Assistant's climate component raises ``NotImplementedError`` on
+    a write of the mode the device is already in. The run has no reason to
+    make that write: it never moved the mode of such a device.
+    """
+
+    def test_a_woken_trv_is_restored_whatever_it_reports(self):
+        """The wake mode alone decides; a stale reading cannot undo it.
+
+        ``wake_step`` wrote the mode, so it has to go back. The device may
+        not have published the change yet, and a reading that still shows
+        the mode the run started from would otherwise leave the TRV in the
+        mode it was woken into.
+        """
+        info = _info(cur_mode=HVACMode.OFF, wake_mode="heat")
+        assert mode_needs_restoring(info, _reports(HVACMode.OFF)) is True
+
+    def test_a_trv_still_in_its_own_mode_is_left_alone(self):
+        """Nothing moved the mode, so writing it back buys nothing."""
+        info = _info(cur_mode="heat", wake_mode=None)
+        assert mode_needs_restoring(info, _reports("heat")) is False
+
+    def test_a_mode_that_moved_without_the_wake_step_is_restored(self):
+        """A device that switched itself on is put back.
+
+        A valve-driven TRV is never woken, and a device that answers a
+        valve write by leaving ``off`` moved a mode the run has to undo.
+        """
+        info = _info(cur_mode=HVACMode.OFF, use_direct_valve=True, wake_mode=None)
+        assert mode_needs_restoring(info, _reports("heat")) is True
+
+    def test_a_trv_without_a_state_is_restored(self):
+        """No reading is no evidence that the mode is where it belongs."""
+        info = _info(cur_mode="heat", wake_mode=None)
+        assert mode_needs_restoring(info, _reports(None)) is True
+
+
+class TestRestoreLeavesAnUnmovedModeAlone:
+    """The guard as the restore applies it, setpoint included."""
+
+    @pytest.mark.asyncio
+    async def test_setpoint_is_restored_and_the_mode_is_not_written(self):
+        """A single-mode TRV gets its setpoint back and no mode write."""
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+        info = _info(cur_temp=21.5, cur_mode="heat", wake_mode=None)
+        await restore_one(
+            info,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            get_state=_reports("heat"),
+        )
+        temp_fn.assert_awaited_once_with("climate.trv1", 21.5)
+        mode_fn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_full_run_writes_no_mode_to_a_trv_that_kept_it(self):
+        """End to end: the run leaves such a TRV's mode untouched.
+
+        The valve cycle drives the TRV through a number entity, so nothing
+        in the run asks its mode to move.
+        """
+        mode_fn = AsyncMock()
+        infos = [_info(entity_id="trv1", cur_mode="heat", use_direct_valve=True)]
+        await run_valve_maintenance(
+            infos,
+            set_valve_fn=AsyncMock(return_value=True),
+            set_temperature_fn=AsyncMock(),
+            set_hvac_mode_fn=mode_fn,
+            get_state=_reports("heat"),
+            device_name="Test",
+            cycle_sleep=0,
         )
         mode_fn.assert_not_awaited()

--- a/tests/unit/test_valve_maintenance.py
+++ b/tests/unit/test_valve_maintenance.py
@@ -63,6 +63,16 @@ def _trv(
     )
 
 
+def _state(entity_id: str, mode: str) -> State:
+    """A ``State`` for ``entity_id``, which is a bare name in this module.
+
+    ``State`` splits the id into a domain and an object id and rejects one
+    without a domain, so a bare name is given the climate domain it stands
+    for. Only the reported mode is read back.
+    """
+    return State(entity_id if "." in entity_id else f"climate.{entity_id}", mode)
+
+
 def _reports(mode: str | None):
     """A ``hass.states.get`` stand-in reporting every TRV in ``mode``.
 
@@ -70,9 +80,7 @@ def _reports(mode: str | None):
     """
 
     def get_state(entity_id: str) -> State | None:
-        # SimpleNamespace, not State: the ids in this module are bare
-        # names and State rejects anything without a domain.
-        return None if mode is None else SimpleNamespace(state=mode)
+        return None if mode is None else _state(entity_id, mode)
 
     return get_state
 
@@ -90,7 +98,7 @@ def _reports_a_moved_mode(infos: list[MaintenanceTrvInfo]):
     }
 
     def get_state(entity_id: str) -> State | None:
-        return SimpleNamespace(state=moved.get(entity_id, HVACMode.OFF))
+        return _state(entity_id, moved.get(entity_id, HVACMode.OFF))
 
     return get_state
 
@@ -940,12 +948,12 @@ class TestModeNeedsRestoring:
         mode it was woken into.
         """
         info = _info(cur_mode=HVACMode.OFF, wake_mode="heat")
-        assert mode_needs_restoring(info, _reports(HVACMode.OFF)) is True
+        assert mode_needs_restoring(info, _reports(HVACMode.OFF), woken=True) is True
 
     def test_a_trv_still_in_its_own_mode_is_left_alone(self):
         """Nothing moved the mode, so writing it back buys nothing."""
         info = _info(cur_mode="heat", wake_mode=None)
-        assert mode_needs_restoring(info, _reports("heat")) is False
+        assert mode_needs_restoring(info, _reports("heat"), woken=False) is False
 
     def test_a_mode_that_moved_without_the_wake_step_is_restored(self):
         """A device that switched itself on is put back.
@@ -954,12 +962,22 @@ class TestModeNeedsRestoring:
         valve write by leaving ``off`` moved a mode the run has to undo.
         """
         info = _info(cur_mode=HVACMode.OFF, use_direct_valve=True, wake_mode=None)
-        assert mode_needs_restoring(info, _reports("heat")) is True
+        assert mode_needs_restoring(info, _reports("heat"), woken=False) is True
+
+    def test_a_wake_that_never_landed_decides_nothing(self):
+        """A selected wake mode is an intention, not a write that happened.
+
+        ``wake_step`` can raise, and the orchestrator already drops such a
+        TRV from the cycle. Its mode is then still the one the snapshot was
+        taken in, so repeating the write that just failed buys nothing.
+        """
+        info = _info(cur_mode=HVACMode.OFF, wake_mode="heat")
+        assert mode_needs_restoring(info, _reports(HVACMode.OFF), woken=False) is False
 
     def test_a_trv_without_a_state_is_restored(self):
         """No reading is no evidence that the mode is where it belongs."""
         info = _info(cur_mode="heat", wake_mode=None)
-        assert mode_needs_restoring(info, _reports(None)) is True
+        assert mode_needs_restoring(info, _reports(None), woken=False) is True
 
 
 class TestRestoreLeavesAnUnmovedModeAlone:

--- a/uv.lock
+++ b/uv.lock
@@ -392,7 +392,7 @@ wheels = [
 
 [[package]]
 name = "better-thermostat"
-version = "1.9.1"
+version = "1.9.2"
 source = { virtual = "." }
 dependencies = [
     { name = "homeassistant" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preserves user-selected entity IDs across restarts and handles thermostat renames more reliably.
  - Supports device-specific manual presets for MQTT thermostats.
  - Automatically selects external temperature sensors on compatible TRVZB devices.
  - Refreshes external temperatures periodically to keep TRVs updated.

- **Bug Fixes**
  - Improves degraded-mode reporting when critical devices are unavailable.
  - Restores valve temperatures and HVAC modes more accurately after maintenance.
  - Cleans up integration data when entries are removed.

- **Chores**
  - Updated the integration version to 1.9.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->