### PR TITLE
chore: remove unreachable branches and correct stale comments

### DIFF
--- a/custom_components/better_thermostat/adapters/base.py
+++ b/custom_components/better_thermostat/adapters/base.py
@@ -76,15 +76,15 @@ async def wait_for_calibration_entity_or_timeout(
         )
         return
 
-    # Wait for the entity to be available with timeout
-    _ready = True
-    _max_retries = 6  # 30 seconds total (6 * 5 seconds)
+    # Six passes with a five-second sleep between them. The last pass forces
+    # the write instead of sleeping again, so the wait spans 25 seconds.
+    _max_retries = 6
     _retry_count = 0
-    while _ready:
+    while True:
         _state = self.hass.states.get(calibration_entity)
         if _state is None or _state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             _LOGGER.info(
-                "better_thermostat %s: waiting for TRV/climate entity with id '%s' to become fully available...",
+                "better_thermostat %s: waiting for local_temperature_calibration entity with id '%s' to become fully available...",
                 self.device_name,
                 calibration_entity,
             )
@@ -111,9 +111,7 @@ async def wait_for_calibration_entity_or_timeout(
                         calibration_entity,
                         e,
                     )
-                _ready = False
                 return
             await asyncio.sleep(5)
             continue
-        _ready = False
         return

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -862,9 +862,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.bt_target_cooltemp = None
         self._support_flags = SUPPORT_FLAGS | ClimateEntityFeature.PRESET_MODE
         self._bt_hvac_mode: HVACMode | None = None
-        # Track min/max encountered target temps (initialize to default span)
-        self.min_target_temp = 18.0
-        self.max_target_temp = 21.0
         self.closed_window_triggered = False
         self.call_for_heat = True
         self.ignore_states = False
@@ -964,7 +961,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self._slope_periodic_last_ts = None
 
         # Anti-flicker state
-        self.flicker_unignore_cancel = None
         self.flicker_candidate = None
         self.plateau_timer_cancel = None
         self.last_change_direction = 0
@@ -1697,13 +1693,12 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 STATE_UNKNOWN,
                 None,
             ):
-                self._current_humidity = (
-                    convert_to_float(
-                        str(_hum_state.state), self.device_name, "startup()"
-                    )
-                    or 0.0
+                # An unreadable value leaves the humidity unknown. 0 % is a
+                # reading a room can publish, so coercing to it would pass a
+                # missing measurement off as a measured one.
+                self._current_humidity = convert_to_float(
+                    str(_hum_state.state), self.device_name, "startup()"
                 )
-            # else: already logged warning above, _current_humidity stays None
 
         # Seed the window and door regions from the sensors' startup state.
         # A non-active sensor (unavailable/unknown) is treated as closed so
@@ -2035,11 +2030,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 )
                 self._current_humidity = 0
             else:
-                self._current_humidity = (
-                    convert_to_float(
-                        str(_hum_state.state), self.device_name, "startup()"
-                    )
-                    or 0.0
+                self._current_humidity = convert_to_float(
+                    str(_hum_state.state), self.device_name, "startup()"
                 )
         else:
             self._current_humidity = 0.0
@@ -2879,12 +2871,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         """
         if self.cur_temp is None:
             return
-
-        # Lazy init of target range bounds
-        if not hasattr(self, "min_target_temp"):
-            self.min_target_temp = self.bt_target_temp or 18.0
-        if not hasattr(self, "max_target_temp"):
-            self.max_target_temp = self.bt_target_temp or 21.0
 
         current_action = self._compute_hvac_action()
         outdoor_temp = self._get_outdoor_temp()

--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -267,7 +267,7 @@ async def trigger_trv_change(self, event):
             str(val_pos), self.device_name, "trv_event"
         )
 
-    if mapped_state in (HVACMode.OFF, HVACMode.HEAT, HVACMode.HEAT_COOL):
+    if mapped_state in (HVACMode.OFF, HVACMode.HEAT):
         if trv.hvac_mode != _org_trv_state.state and not child_lock:
             _old = trv.hvac_mode
             _LOGGER.debug(
@@ -524,7 +524,6 @@ def convert_outbound_states(self, entity_id, hvac_mode) -> dict | None:
     """
     _new_local_calibration = None
     _new_heating_setpoint = None
-    _new_valve_position = None
     advanced = self.real_trvs[entity_id].advanced or {}
 
     try:
@@ -618,8 +617,6 @@ def convert_outbound_states(self, entity_id, hvac_mode) -> dict | None:
         }
         if _new_local_calibration is not None:
             _payload["local_temperature_calibration"] = _new_local_calibration
