### PR TITLE
fix: write select-based calibration offsets through the right service (1.9)

### DIFF
--- a/custom_components/better_thermostat/adapters/base.py
+++ b/custom_components/better_thermostat/adapters/base.py
@@ -11,6 +11,69 @@ from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 _LOGGER = logging.getLogger(__name__)
 
 
+def _zero_offset_option(state) -> str:
+    """Return the option of a calibration select that carries a zero offset.
+
+    Parameters
+    ----------
+    state : State or None
+        State of the calibration select, or None when it has none yet.
+
+    Returns
+    -------
+    str
+        The offered option that reads as zero Kelvin, or the Kelvin spelling
+        of zero when the entity offers nothing that does.
+    """
+    if state is None:
+        return "0.0k"
+    for option in state.attributes.get("options") or []:
+        try:
+            if float(str(option).replace("k", "")) == 0.0:
+                return str(option)
+        except ValueError, TypeError:
+            continue
+    return "0.0k"
+
+
+async def _write_zero_calibration(self, calibration_entity, state):
+    """Write a zero offset through the service the entity's domain answers to.
+
+    Discovery accepts a calibration helper in either the ``number`` or the
+    ``select`` domain, and each takes its own service: a select rejects
+    ``number.set_value`` and only moves when told an option it offers.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    calibration_entity : str
+        Entity ID of the calibration helper to write to
+    state : State or None
+        State of that entity, used to pick an option it actually offers
+
+    Returns
+    -------
+    None
+    """
+    if calibration_entity.split(".", 1)[0] == "select":
+        await self.hass.services.async_call(
+            "select",
+            "select_option",
+            {"entity_id": calibration_entity, "option": _zero_offset_option(state)},
+            blocking=False,
+            context=self.context,
+        )
+        return
+    await self.hass.services.async_call(
+        "number",
+        SERVICE_SET_VALUE,
+        {"entity_id": calibration_entity, "value": 0},
+        blocking=False,
+        context=self.context,
+    )
+
+
 async def wait_for_calibration_entity_or_timeout(self, entity_id, calibration_entity):
     """Wait for calibration entity to become available with timeout.
 
@@ -58,13 +121,7 @@ async def wait_for_calibration_entity_or_timeout(self, entity_id, calibration_en
                 )
                 # Force set calibration to 0 to initialize the entity
                 try:
-                    await self.hass.services.async_call(
-                        "number",
-                        SERVICE_SET_VALUE,
-                        {"entity_id": calibration_entity, "value": 0},
-                        blocking=False,
-                        context=self.context,
-                    )
+                    await _write_zero_calibration(self, calibration_entity, _state)
                 except Exception as e:
                     _LOGGER.error(
                         "better_thermostat %s: Failed to set calibration to 0 for entity '%s': %s",

--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -11,12 +11,13 @@ import logging
 from typing import Final
 
 from homeassistant.components.number.const import SERVICE_SET_VALUE
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
 from ..utils.helpers import find_local_calibration_entity, find_valve_entity
 from .base import wait_for_calibration_entity_or_timeout
 from .generic import (
+    get_current_offset as generic_get_current_offset,
     set_hvac_mode as generic_set_hvac_mode,
+    set_offset as generic_set_offset,
     set_temperature as generic_set_temperature,
 )
 
@@ -156,21 +157,22 @@ async def set_hvac_mode(self, entity_id, hvac_mode):
 
 
 async def get_current_offset(self, entity_id):
-    """Get current offset."""
-    state = self.hass.states.get(
-        self.real_trvs[entity_id].local_temperature_calibration_entity
-    )
-    if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
-        return 0.0
-    try:
-        return float(str(state.state))
-    except ValueError, TypeError:
-        _LOGGER.warning(
-            "better_thermostat %s: Could not convert calibration offset '%s' to float, using 0",
-            self.device_name,
-            state.state,
-        )
-        return 0.0
+    """Read the offset the calibration entity currently reports.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV to read for
+
+    Returns
+    -------
+    float
+        Offset in Kelvin, 0.0 when the TRV has no calibration entity or the
+        entity reports nothing readable.
+    """
+    return await generic_get_current_offset(self, entity_id)
 
 
 async def get_offset_step(self, entity_id):
@@ -221,35 +223,7 @@ async def set_offset(self, entity_id, offset) -> bool:
         True once the write went out, False when no calibration entity was
         discovered for this TRV and there is nothing to write to.
     """
