### PR TITLE
fix: cancel the plateau timer when the entity is removed

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -4287,6 +4287,14 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.kernel_state = replace(
             self.kernel_state, lifecycle=lifecycle_stop(self.kernel_state.lifecycle)
         )
+        # The plateau timer is scheduled on hass, not on the entity, so a
+        # pending one outlives the unload and would write the external
+        # temperature to TRVs this entity no longer drives. Awaiting the
+        # workers below yields to the loop, which is long enough for a due
+        # timer to fire, so it goes first.
+        if self.plateau_timer_cancel is not None:
+            self.plateau_timer_cancel()
+            self.plateau_timer_cancel = None
         if self._control_task:
             self._control_task.cancel()
             try:
@@ -4305,12 +4313,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 await self._door_task
             except asyncio.CancelledError:
                 pass
-        # The plateau timer is scheduled on hass, not on the entity, so a
-        # pending one outlives the unload and would write the external
-        # temperature to TRVs this entity no longer drives.
-        if self.plateau_timer_cancel is not None:
-            self.plateau_timer_cancel()
-            self.plateau_timer_cancel = None
         await super().async_will_remove_from_hass()
 
 

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -4305,6 +4305,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 await self._door_task
             except asyncio.CancelledError:
                 pass
+        # The plateau timer is scheduled on hass, not on the entity, so a
+        # pending one outlives the unload and would write the external
+        # temperature to TRVs this entity no longer drives.
+        if self.plateau_timer_cancel is not None:
+            self.plateau_timer_cancel()
+            self.plateau_timer_cancel = None
         await super().async_will_remove_from_hass()
 
 

