### PR TITLE
fix: stop reporting valve support for TRVs without a valve quirk (1.9)

### DIFF
--- a/custom_components/better_thermostat/model_fixes/default.py
+++ b/custom_components/better_thermostat/model_fixes/default.py
@@ -2,6 +2,11 @@
 
 These helpers implement safe no-op defaults for devices that do not
 require specific quirks.
+
+There is no ``override_set_valve`` among them. Callers probe for that
+one with ``getattr`` and read a hit as "this model drives its valve
+itself", so an implementation here would claim valve support for every
+device without a quirk file of its own.
 """
 
 from __future__ import annotations
@@ -62,11 +67,6 @@ async def override_set_hvac_mode(self, entity_id, hvac_mode):
 
 async def override_set_temperature(self, entity_id, temperature):
     """Do not override set temperature by default."""
-    return False
-
-
-async def override_set_valve(self, entity_id, percent: int):
-    """Do not override valve by default."""
     return False
 
 

--- a/custom_components/better_thermostat/utils/valve_maintenance.py
+++ b/custom_components/better_thermostat/utils/valve_maintenance.py
@@ -219,9 +219,9 @@ def build_trv_snapshots(
             continue
         valve_entity = trv_data.valve_position_entity
         quirks = trv_data.model_quirks
-        support_valve = bool(valve_entity) or bool(
-            getattr(quirks, "override_set_valve", None)
-        )
+        support_valve = bool(
+            valve_entity and trv_data.valve_position_writable is True
+        ) or bool(getattr(quirks, "override_set_valve", None))
         adv = _get_advanced(trv_data)
         cal_type = adv.get("calibration")
         use_direct = bool(

--- a/tests/unit/test_default_quirk.py
+++ b/tests/unit/test_default_quirk.py
@@ -15,6 +15,7 @@ halves are tested apart because they promise different things:
   independent, and must not take the others down when it fails.
 """
 
+import importlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.lock import LockState
@@ -22,8 +23,12 @@ from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import State
 import pytest
 
+from custom_components.better_thermostat.calibration import (
+    _supports_direct_valve_control,
+)
 from custom_components.better_thermostat.model_fixes import default as default_quirk
 from custom_components.better_thermostat.trv import Trv
+from custom_components.better_thermostat.utils.const import CalibrationType
 
 ENTITY_ID = "climate.trv"
 DEVICE_ID = "device-1"
@@ -175,13 +180,48 @@ class TestTheDefaultQuirkChangesNothing:
             is False
         )
 