-    if self.real_trvs[entity_id].local_temperature_calibration_entity is None:
-        return False
-
-    max_calibration = await get_max_offset(self, entity_id)
-    min_calibration = await get_min_offset(self, entity_id)
-
-    offset = min(max_calibration, offset)
-    offset = max(min_calibration, offset)
-
-    await self.hass.services.async_call(
-        "number",
-        SERVICE_SET_VALUE,
-        {
-            "entity_id": self.real_trvs[entity_id].local_temperature_calibration_entity,
-            "value": offset,
-        },
-        blocking=True,
-        context=self.context,
-    )
-    self.real_trvs[entity_id].last_calibration = offset
-    if (
-        self.real_trvs[entity_id].last_hvac_mode is not None
-        and self.real_trvs[entity_id].last_hvac_mode != "off"
-    ):
-        await asyncio.sleep(3)
-        await generic_set_hvac_mode(
-            self, entity_id, self.real_trvs[entity_id].last_hvac_mode
-        )
-    return True
+    return await generic_set_offset(self, entity_id, offset)
 
 
 async def set_valve(self, entity_id, valve):

--- a/custom_components/better_thermostat/adapters/zwave_js.py
+++ b/custom_components/better_thermostat/adapters/zwave_js.py
@@ -10,11 +10,9 @@ family, which control the valve via the Multilevel Switch command class while
 in their manufacturer-specific mode).
 """
 
-import asyncio
 import logging
 
 from homeassistant.components.number.const import SERVICE_SET_VALUE
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 
 from ..utils.helpers import (
     find_local_calibration_entity,
@@ -23,7 +21,9 @@ from ..utils.helpers import (
 )
 from .base import wait_for_calibration_entity_or_timeout
 from .generic import (
+    get_current_offset as generic_get_current_offset,
     set_hvac_mode as generic_set_hvac_mode,
+    set_offset as generic_set_offset,
     set_temperature as generic_set_temperature,
 )
 
@@ -113,23 +113,22 @@ async def init(self, entity_id):
 
 
 async def get_current_offset(self, entity_id):
-    """Get current offset."""
-    if self.real_trvs[entity_id].local_temperature_calibration_entity is None:
-        return 0.0
-    state = self.hass.states.get(
-        self.real_trvs[entity_id].local_temperature_calibration_entity
-    )
-    if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
-        return 0.0
-    try:
-        return float(str(state.state))
-    except ValueError, TypeError:
-        _LOGGER.warning(
-            "better_thermostat %s: Could not convert calibration offset '%s' to float, using 0",
-            self.device_name,
-            state.state,
-        )
-        return 0.0
+    """Read the offset the calibration entity currently reports.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    entity_id : str
+        Entity ID of the TRV to read for
+
+    Returns
+    -------
+    float
+        Offset in Kelvin, 0.0 when the TRV has no calibration entity or the
+        entity reports nothing readable.
+    """
+    return await generic_get_current_offset(self, entity_id)
 
 
 async def get_offset_step(self, entity_id):
@@ -196,35 +195,7 @@ async def set_offset(self, entity_id, offset) -> bool:
         True once the write went out, False when no calibration entity was
         discovered for this TRV and there is nothing to write to.
     """
-    if self.real_trvs[entity_id].local_temperature_calibration_entity is None:
-        return False
-
-    max_calibration = await get_max_offset(self, entity_id)
-    min_calibration = await get_min_offset(self, entity_id)
-
-    offset = min(max_calibration, offset)
-    offset = max(min_calibration, offset)
-
-    await self.hass.services.async_call(
-        "number",
-        SERVICE_SET_VALUE,
-        {
-            "entity_id": self.real_trvs[entity_id].local_temperature_calibration_entity,
-            "value": offset,
-        },
-        blocking=True,
-        context=self.context,
-    )
-    self.real_trvs[entity_id].last_calibration = offset
-    if (
-        self.real_trvs[entity_id].last_hvac_mode is not None
-        and self.real_trvs[entity_id].last_hvac_mode != "off"
-    ):
-        await asyncio.sleep(3)
-        await generic_set_hvac_mode(
-            self, entity_id, self.real_trvs[entity_id].last_hvac_mode
-        )
-    return True
+    return await generic_set_offset(self, entity_id, offset)
 
 
 async def set_valve(self, entity_id, valve):