--- a/custom_components/better_thermostat/utils/watcher.py
+++ b/custom_components/better_thermostat/utils/watcher.py
@@ -300,6 +300,11 @@ async def await_optional_sensors(
     pending: list[str] = []
 
     for idx, delay in enumerate(delays):
+        # The entity may be torn down mid-wait; stop retrying immediately
+        # instead of running out the (up to ~60 s) schedule against a
+        # being-removed instance.
+        if getattr(self, "is_removed", False):
+            return pending
         pending = [
             eid
             for eid in get_optional_sensors(self)
@@ -323,6 +328,8 @@ async def await_optional_sensors(
         )
         await _sleep(delay)
         elapsed += delay
+        if getattr(self, "is_removed", False):
+            return pending
 
     # Final check after the last sleep
     pending = [

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -360,6 +360,40 @@ class TestPlateauTimerOnRemoval:
         _external_temperature_writes(plateau_bt).assert_not_awaited()
         assert plateau_bt.plateau_timer_cancel is None
 
+    @pytest.mark.asyncio
+    async def test_the_timer_goes_before_the_workers_are_awaited(
+        self, hass, plateau_bt
+    ):
+        """Shutting the workers down yields, and a due timer fires in that gap.
+
+        Every `await` in the teardown hands the loop back, so a timer still
+        armed at that point gets its turn and writes to devices the entity is
+        in the middle of letting go of.
+        """
+        await _arm_plateau_timer(plateau_bt)
+        order = []
+        withdraw_timer = plateau_bt.plateau_timer_cancel
+
+        def record_timer_withdrawal():
+            order.append("timer")
+            withdraw_timer()
+
+        plateau_bt.plateau_timer_cancel = record_timer_withdrawal
+
+        async def never_finishes():
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                order.append("worker")
+                raise
+
+        plateau_bt._control_task = hass.async_create_task(never_finishes())
+        await asyncio.sleep(0)
+
+        await BetterThermostat.async_will_remove_from_hass(plateau_bt)
+
+        assert order == ["timer", "worker"]
+
 
 # ---------------------------------------------------------------------------
 # 1. _check_entities_ready

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -6,6 +6,7 @@ _restore_state, _validate_hvac_mode.
 """
 
 import asyncio
+from datetime import timedelta
 import json
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -19,19 +20,26 @@ from homeassistant.const import (
 )
 from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util import dt as dt_util
 import pytest
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from custom_components.better_thermostat.climate import (
     DEFAULT_FALLBACK_TEMPERATURE,
     BetterThermostat,
 )
 from custom_components.better_thermostat.core.decide import KernelState
+from custom_components.better_thermostat.events.temperature import (
+    PLATEAU_ACCEPT_WINDOW,
+    trigger_temperature_change,
+)
 from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils.const import (
     ATTR_STATE_CALL_FOR_HEAT,
     ATTR_STATE_HEAT_LOSS,
     ATTR_STATE_HEATING_POWER,
     ATTR_STATE_PRESET_COOL_TEMPERATURES,
+    CONF_HOMEMATICIP,
     DEFAULT_TARGET_TEMP,
     MAX_HEAT_LOSS,
     MAX_HEATING_POWER,
@@ -129,6 +137,39 @@ def bt():
         mock, value
     )
     return mock
+
+
+@pytest.fixture
+def plateau_bt(bt, hass):
+    """A thermostat whose plateau timer is scheduled on a real event loop.
+
+    The plateau path only exists once a reading has been accepted, so the
+    baseline reading is fed through the production handler rather than
+    assigned, and the TRV write the timer performs is observable on the
+    quirk the handler delegates to.
+    """
+    bt.hass = hass
+    bt.startup_running = False
+    bt._control_task = None
+    bt._window_task = None
+    bt._door_task = None
+    bt.control_queue_task = None
+    bt.in_maintenance = False
+    bt._control_needed_after_maintenance = False
+    bt.last_external_sensor_change = None
+    bt.prev_stable_temp = None
+    bt.last_change_direction = 0
+    bt.accum_delta = 0.0
+    bt.accum_dir = 0
+    bt.pending_temp = None
+    bt.pending_since = None
+    bt.plateau_timer_cancel = None
+    bt.all_trvs = [{"advanced": {CONF_HOMEMATICIP: False}}]
+    trv = MagicMock()
+    trv.model_quirks = MagicMock()
+    trv.model_quirks.maybe_set_external_temperature = AsyncMock()
+    bt.real_trvs = {TRV_ID: trv}
+    return bt
 
 
 def _make_trv_state(entity_id=TRV_ID, state="heat", attrs=None):
@@ -234,10 +275,90 @@ class TestStartupUnloadBailout:
         bt._control_task = None
         bt._window_task = None
         bt._door_task = None
+        bt.plateau_timer_cancel = None
 
         await BetterThermostat.async_will_remove_from_hass(bt)
 
         assert bt.kernel_state.lifecycle.startup_running is False
+
+
+# ---------------------------------------------------------------------------
+# 0b. what an unload has to withdraw from hass
+# ---------------------------------------------------------------------------
+
+
+# Half the significance threshold, so this reading reaches the TRVs through
+# the plateau timer and through no other accept path.
+SUB_THRESHOLD_TEMP = 20.05
+
+
+async def _feed_sensor_reading(entity, temperature):
+    """Deliver one external temperature reading to the event handler."""
+    event = MagicMock()
+    event.data = {"new_state": State(SENSOR_ID, str(temperature))}
+    await trigger_temperature_change(entity, event)
+
+
+def _external_temperature_writes(entity):
+    """Return the TRV write an accepted reading performs."""
+    return entity.real_trvs[TRV_ID].model_quirks.maybe_set_external_temperature
+
+
+async def _arm_plateau_timer(entity):
+    """Establish a baseline reading, then leave a plateau timer pending."""
+    await _feed_sensor_reading(entity, 20.0)
+    _external_temperature_writes(entity).assert_awaited_once()
+    _external_temperature_writes(entity).reset_mock()
+
+    # The accepted reading is a minute old, so the debounce interval the
+    # timer re-checks when it fires has long passed.
+    entity.last_external_sensor_change = dt_util.now() - timedelta(seconds=60)
+
+    await _feed_sensor_reading(entity, SUB_THRESHOLD_TEMP)
+    assert entity.plateau_timer_cancel is not None
+    assert entity.pending_temp == SUB_THRESHOLD_TEMP
+    _external_temperature_writes(entity).assert_not_awaited()
+
+
+def _pass_the_plateau_window(hass):
+    """Advance the loop past the plateau window so a pending timer fires."""
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=PLATEAU_ACCEPT_WINDOW + 5)
+    )
+
+
+class TestPlateauTimerOnRemoval:
+    """A pending plateau timer must not outlive the entity that armed it.
+
+    The timer is scheduled on hass, so nothing about the unload stops it on
+    its own: it fires against the torn-down instance and writes to devices
+    the entity no longer drives.
+    """
+
+    @pytest.mark.asyncio
+    async def test_armed_timer_fires_while_the_entity_lives(self, hass, plateau_bt):
+        """The window elapsing accepts the reading and writes it to the TRV."""
+        await _arm_plateau_timer(plateau_bt)
+
+        _pass_the_plateau_window(hass)
+        await hass.async_block_till_done()
+
+        _external_temperature_writes(plateau_bt).assert_awaited_once_with(
+            plateau_bt, TRV_ID, SUB_THRESHOLD_TEMP
+        )
+
+    @pytest.mark.asyncio
+    async def test_armed_timer_writes_nothing_after_removal(self, hass, plateau_bt):
+        """Removal withdraws the timer, so the window passes without a write."""
+        await _arm_plateau_timer(plateau_bt)
+
+        await BetterThermostat.async_will_remove_from_hass(plateau_bt)
+
+        _pass_the_plateau_window(hass)
+        await hass.async_block_till_done()
+
+        _external_temperature_writes(plateau_bt).assert_not_awaited()
+        assert plateau_bt.plateau_timer_cancel is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -1411,6 +1411,61 @@ class TestAwaitOptionalSensors:
         )
         assert sleep_calls == [2, 4]
 
+    def test_returns_immediately_when_already_removed(self, mock_bt_instance):
+        """An entity torn down before the wait starts never checks a sensor."""
+        from custom_components.better_thermostat.utils.watcher import (
+            await_optional_sensors,
+        )
+
+        mock_bt_instance.is_removed = True
+
+        sleep_calls = []
+
+        async def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+
+        result = self._run(
+            await_optional_sensors(
+                mock_bt_instance, delays=(3, 5, 10), _sleep=fake_sleep
+            )
+        )
+
+        assert result == []
+        assert sleep_calls == []
+        mock_bt_instance.hass.states.get.assert_not_called()
+
+    def test_stops_early_when_removed_mid_wait(self, mock_bt_instance):
+        """A teardown during the wait aborts the retry schedule immediately."""
+        from custom_components.better_thermostat.utils.watcher import (
+            await_optional_sensors,
+        )
+
+        mock_bt_instance.window_id = None
+        mock_bt_instance.humidity_sensor_entity_id = None
+        mock_bt_instance.weather_entity = None
+
+        mock_state = MagicMock()
+        mock_state.state = "unavailable"  # never comes online
+        mock_bt_instance.hass.states.get.return_value = mock_state
+
+        sleep_calls = []
+
+        async def fake_sleep(seconds):
+            sleep_calls.append(seconds)
+            # Instance torn down while we were waiting.
+            mock_bt_instance.is_removed = True
+
+        result = self._run(
+            await_optional_sensors(
+                mock_bt_instance, delays=(3, 5, 10, 15), _sleep=fake_sleep
+            )
+        )
+
+        # Only the first delay elapses; the post-sleep is_removed check returns
+        # instead of running the remaining schedule.
+        assert sleep_calls == [3]
+        assert result == ["sensor.outdoor_temp"]
+
 
 class TestAwaitCriticalEntities:
     """Tests for await_critical_entities retry logic.


### PR DESCRIPTION
## Problem

Better Thermostat accepts a sub-threshold external temperature change once the
new value has held for two minutes. It arms that acceptance with a timer that
lives on `hass`, not on the entity.

`async_will_remove_from_hass` cancels the control, window and door tasks, but
not that timer. Removing an entity, unloading or reloading a config entry
therefore leaves an armed timer behind. When it fires, it applies the pending
reading, writes the external temperature to the TRVs and keeps the torn-down
instance alive for up to two minutes past the unload. On a reload the old
instance writes to the same devices the new one has just taken over.

The startup wait for optional sensors has the same shape of problem: unlike the
wait for critical entities it never checks `is_removed`, so an entity removed
during startup keeps polling its sensors through the remaining retry schedule
(about a minute).

## Change

- `async_will_remove_from_hass` cancels a pending plateau timer and clears the
  handle, alongside the three tasks it already cancels.
- `await_optional_sensors` checks `is_removed` before each attempt and after
  each sleep, the same guard `await_critical_entities` already carries, and
  returns the pending list instead of running out its schedule.

## Verification

`tests/unit/test_climate_startup.py::TestPlateauTimerOnRemoval` drives a
baseline reading and then a sub-threshold one through the real event handler,
so a real timer is armed on a real event loop. One test lets the window elapse
with the entity in place and sees the TRV write arrive; the other removes the
entity first and asserts the same window passes without a write.

Without the change, `test_armed_timer_writes_nothing_after_removal` fails with
"Expected maybe_set_external_temperature to not have been awaited. Awaited 1
times." — the timer really does write after the unload. The companion test
stays green either way, which is what shows the window is actually being
crossed.

`tests/unit/test_watcher.py::TestAwaitOptionalSensors` gains the two cases the
critical-entity wait already had; both fail without the guard (the full
schedule `[3, 5, 10, 15]` runs instead of stopping after the first sleep).

The existing `test_will_remove_from_hass_stops_startup_loop` builds its
thermostat from a spec'd mock and had to name the handles teardown touches, so
it now names the timer handle too.

Suite: 6618 passed, 1 skipped (baseline 6614 passed, 1 skipped). `ruff check`,
`ruff format --check` and `pyrefly` report no new findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Thermostats now cancel pending temperature-control timers when removed.
  * Removed thermostats no longer continue checking sensors or updating connected TRVs.
  * Improved shutdown behavior prevents delayed temperature updates after an entity is unloaded.
  * Thermostat removal now completes promptly, avoiding unnecessary background activity and ensuring no stale readings are sent during teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->