### PR TITLE
fix: serialise concurrent temperature updates per entity

### DIFF
--- a/custom_components/better_thermostat/events/temperature.py
+++ b/custom_components/better_thermostat/events/temperature.py
@@ -8,6 +8,7 @@ propagated to the target devices.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 import math
@@ -74,10 +75,37 @@ def _update_external_temp_ema(self, temp_q: float) -> float:
     return float(ema)
 
 
+def _filter_lock(self) -> asyncio.Lock:
+    """Return the lock that serialises this entity's temperature filter.
+
+    The filter carries state from one reading to the next: the accumulated
+    delta, the pending plateau value and its timer. Home Assistant handles
+    every sensor update in its own task, and applying a reading suspends
+    while the value is written to the TRVs. Without the lock a reading that
+    arrives during such a write is decided against, and committed on top of,
+    a half-applied predecessor. The lock is created on first use and lives
+    on the entity, so each Better Thermostat only queues behind itself.
+    """
+    lock = getattr(self, "_temperature_filter_lock", None)
+    if lock is None:
+        lock = asyncio.Lock()
+        self._temperature_filter_lock = lock
+    return lock
+
+
 async def _apply_temperature_update(self, new_temp):
-    """Apply the new external temperature and trigger updates."""
+    """Apply the new external temperature once the filter is free."""
+    async with _filter_lock(self):
+        await _commit_temperature_update(self, new_temp)
+
+
+async def _commit_temperature_update(self, new_temp):
+    """Apply the new external temperature and trigger updates.
+
+    Callers hold the filter lock.
+    """
     _LOGGER.debug(
-        "better_thermostat %s: _apply_temperature_update called with %.2f",
+        "better_thermostat %s: _commit_temperature_update called with %.2f",
         self.device_name,
         new_temp,
     )
@@ -154,12 +182,16 @@ async def _apply_temperature_update(self, new_temp):
         else:
             request_control_cycle(self)
     _LOGGER.debug(
-        "better_thermostat %s: _apply_temperature_update finished", self.device_name
+        "better_thermostat %s: _commit_temperature_update finished", self.device_name
     )
 
 
 async def trigger_temperature_change(self, event):
     """Handle temperature changes.
+
+    Readings are handled one at a time; a reading that arrives while an
+    earlier one is still being applied waits its turn instead of being
+    dropped, so it is judged against the state the earlier one left behind.
 
     Parameters
     ----------
@@ -171,6 +203,15 @@ async def trigger_temperature_change(self, event):
     Returns
     -------
     None
+    """
+    async with _filter_lock(self):
+        await _evaluate_temperature_reading(self, event)
+
+
+async def _evaluate_temperature_reading(self, event):
+    """Decide whether one external temperature reading is applied.
+
+    Callers hold the filter lock.
     """
     if self.startup_running:
         return
@@ -354,7 +395,7 @@ async def trigger_temperature_change(self, event):
             (self.accum_delta if _cur_q is not None else 0.0),
             ("+" if self.accum_dir > 0 else ("-" if self.accum_dir < 0 else "0")),
         )
