### PR TITLE
fix: let the MPC governor follow setpoint reductions (1.9)

### DIFF
--- a/custom_components/better_thermostat/utils/calibration/mpc_v2/controller.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc_v2/controller.py
@@ -203,13 +203,18 @@ class MpcV2Controller:
             return self._last_u, self._diagnostics()
         self._last_t_s = t_s
 
-        sp_for_opt = self.governor.update(
-            T_sp=T_target_C, T_outdoor_C=T_outdoor_C, T_room_now=T_room_C
-        )
-
         innovation = self.kalman.innovation(T_room_C, self._last_u, T_outdoor_C)
         x_hat = self.kalman.update(T_room_C, self._last_u, T_outdoor_C)
         self.dob.update(innovation, dt_s)
+
+        # The governor runs behind the observer so it judges which setpoints
+        # are reachable on the same disturbance estimate the QP plans with.
+        sp_for_opt = self.governor.update(
+            T_sp=T_target_C,
+            T_outdoor_C=T_outdoor_C,
+            T_room_now=T_room_C,
+            D_hat_K_per_min=self.dob.D_hat_K_per_min,
+        )
 
         if t_s < self._next_mpc_t_s:
             return self._last_u, self._diagnostics()

--- a/custom_components/better_thermostat/utils/calibration/mpc_v2_internals/governor.py
+++ b/custom_components/better_thermostat/utils/calibration/mpc_v2_internals/governor.py
@@ -6,8 +6,10 @@ Kolmanovsky (Automatica 75, 2017). Each step computes
     v_k = v_{k-1} + κ · (T_sp − v_{k-1})
 
 with ``κ ∈ [0,1]`` the largest value for which the steady-state input
-implied by ``v_k`` stays inside ``[u_min + δ, u_max − δ]``. When the user
-setpoint is already feasible, the governor is transparent (``κ = 1``).
+implied by ``v_k`` stays inside ``[u_min + δ, u_max − δ]``. Shaping guards
+the open rail: a setpoint the valve can hold without saturating open passes
+through untouched (``κ = 1``), because a heating valve reaches any reference
+that needs *less* flow simply by closing further.
 
 Only the static feasibility variant is implemented. The dynamic (rollout)
 variant is out of scope: it needs per-plant tuning of horizon and overshoot
@@ -62,26 +64,70 @@ class ScalarReferenceGovernor:
         """Restore a previously persisted governed reference."""
         self._v_C = v_C
 
-    def _u_steady_for(self, v_C: float, T_outdoor_C: float) -> float:
-        return self.plant.steady_input(v_C, T_outdoor_C)
+    def _u_steady_for(
+        self, v_C: float, T_outdoor_C: float, D_hat_K_per_min: float
+    ) -> float:
+        return self.plant.steady_input(v_C, T_outdoor_C, D_hat_K_per_min)
 
-    def _is_feasible(self, v_C: float, T_outdoor_C: float) -> bool:
-        u_ss = self._u_steady_for(v_C, T_outdoor_C)
+    def _is_holdable(
+        self, v_C: float, T_outdoor_C: float, D_hat_K_per_min: float
+    ) -> bool:
+        """Return whether the valve can hold ``v_C`` without saturating open.
+
+        Only the upper bound decides whether a reference is attainable at all.
+        A reference below the tightened lower bound asks for less flow than the
+        margin, and the valve delivers that by closing further — holding the
+        governed reference above such a setpoint would keep heating a room the
+        user asked to cool down.
+        """
+        u_ss = self._u_steady_for(v_C, T_outdoor_C, D_hat_K_per_min)
+        return u_ss <= self.params.u_max - self.params.safety_margin
+
+    def _is_feasible(
+        self, v_C: float, T_outdoor_C: float, D_hat_K_per_min: float
+    ) -> bool:
+        """Return whether ``v_C`` keeps the steady-state input strictly interior.
+
+        Applied to the intermediate references the bisection walks over, which
+        keep margin on both rails so the optimiser retains authority in either
+        direction while the reference travels.
+        """
+        u_ss = self._u_steady_for(v_C, T_outdoor_C, D_hat_K_per_min)
         delta = self.params.safety_margin
         return self.params.u_min + delta <= u_ss <= self.params.u_max - delta
 
