### PR TITLE
fix: stop reporting valve support for TRVs without a valve quirk

### DIFF
--- a/custom_components/better_thermostat/model_fixes/default.py
+++ b/custom_components/better_thermostat/model_fixes/default.py
@@ -52,11 +52,6 @@ async def override_set_temperature(
     return False
 
 
-async def override_set_valve(self: ModelFixHost, entity_id: str, percent: int) -> bool:
-    """Do not override valve by default."""
-    return False
-
-
 async def initial_tweak(self: ModelFixHost, entity_id: str) -> None:
     """Run initial tweaks for the device."""
     entity_registry = er.async_get(self.hass)

--- a/custom_components/better_thermostat/trv.py
+++ b/custom_components/better_thermostat/trv.py
@@ -28,7 +28,10 @@ class ModelQuirks(Protocol):
     Quirk modules are plain modules under ``model_fixes/``; this is the
     contract every one of them provides. ``override_set_valve`` is the
     one optional extension — callers probe it with ``getattr``, and
-    :meth:`Trv.capabilities` turns its presence into a capability.
+    :meth:`Trv.capabilities` turns its presence into a capability. Only
+    a module that really drives its device's valve defines it: a module
+    that answers the probe without commanding anything would report
+    valve support for a device that has none.
     """
 
     fix_local_calibration: Callable[..., float]

--- a/tests/unit/test_adapter_write_contract.py
+++ b/tests/unit/test_adapter_write_contract.py
@@ -21,6 +21,7 @@ value has not changed. No adapter does that, and none should — the shell
 already decides it, once, for every ecosystem.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.climate.const import HVACMode
@@ -184,6 +185,48 @@ class TestTheDeclarationIsTheContract:
 
         assert answer is False
         assert _calls(thermostat) == []
+
+
+class TestAValveQuirkOutranksTheAdapter:
+    """A model driving its own valve is asked before the adapter is."""
+
+    @pytest.mark.parametrize("name", ADAPTER_IDS)
+    @pytest.mark.asyncio
+    async def test_a_handled_override_is_the_whole_write(self, name):
+        """The quirk took the position, so no adapter write follows it.
+
+        This is the channel a valve capability sourced from the quirks
+        stands for, and it works for an ecosystem that declares no valve
+        channel of its own just as well.
+        """
+        thermostat = _thermostat(adapter=ADAPTERS[name])
+        trv = thermostat.real_trvs[ENTITY_ID]
+        trv.model_quirks = SimpleNamespace(
+            override_set_valve=AsyncMock(return_value=True)
+        )
+
+        answer = await delegate.set_valve(thermostat, ENTITY_ID, 50)
+
+        assert answer is True
+        assert _calls(thermostat) == []
+        assert trv.last_valve_percent == 50
+        assert trv.last_valve_method == "override"
+
+    @pytest.mark.parametrize("name", VALVE_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_a_declined_override_leaves_the_write_to_the_adapter(self, name):
+        """A quirk that does not take this one steps out of the way."""
+        thermostat = _thermostat(adapter=ADAPTERS[name])
+        trv = thermostat.real_trvs[ENTITY_ID]
+        trv.model_quirks = SimpleNamespace(
+            override_set_valve=AsyncMock(return_value=False)
+        )
+
+        answer = await delegate.set_valve(thermostat, ENTITY_ID, 50)
+
+        assert answer is True
+        assert len(_calls(thermostat)) == 1
+        assert trv.last_valve_method == "adapter"
 
 
 # Grids a number entity can publish, including the ones where the step does

--- a/tests/unit/test_default_quirk.py
+++ b/tests/unit/test_default_quirk.py
@@ -175,13 +175,14 @@ class TestTheDefaultQuirkChangesNothing:
             is False
         )
 
-    @pytest.mark.asyncio
-    async def test_the_valve_write_is_not_overridden(self):
-        """Declining the override is what lets the adapter write."""
-        assert (
-            await default_quirk.override_set_valve(_thermostat(), ENTITY_ID, 50)
-            is False
-        )
+    def test_no_valve_override_is_offered(self):
+        """The valve override is absent, not a declining one.
+
+        Callers probe for it with ``getattr`` and read a hit as "this
+        model drives its valve directly". A declining implementation
+        here would answer that probe for every device on this module.
+        """
+        assert not hasattr(default_quirk, "override_set_valve")
 
 
 class TestAdoptionNeedsADevice:

--- a/tests/unit/test_mock_discipline.py
+++ b/tests/unit/test_mock_discipline.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import ast
 from collections.abc import Iterator
+import importlib
 import inspect
 from pathlib import Path
 from types import ModuleType
@@ -63,7 +64,24 @@ def _async_surface(module: ModuleType) -> set[str]:
     }
 
 
-SEAM = _async_surface(delegate) | _async_surface(default_quirk)
+def _quirk_surface() -> set[str]:
+    """Public coroutine functions across every quirk module.
+
+    The optional half of the quirk surface lives only in the modules
+    that need it, so deriving the seam from ``default.py`` alone would
+    leave those names unguarded wherever a test patches one.
+    """
+    directory = Path(default_quirk.__file__).parent
+    package = "custom_components.better_thermostat.model_fixes"
+    names: set[str] = set()
+    for path in sorted(directory.glob("*.py")):
+        if path.stem in {"__init__", "types"}:
+            continue
+        names |= _async_surface(importlib.import_module(f"{package}.{path.stem}"))
+    return names
+
+
+SEAM = _async_surface(delegate) | _quirk_surface()
 
 
 class PatchSite(NamedTuple):

--- a/tests/unit/test_model_quirk_surface.py
+++ b/tests/unit/test_model_quirk_surface.py
@@ -499,15 +499,33 @@ class TestTheDispatchAlwaysFindsWhatItReachesFor:
         assert _dispatched_from_the_shell(name), f"{name} is dispatched from nowhere"
 
 
-class TestAnImplementationMatchesTheDefault:
-    """A model's version is callable wherever the default one is."""
+def _reference_for(name):
+    """The implementation every other one of that name has to match.
+
+    ``default.py`` is it wherever it carries the function. An optional
+    one it leaves out has no such anchor, so the models implementing it
+    are each other's: the dispatch reaches all of them through the same
+    call, so they all have to answer it the same way.
+    """
+    reference = getattr(default_quirk, name, None)
+    if reference is not None:
+        return reference
+    implementers = [
+        getattr(MODEL_MODULES[model], name)
+        for model in MODEL_IDS
+        if hasattr(MODEL_MODULES[model], name)
+    ]
+    return implementers[0] if implementers else None
+
+
+class TestAnImplementationMatchesTheReference:
+    """A model's version is callable wherever the reference one is."""
 
     @pytest.mark.parametrize(("model", "name"), IMPLEMENTED, ids=IMPLEMENTED_IDS)
     def test_the_signature_and_kind_match(self, model, name):
         """The dispatch awaits some of these and calls others plainly."""
-        reference = getattr(default_quirk, name, None)
-        if reference is None:
-            pytest.skip(f"{name} has no counterpart in default.py")
+        reference = _reference_for(name)
+        assert reference is not None, f"{name} has no implementation to match"
         assert _signature(getattr(MODEL_MODULES[model], name)) == _signature(reference)
 
 

--- a/tests/unit/test_trv_object.py
+++ b/tests/unit/test_trv_object.py
@@ -1,7 +1,10 @@
 """Tests for the Trv domain object."""
 
+import importlib
+
 import pytest
 
+from custom_components.better_thermostat.model_fixes import default as default_quirk
 from custom_components.better_thermostat.trv import Trv
 
 
@@ -191,6 +194,27 @@ class TestTrvCapabilities:
 
         trv = _make()
         trv.model_quirks = _Quirk()
+        assert trv.capabilities().supports_valve_write is True
+
+    def test_the_default_quirks_claim_no_valve_support(self):
+        """A model without a quirk file of its own gets the default module.
+
+        Every device whose model has no ``model_fixes/<model>.py`` loads
+        this module, so a valve override living in it would report valve
+        support for the entire long tail of TRVs.
+        """
+        trv = _make()
+        trv.model_quirks = default_quirk
+        trv.valve_position_entity = None
+        assert trv.capabilities().supports_valve_write is False
+
+    @pytest.mark.parametrize("model", ["TRVZB", "ZWA021"])
+    def test_a_model_that_drives_its_valve_keeps_the_capability(self, model):
+        """The modules that do command a valve still report one."""
+        trv = _make()
+        trv.model_quirks = importlib.import_module(
+            f"custom_components.better_thermostat.model_fixes.{model}"
+        )
         assert trv.capabilities().supports_valve_write is True
 
 

--- a/tests/unit/test_valve_maintenance.py
+++ b/tests/unit/test_valve_maintenance.py
@@ -23,6 +23,7 @@ from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
 import pytest
 
+from custom_components.better_thermostat.model_fixes import default as default_quirk
 from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils.valve_maintenance import (
     MaintenanceTrvInfo,
@@ -293,6 +294,22 @@ class TestBuildTrvSnapshots:
         }
         result = build_trv_snapshots(trvs, ["trv1"], lambda _: _ha_state(), "Test")
         assert result[0].use_direct_valve is True
+
+    def test_a_model_without_a_valve_quirk_is_not_direct(self):
+        """A model with no quirk file of its own runs on the default one.
+
+        Direct valve mode makes a maintenance cycle write valve
+        percentages and skip the setpoint sweep altogether, so a device
+        that has no valve channel would sit through a run that commands
+        nothing at all.
+        """
+        trvs = {
+            "trv1": _trv(
+                maintenance=True, quirks=default_quirk, calibration="direct_valve_based"
+            )
+        }
+        result = build_trv_snapshots(trvs, ["trv1"], lambda _: _ha_state(), "Test")
+        assert result[0].use_direct_valve is False
 
     def test_valve_entity_direct(self):
         """Test Valve entity direct."""


### PR DESCRIPTION
## Problem

A TRV's valve capability has two sources: a writable valve position entity, or a model quirk that drives the valve itself. The second one is probed by asking the loaded quirk module for `override_set_valve`.

The default quirk module carried that function as a declining no-op, and every device whose model has no `model_fixes/<model>.py` of its own loads exactly that module. The probe therefore succeeded for the entire long tail of TRVs, so `supports_valve_write` came back true for devices with no valve channel at all. A bare `Trv` with the real default module reports `TrvCapabilities(supports_valve_write=True)`.

Two consumers read that capability, both alongside a `direct_valve_based` calibration setting:

- `calibration._supports_direct_valve_control`
- `valve_maintenance.build_trv_snapshots`, which keys `use_direct_valve` on it

`use_direct_valve` makes `open_step`/`close_step` write a valve percentage and skip the setpoint sweep altogether, so on such a device the weekly maintenance run commands nothing at all instead of exercising the valve.

The reach is limited to existing configurations: the config flow only offers direct valve calibration when adapter discovery reports `support_valve`, so a fresh setup cannot select the mode on an affected device. An installation that once had it selected keeps it.

## Change

- `model_fixes/default.py` no longer defines `override_set_valve`. Both callers already handle its absence: `adapters/delegate.set_valve` probes with `getattr(..., None)`, and `Trv.capabilities` with `callable(getattr(...))`. Only `TRVZB` and `ZWA021` define it, and both keep the capability.
- `Trv.ModelQuirks` spells out what defining the function means, so the next module that adds one adds it because it drives a valve.

Test changes that follow from it:

- `test_default_quirk.py` asserted that the default valve override declines. That assertion pinned the defect: the probe reads presence, not the answer. It is replaced by the absence of the function.
- `test_mock_discipline.py` derived the quirk half of the adapter seam from `default.py` alone, so `override_set_valve` dropped out of the seam with it. The seam now comes from every quirk module, which is what the file's own derivation-over-listing rule asks for.
- `test_model_quirk_surface.py` compared each model's implementation against `default.py` and skipped where there is no counterpart, which would have silently stopped checking the two real valve overrides. Implementations of a function the default leaves out are now each other's reference, which also restores the check for `maybe_set_external_temperature`.

## Verification

Counterfactual: reinstating the no-op in `default.py` turns three new tests red and nothing else.

- `test_trv_object.py::TestTrvCapabilities::test_the_default_quirks_claim_no_valve_support`
- `test_valve_maintenance.py::TestBuildTrvSnapshots::test_a_model_without_a_valve_quirk_is_not_direct`
- `test_default_quirk.py::TestTheDefaultQuirkChangesNothing::test_no_valve_override_is_offered`

The suite already held both halves of this apart: one test stubs a quirk with a valve override and expects the capability, another checks the real default declines the write. Nothing crossed them.

`TRVZB` and `ZWA021` are asserted to keep `supports_valve_write` through the real modules, not a stub.

Removing the no-op also left `delegate.set_valve`'s override branch without a single caller in the suite, which the per-module coverage floor caught: `adapters/delegate.py` fell from 77.6 to 75.2 percent. The branch is now covered on its own terms, for a handled and for a declined override, and the module is at 80.8 percent.

`pytest tests`: 7366 passed, up from 7354 passed and 1 skipped. All coverage floors hold. `ruff check`, `ruff format --check` and `pyrefly` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unknown or unsupported thermostat models from being treated as directly controlling valve position.
  * Ensured valve commands use model-specific support when available and otherwise fall back to the standard adapter behavior.
  * Improved valve capability detection and maintenance status reporting for default thermostat configurations.

* **Tests**
  * Added coverage for valve override handling, model capabilities, and fallback behavior across supported adapters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->