-    @pytest.mark.asyncio
-    async def test_the_valve_write_is_not_overridden(self):
-        """Declining the override is what lets the adapter write."""
-        assert (
-            await default_quirk.override_set_valve(_thermostat(), ENTITY_ID, 50)
-            is False
+    def test_no_valve_override_is_offered(self):
+        """The valve override is absent, not a declining one.
+
+        Callers probe for it with ``getattr`` and read a hit as "this
+        model drives its valve directly". A declining implementation
+        here would answer that probe for every device on this module.
+        """
+        assert not hasattr(default_quirk, "override_set_valve")
+
+
+class TestDirectValveControlNeedsAValveToDrive:
+    """What the shell makes of a module without a valve override."""
+
+    @staticmethod
+    def _thermostat_with(quirks):
+        """A thermostat whose one TRV runs *quirks* in direct valve mode."""
+        thermostat = MagicMock()
+        thermostat.real_trvs = {
+            ENTITY_ID: Trv(
+                entity_id=ENTITY_ID,
+                advanced={"calibration": CalibrationType.DIRECT_VALVE_BASED},
+                model_quirks=quirks,
+            )
+        }
+        return thermostat
+
+    def test_a_model_on_the_default_module_drives_no_valve(self):
+        """No valve entity and no valve quirk leaves nothing to write to."""
+        thermostat = self._thermostat_with(default_quirk)
+
+        assert _supports_direct_valve_control(thermostat, ENTITY_ID) is False
+
+    @pytest.mark.parametrize("model", ["TRVZB", "ZWA021"])
+    def test_a_model_that_drives_its_valve_still_does(self, model):
+        """The modules that do command a valve keep the capability."""
+        thermostat = self._thermostat_with(
+            importlib.import_module(
+                f"custom_components.better_thermostat.model_fixes.{model}"
+            )
         )
+
+        assert _supports_direct_valve_control(thermostat, ENTITY_ID) is True
 
 
 class TestAdoptionNeedsADevice:

--- a/tests/unit/test_model_quirk_surface.py
+++ b/tests/unit/test_model_quirk_surface.py
@@ -499,15 +499,33 @@ class TestTheDispatchAlwaysFindsWhatItReachesFor:
         assert _dispatched_from_the_shell(name), f"{name} is dispatched from nowhere"
 
 
-class TestAnImplementationMatchesTheDefault:
-    """A model's version is callable wherever the default one is."""
+def _reference_for(name):
+    """The implementation every other one of that name has to match.
+
+    ``default.py`` is it wherever it carries the function. An optional
+    one it leaves out has no such anchor, so the models implementing it
+    are each other's: the dispatch reaches all of them through the same
+    call, so they all have to answer it the same way.
+    """
+    reference = getattr(default_quirk, name, None)
+    if reference is not None:
+        return reference
+    implementers = [
+        getattr(MODEL_MODULES[model], name)
+        for model in MODEL_IDS
+        if hasattr(MODEL_MODULES[model], name)
+    ]
+    return implementers[0] if implementers else None
+
+
+class TestAnImplementationMatchesTheReference:
+    """A model's version is callable wherever the reference one is."""
 
     @pytest.mark.parametrize(("model", "name"), IMPLEMENTED, ids=IMPLEMENTED_IDS)
     def test_the_signature_and_kind_match(self, model, name):
         """The dispatch awaits some of these and calls others plainly."""
-        reference = getattr(default_quirk, name, None)
-        if reference is None:
-            pytest.skip(f"{name} has no counterpart in default.py")
+        reference = _reference_for(name)
+        assert reference is not None, f"{name} has no implementation to match"
         assert _signature(getattr(MODEL_MODULES[model], name)) == _signature(reference)
 
 

--- a/tests/unit/test_valve_maintenance.py
+++ b/tests/unit/test_valve_maintenance.py
@@ -22,6 +22,7 @@ from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
 import pytest
 
+from custom_components.better_thermostat.model_fixes import default as default_quirk
 from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils.valve_maintenance import (
     MaintenanceTrvInfo,
@@ -48,6 +49,7 @@ def _trv(
     min_temp: float = 5,
     quirks: object | None = None,
     valve_entity: str | None = None,
+    valve_writable: bool | None = True,
     calibration: str | None = None,
 ) -> Trv:
     """Build a ``real_trvs[entity_id]`` entry for testing."""
@@ -59,6 +61,7 @@ def _trv(
             "min_temp": min_temp,
             "model_quirks": quirks,
             "valve_position_entity": valve_entity,
+            "valve_position_writable": valve_writable,
         },
     )
 
@@ -300,6 +303,39 @@ class TestBuildTrvSnapshots:
         }
         result = build_trv_snapshots(trvs, ["trv1"], lambda _: _ha_state(), "Test")
         assert result[0].use_direct_valve is True
+
+    @pytest.mark.parametrize("writable", [False, None])
+    def test_a_valve_entity_that_cannot_be_written_is_not_direct(self, writable):
+        """Discovery reports the entity; only writability makes it a channel.
+
+        A direct cycle writes valve percentages and skips the setpoint
+        sweep altogether, so reading a position the device only reports
+        would turn the whole run into a no-op.
+        """
+        trvs = {
+            "trv1": _trv(
+                maintenance=True,
+                valve_entity="number.valve",
+                valve_writable=writable,
+                calibration="direct_valve_based",
+            )
+        }
+        result = build_trv_snapshots(trvs, ["trv1"], lambda _: _ha_state(), "Test")
+        assert result[0].use_direct_valve is False
+
+    def test_a_model_without_a_valve_quirk_is_not_direct(self):
+        """A model with no quirk file of its own runs on the default one.
+
+        That module drives no valve, so a device on it has no valve
+        channel to run a direct cycle through.
+        """
+        trvs = {
+            "trv1": _trv(
+                maintenance=True, quirks=default_quirk, calibration="direct_valve_based"
+            )
+        }
+        result = build_trv_snapshots(trvs, ["trv1"], lambda _: _ha_state(), "Test")
+        assert result[0].use_direct_valve is False
 
     def test_wake_mode_from_enum_repr_capabilities(self):
         """An off TRV spelling its capabilities as ``HVACMode.*`` still wakes."""