-    def update(self, T_sp: float, T_outdoor_C: float, T_room_now: float) -> float:
+    def update(
+        self,
+        T_sp: float,
+        T_outdoor_C: float,
+        T_room_now: float,
+        D_hat_K_per_min: float = 0.0,
+    ) -> float:
         """Return the governed reference for this step.
 
-        Passes ``T_sp`` through unchanged when disabled or already feasible.
-        Otherwise bisects ``κ ∈ [0,1]`` to find the largest feasible step from
-        the previous reference toward ``T_sp`` and advances by that fraction.
+        Passes ``T_sp`` through unchanged when disabled, or when the valve can
+        hold it without saturating open. Otherwise bisects ``κ ∈ [0,1]`` to
+        find the largest feasible step from the previous reference toward
+        ``T_sp`` and advances by that fraction.
+
+        Parameters
+        ----------
+        T_sp : float
+            User setpoint the reference travels toward.
+        T_outdoor_C : float
+            Outdoor temperature driving the steady-state loss term.
+        T_room_now : float
+            Current room temperature; seeds the reference on the first call.
+        D_hat_K_per_min : float, optional
+            Estimated lumped disturbance, in K/min. Passing the same estimate
+            the optimiser plans with keeps both judging reachability on one
+            model — solar gain lowers the flow a setpoint needs.
         """
         if not self.params.enabled:
             return T_sp
         if self._v_C is None:
             self._v_C = T_room_now
-        if self._is_feasible(T_sp, T_outdoor_C):
+        if self._is_holdable(T_sp, T_outdoor_C, D_hat_K_per_min):
             self._v_C = T_sp
             return self._v_C
         v_prev = self._v_C
@@ -89,7 +135,7 @@ class ScalarReferenceGovernor:
         for _ in range(self.params.bisection_iters):
             mid = 0.5 * (lo + hi)
             v_trial = v_prev + mid * (T_sp - v_prev)
-            if self._is_feasible(v_trial, T_outdoor_C):
+            if self._is_feasible(v_trial, T_outdoor_C, D_hat_K_per_min):
                 lo = mid
             else:
                 hi = mid

--- a/tests/unit/mpc_v2/test_compute_mpc_v2.py
+++ b/tests/unit/mpc_v2/test_compute_mpc_v2.py
@@ -421,6 +421,32 @@ def test_controller_drives_simulated_plant_toward_setpoint() -> None:
     assert abs(last_T_room - 21.0) < 1.0
 
 
+def test_governor_uses_the_disturbance_estimate_of_the_current_cycle(
+    monkeypatch,
+) -> None:
+    """Governor and QP judge a setpoint on the same disturbance estimate."""
+    controller = MpcV2Controller(MpcV2Params())
+    controller.step(t_s=0.0, T_room_C=20.0, T_target_C=21.0, T_outdoor_C=5.0)
+
+    seen: list[float] = []
+    governor_update = controller.governor.update
+
+    def _record(*, D_hat_K_per_min: float, **kwargs: float) -> float:
+        seen.append(D_hat_K_per_min)
+        return governor_update(D_hat_K_per_min=D_hat_K_per_min, **kwargs)
+
+    def _observe(innovation_K: float, dt_s: float) -> float:
+        controller.dob.D_hat_K_per_min = 0.05
+        return 0.05
+
+    controller.dob.D_hat_K_per_min = -99.0
+    monkeypatch.setattr(controller.governor, "update", _record)
+    monkeypatch.setattr(controller.dob, "update", _observe)
+    controller.step(t_s=300.0, T_room_C=20.0, T_target_C=21.0, T_outdoor_C=5.0)
+
+    assert seen == [0.05]
+
+
 def test_malformed_snapshot_values_are_rejected(caplog) -> None:
     """Non-numeric persisted values drop the whole snapshot, not the process."""
     bogus = {"v": SNAPSHOT_VERSION, "last_u": "junk"}

--- a/tests/unit/mpc_v2/test_governor.py
+++ b/tests/unit/mpc_v2/test_governor.py
@@ -60,3 +60,38 @@ def test_reset_drops_internal_reference() -> None:
     gov.update(T_sp=21.0, T_outdoor_C=5.0, T_room_now=20.0)
     gov.reset()
     assert gov.state() is None