--- a/tests/unit/test_adapter_offset_contract.py
+++ b/tests/unit/test_adapter_offset_contract.py
@@ -6,12 +6,13 @@ offset channel". A written offset cannot carry that: the legitimate value
 0.0 reads the same as a device that wrote nothing.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.core import State
 import pytest
 
 from custom_components.better_thermostat.adapters import (
+    base,
     deconz,
     generic,
     mqtt,
@@ -92,13 +93,38 @@ class TestOffsetWriteReportsTrue:
         assert mock_self.real_trvs[ENTITY_ID].last_calibration == -2.5
 
 
-def _mock_self_with_select(options=SELECT_OPTIONS):
+class TestOffsetBoundsComeFromTheCalibrationEntity:
+    """The bounds an entity-backed adapter reports are the entity's own.
+
+    The calibration control clamps its request against these, so an adapter
+    that answers from a table instead of from the discovered entity lets the
+    control aim at offsets the device will never take.
+    """
+
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS)
+    @pytest.mark.parametrize(
+        ("getter", "expected"),
+        [("get_min_offset", -5.0), ("get_max_offset", 5.0), ("get_offset_step", 0.5)],
+    )
+    @pytest.mark.asyncio
+    async def test_the_entity_attributes_are_what_is_reported(
+        self, adapter, getter, expected
+    ):
+        """Each bound is read off the calibration entity that was discovered."""
+        mock_self = _mock_self()
+
+        assert await getattr(adapter, getter)(mock_self, ENTITY_ID) == expected
+
+
+def _mock_self_with_select(options=SELECT_OPTIONS, reported="0.0k"):
     """Build a thermostat whose calibration entity is a select.
 
     Parameters
     ----------
     options : list of str
         Options the select entity offers, as it publishes them.
+    reported : str
+        The option the select currently reports as its state.
 
     Returns
     -------
@@ -111,7 +137,7 @@ def _mock_self_with_select(options=SELECT_OPTIONS):
     mock_self.hass = MagicMock()
     mock_self.hass.services.async_call = AsyncMock()
     mock_self.hass.states.get = lambda requested: (
-        State(SELECT_CALIBRATION_ENTITY, "0.0k", {"options": list(options)})
+        State(SELECT_CALIBRATION_ENTITY, reported, {"options": list(options)})
         if requested == SELECT_CALIBRATION_ENTITY
         else State(ENTITY_ID, "heat", {})
     )
@@ -126,61 +152,198 @@ def _selected_option(mock_self):
     return mock_self.hass.services.async_call.await_args.args[2]["option"]
 
 
+def _called_service(mock_self):
+    """Return the (domain, service) pair the recorded service call addressed."""
+    return mock_self.hass.services.async_call.await_args.args[:2]
+
+
 class TestSelectOffsetRecordsWhatItSelected:
     """A select write records the offset the chosen option carries.
+
+    Discovery accepts a calibration helper in the ``number`` or the ``select``
+    domain, so every adapter that writes through a discovered entity can be
+    handed a select and has to address it as one. A select ignores
+    ``number.set_value``, so a write sent there never reaches the device while
+    still reporting success, and the offset control never converges.
 
     The confirmation compares the device's report against the recorded
     command, so a command that never went on the wire would leave the two
     permanently apart and re-assert the write every cycle.
+
+    The service adapters are absent from this axis on purpose: their offset
+    rides on the ecosystem's own service call and never addresses an entity.
     """
 
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS)
     @pytest.mark.asyncio
-    async def test_a_request_between_options_reaches_the_closest_one(self):
+    async def test_the_write_addresses_the_select_service(self, adapter):
+        """The option goes out through the service a select answers to."""
+        mock_self = _mock_self_with_select()
+
+        await adapter.set_offset(mock_self, ENTITY_ID, -2.0)
+
+        assert _called_service(mock_self) == ("select", "select_option")
+
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_a_request_between_options_reaches_the_closest_one(self, adapter):
         """The option nearest the request is what the device is told."""
         mock_self = _mock_self_with_select()
 
-        result = await generic.set_offset(mock_self, ENTITY_ID, -2.0)
+        result = await adapter.set_offset(mock_self, ENTITY_ID, -2.0)
 
         assert result is True
         assert _selected_option(mock_self) == "-3.0k"
 
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS)
     @pytest.mark.asyncio
-    async def test_the_snapped_option_is_the_recorded_command(self):
+    async def test_the_snapped_option_is_the_recorded_command(self, adapter):
         """The command is the snapped option's value, not the request."""
         mock_self = _mock_self_with_select()
 
