### PR TITLE
fix: keep the control cycle running when a TRV write fails (1.9)

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -42,6 +42,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import CALLBACK_TYPE, Context, ServiceCall, State, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import dispatcher_send
@@ -1112,16 +1113,32 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                             self.device_name,
                             trv_id,
                         )
-                except OSError, RuntimeError, AttributeError, TypeError:
-                    _LOGGER.debug(
-                        "better_thermostat %s: external_temperature keepalive write failed for %s (non critical)",
+                except (
+                    HomeAssistantError,
+                    OSError,
+                    RuntimeError,
+                    AttributeError,
+                    TypeError,
+                ) as exc:
+                    # A device that refuses the write does not hold back the
+                    # others, and the value is re-sent on the next tick.
+                    _LOGGER.warning(
+                        "better_thermostat %s: external_temperature keepalive write failed for %s: %s",
                         self.device_name,
                         trv_id,
+                        exc,
                     )
-        except OSError, RuntimeError, AttributeError, TypeError:
-            _LOGGER.debug(
-                "better_thermostat %s: external_temperature keepalive encountered an error",
+        except (
+            HomeAssistantError,
+            OSError,
+            RuntimeError,
+            AttributeError,
+            TypeError,
+        ) as exc:
+            _LOGGER.warning(
+                "better_thermostat %s: external_temperature keepalive failed: %s",
                 self.device_name,
+                exc,
             )
 
     async def _trigger_humidity_change(self, event):

--- a/custom_components/better_thermostat/events/temperature.py
+++ b/custom_components/better_thermostat/events/temperature.py
@@ -126,11 +126,19 @@ async def _apply_temperature_update(self, new_temp):
             float(_ema),
         )
     # Write the value used by BT (self.cur_temp) to the TRV
+    trv_ids: list[str] = []
     try:
         trv_ids = list(self.real_trvs.keys())
         if not trv_ids and hasattr(self, "entity_ids"):
             trv_ids = list(self.entity_ids or [])
-        for trv_id in trv_ids:
+    except (AttributeError, TypeError) as exc:
+        _LOGGER.warning(
+            "better_thermostat %s: no TRV list to write external_temperature to: %s",
+            self.device_name,
+            exc,
+        )
+    for trv_id in trv_ids:
+        try:
             _trv = self.real_trvs.get(trv_id) if hasattr(self, "real_trvs") else None
             quirks = _trv.model_quirks if _trv is not None else None
             if quirks and hasattr(quirks, "maybe_set_external_temperature"):
@@ -141,23 +149,23 @@ async def _apply_temperature_update(self, new_temp):
                     self.device_name,
                     trv_id,
                 )
-    except (
-        HomeAssistantError,
-        OSError,
-        AttributeError,
-        KeyError,
-        TypeError,
-        ValueError,
-        RuntimeError,
-    ) as exc:
-        # A device that refuses the value keeps its old one, but the room
-        # temperature BT decides on has already changed, so the control cycle
-        # below still has to run on the new reading.
-        _LOGGER.warning(
-            "better_thermostat %s: external_temperature write to TRV failed: %s",
-            self.device_name,
-            exc,
-        )
+        except (
+            HomeAssistantError,
+            OSError,
+            AttributeError,
+            KeyError,
+            TypeError,
+            ValueError,
+            RuntimeError,
+        ) as exc:
+            # A device that refuses the value keeps its old one; the other TRVs
+            # still get the reading, and the control cycle below runs on it.
+            _LOGGER.warning(
+                "better_thermostat %s: external_temperature write to %s failed: %s",
+                self.device_name,
+                trv_id,
+                exc,
+            )
     # Enqueue control action (skip during valve maintenance to avoid overwriting exercise).
     # Still mark that a control cycle is needed after maintenance so we immediately
     # resume with the latest temperature.

--- a/custom_components/better_thermostat/events/temperature.py
+++ b/custom_components/better_thermostat/events/temperature.py
@@ -125,12 +125,12 @@ async def _apply_temperature_update(self, new_temp):
             float(new_temp_q),
             float(_ema),
         )
