### PR TITLE
fix: debounce internal TRV temperature per device instead of per room

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -872,7 +872,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.version = VERSION
         self.last_change = self.clock.now() - timedelta(hours=2)
         self.last_external_sensor_change = self.clock.now() - timedelta(hours=2)
-        self.last_internal_sensor_change = self.clock.now() - timedelta(hours=2)
         self._temp_lock = asyncio.Lock()
         self.bt_update_lock = False
         self._saved_temperature = None

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -166,20 +166,20 @@ async def trigger_trv_change(self, event):
         )
         _new_current_temp = None
 
-    _time_diff = 5
-    try:
-        for trv_conf in self.all_trvs:
-            if trv_conf["advanced"][CONF_HOMEMATICIP]:
-                _time_diff = 600
-    except KeyError:
-        pass
+    # A HomematicIP valve is radio-duty-cycle limited and is therefore read
+    # far apart; every other integration only needs the short anti-flicker
+    # window. Both the interval and the stamp it is measured against belong to
+    # the device this event came from, so a duty-cycle limit on one valve does
+    # not hold back the internal temperature of the other valves in the room.
+    _time_diff = 600 if advanced.get(CONF_HOMEMATICIP) else 5
+    _last_internal_change = trv.last_internal_sensor_change
     if (
         _new_current_temp is not None
         and trv.current_temperature != _new_current_temp
         and (
             trv.consume_accept_next_internal_temp()
-            or (dt_util.now() - self.last_internal_sensor_change).total_seconds()
-            > _time_diff
+            or _last_internal_change is None
+            or (dt_util.now() - _last_internal_change).total_seconds() > _time_diff
             or (trv.calibration_received is False and trv.calibration != 1)
         )
     ):
@@ -192,7 +192,7 @@ async def trigger_trv_change(self, event):
             _old_temp,
             _new_current_temp,
         )
-        self.last_internal_sensor_change = dt_util.now()
+        trv.last_internal_sensor_change = dt_util.now()
         _main_change = True
 
         # async def in controlling? (left as note)

--- a/custom_components/better_thermostat/trv.py
+++ b/custom_components/better_thermostat/trv.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from collections import deque
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import datetime
 from types import ModuleType
 from typing import Any, Protocol, runtime_checkable
 
@@ -96,6 +97,12 @@ class Trv:
     # One-shot flag: the next live internal reading after an outage must
     # bypass the debounce so it is not dropped as a stale duplicate.
     accept_next_internal_temp: bool = False
+    # When this device's internal temperature was last accepted. The debounce
+    # that guards it is a property of the device that reported it, so the
+    # stamp belongs to that device: a reading taken from one valve says
+    # nothing about how fresh another valve's reading is. ``None`` means no
+    # reading has been accepted yet and the next one passes.
+    last_internal_sensor_change: datetime | None = None
     last_temperature: float | None = None
     last_valve_position: float | None = None
     last_hvac_mode: str | None = None

