### PR TITLE
fix: skip unreadable TRV modes when snapshotting for valve maintenance

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2631,12 +2631,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         """Periodic maintenance tick: runs valve exercise when due and enabled."""
         # quick availability check - only critical entities needed for maintenance
         try:
-            # The degradation ladder advances first: it must keep stepping
-            # even while an unavailable TRV aborts the tick.
+            # The ladder has to keep stepping and the repair issues have to
+            # stay current, but neither decides this run. A head that reports
+            # nothing gets no snapshot and stays out of the exercise; the
+            # valves that do answer still need theirs, and a valve left
+            # unmoved for a season is what this tick exists to prevent.
             await check_and_update_degraded_mode(self)
-            ok = await check_critical_entities(self)
-            if ok is False:
-                return
+            await check_critical_entities(self)
         except Exception:
             _LOGGER.debug(
                 "better_thermostat %s: maintenance availability check failed; "

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2720,13 +2720,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 except KeyError, TypeError:
                     pass
 
-            # Build snapshots (skips TRVs with state=None)
+            # Build snapshots. A TRV that publishes no state, or one whose
+            # state names no mode to restore, gets none and stays out of the
+            # run below.
             infos = build_trv_snapshots(
                 self.real_trvs, trvs, self.hass.states.get, self.device_name
             )
             serviced_ids = {info.entity_id for info in infos}
 
-            # Release guard for TRVs that were skipped (state=None)
+            # Release guard for the TRVs that got no snapshot
             for trv_id in trvs:
                 if trv_id not in serviced_ids:
                     try:

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -196,14 +196,28 @@ def build_trv_snapshots(
 ) -> list[MaintenanceTrvInfo]:
     """Build per-TRV snapshots needed for the maintenance cycle.
 
-    *get_state* should be ``hass.states.get``.
-
     A TRV without a readable state is left out of the run entirely: it
     publishes no state at all, or the one it publishes is ``unavailable``
     or ``unknown`` and therefore names no mode and no setpoint to put back
     afterwards. Only a TRV with a snapshot is driven, so the one skipped
     here is never left standing in one of the cycle's temperature
     extremes. Every skip is logged at debug level.
+
+    Parameters
+    ----------
+    real_trvs : TrvMap
+            the cached TRV records, keyed by entity id
+    trv_ids : list[str]
+            entity ids to consider for this run
+    get_state : Callable[[str], State | None]
+            reads a TRV's reported state; ``hass.states.get``
+    device_name : str
+            thermostat instance name, for logging
+
+    Returns
+    -------
+    list[MaintenanceTrvInfo]
+            one snapshot per TRV the cycle may drive, in the order given
     """
     infos: list[MaintenanceTrvInfo] = []
     for trv_id in trv_ids:

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -14,6 +14,7 @@ import logging
 from random import randint
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import State
 from homeassistant.util import dt as dt_util
 
@@ -195,17 +196,25 @@ def build_trv_snapshots(
 ) -> list[MaintenanceTrvInfo]:
     """Build per-TRV snapshots needed for the maintenance cycle.
 
-    *get_state* should be ``hass.states.get``.  TRVs whose HA state is
-    ``None`` are silently skipped (logged at debug level).
+    *get_state* should be ``hass.states.get``.
+
+    A TRV without a readable state is left out of the run entirely: it
+    publishes no state at all, or the one it publishes is ``unavailable``
+    or ``unknown`` and therefore names no mode and no setpoint to put back
+    afterwards. Only a TRV with a snapshot is driven, so the one skipped
+    here is never left standing in one of the cycle's temperature
+    extremes. Every skip is logged at debug level.
     """
     infos: list[MaintenanceTrvInfo] = []
     for trv_id in trv_ids:
         trv_state = get_state(trv_id)
-        if trv_state is None:
+        if trv_state is None or trv_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             _LOGGER.debug(
-                "better_thermostat %s: maintenance skip %s (state None)",
+                "better_thermostat %s: maintenance skip %s (reports %s, so it names "
+                "no state to restore afterwards)",
                 device_name,
                 trv_id,
+                trv_state.state if trv_state is not None else None,
             )
             continue
 

--- a/tests/unit/test_climate_maintenance.py
+++ b/tests/unit/test_climate_maintenance.py
@@ -48,15 +48,29 @@ def bt():
 
 
 @pytest.mark.asyncio
-async def test_critical_entities_unavailable_returns_early(bt):
-    """When critical entities are unavailable, nothing is scheduled or dispatched."""
+async def test_one_unreadable_head_does_not_cost_the_others_their_exercise(bt):
+    """Availability is reported, not obeyed: the readable valves still run.
+
+    `check_critical_entities` rejects a room as soon as one head reports
+    `unavailable` or `unknown` — the same two states the snapshot step
+    filters on. Returning on it means a single flaky head suspends the
+    exercise for every healthy valve in the room, for as long as it stays
+    flaky, and the snapshot filter never gets to do its job.
+    """
+    critical = AsyncMock(return_value=False)
     with (
-        patch(f"{_CLIMATE}.check_critical_entities", AsyncMock(return_value=False)),
+        patch(f"{_CLIMATE}.check_critical_entities", critical),
         patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
+        patch(
+            f"{_CLIMATE}.collect_maintenance_trvs",
+            MagicMock(return_value=["climate.trv"]),
+        ),
     ):
         await BetterThermostat._maintenance_tick(bt)
-    assert bt.next_valve_maintenance is None
-    bt.hass.async_create_background_task.assert_not_called()
+
+    # Still consulted, so the repair issues it raises and clears stay current.
+    critical.assert_awaited_once_with(bt)
+    bt.hass.async_create_background_task.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_valve_maintenance.py
+++ b/tests/unit/test_valve_maintenance.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
 import pytest
@@ -1051,4 +1052,110 @@ class TestRestoreLeavesAnUnmovedModeAlone:
             device_name="Test",
             cycle_sleep=0,
         )