-    # Write the value used by BT (self.cur_temp) to the TRV
+    # Write the value used by BT (self.cur_temp) to the TRV. The heads are
+    # read from `real_trvs`, which is what carries the quirks the write goes
+    # through: an id from anywhere else resolves to no TRV and no write.
     trv_ids: list[str] = []
     try:
         trv_ids = list(self.real_trvs.keys())
-        if not trv_ids and hasattr(self, "entity_ids"):
-            trv_ids = list(self.entity_ids or [])
     except (AttributeError, TypeError) as exc:
         _LOGGER.warning(
             "better_thermostat %s: no TRV list to write external_temperature to: %s",
@@ -139,7 +139,7 @@ async def _apply_temperature_update(self, new_temp):
         )
     for trv_id in trv_ids:
         try:
-            _trv = self.real_trvs.get(trv_id) if hasattr(self, "real_trvs") else None
+            _trv = self.real_trvs.get(trv_id)
             quirks = _trv.model_quirks if _trv is not None else None
             if quirks and hasattr(quirks, "maybe_set_external_temperature"):
                 await quirks.maybe_set_external_temperature(self, trv_id, self.cur_temp)

--- a/custom_components/better_thermostat/events/temperature.py
+++ b/custom_components/better_thermostat/events/temperature.py
@@ -15,6 +15,7 @@ from time import monotonic
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util import dt as dt_util
@@ -140,10 +141,22 @@ async def _apply_temperature_update(self, new_temp):
                     self.device_name,
                     trv_id,
                 )