--- a/tests/unit/test_per_trv_target_temp_step.py
+++ b/tests/unit/test_per_trv_target_temp_step.py
@@ -8,13 +8,11 @@ fine-grained TRV by less than the coarse step would have the change
 classified as an echo of a Better Thermostat write and dropped.
 """
 
-from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.climate.const import ATTR_TARGET_TEMP_STEP, HVACMode
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import State
-from homeassistant.util import dt as dt_util
 import pytest
 
 from custom_components.better_thermostat.climate import BetterThermostat
@@ -75,7 +73,6 @@ def bt():
     mock.window_open = False
     mock.control_queue_task = MagicMock()
     mock.context = MagicMock()
-    mock.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
     mock._clamp_inbound_heat_target = lambda v: (
         BetterThermostat._clamp_inbound_heat_target(mock, v)
     )

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -30,6 +30,7 @@ from custom_components.better_thermostat.utils.const import (
 from custom_components.better_thermostat.utils.helpers import mode_remap
 
 ENTITY_ID = "climate.test_trv"
+PEER_ID = "climate.test_trv_peer"
 
 
 # ---------------------------------------------------------------------------
@@ -63,7 +64,6 @@ def mock_bt():
     bt.cooler_entity_id = None
     bt.ignore_states = False
     bt.context = MagicMock()  # unique context so != event.context
-    bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
     bt.async_write_ha_state = MagicMock()
     bt._enforce_cool_above_heat = lambda **kwargs: (
         BetterThermostat._enforce_cool_above_heat(bt, **kwargs)
@@ -132,6 +132,63 @@ def _make_event(bt, new_state=None, old_state=None, entity_id=ENTITY_ID):
     }
     event.context = MagicMock()  # differs from bt.context
     return event
+
+
+def _add_homematicip_peer(bt):
+    """Put a second, HomematicIP-flagged valve into the same room.
+
+    Returns the state the peer reports, so a caller can route
+    ``hass.states.get`` to the right state per entity.
+    """
+    peer = Trv.from_legacy_dict(
+        PEER_ID,
+        {
+            "hvac_mode": HVACMode.HEAT,
+            "hvac_modes": [HVACMode.OFF, HVACMode.HEAT],
+            "min_temp": 5.0,
+            "max_temp": 30.0,
+            "current_temperature": 18.0,
+            "temperature": 19.0,
+            "last_temperature": 19.0,
+            "last_hvac_mode": "heat",
+            "target_temp_received": True,
+            "system_mode_received": True,
+            "calibration_received": True,
+            "calibration": 1,
+            "last_calibration": 0.0,
+            "ignore_trv_states": False,
+            "model": "SomeModel",
+            "model_quirks": None,
+            "hvac_action": "heating",
+            "valve_position": 50,
+            "advanced": {
+                "calibration": CalibrationType.LOCAL_BASED,
+                "calibration_mode": CalibrationMode.DEFAULT,
+                "no_off_system_mode": False,
+                "heat_auto_swapped": False,
+                "child_lock": False,
+                CONF_HOMEMATICIP: True,
+            },
+        },
+    )
+    bt.real_trvs[PEER_ID] = peer
+    bt.all_trvs = [
+        {"advanced": {CONF_HOMEMATICIP: False}},
+        {"advanced": {CONF_HOMEMATICIP: True}},
+    ]
+    peer_state = State(
+        PEER_ID, "heat", attributes={"current_temperature": 20.0, "temperature": 19.0}
+    )
+
+    def _state_for(entity_id):
+        return (
+            peer_state
+            if entity_id == PEER_ID
+            else _make_state(attributes={"current_temperature": 20.0})
+        )
+
+    bt.hass.states.get.side_effect = _state_for
+    return peer_state
 
 
 def _bind_cooler_hvac_mode(bt):
@@ -288,7 +345,7 @@ class TestInternalTemperatureChange:
         assert mock_bt.real_trvs[ENTITY_ID].current_temperature is None
 
         # The TRV recovers well inside the 5 s debounce window.
-        mock_bt.last_internal_sensor_change = dt_util.now()
+        mock_bt.real_trvs[ENTITY_ID].last_internal_sensor_change = dt_util.now()
         trv_state = _make_state(attributes={"current_temperature": 18.0})
         mock_bt.hass.states.get.return_value = trv_state
         event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
@@ -351,8 +408,10 @@ class TestInternalTemperatureChange:
 
     @pytest.mark.asyncio
     async def test_temp_change_respects_time_diff(self, mock_bt):
-        """Changes within 5 s of the last internal sensor change are skipped."""
-        mock_bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=2)
+        """Changes within 5 s of the TRV's last internal sensor change are skipped."""
+        mock_bt.real_trvs[ENTITY_ID].last_internal_sensor_change = dt_util.now() - (
+            timedelta(seconds=2)
+        )
         trv_state = _make_state(attributes={"current_temperature": 20.0})
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
@@ -372,9 +431,11 @@ class TestInternalTemperatureChange:
 
     @pytest.mark.asyncio
     async def test_temp_change_homematicip_600s(self, mock_bt):
-        """HomematicIP uses a 600 s guard instead of 5 s."""
-        mock_bt.all_trvs = [{"advanced": {CONF_HOMEMATICIP: True}}]
-        mock_bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=30)
+        """A HomematicIP TRV guards its own readings with 600 s instead of 5 s."""
+        mock_bt.real_trvs[ENTITY_ID].advanced[CONF_HOMEMATICIP] = True
+        mock_bt.real_trvs[ENTITY_ID].last_internal_sensor_change = dt_util.now() - (
+            timedelta(seconds=30)
+        )
         trv_state = _make_state(attributes={"current_temperature": 20.0})
         mock_bt.hass.states.get.return_value = trv_state
         mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
@@ -391,6 +452,61 @@ class TestInternalTemperatureChange:
 
         # 30 s elapsed < 600 s → blocked
         assert mock_bt.real_trvs[ENTITY_ID].current_temperature == 18.0