-        await generic.set_offset(mock_self, ENTITY_ID, -2.0)
+        await adapter.set_offset(mock_self, ENTITY_ID, -2.0)
 
         assert mock_self.real_trvs[ENTITY_ID].last_calibration == -3.0
 
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS)
     @pytest.mark.asyncio
-    async def test_the_adapter_leaves_the_requested_intent_alone(self):
+    async def test_the_adapter_leaves_the_requested_intent_alone(self, adapter):
         """Recording the intent stays the delegate's business."""
         mock_self = _mock_self_with_select()
 
-        await generic.set_offset(mock_self, ENTITY_ID, -2.0)
+        await adapter.set_offset(mock_self, ENTITY_ID, -2.0)
 
         assert mock_self.real_trvs[ENTITY_ID].last_calibration_requested is None
 
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS)
     @pytest.mark.asyncio
-    async def test_an_offered_option_is_recorded_as_it_is(self):
+    async def test_an_offered_option_is_recorded_as_it_is(self, adapter):
         """A request the select offers verbatim needs no correction."""
         mock_self = _mock_self_with_select()
 
-        await generic.set_offset(mock_self, ENTITY_ID, -3.0)
+        await adapter.set_offset(mock_self, ENTITY_ID, -3.0)
 
         assert _selected_option(mock_self) == "-3.0k"
         assert mock_self.real_trvs[ENTITY_ID].last_calibration == -3.0
 
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS)
     @pytest.mark.asyncio
-    async def test_the_option_format_decides_the_command(self):
+    async def test_the_option_format_decides_the_command(self, adapter):
         """An option carries one decimal, so that is what was commanded."""
         mock_self = _mock_self_with_select(options=["-2.3k", "-2.2k"])
 
-        await generic.set_offset(mock_self, ENTITY_ID, -2.26)
+        await adapter.set_offset(mock_self, ENTITY_ID, -2.26)
 
         assert _selected_option(mock_self) == "-2.3k"
         assert mock_self.real_trvs[ENTITY_ID].last_calibration == -2.3