-    except AttributeError, KeyError, TypeError, ValueError, RuntimeError:
-        _LOGGER.debug(
-            "better_thermostat %s: external_temperature write to TRV failed (non critical)",
+    except (
+        HomeAssistantError,
+        OSError,
+        AttributeError,
+        KeyError,
+        TypeError,
+        ValueError,
+        RuntimeError,
+    ) as exc:
+        # A device that refuses the value keeps its old one, but the room
+        # temperature BT decides on has already changed, so the control cycle
+        # below still has to run on the new reading.
+        _LOGGER.warning(
+            "better_thermostat %s: external_temperature write to TRV failed: %s",
             self.device_name,
+            exc,
         )
     # Enqueue control action (skip during valve maintenance to avoid overwriting exercise).
     # Still mark that a control cycle is needed after maintenance so we immediately

--- a/custom_components/better_thermostat/model_fixes/TRVZB.py
+++ b/custom_components/better_thermostat/model_fixes/TRVZB.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 _LOGGER = logging.getLogger(__name__)
@@ -618,10 +619,23 @@ async def maybe_set_external_temperature(self, entity_id, temperature: float) ->
         # that is regulating on it.
         await maybe_select_external_sensor(self, entity_id)
         return True
-    except (TypeError, ValueError, KeyError, AttributeError) as ex:
-        _LOGGER.debug(
-            "better_thermostat %s: TRVZB maybe_set_external_temperature exception: %s",
+    except (
+        HomeAssistantError,
+        OSError,
+        TypeError,
+        ValueError,
+        KeyError,
+        AttributeError,
+    ) as ex:
+        # The device did not take the value: it is asleep, out of reach, its
+        # integration is reloading, or it declares a narrower range than the
+        # clamp above. Reporting the refused write as a declined one leaves
+        # the caller free to serve the remaining TRVs and to control on the
+        # new reading; the next write retries.
+        _LOGGER.warning(
+            "better_thermostat %s: TRVZB external temperature write for %s failed: %s",
             self.device_name,
+            entity_id,
             ex,
         )
         return False

--- a/tests/unit/test_external_temperature_keepalive.py
+++ b/tests/unit/test_external_temperature_keepalive.py
@@ -10,6 +10,7 @@ value while the room is settled.
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 import pytest
 
 from custom_components.better_thermostat.climate import (
@@ -21,6 +22,26 @@ from custom_components.better_thermostat.trv import Trv
 _CLIMATE = "custom_components.better_thermostat.climate"
 TRV_ID = "climate.trv"
 TRV_ID_2 = "climate.trv2"
+ROOM_TEMPERATURE = 21.4
+
+
+def _bt_with_two_trvs(quirks):
+    """A BT stand-in holding a room reading and two TRVs carrying quirks."""
+    bt = MagicMock()
+    bt.device_name = "Test BT"
+    bt.cur_temp = ROOM_TEMPERATURE
+    bt.real_trvs = {
+        TRV_ID: Trv(entity_id=TRV_ID, model_quirks=quirks),
+        TRV_ID_2: Trv(entity_id=TRV_ID_2, model_quirks=quirks),
+    }
+    return bt
+
+
+def _written_values(quirks):
+    """The (TRV, value) pairs the tick handed to the quirk."""
+    return [
+        call.args[1:] for call in quirks.maybe_set_external_temperature.await_args_list
+    ]
 
 
 def _startup_bt():
@@ -94,21 +115,16 @@ async def test_the_interval_stays_inside_the_shortest_known_fallback():
 @pytest.mark.asyncio
 async def test_the_tick_writes_the_room_temperature_to_every_trv():
     """Each TRV with the quirk gets the temperature BT is regulating on."""
-    bt = MagicMock()
-    bt.device_name = "Test BT"
-    bt.cur_temp = 21.4
     quirks = MagicMock()
     quirks.maybe_set_external_temperature = AsyncMock(return_value=True)
-    bt.real_trvs = {
-        TRV_ID: Trv(entity_id=TRV_ID, model_quirks=quirks),
-        TRV_ID_2: Trv(entity_id=TRV_ID_2, model_quirks=quirks),
-    }
+    bt = _bt_with_two_trvs(quirks)
 
     await BetterThermostat._external_temperature_keepalive(bt)
 
-    assert [
-        call.args[1:] for call in quirks.maybe_set_external_temperature.await_args_list
-    ] == [(TRV_ID, 21.4), (TRV_ID_2, 21.4)]
+    assert _written_values(quirks) == [
+        (TRV_ID, ROOM_TEMPERATURE),
+        (TRV_ID_2, ROOM_TEMPERATURE),
+    ]
 
 
 @pytest.mark.asyncio
@@ -124,3 +140,35 @@ async def test_the_tick_writes_nothing_without_a_room_temperature():
     await BetterThermostat._external_temperature_keepalive(bt)
 
     quirks.maybe_set_external_temperature.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "refusal",
+    [
+        HomeAssistantError("device did not answer"),
+        ServiceValidationError("value is out of range"),
+        OSError("connection reset"),
+    ],
+    ids=["unreachable", "out_of_range", "transport"],
+)
+@pytest.mark.asyncio
+async def test_a_trv_that_refuses_the_write_does_not_cost_the_others_their_tick(
+    refusal,
+):
+    """The tick serves every TRV, whatever the one before it answered.
+
+    A refused write is the normal answer of a device that is asleep or
+    whose integration is reloading, and it says nothing about the TRVs
+    further down the list. Letting it end the tick would drop them back
+    onto their internal sensors for a full interval.
+    """
+    quirks = MagicMock()
+    quirks.maybe_set_external_temperature = AsyncMock(side_effect=[refusal, True])
+    bt = _bt_with_two_trvs(quirks)
+
+    await BetterThermostat._external_temperature_keepalive(bt)
+
+    assert _written_values(quirks) == [
+        (TRV_ID, ROOM_TEMPERATURE),
+        (TRV_ID_2, ROOM_TEMPERATURE),
+    ]

--- a/tests/unit/test_temperature_events.py
+++ b/tests/unit/test_temperature_events.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.core import State
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.util import dt as dt_util
 import pytest
 
@@ -273,6 +274,38 @@ class TestApplyTemperatureUpdate:
         quirks.maybe_set_external_temperature.assert_awaited_once_with(
             mock_bt, "climate.trv1", 21.0
         )
+
+    @pytest.mark.parametrize(
+        "refusal",
+        [
+            HomeAssistantError("device did not answer"),
+            ServiceValidationError("value is out of range"),
+            OSError("connection reset"),
+        ],
+        ids=["unreachable", "out_of_range", "transport"],
+    )
+    @pytest.mark.asyncio
+    async def test_a_refused_trv_write_still_starts_a_control_cycle(
+        self, mock_bt, refusal
+    ):
+        """The reading is already accepted when the write goes out.
+
+        A device that answers the write with an error keeps its old valve
+        position, and without a cycle on the new reading it keeps it until
+        the next room sensor change: the room is then regulated on a
+        temperature Better Thermostat has already discarded.
+        """
+        quirks = AsyncMock()
+        quirks.maybe_set_external_temperature.side_effect = refusal
+        mock_bt.real_trvs = {
+            "climate.trv1": Trv.from_legacy_dict(
+                "climate.trv1", {"model_quirks": quirks}
+            )
+        }
+
+        await _apply_temperature_update(mock_bt, 21.0)
+
+        mock_bt.control_queue_task.put.assert_awaited_once_with(mock_bt)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_temperature_events.py
+++ b/tests/unit/test_temperature_events.py
@@ -5,6 +5,7 @@ acceptance logic, accumulation tracking, and plateau acceptance.
 """
 
 from datetime import timedelta
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.core import State
@@ -305,6 +306,51 @@ class TestApplyTemperatureUpdate:
 
         await _apply_temperature_update(mock_bt, 21.0)
 
+        mock_bt.control_queue_task.put.assert_awaited_once_with(mock_bt)
+
+    @pytest.mark.asyncio
+    async def test_a_refused_trv_write_does_not_skip_the_other_heads(self, mock_bt):
+        """Every head in the room gets the reading, whatever the first one answers.
+
+        In a multi-head room the write goes out head by head. One device that
+        refuses must not cost the remaining heads their reading, or they keep
+        regulating on a room temperature Better Thermostat has discarded.
+        """
+        refusing = AsyncMock()
+        refusing.maybe_set_external_temperature.side_effect = HomeAssistantError(
+            "device did not answer"
+        )
+        answering = AsyncMock()
+        mock_bt.real_trvs = {
+            "climate.trv1": Trv.from_legacy_dict(
+                "climate.trv1", {"model_quirks": refusing}
+            ),
+            "climate.trv2": Trv.from_legacy_dict(
+                "climate.trv2", {"model_quirks": answering}
+            ),
+        }
+
+        await _apply_temperature_update(mock_bt, 21.0)
+
+        answering.maybe_set_external_temperature.assert_awaited_once_with(
+            mock_bt, "climate.trv2", 21.0
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_missing_trv_map_still_starts_a_control_cycle(
+        self, mock_bt, caplog
+    ):
+        """Losing the head list costs the write, not the cycle.
+
+        The reading has already been accepted at this point, so the room has to
+        be regulated on it even when there is nobody left to send it to.
+        """
+        del mock_bt.real_trvs
+
+        with caplog.at_level(logging.WARNING):
+            await _apply_temperature_update(mock_bt, 21.0)
+
+        assert "no TRV list to write external_temperature to" in caplog.text
         mock_bt.control_queue_task.put.assert_awaited_once_with(mock_bt)
 
 

--- a/tests/unit/test_trvzb_quirk_overrides.py
+++ b/tests/unit/test_trvzb_quirk_overrides.py
@@ -5,6 +5,7 @@ import contextlib
 import importlib
 from unittest.mock import AsyncMock, MagicMock
 
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 import pytest
 
 from custom_components.better_thermostat.trv import Trv
@@ -447,3 +448,66 @@ class TestExternalTemperatureWriteSelectsTheSensor:
                 "option": "external",
             },
         ]
+
+
+class TestExternalTemperatureWriteTheDeviceRefuses:
+    """A refused write is reported, not raised.
+
+    Batteries sleep, devices go out of reach, an integration reloads its
+    config entry, and a device may declare a narrower range than the clamp
+    the quirk applies. All of these answer a blocking service call with a
+    ``HomeAssistantError``. Raising it here would abandon the caller's own
+    work on the room temperature it just accepted, so the quirk reports the
+    write as declined instead.
+    """
+
+    @staticmethod
+    def _device_on_the_internal_sensor(monkeypatch):
+        """A TRVZB whose device carries both the input and the selector."""
+        trv = _registry_entry("climate.trv1", domain="climate")
+        number = _registry_entry(
+            "number.trv1_external_temperature_input",
+            domain="number",
+            translation_key="external_temperature_input",
+        )
+        selector = _registry_entry(
+            "select.trv1_temperature_sensor_select",
+            domain="select",
+            translation_key="temperature_sensor_select",
+        )
+        mock_self = _make_selector_self("internal", entries=[trv, number, selector])
+        mock_self.real_trvs = {
+            "climate.trv1": Trv(entity_id="climate.trv1", model="TRVZB")
+        }
+        monkeypatch.setattr(
+            quirk.er, "async_get", lambda hass: mock_self._registry, raising=True
+        )
+        return mock_self
+
+    @pytest.mark.parametrize("failing_domain", ["number", "select"])
+    @pytest.mark.parametrize(
+        "refusal",
+        [
+            HomeAssistantError("device did not answer"),
+            ServiceValidationError("value is out of range"),
+            OSError("connection reset"),
+        ],
+        ids=["unreachable", "out_of_range", "transport"],
+    )
+    @pytest.mark.asyncio
+    async def test_the_refusal_is_reported_as_a_declined_write(
+        self, monkeypatch, failing_domain, refusal
+    ):
+        """Either half of the write may be refused; both yield False."""
+        mock_self = self._device_on_the_internal_sensor(monkeypatch)
+
+        async def _refuse(domain, *args, **kwargs):
+            if domain == failing_domain:
+                raise refusal
+
+        mock_self.hass.services.async_call = AsyncMock(side_effect=_refuse)
+
+        assert (
+            await quirk.maybe_set_external_temperature(mock_self, "climate.trv1", 21.42)
+            is False
+        )


### PR DESCRIPTION
## Problem

Better Thermostat mirrors the room temperature into TRVs that regulate on an
external value, for example the `external_temperature_input` number of a Sonoff
TRVZB. The reading Better Thermostat decides on is already updated when that
write goes out, and the control cycle that turns the new reading into valve
positions runs after it.

A device can refuse the write. The service call is blocking, so the caller sees
whatever the target integration reports: a `HomeAssistantError` from a battery
device that is asleep or out of reach, from an integration whose config entry is
being reloaded, or a `ServiceValidationError` when the value falls outside the
range the entity declares and which can be narrower than the range the quirk
clamps to. None of the three handlers on this path listed those exceptions.

What was lost is not the write but everything behind it:

- on a room sensor change the exception left `_apply_temperature_update` before
  the control cycle was queued, so every valve kept the position computed from
  the previous reading until the next sensor change,
- in the periodic re-send one refusing TRV ended the tick, so the TRVs after it
  in the list got no value for a full interval and fell back to their internal
  sensors,
- the quirk raised instead of reporting a declined write, so the caller's loop
  over the remaining TRVs was abandoned as well.

The failure was invisible: what the user sees is a device that stops following
the room sensor.

## Change

Add `HomeAssistantError` (which covers `ServiceValidationError`) and `OSError`
to the three exception tuples on this path: the TRVZB external temperature
quirk, the write loop in the external temperature event handler, and both
handlers of the periodic re-send. Each site keeps going exactly as it does for
the exceptions it already caught: the quirk reports the write as declined, the
event handler falls through to the control cycle, and the tick moves on to the
next TRV.

The failure is logged at warning level with the exception, because a device that
stops taking the room temperature is worth a line the user can find.

Catching was chosen over moving the queue put into a `finally`: only one of the
three sites has a cycle to queue, the other two need the following code to keep
running just as much, and a `finally` would still let the exception escape into
the event loop and abandon the rest of the function.

## Verification

Three tests, one per site, each parametrized over an unreachable device, an
out-of-range value and a transport error:

- `tests/unit/test_temperature_events.py::TestApplyTemperatureUpdate::test_a_refused_trv_write_still_starts_a_control_cycle`
- `tests/unit/test_external_temperature_keepalive.py::test_a_trv_that_refuses_the_write_does_not_cost_the_others_their_tick`
- `tests/unit/test_trvzb_quirk_overrides.py::TestExternalTemperatureWriteTheDeviceRefuses::test_the_refusal_is_reported_as_a_declined_write`

With the production change stashed, 11 of their 12 cases fail (the keepalive
transport case passes, since `OSError` was already caught there). With the
change in place all of them pass.

Full unit suite: 4499 passed, 1 skipped. `ruff check` and `ruff format --check`
are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when thermostatic radiator valves reject external-temperature updates.
  * Other connected valves continue receiving temperature updates when one device fails.
  * Control cycles continue running when an external-temperature update cannot be applied.
  * Failed writes are now reported with clearer warning details instead of interrupting control cycles.

* **Tests**
  * Added coverage for rejected updates across supported device and service error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->