### PR TITLE
test: assert sequence properties on the stateful controllers (TG15)

### DIFF
--- a/.coverage-floors.json
+++ b/.coverage-floors.json
@@ -73,7 +73,7 @@
   "custom_components/better_thermostat/utils/calibration/mpc_v2_internals/__init__.py": 100.0,
   "custom_components/better_thermostat/utils/calibration/mpc_v2_internals/_types.py": 100.0,
   "custom_components/better_thermostat/utils/calibration/mpc_v2_internals/dob.py": 100.0,
-  "custom_components/better_thermostat/utils/calibration/mpc_v2_internals/governor.py": 96.3,
+  "custom_components/better_thermostat/utils/calibration/mpc_v2_internals/governor.py": 100.0,
   "custom_components/better_thermostat/utils/calibration/mpc_v2_internals/kalman.py": 100.0,
   "custom_components/better_thermostat/utils/calibration/mpc_v2_internals/plant.py": 100.0,
   "custom_components/better_thermostat/utils/calibration/mpc_v2_internals/qp_optimiser.py": 94.7,

--- a/tests/test_tpi.py
+++ b/tests/test_tpi.py
@@ -1,6 +1,9 @@
 """Tests for the TPI (Time Proportional Integrator) controller."""
 
+from random import Random
 from unittest.mock import patch
