### PR TITLE
fix: report refused valve writes in the TRVZB quirk

### DIFF
--- a/custom_components/better_thermostat/model_fixes/TRVZB.py
+++ b/custom_components/better_thermostat/model_fixes/TRVZB.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from custom_components.better_thermostat.model_fixes.types import (
@@ -131,7 +132,8 @@ async def maybe_set_sonoff_valve_percent(
     Prefers explicit Sonoff entities:
       - number.*.valve_opening_degree = percent
       - number.*.valve_closing_degree = 100 - percent
-    Returns True if at least one write succeeds, False otherwise.
+    Returns True when the requested position went out, False when no number
+    entity matched or the device refused one of the writes.
     """
     try:
         model = str(self.real_trvs[entity_id].model or "")
@@ -299,10 +301,23 @@ async def maybe_set_sonoff_valve_percent(
                 entity_id,
             )
         return wrote
-    except (TypeError, ValueError, KeyError, AttributeError) as ex:
-        _LOGGER.debug(
-            "better_thermostat %s: TRVZB maybe_set_sonoff_valve_percent exception: %s",
+    except (
+        HomeAssistantError,
+        OSError,
+        TypeError,
+        ValueError,
+        KeyError,
+        AttributeError,
+    ) as ex:
+        # The device did not take the position: it is asleep, out of reach,
+        # its integration is reloading, or the number entity declares a
+        # narrower range than the clamp above. Reporting the refused write as
+        # a declined one keeps the caller from recording a position the valve
+        # never reached, and lets it fall back to its own valve channel.
+        _LOGGER.warning(
+            "better_thermostat %s: TRVZB valve write for %s failed: %s",
             self.device_name,
+            entity_id,
             ex,
         )
         return False

--- a/custom_components/better_thermostat/model_fixes/TRVZB.py
+++ b/custom_components/better_thermostat/model_fixes/TRVZB.py
@@ -127,13 +127,26 @@ async def maybe_set_sonoff_valve_percent(
 ) -> bool:
     """Try to set Sonoff TRVZB valve percent via a number entity on the same device.
 
-    Scans the device of the given climate entity for a `number.*` entity that
-    represents valve opening/position and writes the provided percentage.
-    Prefers explicit Sonoff entities:
-      - number.*.valve_opening_degree = percent
-      - number.*.valve_closing_degree = 100 - percent
-    Returns True when the requested position went out, False when no number
-    entity matched or the device refused one of the writes.
+    Scans the device of the given climate entity for a ``number.*`` entity
+    that represents valve opening/position and writes the provided
+    percentage. Prefers explicit Sonoff entities:
+      - ``number.*.valve_opening_degree`` = percent
+      - ``number.*.valve_closing_degree`` = 100 - percent
+
+    Parameters
+    ----------
+    self : ModelFixHost
+            Better Thermostat host providing device state and HA access
+    entity_id : str
+            entity_id of the TRV
+    percent : int
+            the valve position to request, in percent
+
+    Returns
+    -------
+    bool
+            True when the requested position went out, False when no
+            number entity matched or the device refused one of the writes
     """
     try:
         model = str(self.real_trvs[entity_id].model or "")

--- a/tests/unit/test_trvzb_quirk_overrides.py
+++ b/tests/unit/test_trvzb_quirk_overrides.py
@@ -5,6 +5,7 @@ import contextlib
 import importlib
 from unittest.mock import AsyncMock, MagicMock
 
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 import pytest
 
 from custom_components.better_thermostat.trv import Trv
@@ -418,3 +419,117 @@ class TestExternalTemperatureWriteSelectsTheSensor:
                 "option": "external",
             },
         ]
+
+
+VALVE_OPENING = "number.trv1_valve_opening_degree"
+VALVE_CLOSING = "number.trv1_valve_closing_degree"
+VALVE_GENERIC = "number.trv1_valve_position"
+
+WRITE_REFUSALS = [
+    HomeAssistantError("device did not answer"),
+    ServiceValidationError("value is out of range"),
+    OSError("connection reset"),
+]
+WRITE_REFUSAL_IDS = ["unreachable", "out_of_range", "transport"]
+
+
+def _valve_number(entity_id, translation_key=None):
+    """A number entity on the TRV's device that the valve write can pick up."""
+    return _registry_entry(entity_id, domain="number", translation_key=translation_key)
+
+
+class TestValveWriteTheDeviceRefuses:
+    """A refused valve write is reported, not raised.
+
+    Batteries sleep, devices go out of reach, an integration reloads its
+    config entry, and a number entity may declare a narrower range than the
+    percentage handed to it. All of these answer a blocking service call with
+    a ``HomeAssistantError``. Raising it strands the caller in two ways: the
+    complement of a written opening degree never goes out, leaving the valve
+    on a range nobody asked for, and the deferred half of the de-sticking bump
+    runs in a background task where nothing is left to catch it.
+    """
+
+    @staticmethod
+    def _trvzb_carrying(monkeypatch, numbers):
+        """A TRVZB whose device carries the given number entities."""
+        trv = _registry_entry(ENTITY, domain="climate")
+        registry = MagicMock()
+        registry.async_get.return_value = trv
+        registry.entities.values.return_value = [trv, *numbers]
+        monkeypatch.setattr(quirk.er, "async_get", lambda hass: registry, raising=True)
+
+        mock_self = _make_self()
+        mock_self.in_maintenance = False
+        mock_self.real_trvs = {ENTITY: Trv(entity_id=ENTITY, model="TRVZB")}
+        mock_self.hass.async_create_background_task = lambda coro, name=None: (
+            asyncio.ensure_future(coro)
+        )
+        return mock_self
+
+    @pytest.mark.parametrize(
+        "refused_entity", [VALVE_OPENING, VALVE_CLOSING], ids=["opening", "closing"]
+    )
+    @pytest.mark.parametrize("refusal", WRITE_REFUSALS, ids=WRITE_REFUSAL_IDS)
+    @pytest.mark.asyncio
+    async def test_the_refusal_is_reported_as_a_declined_write(
+        self, monkeypatch, refused_entity, refusal
+    ):
+        """Either degree may be refused; both yield False."""
+        mock_self = self._trvzb_carrying(
+            monkeypatch,
+            [
+                _valve_number(VALVE_OPENING, "valve_opening_degree"),
+                _valve_number(VALVE_CLOSING, "valve_closing_degree"),
+            ],
+        )
+
+        async def _refuse(_domain, _service, data, **_kwargs):
+            if data["entity_id"] == refused_entity:
+                raise refusal
+
+        mock_self.hass.services.async_call = AsyncMock(side_effect=_refuse)
+
+        assert (
+            await quirk.maybe_set_sonoff_valve_percent(mock_self, ENTITY, 30) is False
+        )
+
+    @pytest.mark.parametrize("refusal", WRITE_REFUSALS, ids=WRITE_REFUSAL_IDS)
+    @pytest.mark.asyncio
+    async def test_a_refused_fallback_write_is_reported_too(self, monkeypatch, refusal):
+        """A device naming neither degree is written through the same handler."""
+        mock_self = self._trvzb_carrying(monkeypatch, [_valve_number(VALVE_GENERIC)])
+        mock_self.hass.services.async_call = AsyncMock(side_effect=refusal)
+
+        assert (
+            await quirk.maybe_set_sonoff_valve_percent(mock_self, ENTITY, 30) is False
+        )
+
+    @pytest.mark.parametrize("refusal", WRITE_REFUSALS, ids=WRITE_REFUSAL_IDS)
+    @pytest.mark.asyncio
+    async def test_a_refused_deferred_write_does_not_strand_its_task(
+        self, monkeypatch, refusal
+    ):
+        """The write carrying the requested position has no caller left.
+
+        The de-sticking bump has already driven the valve further open by the
+        time it goes out, and the commanded position is recorded as taken. An
+        error escaping the background task leaves the valve on the bump.
+        """
+        monkeypatch.setattr(quirk, "_TRVZB_CLOSE_BUMP_DELAY_S", 0.0)
+        mock_self = self._trvzb_carrying(
+            monkeypatch, [_valve_number(VALVE_OPENING, "valve_opening_degree")]
+        )
+        mock_self.real_trvs[ENTITY].last_valve_percent = 40
+
+        async def _refuse(_domain, _service, data, **_kwargs):
+            if data["value"] == 30:
+                raise refusal
+
+        mock_self.hass.services.async_call = AsyncMock(side_effect=_refuse)
+
+        await quirk.override_set_valve(mock_self, ENTITY, 30)
+        task = mock_self.real_trvs[ENTITY].extra["_trvzb_valve_bump_task"]
+        await asyncio.wait([task])
+
+        assert task.exception() is None


### PR DESCRIPTION
## Problem

The Sonoff TRVZB quirk writes the valve position through blocking `number.set_value`
service calls: the opening degree, the complementary closing degree, and a generic
fallback entity. Those writes are wrapped in a handler that only covers
`TypeError`, `ValueError`, `KeyError` and `AttributeError`. The error a device
actually answers with is `HomeAssistantError`, including the `ServiceValidationError`
raised when a value falls outside the entity's declared range, and it escapes the
quirk uncaught.

Two consequences, both measured:

- A refused closing degree abandons the function after the opening degree has already
  been written, so the valve is left on an opening/closing pair nobody asked for. The
  error unwinds all the way into `adapters/delegate.set_valve`, whose blanket handler
  logs it at debug level and returns False, which also skips the adapter's own valve
  channel.
- The de-sticking bump is worse. It drives the valve 10 % further open, returns True so
  the requested position is recorded as commanded, and defers the actual write into a
  background task whose handler covers only `RuntimeError`, `ValueError` and
  `KeyError`. A device that refuses that deferred write leaves the valve sitting on the
  bump while Better Thermostat believes it is on the requested position. Because the
  recorded position is the one the valve never reached, nothing corrects it.

A sleeping battery device, a device briefly out of reach, and an integration reloading
its config entry all produce exactly this error.

## Change

`maybe_set_sonoff_valve_percent` merges `HomeAssistantError` and `OSError` into its
existing handler, binds the exception and logs the refusal at warning level with the
TRV and the error text instead of at debug level without them. The function keeps its
boolean contract and reports a refused write as a declined one, which is what the
callers already handle: the bump falls back to a direct write, and the delegate falls
through to the adapter's own valve channel.

The docstring is corrected to match: True means the requested position went out, not
that any single write of the pair happened to land.

## Verification

`tests/unit/test_trvzb_quirk_overrides.py::TestValveWriteTheDeviceRefuses` covers a
refused opening degree, a refused closing degree, a refused generic fallback write and
a refused deferred write, each against `HomeAssistantError`, `ServiceValidationError`
and `OSError`.

Counterfactual on the production file: with the handler restored to its previous tuple,
12 of the 12 new cases fail. Dropping only `HomeAssistantError` from the merged tuple
fails 8, dropping only `OSError` fails 4, so both additions carry weight.

Full unit suite: 6626 passed, 1 skipped (baseline 6614 passed, 1 skipped).
`ruff check`, `ruff format --check` and `pyrefly check` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sonoff TRVZB valve control reliability.
  * Device refusal, unreachable devices, invalid values, and communication failures are now handled gracefully.
  * Valve write failures are logged with more visible warnings instead of being silently overlooked.

* **Tests**
  * Added coverage for rejected valve updates and transport-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->