+
+    @pytest.mark.asyncio
+    async def test_homematicip_peer_does_not_hold_back_the_other_trv(self, mock_bt):
+        """A HomematicIP valve does not stretch its room mates' debounce window.
+
+        The 600 s window belongs to the HomematicIP radio, so the Zigbee valve
+        of the same room keeps the 5 s window: its reading is taken 30 s after
+        its own last one, while the HomematicIP valve reported a moment ago.
+        """
+        _add_homematicip_peer(mock_bt)
+        mock_bt.real_trvs[PEER_ID].last_internal_sensor_change = dt_util.now()
+        mock_bt.real_trvs[ENTITY_ID].last_internal_sensor_change = dt_util.now() - (
+            timedelta(seconds=30)
+        )
+        mock_bt.real_trvs[ENTITY_ID].current_temperature = 18.0
+        mock_bt.real_trvs[ENTITY_ID].calibration_received = True
+        mock_bt.real_trvs[ENTITY_ID].calibration = 1
+
+        trv_state = _make_state(attributes={"current_temperature": 20.0})
+        event = _make_event(mock_bt, new_state=trv_state, old_state=trv_state)
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[ENTITY_ID].current_temperature == 20.0
+
+    @pytest.mark.asyncio
+    async def test_homematicip_trv_keeps_its_own_600s_window(self, mock_bt):
+        """The HomematicIP valve of a mixed room still waits out its 600 s.
+
+        A room mate on another radio does not shorten the duty-cycle window,
+        just as the window does not lengthen the room mate's.
+        """
+        peer_state = _add_homematicip_peer(mock_bt)
+        mock_bt.real_trvs[PEER_ID].last_internal_sensor_change = dt_util.now() - (
+            timedelta(seconds=30)
+        )
+        mock_bt.real_trvs[PEER_ID].current_temperature = 18.0
+        mock_bt.real_trvs[ENTITY_ID].last_internal_sensor_change = dt_util.now() - (
+            timedelta(seconds=30)
+        )
+        event = _make_event(
+            mock_bt, new_state=peer_state, old_state=peer_state, entity_id=PEER_ID
+        )
+
+        with patch(
+            "custom_components.better_thermostat.events.trv.convert_inbound_states",
+            return_value=HVACMode.HEAT,
+        ):
+            await trigger_trv_change(mock_bt, event)
+
+        assert mock_bt.real_trvs[PEER_ID].current_temperature == 18.0
 
     @pytest.mark.asyncio
     async def test_calibration_received_flag_set(self, mock_bt):
@@ -2466,7 +2582,6 @@ def _make_group_bt(entity_ids, *, no_off=False, bt_hvac_mode=HVACMode.HEAT):
     bt.cooler_entity_id = None
     bt.ignore_states = False
     bt.context = MagicMock()
-    bt.last_internal_sensor_change = dt_util.now() - timedelta(seconds=60)
     bt.async_write_ha_state = MagicMock()
     bt.hvac_mode = bt_hvac_mode
     bt._enforce_cool_above_heat = lambda **kwargs: (


### PR DESCRIPTION
## Problem

In a room with more than one TRV, the debounce that guards a TRV's internal
temperature reading was room-wide in two ways:

- a single timestamp on the thermostat recorded the last accepted reading of
  *any* valve, so one valve's accepted reading suppressed every other valve's
  reading until that timestamp aged out;
- the interval rose to 600 s as soon as *any* configured valve carried the
  HomematicIP flag, so a Zigbee valve sharing a room with a HomematicIP valve
  inherited a duty-cycle interval its radio does not need.

Together this means a single HomematicIP valve holds the whole room at ten
minutes: `current_temperature` of the other valves — the input of the sensor
fallback ladder and of their own calibration — can be that old. Only the two
per-valve exceptions in the same condition (the accept-next-reading one-shot
after an outage, and an unacknowledged calibration) let a reading through in
the meantime.

## Change

- `Trv` carries `last_internal_sensor_change`. The stamp is written on the
  valve whose reading was accepted and read back from that same valve;
  `None` means nothing has been accepted yet, so the first reading passes.
- The interval follows the HomematicIP flag of the valve the event came from
  (`trv.advanced`) instead of a scan over every configured valve. A
  HomematicIP valve keeps its 600 s, its room mates keep the 5 s
  anti-flicker window.
- The room-wide `last_internal_sensor_change` on the thermostat has no reader
  left and is removed.
- Reading the flag off the already-resolved per-valve `advanced` mapping also
  retires the `KeyError`-only guard around that scan, which did not cover the
  `TypeError` an `advanced` of `None` raises.

The external room sensor keeps its own room-wide interval: accepting a reading
there queues one control cycle that writes to every valve of the room, so that
throttle is room-scoped by construction and is left untouched.

## Verification

`tests/unit/test_trv_events.py::TestInternalTemperatureChange::test_homematicip_peer_does_not_hold_back_the_other_trv`
is the counterfactual test: a room with one HomematicIP and one Zigbee valve,
the HomematicIP valve having reported a moment ago, the Zigbee valve reporting
30 s after its own last accepted reading. With the handler restored to the
room-wide stamp and scan it fails — the Zigbee reading is dropped and
`current_temperature` stays at 18.0 — and it is the only failure in that file.

`test_homematicip_trv_keeps_its_own_600s_window` pins the other half: it fails
when the interval is flattened to 5 s for every device, so the duty-cycle
window is not silently lost.

Two existing tests moved from the room-wide setup to the per-valve one
(`test_temp_change_respects_time_diff`, `test_temp_change_homematicip_600s`);
they assert the same behaviour, now against the device instead of the room.

`tests/unit`: 6616 passed, 1 skipped. `ruff check` and `ruff format --check`
clean; pyrefly reports the same counts as the base.

https://claude.ai/code/session_01PyFGJWerLK4bNTU4wp5zXp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal temperature update handling so each thermostat valve is evaluated independently.
  * Prevented delayed updates from one valve from suppressing timely updates from others.
  * Applied the appropriate debounce interval for HomematicIP and other supported valves.
* **Tests**
  * Added coverage confirming independent temperature update timing across mixed valve types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->