+        mode_fn.assert_not_awaited()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# TRVs whose state cannot be read
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _unreadable_ha_state(state: str):
+    """A TRV state carrying no attributes, as an offline device publishes."""
+    return SimpleNamespace(state=state, attributes={})
+
+
+class TestUnreadableTrvStates:
+    """A TRV reporting ``unavailable`` or ``unknown`` names nothing to restore."""
+
+    @pytest.mark.parametrize("reported", [STATE_UNAVAILABLE, STATE_UNKNOWN])
+    def test_the_snapshot_leaves_it_out(self, reported, caplog):
+        """No snapshot is taken, and the skip says which state caused it."""
+        trvs = {"climate.trv1": _trv(maintenance=True)}
+        with caplog.at_level(logging.DEBUG, logger=_MAINTENANCE_LOGGER):
+            result = build_trv_snapshots(
+                trvs, ["climate.trv1"], lambda _: _unreadable_ha_state(reported), "Test"
+            )
+        assert result == []
+        assert f"maintenance skip climate.trv1 (reports {reported}" in caplog.text
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("reported", [STATE_UNAVAILABLE, STATE_UNKNOWN])
+    async def test_a_full_run_writes_nothing_to_it(self, reported):
+        """It is neither driven nor restored, so nothing is written to it.
+
+        The run writes back what a snapshot names, and a TRV without a
+        readable state names neither a mode nor a setpoint.
+        """
+        trvs = {"climate.trv1": _trv(maintenance=True)}
+        infos = build_trv_snapshots(
+            trvs, ["climate.trv1"], lambda _: _unreadable_ha_state(reported), "Test"
+        )
+        valve_fn = AsyncMock(return_value=True)
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+
+        await run_valve_maintenance(
+            infos,
+            set_valve_fn=valve_fn,
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            get_state=_reports("heat"),
+            device_name="Test",
+            cycle_sleep=0,
+        )
+
+        valve_fn.assert_not_awaited()
+        temp_fn.assert_not_awaited()
+        mode_fn.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_trv_that_drops_out_mid_run_gets_its_snapshot_state_back(self):
+        """A TRV readable at the snapshot is restored to what it reported then.
+
+        Going offline during the cycle changes nothing about the target:
+        the snapshot names a real mode and a real setpoint, and both are
+        written back.
+        """
+        trvs = {"climate.trv1": _trv(maintenance=True)}
+        infos = build_trv_snapshots(
+            trvs, ["climate.trv1"], lambda _: _ha_state("heat", 21.0), "Test"
+        )
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+
+        await run_valve_maintenance(
+            infos,
+            set_valve_fn=AsyncMock(return_value=True),
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            get_state=_reports(STATE_UNAVAILABLE),
+            device_name="Test",
+            cycle_sleep=0,
+        )
+
+        assert temp_fn.await_args_list[-1].args == ("climate.trv1", 21.0)
+        mode_fn.assert_awaited_once_with("climate.trv1", "heat")
+
+    @pytest.mark.asyncio
+    async def test_a_trv_that_comes_back_before_the_restore_keeps_its_mode(self):
+        """Back in the mode the snapshot was taken in, only the setpoint moves."""
+        trvs = {"climate.trv1": _trv(maintenance=True)}
+        infos = build_trv_snapshots(
+            trvs, ["climate.trv1"], lambda _: _ha_state("heat", 21.0), "Test"
+        )
+        temp_fn = AsyncMock()
+        mode_fn = AsyncMock()
+
+        await run_valve_maintenance(
+            infos,
+            set_valve_fn=AsyncMock(return_value=True),
+            set_temperature_fn=temp_fn,
+            set_hvac_mode_fn=mode_fn,
+            get_state=_reports("heat"),
+            device_name="Test",
+            cycle_sleep=0,
+        )
+
+        assert temp_fn.await_args_list[-1].args == ("climate.trv1", 21.0)
         mode_fn.assert_not_awaited()