+
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_the_request_is_held_to_what_the_options_offer(self, adapter):
+        """A request beyond the offered range reaches the outermost option."""
+        mock_self = _mock_self_with_select()
+
+        await adapter.set_offset(mock_self, ENTITY_ID, -12.0)
+
+        assert _selected_option(mock_self) == "-6.0k"
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration == -6.0
+
+
+class TestSelectOffsetIsReadBackAsKelvin:
+    """The offset a select reports is read as the number its option carries.
+
+    The confirmation and the calibration control both read this value back. An
+    adapter that cannot parse the Kelvin suffix reads every select as 0.0 and
+    keeps re-asserting a write the device already carries out.
+    """
+
+    @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_the_reported_option_is_read_as_its_offset(self, adapter):
+        """The device's own option is what the reading reports."""
+        mock_self = _mock_self_with_select(reported="-3.0k")
+
+        assert await adapter.get_current_offset(mock_self, ENTITY_ID) == -3.0
+
+
+class TestForcedZeroAddressesTheEntitysOwnDomain:
+    """A calibration helper that never showed up is zeroed through its own service.
+
+    The startup wait gives up after its retries and writes a zero to nudge the
+    entity into reporting. That write is fire-and-forget, so a request sent to
+    the wrong domain leaves no trace at all: the helper keeps its old offset
+    and nothing says so.
+    """
+
+    @pytest.mark.parametrize(
+        ("calibration_entity", "expected_service", "expected_payload"),
+        [
+            (
+                CALIBRATION_ENTITY,
+                ("number", "set_value"),
+                {"entity_id": CALIBRATION_ENTITY, "value": 0},
+            ),
+            (
+                SELECT_CALIBRATION_ENTITY,
+                ("select", "select_option"),
+                {"entity_id": SELECT_CALIBRATION_ENTITY, "option": "0.0k"},
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_the_zero_goes_out_through_the_matching_service(
+        self, calibration_entity, expected_service, expected_payload
+    ):
+        """Each domain is addressed through the service it answers to."""
+        mock_self = _mock_self_with_select()
+        mock_self.hass.states.get = lambda requested: State(
+            calibration_entity, "unavailable", {"options": list(SELECT_OPTIONS)}
+        )
+
+        with patch(
+            "custom_components.better_thermostat.adapters.base.asyncio.sleep",
+            AsyncMock(),
+        ):
+            await base.wait_for_calibration_entity_or_timeout(
+                mock_self, ENTITY_ID, calibration_entity
+            )
+
+        assert _called_service(mock_self) == expected_service
+        assert mock_self.hass.services.async_call.await_args.args[2] == expected_payload
+
+    @pytest.mark.asyncio
+    async def test_a_select_without_options_is_told_the_kelvin_spelling_of_zero(self):
+        """With no option list to go by, zero Kelvin is spelled out."""
+        mock_self = _mock_self_with_select()
+        mock_self.hass.states.get = lambda requested: None
+
+        with patch(
+            "custom_components.better_thermostat.adapters.base.asyncio.sleep",
+            AsyncMock(),
+        ):
+            await base.wait_for_calibration_entity_or_timeout(
+                mock_self, ENTITY_ID, SELECT_CALIBRATION_ENTITY
+            )
+
+        assert _selected_option(mock_self) == "0.0k"
+
+    @pytest.mark.asyncio
+    async def test_the_zero_option_the_device_offers_is_the_one_used(self):
+        """A device that spells zero its own way is told its own spelling."""
+        mock_self = _mock_self_with_select()
+        mock_self.hass.states.get = lambda requested: State(
+            SELECT_CALIBRATION_ENTITY, "unavailable", {"options": ["-3k", "0k", "3k"]}
+        )
+
+        with patch(
+            "custom_components.better_thermostat.adapters.base.asyncio.sleep",
+            AsyncMock(),
+        ):
+            await base.wait_for_calibration_entity_or_timeout(
+                mock_self, ENTITY_ID, SELECT_CALIBRATION_ENTITY
+            )
+
+        assert _selected_option(mock_self) == "0k"
 
 
 class TestNoOffsetChannelReportsFalse:


### PR DESCRIPTION
## Problem

Calibration discovery accepts a helper entity in either the `number` or the
`select` domain: several TRVs expose their local temperature calibration as a
select whose options carry a Kelvin suffix, such as `-3.0k`. Only the generic
adapter handles both. The MQTT and Z-Wave JS adapters address every discovered
calibration entity as a number:

- `set_offset` calls `number.set_value` on the select. Home Assistant finds no
  entity of that domain, logs that the target is missing and returns without
  raising, so the adapter reports the write as successful and records the
  offset as the device's current command.
- `get_current_offset` parses the reported option as a float, fails on the `k`
  suffix, logs a warning and answers 0.0.

Together those make offset calibration a silent no-op on such devices: nothing
reaches the TRV, the read-back never matches what was commanded, and the
control keeps re-asserting an offset that never lands. No error surfaces, so
the write is not retried either.

The forced zero that the startup wait writes when a calibration entity never
becomes available had the same assumption, and sends its call with
`blocking=False`, so on a select it disappears without any trace at all.

## Change

- `mqtt.set_offset`, `mqtt.get_current_offset`, `zwave_js.set_offset` and
  `zwave_js.get_current_offset` delegate to the generic implementations, the
  same way `set_temperature` and `set_hvac_mode` already do. A select is now
  written through `select.select_option` with the offered option nearest the
  request, and read back through the option's own value. As a side effect the
  write path clamps against the generic bounds, which for a select are inferred
  from the offered options instead of from absent `min`/`max` attributes, and
  `mqtt.get_current_offset` stops looking up a `None` entity id for a TRV whose
  discovery found no calibration helper.
- The startup wait picks the service by the calibration entity's domain and, on
  a select, the offered option that reads as zero Kelvin.

## Verification

The offset contract test had both axes — five adapters against a number entity,
and a select against the generic adapter only — but never crossed them. The
select axis is now parametrised over every adapter that writes through a
discovered entity, and the forced zero is covered per domain. With the
production change reverted, 17 of those tests fail (every select assertion for
`mqtt` and `zwave_js`, and the three select assertions on the startup wait);
with it, all 55 pass.

Unit suite: 4519 passed, 1 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved thermostat calibration support for both selectable and numeric calibration controls.
  - Calibration values now automatically use valid zero-offset options when required.
  - Offset handling is more consistent across MQTT and Z-Wave thermostat integrations.

- **Bug Fixes**
  - Improved calibration bounds handling, value parsing, and readback behavior.
  - Prevented calibration writes when the required calibration entity is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->