+
+
+def test_lowered_setpoint_is_reached_and_not_only_approached() -> None:
+    """Lowering the setpoint in mild weather must reach the new target.
+
+    A setpoint that needs almost no flow is still attainable — the valve
+    closes. Holding the governed reference above it would keep the room warm
+    against the user's wish.
+    """
+    gov = _make_governor()
+    gov.update(T_sp=21.0, T_outdoor_C=16.0, T_room_now=21.0)
+    v = 21.0
+    for _ in range(200):
+        v = gov.update(T_sp=17.0, T_outdoor_C=16.0, T_room_now=21.0)
+    assert abs(v - 17.0) < 1e-9, f"governed reference stalled at {v:.3f} C"
+
+
+def test_small_rise_in_mild_weather_reaches_the_setpoint() -> None:
+    """A modest raise below the flow margin must not stall the reference."""
+    gov = _make_governor()
+    gov.update(T_sp=17.0, T_outdoor_C=16.0, T_room_now=17.0)
+    v = gov.update(T_sp=17.5, T_outdoor_C=16.0, T_room_now=17.0)
+    assert abs(v - 17.5) < 1e-9, f"governed reference stalled at {v:.3f} C"
+
+
+def test_disturbance_estimate_enters_the_reachability_check() -> None:
+    """Free heat counts toward the flow a setpoint needs."""
+    gov = _make_governor()
+    without_gain = gov.update(T_sp=25.0, T_outdoor_C=-20.0, T_room_now=19.0)
+    assert without_gain < 25.0
+    gov.reset()
+    with_gain = gov.update(
+        T_sp=25.0, T_outdoor_C=-20.0, T_room_now=19.0, D_hat_K_per_min=0.1
+    )
+    assert abs(with_gain - 25.0) < 1e-9


### PR DESCRIPTION
## Problem

With MPC v2 selected, lowering the target temperature in mild weather leaves the room permanently too warm.

The scalar reference governor shapes the setpoint the optimiser plans against. It accepted a reference only when the implied steady-state valve fraction stayed inside `[u_min + 2 %, u_max - 2 %]`. A lowered setpoint in mild weather needs less than that lower margin: at an outdoor temperature of 16 C, holding 17 C works out to about 1 % valve opening. The governor therefore declared the user's own setpoint unreachable, its bisection converged to a zero step, and the governed reference stalled above the setpoint instead of following it. Measured on the default plant parameters, a change from 21 C to 17 C at 16 C outdoor settles at 17.8 C, so the room is held 0.8 K too warm indefinitely. A closer-to-everyday case, target 20 C at 19 C outdoor, stalls at 20.7 C.

The same mechanism freezes the reference without any setpoint change: once the disturbance observer reports solar gain, the flow the current reference needs drops below the margin as well.

Raising the setpoint was unaffected, which is why this only shows up as "the room stays warm after I turn it down".

A second, smaller inconsistency sits next to it: the optimiser was handed the disturbance estimate, the governor was not, so the two evaluated the same setpoint on different models.

## Change

- The pass-through test in the governor now checks the upper input bound only. A heating valve reaches any reference that needs less flow by closing further, so the closed rail cannot make a setpoint unreachable. The intermediate references the bisection walks over still keep margin on both rails, so a setpoint that really would saturate the valve open is shaped exactly as before.
- `update()` takes the disturbance estimate and forwards it to the steady-state input calculation.
- The controller runs the governor behind the observer and passes it the estimate of the current cycle, the same one the optimiser plans with.

## Verification

The governor module is byte-identical on both lines, and the stall reproduces with the same numbers here (17.815 C and 20.704 C), so this carries the same change; only the controller call site differs in its surroundings.

Counter-checks, each by reintroducing one part of the defect on top of the finished branch:

- Two-sided pass-through bound restored: `test_lowered_setpoint_is_reached_and_not_only_approached` (stalls at 17.815 C), `test_small_rise_in_mild_weather_reaches_the_setpoint`, and `test_disturbance_estimate_enters_the_reachability_check` fail.
- Governor ignoring the disturbance estimate: `test_disturbance_estimate_enters_the_reachability_check` fails.
- Controller not passing the estimate and calling the governor ahead of the observer: `test_governor_uses_the_disturbance_estimate_of_the_current_cycle` fails.

No existing test changed. Unit suite: 4491 passed, 1 skipped. `ruff check` and `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat setpoint handling when lowering temperatures or making small increases.
  * Setpoints that can be safely maintained now pass through without unnecessary limiting.
  * Reachability decisions now account for the latest estimated disturbances, improving control accuracy.

* **Tests**
  * Added coverage for setpoint convergence and disturbance-aware reachability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->