### PR DESCRIPTION
## Problem

Valve maintenance snapshots every TRV before it drives the valve through its full range, so it can put the setpoint and the HVAC mode back when the run finishes. A TRV that is offline publishes `unavailable` (or `unknown` right after a restart) and carries no attributes, and that word was taken as the mode to restore.

Three things followed for such a TRV:

- The cycle drove it. The snapshot mode is not `off`, so the run counted the setpoint writes as reaching the valve and wrote max and min temperature twice.
- Its setpoint was never restored. The missing attributes left nothing to write back, so the device stayed on the last extreme the cycle had written, typically the minimum temperature.
- The restore issued `set_hvac_mode(..., "unavailable")`. The mode a TRV reports is never the word `unavailable`, so the mode guard saw a mode that had moved on every single run and always wrote the invalid value out. Home Assistant rejects it; the failure is only visible at debug level.

## Change

A TRV whose state cannot be read is skipped at the snapshot, and with it left out of the whole run. Nothing is written to it, so nothing has to be put back and it cannot be left standing in a cycle extreme. The two skip reasons (no state at all, or a state that names nothing) share one debug log that reports what the TRV published.

The mid-run case needs no change and is now pinned: a TRV that is readable at the snapshot and drops out during the cycle carries a real mode and a real setpoint in its snapshot, and both are still written back at the end.

## Verification

New tests in `tests/unit/test_valve_maintenance.py::TestUnreadableTrvStates`. Four of them are red without the fix, with the guard mutated back to the plain `trv_state is None` check:

- `test_the_snapshot_leaves_it_out[unavailable|unknown]` — a snapshot is built where none should be
- `test_a_full_run_writes_nothing_to_it[unavailable|unknown]` — `AssertionError: Expected mock to not have been awaited. Awaited 4 times.` on the setpoint writes, plus the `set_hvac_mode(..., "unavailable")` at the restore

The remaining two cover the mid-run drop-out and the return before the restore; both are green either way and stand as regression guards.

Suite: 7360 passed, 1 skipped (`pytest tests`). All 99 coverage floors hold. `ruff check`, `ruff format --check` and `pyrefly check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved valve maintenance handling for thermostatic radiator valves with `unavailable` or `unknown` states.
  * Prevented maintenance actions when a valve’s state cannot be read or restored.
  * Ensured healthy valves continue receiving maintenance when another valve is unavailable.
  * Preserved and restored valve settings correctly when a valve temporarily becomes unavailable during maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->