+
+import pytest
 
 from custom_components.better_thermostat.utils.calibration.tpi import (
     TpiInput,
@@ -134,3 +137,87 @@ class TestTpiTimeHandling:
 
         assert result is not None
         assert state.last_update_ts == 500.0
+
+
+class TestTpiOverManyCycles:
+    """Properties of a run of cycles, not of a single computation."""
+
+    def test_duty_cycle_depends_only_on_the_current_readings(self):
+        """With both temperatures present, no earlier cycle may shift the output.
+
+        TPI carries no accumulator, so replaying a reading against a fresh
+        state has to give the same duty cycle as the same reading reached at
+        the end of a long, varied run.
+        """
+        params = TpiParams()
+        rng = Random(7)
+        state = TpiState()
+
+        for cycle in range(200):
+            inp = TpiInput(
+                key="k",
+                current_temp_C=18.0 + rng.random() * 6.0,
+                target_temp_C=20.0 + rng.random() * 3.0,
+                outdoor_temp_C=-10.0 + rng.random() * 30.0,
+            )
+            carried, state = compute_tpi(inp, params, state=state, now=float(cycle))
+            fresh, _ = compute_tpi(inp, params, state=TpiState(), now=float(cycle))
+            assert carried.duty_cycle_pct == fresh.duty_cycle_pct
+
+    def test_constant_error_holds_a_constant_duty_cycle(self):
+        """A standing error must neither ramp the duty cycle up nor let it decay.
+
+        The command is proportional to the current error, so repeating the same
+        reading has to repeat the same duty cycle for as long as the error
+        stands.
+        """
+        params = TpiParams(coef_int=0.6, coef_ext=0.01)
+        state = TpiState()
+        inp = TpiInput(
+            key="k", current_temp_C=21.8, target_temp_C=22.0, outdoor_temp_C=5.0
+        )
+        expected_pct = 100.0 * (
+            params.coef_int * (22.0 - 21.8) + params.coef_ext * (22.0 - 5.0)
+        )
+
+        duty_cycles = []
+        for cycle in range(50):
+            result, state = compute_tpi(
+                inp, params, state=state, now=float(cycle) * 300.0
+            )
+            duty_cycles.append(result.duty_cycle_pct)
+
+        assert duty_cycles == pytest.approx([expected_pct] * 50)
+
+    def test_last_duty_cycle_is_held_for_every_cycle_of_a_sensor_dropout(self):
+        """A room sensor that stops reporting must freeze the command, not drop it.
+
+        The held value is the only state that reaches across cycles, so it has
+        to survive the whole gap and give way to live readings again once the
+        sensor returns.
+        """
+        params = TpiParams()
+        state = TpiState()
+        reading = TpiInput(
+            key="k", current_temp_C=21.7, target_temp_C=22.0, outdoor_temp_C=5.0
+        )
+        gap = TpiInput(
+            key="k", current_temp_C=None, target_temp_C=22.0, outdoor_temp_C=5.0
+        )
+
+        warm, state = compute_tpi(reading, params, state=state, now=0.0)
+        held_pct = warm.duty_cycle_pct
+        assert held_pct > 0.0
+
+        for cycle in range(1, 13):
+            result, state = compute_tpi(gap, params, state=state, now=float(cycle))
+            assert result.debug["reason"] == "missing_temps"
+            assert result.duty_cycle_pct == held_pct
+
+        colder = TpiInput(
+            key="k", current_temp_C=21.0, target_temp_C=22.0, outdoor_temp_C=5.0
+        )
+        after_gap, _ = compute_tpi(colder, params, state=state, now=200.0)
+        fresh, _ = compute_tpi(colder, params, state=TpiState(), now=200.0)
+        assert after_gap.duty_cycle_pct == fresh.duty_cycle_pct
+        assert after_gap.duty_cycle_pct != held_pct

--- a/tests/test_tpi.py
+++ b/tests/test_tpi.py
@@ -147,22 +147,39 @@ class TestTpiOverManyCycles:
 
         TPI carries no accumulator, so replaying a reading against a fresh
         state has to give the same duty cycle as the same reading reached at
-        the end of a long, varied run.
+        the end of a long, varied run. The readings are drawn so that almost
+        every cycle lands strictly between the clamps: a duty cycle resting on
+        one of them would agree with the fresh run whatever the carried state
+        had done to it.
         """
         params = TpiParams()
         rng = Random(7)
         state = TpiState()
+        cycles = 200
+        duty_cycles = []
 
-        for cycle in range(200):
+        for cycle in range(cycles):
+            target_temp_C = 20.0 + rng.random() * 3.0
+            error_K = -0.25 + rng.random() * 1.4
+            delta_outdoor_K = 8.0 + rng.random() * 16.0
             inp = TpiInput(
                 key="k",
-                current_temp_C=18.0 + rng.random() * 6.0,
-                target_temp_C=20.0 + rng.random() * 3.0,
-                outdoor_temp_C=-10.0 + rng.random() * 30.0,
+                current_temp_C=target_temp_C - error_K,
+                target_temp_C=target_temp_C,
+                outdoor_temp_C=target_temp_C - delta_outdoor_K,
             )
             carried, state = compute_tpi(inp, params, state=state, now=float(cycle))
             fresh, _ = compute_tpi(inp, params, state=TpiState(), now=float(cycle))
             assert carried.duty_cycle_pct == fresh.duty_cycle_pct
+            duty_cycles.append(carried.duty_cycle_pct)
+
+        assert (
+            sum(
+                params.clamp_min_pct < duty_cycle < params.clamp_max_pct
+                for duty_cycle in duty_cycles
+            )
+            > cycles // 2
+        )
 
     def test_constant_error_holds_a_constant_duty_cycle(self):
         """A standing error must neither ramp the duty cycle up nor let it decay.

--- a/tests/unit/mpc_v2/test_compute_mpc_v2.py
+++ b/tests/unit/mpc_v2/test_compute_mpc_v2.py
@@ -606,34 +606,65 @@ def test_restore_without_estimate_matches_a_freshly_built_controller(
     assert out_restored.valve_percent == out_fresh.valve_percent
 
 
-def test_restored_snapshot_reproduces_the_uninterrupted_command_sequence() -> None:
+@pytest.mark.parametrize(
+    "cycle_s", [120.0, 300.0], ids=["cycle-under-replan-step", "cycle-over-replan-step"]
+)
+def test_restored_snapshot_reproduces_the_uninterrupted_command_sequence(
+    cycle_s: float,
+) -> None:
     """A restart mid-run must not change a single later valve command.
 
     The snapshot is the controller's whole memory, so a controller resumed
     from one has to issue exactly the commands the uninterrupted controller
-    would have issued for the remaining inputs. The plant carries a valve
-    command delay so the replayed command history takes part as well.
+    would have issued for the remaining inputs. Both cadences are driven
+    because they reach different parts of that memory: cycles longer than the
+    MPC re-plan interval re-plan on every one, while shorter cycles hand back
+    the held command in between and so depend on the stored re-plan deadline
+    as well.
+
+    The outdoor temperature sits just under the setpoint, which puts the
+    steady-state valve fraction below the governor's safety margin. That is
+    the regime in which the governed reference stays pinned to the room
+    temperature of the very first cycle, so a restart that re-seeds it from a
+    later reading diverges. The plant carries a valve command delay, which
+    brings the replayed command history into the comparison too.
     """
     params = MpcV2Params()
     params.plant = replace(params.plant, valve_command_delay_s=900.0)
-    steps = 24
-    resume_at = 10
+    T_target_C, T_outdoor_C = 19.0, 18.0
+    steps, resume_at = 40, 17
+
+    # Only an infeasible setpoint leaves the governed reference observable;
+    # a transparent governor carries no state for the snapshot to lose.
+    plant = PlantModelRC2(params.plant, dt_s=params.qp.step_s)
+    assert (
+        plant.steady_input(T_target_C, T_outdoor_C)
+        < params.governor.u_min + params.governor.safety_margin
+    )
+
+    def room_temperature(cycle: int) -> float:
+        """A room cooling off slowly, with a small ripple on top."""
+        return 19.2 - 0.02 * cycle + 0.15 * math.sin(cycle / 4.0)
 
     def drive(controller: MpcV2Controller, cycles: range) -> list[float]:
         return [
             controller.step(
-                t_s=1000.0 + 300.0 * cycle,
-                T_room_C=21.0 + 0.4 * math.sin(cycle / 3.0),
-                T_target_C=21.0,
-                T_outdoor_C=12.0,
+                t_s=1000.0 + cycle_s * cycle,
+                T_room_C=room_temperature(cycle),
+                T_target_C=T_target_C,
+                T_outdoor_C=T_outdoor_C,
             )[0]
             for cycle in cycles
         ]
 
     uninterrupted = drive(MpcV2Controller(params), range(steps))
-    # The scenario has to keep the valve moving: a command pinned to a rail
-    # would match no matter what the restore dropped.
-    assert len(set(uninterrupted)) > steps // 2
+    # A command resting on a rail would match no matter what the restore
+    # dropped. Rounding folds away commands that are all but zero and differ
+    # only in their last bits, so the count below is of real valve positions.
+    assert len({round(command, 6) for command in uninterrupted}) >= steps // 4
+    assert max(uninterrupted) - min(uninterrupted) > 0.1 * (
+        params.qp.u_max - params.qp.u_min
+    )
 
     interrupted = MpcV2Controller(params)
     before_restart = drive(interrupted, range(resume_at))

--- a/tests/unit/mpc_v2/test_compute_mpc_v2.py
+++ b/tests/unit/mpc_v2/test_compute_mpc_v2.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import copy
-from dataclasses import replace
+from dataclasses import asdict, replace
 import json
+import math
 
 import numpy as np
 import pytest
@@ -603,3 +604,45 @@ def test_restore_without_estimate_matches_a_freshly_built_controller(
         out_fresh.diagnostics.T_room_hat
     )
     assert out_restored.valve_percent == out_fresh.valve_percent
+
+
+def test_restored_snapshot_reproduces_the_uninterrupted_command_sequence() -> None:
+    """A restart mid-run must not change a single later valve command.
+
+    The snapshot is the controller's whole memory, so a controller resumed
+    from one has to issue exactly the commands the uninterrupted controller
+    would have issued for the remaining inputs. The plant carries a valve
+    command delay so the replayed command history takes part as well.
+    """
+    params = MpcV2Params()
+    params.plant = replace(params.plant, valve_command_delay_s=900.0)
+    steps = 24
+    resume_at = 10
+
+    def drive(controller: MpcV2Controller, cycles: range) -> list[float]:
+        return [
+            controller.step(
+                t_s=1000.0 + 300.0 * cycle,
+                T_room_C=21.0 + 0.4 * math.sin(cycle / 3.0),
+                T_target_C=21.0,
+                T_outdoor_C=12.0,
+            )[0]
+            for cycle in cycles
+        ]
+
+    uninterrupted = drive(MpcV2Controller(params), range(steps))
+    # The scenario has to keep the valve moving: a command pinned to a rail
+    # would match no matter what the restore dropped.
+    assert len(set(uninterrupted)) > steps // 2
+
+    interrupted = MpcV2Controller(params)
+    before_restart = drive(interrupted, range(resume_at))
+    stored = json.loads(json.dumps(asdict(interrupted.export_snapshot())))
+    snapshot = ControllerSnapshot.from_mapping(stored)
+    assert snapshot is not None
+
+    resumed = MpcV2Controller(params)
+    resumed.restore_snapshot(snapshot)
+    after_restart = drive(resumed, range(resume_at, steps))
+
+    assert before_restart + after_restart == uninterrupted

--- a/tests/unit/mpc_v2/test_dob.py
+++ b/tests/unit/mpc_v2/test_dob.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
 from custom_components.better_thermostat.utils.calibration.mpc_v2_internals.dob import (
@@ -81,3 +83,44 @@ def test_large_sensor_jump_is_bounded_before_feed_forward() -> None:
     """Quantised sensor jumps cannot create an implausible steady-state load."""
     dob = DisturbanceObserver(DobParams(tau_s=1.0, max_abs_K_per_min=0.05))
     assert dob.update(5.0, dt_s=60.0) == pytest.approx(0.05)
+
+
+def test_estimate_stays_inside_its_bound_across_a_long_run() -> None:
+    """The bound holds at every step, whatever the innovation sequence.
+
+    A single bounded update says nothing about a run: the estimate feeds back
+    into itself, so the bound has to survive alternating signs, saturating
+    magnitudes and mixed intervals.
+    """
+    params = DobParams(tau_s=600.0, max_abs_K_per_min=0.05)
+    dob = DisturbanceObserver(params)
+    intervals_s = (30.0, 300.0, 1800.0, 0.5)
+
+    for k in range(400):
+        innovation_K = (2.0 if k % 3 else -3.0) * (1.0 + k % 7)
+        estimate = dob.update(innovation_K, dt_s=intervals_s[k % len(intervals_s)])
+        assert math.isfinite(estimate)
+        assert abs(estimate) <= params.max_abs_K_per_min
+
+
+def test_saturated_estimate_decays_once_innovations_stop() -> None:
+    """A saturated estimate must relax again instead of staying parked.
+
+    The EMA weight follows from ``dt_s`` and ``tau_s``, so each quiet step has
+    to scale the estimate by exactly ``1 - dt_s / tau_s``.
+    """
+    tau_s, dt_s = 600.0, 300.0
+    params = DobParams(tau_s=tau_s, max_abs_K_per_min=0.05)
+    weight = dt_s / tau_s
+
+    dob = DisturbanceObserver(params)
+    dob.update(5.0, dt_s=dt_s)
+    saturated = dob.D_hat_K_per_min
+    assert saturated == pytest.approx(params.max_abs_K_per_min)
+
+    for quiet_steps in range(1, 21):
+        dob.update(0.0, dt_s=dt_s)
+        assert dob.D_hat_K_per_min == pytest.approx(
+            saturated * (1.0 - weight) ** quiet_steps
+        )
+    assert dob.D_hat_K_per_min < saturated * 1e-3

--- a/tests/unit/mpc_v2/test_dob.py
+++ b/tests/unit/mpc_v2/test_dob.py
@@ -85,22 +85,70 @@ def test_large_sensor_jump_is_bounded_before_feed_forward() -> None:
     assert dob.update(5.0, dt_s=60.0) == pytest.approx(0.05)
 
 
+def test_estimate_climbs_to_a_standing_disturbance_along_its_time_constant() -> None:
+    """A standing disturbance is approached geometrically, not in one step.
+
+    The observer is a first-order EMA with weight ``dt_s / tau_s``, so a
+    constant innovation rate ``r`` starting from zero stands at
+    ``r * (1 - (1 - dt_s / tau_s) ** k)`` after ``k`` steps. The interval is a
+    twentieth of the time constant, which keeps the weight far below the
+    scale a fixed floor would impose, and the rate is an order of magnitude
+    under ``max_abs_K_per_min`` so the whole sequence runs inside the bound
+    and the EMA alone decides every value.
+    """
+    tau_s, dt_s, steps = 600.0, 30.0, 120
+    params = DobParams(tau_s=tau_s, max_abs_K_per_min=0.05)
+    weight = dt_s / tau_s
+    innovation_K = 0.001
+    rate_K_per_min = innovation_K / (dt_s / 60.0)
+    assert rate_K_per_min < params.max_abs_K_per_min / 10.0
+
+    dob = DisturbanceObserver(params)
+    estimates = [dob.update(innovation_K, dt_s=dt_s) for _ in range(steps)]
+
+    assert estimates == pytest.approx(
+        [rate_K_per_min * (1.0 - (1.0 - weight) ** k) for k in range(1, steps + 1)]
+    )
+    # The bound must never take over, or the geometry above says nothing.
+    assert max(estimates) < params.max_abs_K_per_min
+    assert len(set(estimates)) == steps
+
+
 def test_estimate_stays_inside_its_bound_across_a_long_run() -> None:
-    """The bound holds at every step, whatever the innovation sequence.
+    """The bound holds at every step and clips both signs, whatever came before.
 
     A single bounded update says nothing about a run: the estimate feeds back
-    into itself, so the bound has to survive alternating signs, saturating
-    magnitudes and mixed intervals.
+    into itself. The run drives a gentle standing load, a sensor jump far past
+    the bound, a quiet stretch on a faster cadence, an opposite jump and a
+    mixed-interval tail, so the estimate spends most of its steps moving
+    freely and still reaches both limits.
     """
     params = DobParams(tau_s=600.0, max_abs_K_per_min=0.05)
+    bound = params.max_abs_K_per_min
     dob = DisturbanceObserver(params)
-    intervals_s = (30.0, 300.0, 1800.0, 0.5)
+    steps = 400
 
-    for k in range(400):
-        innovation_K = (2.0 if k % 3 else -3.0) * (1.0 + k % 7)
-        estimate = dob.update(innovation_K, dt_s=intervals_s[k % len(intervals_s)])
-        assert math.isfinite(estimate)
-        assert abs(estimate) <= params.max_abs_K_per_min
+    def episode(k: int) -> tuple[float, float]:
+        """Innovation in K and its interval in seconds for step ``k``."""
+        if k < 100:
+            return 0.02, 300.0
+        if k < 150:
+            return 4.0, 300.0
+        if k < 250:
+            return 0.0, 30.0
+        if k < 300:
+            return -4.0, 300.0
+        return (0.01 if k % 2 else -0.015), (30.0, 300.0, 1800.0, 0.5)[k % 4]
+
+    estimates = [dob.update(*episode(k)) for k in range(steps)]
+
+    assert all(math.isfinite(estimate) for estimate in estimates)
+    assert all(abs(estimate) <= bound for estimate in estimates)
+    assert max(estimates) == pytest.approx(bound)
+    assert min(estimates) == pytest.approx(-bound)
+    # Most of the run has to happen away from the limits, or the bound would
+    # be the only thing the sequence ever reports.
+    assert sum(abs(estimate) < 0.99 * bound for estimate in estimates) > steps // 2
 
 
 def test_saturated_estimate_decays_once_innovations_stop() -> None:
@@ -123,4 +171,3 @@ def test_saturated_estimate_decays_once_innovations_stop() -> None:
         assert dob.D_hat_K_per_min == pytest.approx(
             saturated * (1.0 - weight) ** quiet_steps
         )
-    assert dob.D_hat_K_per_min < saturated * 1e-3

--- a/tests/unit/mpc_v2/test_governor.py
+++ b/tests/unit/mpc_v2/test_governor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from custom_components.better_thermostat.utils.calibration.mpc_v2_internals.governor import (
     GovernorParams,
     ScalarReferenceGovernor,
@@ -60,3 +62,88 @@ def test_reset_drops_internal_reference() -> None:
     gov.update(T_sp=21.0, T_outdoor_C=5.0, T_room_now=20.0)
     gov.reset()
     assert gov.state() is None
+
+
+def _highest_feasible_reference(
+    plant: PlantModelRC2, params: GovernorParams, T_outdoor_C: float, above_C: float
+) -> float:
+    """Return the warmest reference the plant can still hold within its bounds.
+
+    ``steady_input`` grows monotonically with the reference, so the feasible
+    band has a single upper edge. Bisecting the plant model locates it without
+    restating the plant algebra in the test; ``above_C`` is a reference known
+    to be past the edge.
+    """
+    lo, hi = T_outdoor_C, above_C
+    for _ in range(100):
+        mid = 0.5 * (lo + hi)
+        if plant.steady_input(mid, T_outdoor_C) <= params.u_max - params.safety_margin:
+            lo = mid
+        else:
+            hi = mid
+    return lo
+
+
+def test_rise_beyond_plant_authority_converges_to_the_feasibility_limit() -> None:
+    """A setpoint the plant cannot hold is approached up to its limit.
+
+    Over the whole sequence the governed reference must never decrease, never
+    pass the user setpoint, stay feasible at every step, and settle at the
+    warmest feasible reference within the resolution of the bisection.
+    """
+    params = GovernorParams()
+    plant = PlantModelRC2(PlantParams(), dt_s=300.0)
+    gov = ScalarReferenceGovernor(plant, params)
+    T_sp, T_outdoor_C, T_room_C = 40.0, 16.0, 19.0
+
+    references = [
+        gov.update(T_sp=T_sp, T_outdoor_C=T_outdoor_C, T_room_now=T_room_C)
+        for _ in range(200)
+    ]
+
+    limit_C = _highest_feasible_reference(plant, params, T_outdoor_C, T_sp)
+    # The bisection still accepts a step of 2**-iters of the remaining gap, so
+    # it can only come to rest this far below the limit.
+    stall_gap_K = (T_sp - limit_C) / (2**params.bisection_iters - 1)
+
+    assert references == sorted(references)
+    assert all(reference <= T_sp for reference in references)
+    assert all(
+        params.u_min + params.safety_margin
+        <= plant.steady_input(reference, T_outdoor_C)
+        <= params.u_max - params.safety_margin
+        for reference in references
+    )
+    assert references[-1] == pytest.approx(limit_C, abs=stall_gap_K)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="_is_feasible applies the lower input bound in both directions, so a "
+    "lowered setpoint whose steady-state valve fraction sits below the safety "
+    "margin is never released",
+)
+def test_lowered_setpoint_is_reached_within_a_bounded_number_of_steps() -> None:
+    """Closing the valve is always available, so a lower setpoint is reachable.
+
+    From a settled warmer reference the sequence must walk down to the new
+    setpoint without ever dropping below it.
+    """
+    params = GovernorParams()
+    plant = PlantModelRC2(PlantParams(), dt_s=300.0)
+    gov = ScalarReferenceGovernor(plant, params)
+    T_outdoor_C, T_start_C, T_sp = 16.0, 21.0, 17.0
+    gov.update(T_sp=T_start_C, T_outdoor_C=T_outdoor_C, T_room_now=T_start_C)
+
+    references = [
+        gov.update(T_sp=T_sp, T_outdoor_C=T_outdoor_C, T_room_now=T_start_C)
+        for _ in range(200)
+    ]
+
+    # A bisection that keeps stepping comes to rest at most this far above the
+    # setpoint; a larger residual is a reference the governor refuses to give up.
+    residual_K = (T_start_C - T_sp) / (2**params.bisection_iters - 1)
+
+    assert references == sorted(references, reverse=True)
+    assert all(reference >= T_sp for reference in references)
+    assert references[-1] == pytest.approx(T_sp, abs=residual_K)

--- a/tests/unit/mpc_v2/test_governor.py
+++ b/tests/unit/mpc_v2/test_governor.py
@@ -84,37 +84,49 @@ def _highest_feasible_reference(
     return lo
 
 
-def test_rise_beyond_plant_authority_converges_to_the_feasibility_limit() -> None:
-    """A setpoint the plant cannot hold is approached up to its limit.
+def test_reference_tracks_a_feasibility_limit_that_moves_every_step() -> None:
+    """The reference follows the plant's authority up as the weather releases it.
 
-    Over the whole sequence the governed reference must never decrease, never
-    pass the user setpoint, stay feasible at every step, and settle at the
-    warmest feasible reference within the resolution of the bisection.
+    A setpoint the plant can never hold keeps the governor engaged for the
+    whole run, so nothing but the governor decides the reference. Warming
+    outdoor air lifts the feasibility limit a little on every step, and the
+    sequence has to ride it: never falling back, never passing the user
+    setpoint, staying feasible against the outdoor temperature of its own
+    step, and closing to within one bisection resolution of that step's limit.
     """
     params = GovernorParams()
     plant = PlantModelRC2(PlantParams(), dt_s=300.0)
     gov = ScalarReferenceGovernor(plant, params)
-    T_sp, T_outdoor_C, T_room_C = 40.0, 16.0, 19.0
+    T_sp, T_room_C, steps = 40.0, 19.0, 200
+    outdoors_C = [16.0 * step / (steps - 1) for step in range(steps)]
 
     references = [
         gov.update(T_sp=T_sp, T_outdoor_C=T_outdoor_C, T_room_now=T_room_C)
-        for _ in range(200)
+        for T_outdoor_C in outdoors_C
     ]
+    limits_C = [
+        _highest_feasible_reference(plant, params, T_outdoor_C, T_sp)
+        for T_outdoor_C in outdoors_C
+    ]
+    # Each step bisects a fraction of the distance from the previous reference
+    # to the setpoint, which never exceeds the distance from the seed, so the
+    # reference lands within this much of the limit it searched against.
+    resolution_K = (T_sp - T_room_C) / 2**params.bisection_iters
 
-    limit_C = _highest_feasible_reference(plant, params, T_outdoor_C, T_sp)
-    # The bisection still accepts a step of 2**-iters of the remaining gap, so
-    # it can only come to rest this far below the limit.
-    stall_gap_K = (T_sp - limit_C) / (2**params.bisection_iters - 1)
-
+    # A reference that stalls after two steps would satisfy everything below
+    # without ever tracking anything.
+    assert len(set(references)) > steps // 2
     assert references == sorted(references)
     assert all(reference <= T_sp for reference in references)
     assert all(
-        params.u_min + params.safety_margin
-        <= plant.steady_input(reference, T_outdoor_C)
+        plant.steady_input(reference, T_outdoor_C)
         <= params.u_max - params.safety_margin
-        for reference in references
+        for reference, T_outdoor_C in zip(references, outdoors_C, strict=True)
     )
-    assert references[-1] == pytest.approx(limit_C, abs=stall_gap_K)
+    assert all(
+        limit_C - reference < resolution_K
+        for reference, limit_C in zip(references, limits_C, strict=True)
+    )
 
 
 @pytest.mark.xfail(
@@ -123,11 +135,13 @@ def test_rise_beyond_plant_authority_converges_to_the_feasibility_limit() -> Non
     "lowered setpoint whose steady-state valve fraction sits below the safety "
     "margin is never released",
 )
-def test_lowered_setpoint_is_reached_within_a_bounded_number_of_steps() -> None:
-    """Closing the valve is always available, so a lower setpoint is reachable.
+def test_lowered_setpoint_is_handed_back_unshaped() -> None:
+    """Asking for less heat needs no shaping, so the setpoint passes straight through.
 
-    From a settled warmer reference the sequence must walk down to the new
-    setpoint without ever dropping below it.
+    The governor exists to keep the implied steady-state input inside the
+    actuator's range, and closing the valve further is always available. From
+    a settled warmer reference the first update therefore has to return the
+    new setpoint itself, and every later one has to keep returning it.
     """
     params = GovernorParams()
     plant = PlantModelRC2(PlantParams(), dt_s=300.0)
@@ -140,10 +154,4 @@ def test_lowered_setpoint_is_reached_within_a_bounded_number_of_steps() -> None:
         for _ in range(200)
     ]
 
-    # A bisection that keeps stepping comes to rest at most this far above the
-    # setpoint; a larger residual is a reference the governor refuses to give up.
-    residual_K = (T_start_C - T_sp) / (2**params.bisection_iters - 1)
-
-    assert references == sorted(references, reverse=True)
-    assert all(reference >= T_sp for reference in references)
-    assert references[-1] == pytest.approx(T_sp, abs=residual_K)
+    assert references == [T_sp] * 200

--- a/tests/unit/mpc_v2/test_kalman.py
+++ b/tests/unit/mpc_v2/test_kalman.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 import pytest
 
@@ -75,3 +77,40 @@ def test_observer_uses_actual_elapsed_time() -> None:
     assert obs.innovation(y_meas, u=0.2, T_outdoor_C=5.0, dt_s=300.0) == pytest.approx(
         expected
     )
+
+
+@pytest.mark.parametrize(
+    ("dt_pattern_s", "steps"),
+    [((30.0,), 800), ((300.0, 300.0, 1800.0), 400)],
+    ids=["steady-cadence", "sparse-cadence"],
+)
+def test_covariance_stays_symmetric_and_positive_semidefinite(
+    dt_pattern_s: tuple[float, ...], steps: int
+) -> None:
+    """Every update must leave a covariance a Kalman gain can be taken from.
+
+    Each step folds its covariance into the next, so a step that loses
+    symmetry or positive semidefiniteness only shows up once the sequence
+    carries it forward. The bound is a rounding bound: the two off-diagonal
+    entries evaluate one algebraic expression in a different operation order,
+    so they may differ by a few units in the last place of the covariance
+    scale, and no more.
+    """
+    eps = float(np.finfo(float).eps)
+    rounding_ulps = 64.0
+    plant = PlantModelRC2(PlantParams(), dt_s=30.0)
+    obs = _make_observer(plant)
+    obs.initialise(np.array([20.0, 22.0]))
+
+    for k in range(steps):
+        dt_s = dt_pattern_s[k % len(dt_pattern_s)]
+        u = 0.9 if (k // 20) % 2 == 0 else 0.05
+        y_meas = 20.0 + 2.0 * math.sin(k / 9.0) + 0.002 * k
+        obs.update(y_meas, u=u, T_outdoor_C=-5.0, dt_s=dt_s)
+
+        P = obs.P
+        scale = float(np.trace(P))
+        assert math.isfinite(scale)
+        tolerance = rounding_ulps * eps * scale
+        assert abs(float(P[0, 1] - P[1, 0])) <= tolerance
+        assert float(np.linalg.eigvalsh(P).min()) >= -tolerance

--- a/tests/unit/mpc_v2/test_kalman.py
+++ b/tests/unit/mpc_v2/test_kalman.py
@@ -84,22 +84,38 @@ def test_observer_uses_actual_elapsed_time() -> None:
     [((30.0,), 800), ((300.0, 300.0, 1800.0), 400)],
     ids=["steady-cadence", "sparse-cadence"],
 )
-def test_covariance_stays_symmetric_and_positive_semidefinite(
+def test_covariance_stays_between_its_noise_floor_and_the_sensor_variance(
     dt_pattern_s: tuple[float, ...], steps: int
 ) -> None:
-    """Every update must leave a covariance a Kalman gain can be taken from.
+    """Every update leaves a covariance the next Kalman gain can be taken from.
 
     Each step folds its covariance into the next, so a step that loses
-    symmetry or positive semidefiniteness only shows up once the sequence
-    carries it forward. The bound is a rounding bound: the two off-diagonal
-    entries evaluate one algebraic expression in a different operation order,
-    so they may differ by a few units in the last place of the covariance
-    scale, and no more.
+    symmetry, over-shrinks or over-grows only shows up once the sequence
+    carries it forward. Three bounds hold after every correction.
+
+    Symmetry is a rounding bound: the two off-diagonal entries evaluate one
+    algebraic expression in a different operation order, so they may differ
+    by a few units in the last place of the covariance scale, and no more.
+
+    The upper bound is the measurement: fusing an estimate with a reading of
+    variance ``r_sensor`` cannot leave the measured channel more uncertain
+    than that reading alone, so ``P[0, 0] < r_sensor``.
+
+    The lower bound is this step's own process noise. In information form the
+    correction is ``P_post⁻¹ = P_pred⁻¹ + Cᵀ·R⁻¹·C``, so the smallest
+    eigenvalue can shrink no further than the parallel combination of
+    ``λ_min(P_pred)`` and ``r_sensor``; and ``P_pred ⪰ Q · q_scale`` bounds
+    ``λ_min(P_pred)`` by the smallest process-noise variance scaled to the
+    interval actually elapsed. A filter that drops the covariance correction
+    breaches the upper bound; one that drops the process noise, or scales it
+    by a fixed step instead of the elapsed one, falls through the floor.
     """
     eps = float(np.finfo(float).eps)
     rounding_ulps = 64.0
     plant = PlantModelRC2(PlantParams(), dt_s=30.0)
     obs = _make_observer(plant)
+    params = obs.params
+    q_min = min(params.q_room, params.q_rad)
     obs.initialise(np.array([20.0, 22.0]))
 
     for k in range(steps):
@@ -111,6 +127,74 @@ def test_covariance_stays_symmetric_and_positive_semidefinite(
         P = obs.P
         scale = float(np.trace(P))
         assert math.isfinite(scale)
-        tolerance = rounding_ulps * eps * scale
-        assert abs(float(P[0, 1] - P[1, 0])) <= tolerance
-        assert float(np.linalg.eigvalsh(P).min()) >= -tolerance
+        assert abs(float(P[0, 1] - P[1, 0])) <= rounding_ulps * eps * scale
+        assert float(P[0, 0]) < params.r_sensor
+        q_step = q_min * dt_s / plant.dt_s
+        noise_floor = q_step * params.r_sensor / (q_step + params.r_sensor)
+        assert float(np.linalg.eigvalsh(P).min()) >= noise_floor
+
+
+def test_reseeding_the_estimate_discards_the_confidence_of_the_run() -> None:
+    """An estimate handed in from outside arrives without the run's confidence.
+
+    A long run correlates the two channels and shrinks the radiator variance
+    far below its prior. ``initialise`` replaces the estimate with a value the
+    filter did not derive, so the covariance that described the old estimate
+    must not survive: nothing links the two new channels yet, and the filter
+    cannot stay more certain about the unmeasured radiator than it was before
+    the run.
+    """
+    plant = PlantModelRC2(PlantParams(), dt_s=30.0)
+    obs = _make_observer(plant)
+    obs.initialise(np.array([20.0, 22.0]))
+    for k in range(400):
+        obs.update(20.0 + 0.01 * k, u=0.5, T_outdoor_C=-5.0, dt_s=30.0)
+
+    P_after_run = obs.P.copy()
+    # The run has to have built something up, or the re-seed asserts nothing.
+    assert float(P_after_run[0, 1]) != 0.0
+
+    obs.initialise(np.array([21.0, 30.0]))
+
+    assert float(obs.P[0, 1]) == 0.0
+    assert float(obs.P[1, 0]) == 0.0
+    assert float(obs.P[1, 1]) > float(P_after_run[1, 1])
+
+
+def test_the_correction_acts_on_the_prediction_the_innovation_reported() -> None:
+    """Both entry points have to advance the model the same way, every cycle.
+
+    A control cycle reads ``innovation`` for the disturbance observer and then
+    calls ``update`` for the same measurement, so the two must not disagree
+    about the predicted output — otherwise the observer folds in a residual
+    the filter never acted on. Feeding back exactly the value the filter just
+    predicted therefore has to leave the estimate on that prediction, at every
+    step of a run whose intervals keep changing. The bound is a rounding
+    bound: the fed-back value is one subtraction away from the prediction, and
+    the correction scales that difference down, so the estimate can only move
+    by a few units in the last place of the measurement scale.
+    """
+    eps = float(np.finfo(float).eps)
+    rounding_ulps = 64.0
+    plant = PlantModelRC2(PlantParams(), dt_s=30.0)
+    obs = _make_observer(plant)
+    obs.initialise(np.array([20.0, 45.0]))
+    intervals_s = (30.0, 300.0, 1800.0, 90.0)
+    probe_C = 20.0
+
+    estimates = []
+    for k in range(200):
+        dt_s = intervals_s[k % len(intervals_s)]
+        u = 0.8 if (k // 7) % 2 == 0 else 0.1
+        predicted_C = probe_C - obs.innovation(
+            probe_C, u=u, T_outdoor_C=-5.0, dt_s=dt_s
+        )
+        x_hat = obs.update(predicted_C, u=u, T_outdoor_C=-5.0, dt_s=dt_s)
+        assert abs(float(x_hat[0]) - predicted_C) <= rounding_ulps * eps * abs(
+            predicted_C
+        )
+        estimates.append(float(x_hat[1]))
+
+    # A radiator estimate that never left its seed would satisfy the above
+    # whatever the two predictions did.
+    assert len(set(estimates)) == len(estimates)


### PR DESCRIPTION
Ticket TG15: every module that carries state between calls gets at least one test that drives it over many steps and asserts a property of the sequence rather than a value after one call. Tests only; no production code is touched.

## What each module now claims about the sequence

**Kalman** (`tests/unit/mpc_v2/test_kalman.py`)
- `test_covariance_stays_between_its_noise_floor_and_the_sensor_variance`: over 800 updates at a steady 30 s cadence and 400 at a mixed 300/300/1800 s cadence, every correction leaves `P` inside three bounds. Symmetry is a rounding bound (`64 * eps * trace(P)`): the two off-diagonal entries evaluate one algebraic expression in a different operation order. The upper bound is `P[0,0] < r_sensor` — fusing an estimate with a reading of variance `r_sensor` cannot leave the measured channel more uncertain than that reading alone. The lower bound is the process noise of the same step: in information form `P_post⁻¹ = P_pred⁻¹ + Cᵀ·R⁻¹·C` and `P_pred ⪰ Q · q_scale`, so `λ_min(P) ≥ q_min·q_scale·r_sensor / (q_min·q_scale + r_sensor)`.
- `test_reseeding_the_estimate_discards_the_confidence_of_the_run`: after a 400-step run that correlates the two channels and shrinks the radiator variance to 0.076, `initialise` has to leave a covariance with no cross-correlation and a radiator variance above the one the run reached.
- `test_the_correction_acts_on_the_prediction_the_innovation_reported`: a cycle reads `innovation` for the disturbance observer and then calls `update`, so both must advance the model the same way. Feeding back the value the filter just predicted has to leave the estimate on that prediction, over 200 steps with intervals from 30 s to 1800 s.

**Disturbance observer** (`tests/unit/mpc_v2/test_dob.py`)
- `test_estimate_climbs_to_a_standing_disturbance_along_its_time_constant`: at `dt_s = tau_s / 20` a constant innovation rate has to produce `r·(1 - (1 - dt_s/tau_s)**k)` at every one of 120 steps, with the whole sequence an order of magnitude below `max_abs_K_per_min` so the bound never decides a value.
- `test_estimate_stays_inside_its_bound_across_a_long_run`: 400 updates across a standing load, a sensor jump far past the bound, a quiet stretch on a faster cadence, an opposite jump and a mixed-interval tail. The estimate reaches both limits and spends 300 of the 400 steps away from them.
- `test_saturated_estimate_decays_once_innovations_stop`: a saturated estimate scales by exactly `1 - dt_s / tau_s` on every quiet step.

**Governor** (`tests/unit/mpc_v2/test_governor.py`)
- `test_reference_tracks_a_feasibility_limit_that_moves_every_step`: outdoor air warming from 0 to 16 °C lifts the feasibility limit on every one of 200 steps, and the governed reference has to ride it — non-decreasing, never past the user setpoint, feasible against the outdoor temperature of its own step, and within `(T_sp - T_room) / 2**bisection_iters` of that step's limit. The limit itself is located by bisecting `PlantModelRC2.steady_input`, so the plant algebra is not restated. The reference takes 197 distinct values over the 200 steps.
- `test_lowered_setpoint_is_handed_back_unshaped`: **xfail(strict=True)**. See below.

**MPC v2 controller** (`tests/unit/mpc_v2/test_compute_mpc_v2.py`)
- `test_restored_snapshot_reproduces_the_uninterrupted_command_sequence`: a controller resumed at step 17 from a JSON round-tripped snapshot issues exactly the commands of the uninterrupted run for the remaining 23 steps, driven at 120 s and at 300 s — either side of the 288 s adaptive MPC re-plan interval, because the stored re-plan deadline is only reachable when cycles are shorter than it. Setpoint 19 °C against 18 °C outdoors puts the steady-state valve fraction at 0.011, below the governor's 0.02 safety margin, which is the regime in which the governed reference stays pinned to the first cycle's room reading. The plant carries a 900 s valve command delay so the replayed command history takes part.

**TPI** (`tests/test_tpi.py`, new class `TestTpiOverManyCycles`)
- `test_duty_cycle_depends_only_on_the_current_readings`: over 200 varied cycles the duty cycle always equals what a fresh state produces from the same reading. The readings are drawn so 196 of the 200 land strictly between the clamps, where a carried-over state could still show.
- `test_constant_error_holds_a_constant_duty_cycle`: a standing error neither ramps the duty cycle up nor lets it decay.
- `test_last_duty_cycle_is_held_for_every_cycle_of_a_sensor_dropout`: the held `last_percent` survives a twelve-cycle gap and gives way to live readings again afterwards.

## xfail(strict=True)

`test_lowered_setpoint_is_handed_back_unshaped` — `_is_feasible` applies the lower input bound in both directions, so a lowered setpoint whose steady-state valve fraction sits below the safety margin is never released. Measured: default `PlantParams`, `dt_s=300`, outdoor 16 °C, setpoint 21 to 17 °C, 200 steps, the governed reference stops at 17.815185546875 °C, 0.815 K above the setpoint. The analytic feasibility edge at that outdoor temperature is `19.24 / 1.08 = 17.8148…` °C, so the residual is the safety margin, not a resolution effect. Closing the valve further is always inside the actuator range, so the released setpoint needs no bisection at all: with the lower bound applied only upward the governor returns 17.0 exactly on every one of the 200 steps, which is what the test asserts.

## TG13 guard list

`scripts/uncovered_guards.py` listed `governor.py:92 -> 93`, the direction in which the bisection finds a feasible intermediate value, as never taken by the whole suite. Before: `1 untaken directions in 1 modules` for `--module governor`, 662 in 53 modules overall. After: `0 untaken directions in 0 modules` for the governor, 661 in 52 modules. `governor.py` reaches 100 % branch coverage and its floor is re-recorded from 96.3.

## Mutation counter-proofs

Each defect was inserted into production code in a throwaway copy of the tree, `tests/unit/mpc_v2/ tests/test_tpi.py` run, and the defect reverted. All 29 die.

| Mutation | Killed by |
|---|---|
| kalman: covariance correction dropped (`P = P_pred`) | covariance bounds, both cadences |
| kalman: `q_scale` forced to 1.0 | covariance bounds, sparse cadence |
| kalman: process-noise term `Q * q_scale` dropped | covariance bounds, both cadences (and the restart sequence) |
| kalman: `initialise` no longer re-seeds `P` | re-seed test |
| kalman: `A @ P @ A` instead of `A @ P @ A.T` | covariance bounds, both cadences |
| kalman: gain not divided by the innovation covariance | covariance bounds, both cadences; restart sequence at 300 s |
| kalman: state correction dropped (`x_hat = x_pred`) | restart sequence, both cadences |
| kalman: `update` predicts over the nominal step, not the elapsed one | prediction-agreement test |
| dob: EMA replaced by the raw innovation rate | time-constant test, decay test |
| dob: EMA weight floored at 0.1 | time-constant test |
| dob: clamp applied on one side only | bound test, decay test, and one single-shot test |
| dob: per-minute rate conversion dropped | time-constant test, and three existing single-shot tests |
| governor: bisection never accepts a trial | tracking test |
| governor: feasibility check forced true | tracking test, one existing single-shot test, and the xfail turns XPASS(strict) |
| governor: safety margin dropped from both rails | tracking test, and the xfail turns XPASS(strict) |
| governor: bisection branches swapped | tracking test |
| governor: reference seeded at 0.0 instead of the room reading | tracking test, restart sequence |
| governor: lower input rail applied only upward (the expected fix) | the xfail reports XPASS(strict), tracking test stays green |
| controller: `governor.restore(rg_v_C)` dropped | restart sequence, both cadences |
| controller: `_next_mpc_t_s` not restored | restart sequence, 120 s cadence only |
| controller: `_last_mpc_t_s` not restored | restart sequence, both cadences |
| controller: `e_integral_K_min` not restored | restart sequence, both cadences |
| controller: `u_history` not restored | restart sequence, both cadences |
| controller: `D_hat_K_per_min` not restored | restart sequence, both cadences |
| controller: covariance not restored | restart sequence, both cadences |
| controller: `last_t_s` not restored | restart sequence, both cadences |
| controller: `last_u` not restored | restart sequence, both cadences |
| tpi: previous command fed back into the duty cycle | all three TPI tests |
| tpi: dropout no longer reuses the held command | dropout test |

The governor field is reachable after all. A command sequence pins it whenever `steady_input(T_sp, T_out) < u_min + safety_margin`, because the governed reference then freezes at the first cycle's room reading and a restart that re-seeds it diverges. In that regime the commands still span 0.25 of the valve range.

## What the sequences actually do

Each new test was measured for the movement its assertion depends on.

| Test | Quantity | Distinct values | On a limit |
|---|---|---|---|
| kalman/covariance bounds [steady] | `λ_min(P)` over 800 steps | 403 | 0 %; floor reserve ×2.96, `P[0,0]/r_sensor` ≤ 0.52 |
| kalman/covariance bounds [sparse] | `λ_min(P)` over 400 steps | 24 (converges to the 3-cycle of the cadence) | 0 %; floor reserve ×1.01, `P[0,0]/r_sensor` ≤ 0.87 |
| kalman/re-seed | `P[0,1]` built over 400 steps | 400 | 0 %; ends at 4.13e-04, re-seed gives 0.0 |
| kalman/prediction agreement | `T_rad` estimate over 200 steps | 200 | 0 % |
| dob/time constant | `D_hat` over 120 steps | 120 | 0 % |
| dob/bound | `D_hat` over 400 steps | 161 | 100 of 400 (25 %), both signs |
| dob/decay | `D_hat` over 20 steps | 20 | 0 % |
| governor/tracking | governed reference over 200 steps | 197 | 3 stalled steps (2 %) |
| controller/restart [120 s] | valve command over 40 steps | 13 (rounded to 1e-6) | 3 of 40 (8 %); span 0.252 |
| controller/restart [300 s] | valve command over 40 steps | 39 (rounded to 1e-6) | 2 of 40 (5 %); span 0.217 |
| tpi/state independence | duty cycle over 200 cycles | 197 | 4 of 200 (2 %) |

The two constant sequences are the claim itself: `tpi/constant error` holds 29.0 % for 50 cycles and `tpi/dropout` holds 35.0 % for 12, and both die under the fed-back-command mutation.

## Tolerances

Every tolerance in the diff is computed from module parameters.

- Kalman symmetry, `64 * eps * trace(P)`: worst observed asymmetry is 3.4e-18 of `trace(P)`, i.e. 0.015 ulp. Normalised against `|P[0,1]|` instead it is 6.6e-16. The bound separates rounding from structure by a wide margin in both directions: the missing-transpose mutation breaches it by 7.6e-03 against 6.8e-15.
- Kalman prediction agreement, `64 * eps * |predicted|`: observed residual is exactly 0 at every step; the mutation that predicts over the nominal step instead of the elapsed one moves it to 4.5e-03 against a bound of 2.8e-13.
- Kalman noise floor: worst margin is ×1.012 (sparse cadence, 1800 s interval), so the bound is tight rather than decorative.
- Governor `resolution_K = (T_sp - T_room) / 2**bisection_iters` = 0.082 K: largest observed gap to the limit is 0.052 K.
- DOB decay and step response: closed-form solutions of the EMA recursion, no tolerance beyond `pytest.approx` defaults.

## Ticket premises this refuted

TG15 asked TPI for "steady-state error goes to zero; no integrator windup after a long saturation". `compute_tpi` is proportional (`coef_int * error + coef_ext * ext_delta`) and `_TpiState` holds only `last_percent` and `last_update_ts`. Measured: a standing 0.2 K error produces 29.0 % on cycle 1 and 29.0 % on cycle 50, and 200 randomised cycles show zero difference against a fresh state. There is no accumulator, so a vanishing steady-state error is unreachable and windup is undefined. The three TPI tests above replace that requirement with the state TPI actually carries.

A follow-up hypothesis, that the `threshold_low` / `threshold_high` hysteresis is the real state mechanism, does not hold either: `threshold_high` is evaluated from the current error alone and does not latch, and `threshold_low` is read nowhere in the repository.

TG15 also asked Kalman **and** DOB for a covariance invariant. The DOB is a scalar EMA and has no covariance; its sequence invariants are the bound and the step response above.

## Runs

- `uv run pytest tests`: 7367 passed, 1 skipped, 1 xfailed, 89.37 % branch coverage (7354 passed on the base commit).
- `uvx ruff@0.15.15 check .` and `format --check .`: clean.
- `uv run python scripts/coverage_floors.py check`: all 99 modules hold their floor.

Note for the maintainer: `scripts/coverage_floors.py update` also wants to raise `number.py` 75.2 to 81.1, `sensor.py` 88.3 to 89.5, `switch.py` 65.6 to 68.2 and `state_manager.py` 94.5 to 94.6. Those four are stale on the base commit and not caused by this branch (measured identically before and after, and with and without randomised test order), so only the governor floor is changed here.

https://claude.ai/code/session_01U6NFDHBVHGP8TvB7b7x9tM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved control behavior during sensor-temperature dropouts, recovery, changing outdoor conditions, and lowered setpoints.
  * Ensured restored controller state reproduces the same valve commands as uninterrupted operation.
  * Improved disturbance and temperature estimation stability across variable operating intervals.

* **Tests**
  * Added comprehensive regression coverage for thermostat cycles, controller restoration, feasibility limits, observer convergence, and estimator accuracy.
  * Raised the required coverage threshold for calibration controls to 100%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->