### PR DESCRIPTION
## Problem

A TRV's valve capability has two sources: a writable valve position entity, or a model quirk that drives the valve itself. The second one is probed by asking the loaded quirk module for `override_set_valve`.

The default quirk module carried that function as a declining no-op, and every device whose model has no `model_fixes/<model>.py` of its own loads exactly that module. The probe therefore succeeded for the entire long tail of TRVs.

Two places read that, both alongside a `direct_valve_based` calibration setting:

- `calibration._supports_direct_valve_control`
- `valve_maintenance.build_trv_snapshots`, which keys `use_direct_valve` on it

The maintenance one has a second hole: it takes a discovered valve entity on its own as a channel, without asking whether that entity can be written. The calibration path already requires `valve_position_writable is True`, so the two disagreed about the same device.

`use_direct_valve` makes `open_step`/`close_step` write a valve percentage and skip the setpoint sweep altogether, so on an affected device the weekly maintenance run commands nothing at all instead of exercising the valve.

The reach is limited to existing configurations: the config flow only offers direct valve calibration when adapter discovery reports `support_valve`, so a fresh setup cannot select the mode on an affected device. An installation that once had it selected keeps it.

## Change

- `model_fixes/default.py` no longer defines `override_set_valve`, and says why. Both callers already handle its absence: `adapters/delegate.set_valve` probes with `getattr(..., None)`, and the two consumers above with `getattr`/`callable`. Only `TRVZB` and `ZWA021` define it, and both keep the capability.
- `valve_maintenance.build_trv_snapshots` requires the valve entity to be writable, matching the calibration path.

Test changes that follow from it:

- `test_default_quirk.py` asserted that the default valve override declines. That assertion pinned the defect: the probe reads presence, not the answer. It is replaced by the absence of the function, plus the shell-level question the absence answers.
- `test_valve_maintenance.py::test_valve_entity_direct` passed a valve entity whose writability the fixture left unset, so it asserted that an entity of unknown writability counts as a channel. The fixture now carries a writability like the production record does, and the read-only and unknown cases are asserted separately.
- `test_model_quirk_surface.py` compared each model's implementation against `default.py` and skipped where there is no counterpart, which would have silently stopped checking the two real valve overrides. Implementations of a function the default leaves out are now each other's reference, which also restores the check for `maybe_set_external_temperature`.

## Verification

Counterfactual, one half at a time.

Reinstating the no-op in `default.py` turns three tests red and nothing else:

- `test_default_quirk.py::TestTheDefaultQuirkChangesNothing::test_no_valve_override_is_offered`
- `test_default_quirk.py::TestDirectValveControlNeedsAValveToDrive::test_a_model_on_the_default_module_drives_no_valve`
- `test_valve_maintenance.py::TestBuildTrvSnapshots::test_a_model_without_a_valve_quirk_is_not_direct`

Putting `build_trv_snapshots` back on a bare entity check turns two red:

- `test_valve_maintenance.py::TestBuildTrvSnapshots::test_a_valve_entity_that_cannot_be_written_is_not_direct[False]` and `[None]`

The suite already held both halves of the first one apart: one test stubs a quirk with a valve override and expects direct valve control, another checks the real default declines the write. Nothing crossed them.

`TRVZB` and `ZWA021` are asserted to keep direct valve control through the real modules, not a stub.

`pytest tests/unit`: 4494 passed, up from 4487 passed and 1 skipped. `ruff check` and `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved valve detection for thermostatic radiator valves by requiring confirmed writable valve control.
  * Devices using the default behavior are no longer incorrectly treated as directly controlling their valve.
  * Prevented maintenance and control decisions from relying solely on the presence of a valve entity.

* **Tests**
  * Added coverage for non-writable valves and default device behavior.
  * Improved validation of model-specific valve control capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->