-        await _apply_temperature_update(self, _incoming_temperature_q)
+        await _commit_temperature_update(self, _incoming_temperature_q)
     else:
         _LOGGER.debug(
             "better_thermostat %s: external_temperature ignored (old=%.2f new=%.2f diff=%s "

--- a/tests/unit/test_temperature_events.py
+++ b/tests/unit/test_temperature_events.py
@@ -4,6 +4,7 @@ Covers EMA calculation, temperature application, guard clauses, debounce
 acceptance logic, accumulation tracking, and plateau acceptance.
 """
 
+import asyncio
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -57,6 +58,9 @@ def mock_bt():
     bt.pending_temp = None
     bt.pending_since = None
     bt.plateau_timer_cancel = None
+
+    # Serialisation of concurrent readings
+    bt._temperature_filter_lock = None
 
     # Anti-flicker state
     bt.flicker_candidate = None
@@ -803,3 +807,130 @@ class TestEdgeCasesAndRobustness:
 
         # 30s < 600s → rejected because one TRV is HomematicIP
         assert mock_bt.cur_temp == 20.0
+
+
+# ---------------------------------------------------------------------------
+# 8. Concurrent readings
+# ---------------------------------------------------------------------------
+
+
+class _RecordingQuirks:
+    """Model quirks that record external-temperature writes and overlap."""
+
+    def __init__(self):
+        self.writes: list[tuple[str, float]] = []
+        self.in_flight = 0
+        self.max_in_flight = 0
+        self.gate: asyncio.Event | None = None
+
+    async def maybe_set_external_temperature(self, entity, entity_id, temperature):
+        """Record one write, yielding long enough for another task to run."""
+        self.in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self.in_flight)
+        try:
+            if self.gate is not None:
+                await self.gate.wait()
+            else:
+                for _ in range(3):
+                    await asyncio.sleep(0)
+            self.writes.append((entity_id, temperature))
+        finally:
+            self.in_flight -= 1
+
+
+class _AdvancingClock:
+    """Hand out timestamps that move forward on every read.
+
+    Each reading is debounced against the previous one, so a clock that
+    stood still would reject the second of two readings long before the
+    handlers could overlap.
+    """
+
+    def __init__(self, start, step_seconds=10):
+        self._current = start
+        self._step = timedelta(seconds=step_seconds)
+
+    def now(self):
+        """Return a timestamp ``step_seconds`` after the previous one."""
+        self._current += self._step
+        return self._current
+
+
+class TestConcurrentReadings:
+    """Two readings handled at the same time must not interleave."""
+
+    @staticmethod
+    def _attach_trvs(mock_bt, quirks, entity_ids):
+        """Give the thermostat TRVs that all share one quirks recorder."""
+        mock_bt.real_trvs = {
+            entity_id: Trv.from_legacy_dict(entity_id, {"model_quirks": quirks})
+            for entity_id in entity_ids
+        }
+
+    @pytest.mark.asyncio
+    async def test_overlapping_readings_reach_every_trv_in_order(self, mock_bt):
+        """Hand both accepted readings to every TRV, oldest first."""
+        quirks = _RecordingQuirks()
+        self._attach_trvs(mock_bt, quirks, ("climate.trv1", "climate.trv2"))
+        start = dt_util.now()
+        mock_bt.last_external_sensor_change = start
+
+        with patch(
+            "custom_components.better_thermostat.events.temperature.dt_util",
+            _AdvancingClock(start),
+        ):
+            await asyncio.gather(
+                trigger_temperature_change(
+                    mock_bt, _make_event(State(SENSOR_ID, "21.0"))
+                ),
+                trigger_temperature_change(
+                    mock_bt, _make_event(State(SENSOR_ID, "22.0"))
+                ),
+            )
+
+        assert quirks.max_in_flight == 1
+        assert quirks.writes == [
+            ("climate.trv1", 21.0),
+            ("climate.trv2", 21.0),
+            ("climate.trv1", 22.0),
+            ("climate.trv2", 22.0),
+        ]
+        assert mock_bt.last_known_external_temp == 22.0
+        assert mock_bt.accum_delta == 0.0
+        assert mock_bt.pending_temp is None
+
+    @pytest.mark.asyncio
+    async def test_overlapping_applies_do_not_share_the_write_loop(self, mock_bt):
+        """Serialise updates that skip the debounce, such as the plateau timer."""
+        quirks = _RecordingQuirks()
+        self._attach_trvs(mock_bt, quirks, ("climate.trv1",))
+
+        await asyncio.gather(
+            _apply_temperature_update(mock_bt, 21.0),
+            _apply_temperature_update(mock_bt, 22.0),
+        )
+
+        assert quirks.max_in_flight == 1
+        assert quirks.writes == [("climate.trv1", 21.0), ("climate.trv1", 22.0)]
+        assert mock_bt.last_known_external_temp == 22.0
+
+    @pytest.mark.asyncio
+    async def test_cancelled_update_lets_the_next_one_through(self, mock_bt):
+        """Release the serialisation when a pending update is cancelled."""
+        quirks = _RecordingQuirks()
+        quirks.gate = asyncio.Event()
+        self._attach_trvs(mock_bt, quirks, ("climate.trv1",))
+
+        cancelled = asyncio.create_task(_apply_temperature_update(mock_bt, 21.0))
+        await asyncio.sleep(0)
+        queued = asyncio.create_task(_apply_temperature_update(mock_bt, 22.0))
+        await asyncio.sleep(0)
+
+        cancelled.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled
+        quirks.gate.set()
+        await queued
+
+        assert quirks.writes == [("climate.trv1", 22.0)]
+        assert mock_bt.last_known_external_temp == 22.0


### PR DESCRIPTION
## Problem

Home Assistant delivers every room-sensor update in its own task, and one
external-temperature handler is started per update. Applying a reading suspends
while the value is written to the TRVs, so a reading that arrives during that
write evaluates the filter and starts its own TRV write while the earlier one is
still running.

With two TRVs configured the effect reaches the devices. Feeding 21.0 and then
22.0 into overlapping handlers writes:

```
climate.trv1 <- 21.0
climate.trv1 <- 22.0
climate.trv2 <- 22.0
climate.trv2 <- 22.0
```

The second TRV never sees 21.0 and is written 22.0 twice. Two service calls for
the same entity are also in flight at the same time, so which value the device
settles on is left to the platform.

## Change

An `asyncio.Lock` on the entity serialises the temperature filter.
`trigger_temperature_change` holds it across the whole decision, and
`_apply_temperature_update` takes it as well, so the plateau timer callback
queues behind a live reading instead of racing it. The body of each is split
into a helper that runs under the lock, which keeps the decision logic
untouched.

No reading is dropped: one that arrives during an in-flight update waits and is
then judged against the state its predecessor left behind, rather than against a
half-applied one. The lock is created on first use and lives on the entity, so
thermostats never queue behind each other, and `async with` releases it when
Home Assistant cancels the background task on unload.

## Verification

Three tests in `tests/unit/test_temperature_events.py::TestConcurrentReadings`:

- `test_overlapping_readings_reach_every_trv_in_order` drives two sensor events
  concurrently and asserts every TRV receives both readings, oldest first, with
  never more than one write in flight. Without the change it reports two
  concurrent writes and the write order above.
- `test_overlapping_applies_do_not_share_the_write_loop` covers the entry point
  the plateau timer uses, which skips the debounce. Without the change it also
  reports two concurrent writes.
- `test_cancelled_update_lets_the_next_one_through` cancels the holder and
  asserts the queued update still runs. Replacing `async with` by a bare
  `acquire()`/`release()` pair makes it hang.

Full suite: 7357 passed, 1 skipped. All 99 per-module coverage floors hold,
`ruff check`, `ruff format --check` and `pyrefly check` are clean.