-        if _new_valve_position is not None:
-            _payload["valve_position"] = _new_valve_position
         return _payload
     except Exception as e:
         _LOGGER.exception(

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -528,6 +528,19 @@ class TestInitializeSensors:
         BetterThermostat._initialize_sensors(bt, sensor)
         assert HUMIDITY_ID in bt.all_entities
 
+    def test_unreadable_humidity_stays_unknown(self, bt):
+        """A humidity that does not parse is not reported as 0 %.
+
+        0 % is a reading a room can publish, so a sensor whose value cannot be
+        read has to stay unknown instead of being answered with a number.
+        """
+        bt.humidity_sensor_entity_id = HUMIDITY_ID
+        bt._current_humidity = 55.0
+        sensor = _make_sensor_state("20.0")
+        bt.hass.states.get.return_value = State(HUMIDITY_ID, "not-a-number")
+        BetterThermostat._initialize_sensors(bt, sensor)
+        assert bt._current_humidity is None
+
     def test_ema_initialized_with_cur_temp(self, bt):
         """Test Ema initialized with cur temp."""
         sensor = _make_sensor_state("21.5")
@@ -1827,6 +1840,21 @@ class TestValidateHvacMode:
         BetterThermostat._validate_hvac_mode(bt, states)
         # humidity should be re-read
         assert bt._current_humidity is not None
+
+    def test_unreadable_humidity_stays_unknown(self, bt):
+        """The humidity re-read keeps an unparsable reading unknown.
+
+        This pass runs after the sensors are initialized and decides the value
+        the entity publishes, so coercing it to 0 % here would present a
+        missing measurement as a measured one.
+        """
+        bt.bt_hvac_mode = HVACMode.HEAT
+        bt.humidity_sensor_entity_id = HUMIDITY_ID
+        bt._current_humidity = 55.0
+        bt.hass.states.get.return_value = State(HUMIDITY_ID, STATE_UNAVAILABLE)
+        states = [_make_trv_state()]
+        BetterThermostat._validate_hvac_mode(bt, states)
+        assert bt._current_humidity is None
 
     def test_humidity_sensor_none_sets_zero(self, bt):
         """Test Humidity sensor none sets zero."""

--- a/tests/unit/test_temperature_events.py
+++ b/tests/unit/test_temperature_events.py
@@ -60,7 +60,6 @@ def mock_bt():
 
     # Anti-flicker state
     bt.flicker_candidate = None
-    bt.flicker_unignore_cancel = None
 
     # Maintenance
     bt.in_maintenance = False

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -2125,6 +2125,22 @@ class TestConvertInboundStates:
             result = convert_inbound_states(mock_bt, ENTITY_ID, state)
         assert result is None
 
+    def test_heat_cool_mode_returns_none(self, mock_bt):
+        """Return None for HEAT_COOL.
+
+        A device that names its heating mode heat_cool is decoded into HEAT by
+        the remap, so a HEAT_COOL reaching this point is a mode the entity does
+        not adopt. The mode adoption downstream relies on that: it only ever
+        sees OFF, HEAT or nothing.
+        """
+        state = _make_state(state_str="heat_cool")
+        with patch(
+            "custom_components.better_thermostat.events.trv.mode_remap",
+            return_value=HVACMode.HEAT_COOL,
+        ):
+            result = convert_inbound_states(mock_bt, ENTITY_ID, state)
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # 8. convert_outbound_states


### PR DESCRIPTION
## Problem

A humidity sensor whose value cannot be parsed was reported as 0 % relative
humidity at startup. 0 % is a reading a room can publish, so a missing
measurement was presented to the user as a measured one. The runtime update
for the same sensor already leaves an unreadable value unset, so the entity
answered the identical failure differently depending on when it happened. A
comment at the startup site pointed at a warning that is only logged for
temperature sensors.

Around that, several places describe a program that does not exist:

- The mode adoption in the TRV event path tests the decoded mode against
  `HEAT_COOL`. `convert_inbound_states()` answers `OFF`, `HEAT` or nothing —
  a device that names its heating mode `heat_cool` is decoded into `HEAT` by
  the remap — so that member can never match.
- `convert_outbound_states()` declares a valve position, never assigns one and
  then guards a payload entry on it. Valve writes go through their own path in
  the control cycle.
- Two target-range trackers are written in `__init__`, re-initialized lazily in
  `calculate_heating_power()` and read nowhere.
- The anti-flicker cancel handle is only ever set to `None`; nothing ever arms
  a callback for it.
- The wait for a calibration entity announces 30 seconds but sleeps five times
  for five, names the TRV in a message that is about the calibration entity,
  and drives its loop with a flag that is only ever cleared immediately before
  a `return`.

## Change

An unparsable humidity reading stays unset at both startup passes, so the
entity reports it as unknown rather than as 0 %. The second pass is the one
that decides the published value, so both had to agree for the change to be
visible at all.

The unreachable `HEAT_COOL` member, the valve-position declaration with its
payload guard, the two unread trackers and the never-armed cancel handle are
removed. The calibration wait states its real timeout, names the entity it
waits for, and uses the loop its returns already describe.

## Verification

`TestInitializeSensors::test_unreadable_humidity_stays_unknown` and
`TestValidateHvacMode::test_unreadable_humidity_stays_unknown` both fail with
`assert 0.0 is None` when the coercion is put back.
`TestConvertInboundStates::test_heat_cool_mode_returns_none` pins the premise
of the removed branch: widening the decoder to pass `HEAT_COOL` through turns
it red.

`pytest tests/unit`: 6617 passed, 1 skipped (6614 before, plus the three new
tests — no existing test pinned any of the removed behavior). Full `pytest
tests` with coverage: 7357 passed, 1 skipped, and all 99 modules hold their
floor; the three touched modules gained coverage (climate.py 88.7 -> 88.86,
events/trv.py 89.9 -> 90.4, adapters/base.py 65.2 -> 65.85), so the floors are
left as recorded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unavailable or unreadable humidity readings now remain unknown instead of being reported as `0`.
  * Improved thermostat startup and calibration handling, including clearer calibration status reporting.
  * Devices reporting a combined heat/cool mode are handled correctly without incorrectly changing the thermostat’s heating mode.
  * Removed obsolete valve-position data from outbound device updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->