### PR TITLE
fix: stop cutting TRV write retries short in the control cycle

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -237,6 +237,18 @@ _LOGGER = logging.getLogger(__name__)
 # interval sits well inside the shortest fallback window rather than near it.
 EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL = timedelta(minutes=30)
 
+# How long one TRV may occupy the serial startup sync before the loop moves
+# on to the next one. The budget has to outlast the retry ladder of the write
+# it wraps, because a device that is not reachable in the first seconds after
+# a restart is precisely what that ladder exists for: five retries at a delay
+# doubling from one second spend 31 s of backoff, or 37 s once the retry
+# jitter is counted against them, and a control call settles for three more
+# seconds after its writes. A shorter budget cancels the write mid-ladder and
+# abandons the device with attempts still unspent. The budget stays a liveness
+# guard for the loop, so a call in which several write channels each spend a
+# full ladder is still cut off.
+STARTUP_CONTROL_BUDGET_S = 45.0
+
 # Default temperature when no sensor data is available (last resort fallback)
 DEFAULT_FALLBACK_TEMPERATURE = 20.0
 
@@ -2221,7 +2233,10 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 "better_thermostat %s: controlling TRV %s...", self.device_name, trv
             )
             try:
-                await asyncio.wait_for(control_trv(self, trv, cycle=cycle), timeout=10)
+                await asyncio.wait_for(
+                    control_trv(self, trv, cycle=cycle),
+                    timeout=STARTUP_CONTROL_BUDGET_S,
+                )
                 _LOGGER.debug(
                     "better_thermostat %s: TRV %s controlled", self.device_name, trv
                 )

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -21,6 +21,9 @@ from homeassistant.core import State
 from homeassistant.exceptions import HomeAssistantError
 import pytest
 
+from custom_components.better_thermostat.adapters.delegate import (
+    set_temperature as delegate_set_temperature,
+)
 from custom_components.better_thermostat.climate import (
     DEFAULT_FALLBACK_TEMPERATURE,
     BetterThermostat,
@@ -1321,6 +1324,52 @@ class TestRestoreState:
 
 _CLIMATE = "custom_components.better_thermostat.climate"
 
+_real_asyncio_sleep = asyncio.sleep
+
+
+class _AdvancingClock:
+    """An event-loop clock that a sleep moves forward instead of waiting.
+
+    A retry ladder spends tens of seconds of backoff, and a deadline
+    around it reads the loop's clock. Handing the loop this clock and this
+    sleep lets both happen in test time: the sleep hands control back at
+    once and charges its delay to the clock the deadline is measured on.
+    """
+
+    def __init__(self, loop):
+        self._loop_time = loop.time
+        self._elapsed = 0.0
+
+    def time(self) -> float:
+        return self._loop_time() + self._elapsed
+
+    async def sleep(self, delay, result=None):
+        if delay and delay > 0:
+            self._elapsed += delay
+        await _real_asyncio_sleep(0)
+        return result
+
+
+def _trv_refusing_every_write(attempts: list[str]):
+    """A thermostat whose only TRV raises on every setpoint write."""
+    trv = MagicMock(spec=Trv)
+    trv.target_temp_step = 0.5
+    trv.min_temp = 5.0
+    trv.max_temp = 30.0
+
+    async def refuse(_self, entity_id, _temperature):
+        attempts.append(entity_id)
+        raise HomeAssistantError("TRV is not reachable")
+
+    trv.adapter = MagicMock()
+    trv.adapter.set_temperature = refuse
+
+    thermostat = MagicMock()
+    thermostat.device_name = "Test BT"
+    thermostat.bt_target_temp_step = None
+    thermostat.real_trvs = {TRV_ID: trv}
+    return thermostat
+
 
 class TestStartupControlSync:
     """The initial device sync must run after the lifecycle gate opens."""
@@ -1386,6 +1435,38 @@ class TestStartupControlSync:
             await BetterThermostat._startup_control_trvs(bt)
 
         assert ctl.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_startup_control_trvs_lets_a_write_spend_its_retries(
+        self, bt, caplog
+    ):
+        """A TRV that is out of reach gets every attempt the write ladder has.
+
+        An unreachable device in the first seconds after a restart is what
+        those retries exist for, so the startup budget has to outlast their
+        backoff. The write runs against a clock this test advances, so the
+        ladder's delays elapse for the budget without costing wall time.
+        """
+        bt.real_trvs = {TRV_ID: {}}
+        loop = asyncio.get_running_loop()
+        clock = _AdvancingClock(loop)
+        attempts: list[str] = []
+        writer = _trv_refusing_every_write(attempts)
+
+        async def control_by_writing(_self, entity_id, cycle=None):
+            return await delegate_set_temperature(writer, entity_id, 21.0)
+
+        with (
+            patch.object(loop, "time", clock.time),
+            patch("asyncio.sleep", clock.sleep),
+            patch(f"{_CLIMATE}.compute_control_cycle", return_value=None),
+            patch(f"{_CLIMATE}.control_trv", control_by_writing),
+            caplog.at_level(logging.ERROR),
+        ):
+            await BetterThermostat._startup_control_trvs(bt)
+
+        assert len(attempts) == 6
+        assert "Timeout controlling TRV" not in caplog.text
 
 
 async def _run_finalize_startup(bt):

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -1337,13 +1337,16 @@ class _AdvancingClock:
     """
 
     def __init__(self, loop):
+        """Start at the loop's own reading with nothing charged to it yet."""
         self._loop_time = loop.time
         self._elapsed = 0.0
 
     def time(self) -> float:
+        """The loop's reading plus everything the slept delays have charged."""
         return self._loop_time() + self._elapsed
 
     async def sleep(self, delay, result=None):
+        """Charge the delay to the clock and hand control back at once."""
         if delay and delay > 0:
             self._elapsed += delay
         await _real_asyncio_sleep(0)
@@ -1358,6 +1361,7 @@ def _trv_refusing_every_write(attempts: list[str]):
     trv.max_temp = 30.0
 
     async def refuse(_self, entity_id, _temperature):
+        """Record the attempt and fail it the way an unreachable TRV does."""
         attempts.append(entity_id)
         raise HomeAssistantError("TRV is not reachable")
 
@@ -1454,6 +1458,11 @@ class TestStartupControlSync:
         writer = _trv_refusing_every_write(attempts)
 
         async def control_by_writing(_self, entity_id, cycle=None):
+            """Stand in for the control call with the setpoint write alone.
+
+            The retry ladder under test sits in the write, so the rest of a
+            control cycle would only add work the budget is not about.
+            """
             return await delegate_set_temperature(writer, entity_id, 21.0)
 
         with (


### PR DESCRIPTION
## Problem

The initial per-TRV sync at startup gives each control call a ten-second
deadline. The setpoint and mode writes inside that call retry five times with
a delay doubling from one second: 31 s of backoff nominally, up to 37 s once
the retry jitter is counted against them, and the call settles for three more
seconds after its writes. The deadline is smaller than the ladder it wraps, so
it cancels the write partway up and reports a timeout while attempts are still
unspent.

A TRV that is briefly out of reach in the first seconds after a Home Assistant
restart — a Zigbee coordinator still coming up, a battery valve that has not
answered yet — is the one situation those retries exist for, and it is exactly
where they were being cut off. The device is left without its initial mode and
setpoint until an unrelated event or the reconcile tick comes round.

Measured against the real write path, a device that refuses every attempt:

| budget | attempts spent | outcome |
|---|---|---|
| 10 s | 4 of 6 | cancelled mid-ladder |
| none | 6 of 6 | ladder spent in 31.9 s |

## Which number was wrong

The deadline, not the retry count. Three things in the code already say so:

- The same call has **no deadline at all** on the runtime path: the control
  cycle gathers `control_trv` without one. A control call spending its full
  retry budget is already the accepted cost in normal operation, every cycle,
  forever. If that budget were considered too long, the runtime path would be
  where it is bounded — not the once-per-startup loop.
- The neighbouring statement in the same serial startup loop already sizes its
  budget to the inner one: the adapter init call gets 30 s, and its docstring
  names the adapter's own 6 x 5 s poll loop as the reason. The rule "the outer
  budget covers the inner one" is written down one method up; the control write
  is the line that did not follow it.
- Shortening the retries instead would take chances away from precisely the
  sleeping battery device the ladder was written for.

What the longer budget costs, checked rather than assumed:

- **Scheduler:** the sync runs inside the entity's own startup task, so a
  longer budget delays neither Home Assistant's setup nor another thermostat.
  It delays this entity going available, on a path that already permits 30 s
  per TRV for init and then sleeps a further 15 s before registering listeners.
- **Write budget:** `MIN_WRITE_INTERVAL_S` spaces *logical* writes per channel
  and is consumed once per channel per control call, before the delegate call.
  The ladder's attempts are re-sends of a write already accounted for and never
  consult it, so the budget adds no new writes to the channel — it only lets
  attempts five and six of a write in progress happen.
- **Five-minute tick and watchdog:** the watchdog's max age is 900 s and it
  treats "no cycle yet" as not stalled, so a slower startup cannot trip it. A
  reconcile tick queues a cycle behind the startup write on a queue of size one
  and the temp lock serialises it, so the tick is deferred, not multiplied.

## Change

Name the startup control budget and size it to outlast one write's retry
ladder plus the call's settle sleep. It stays a liveness guard for the serial
loop: a call in which several write channels each spend a full ladder is still
cut off, so one unreachable TRV cannot hold up the rest.

## Verification

New test `test_startup_control_trvs_lets_a_write_spend_its_retries` drives the
real delegate write against a TRV that refuses every attempt and asserts all
six attempts run and nothing is reported as a timeout. It runs on a clock the
test advances, so the ladder's backoff elapses for the deadline without
costing wall time.

Counterfactual: with the budget put back to ten seconds the test fails with
`ERROR ... Timeout controlling TRV climate.test_trv` and four of six attempts
spent. Restored, it passes.

Unit suite 6615 passed, 1 skipped (baseline 6614 + this test). Full tree 7355
passed, 1 skipped; all 99 per-module coverage floors hold. ruff check, ruff
format --check and pyrefly clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat startup control reliability by allowing more time for TRV commands to complete.
  * Startup synchronization now gives failed setpoint writes enough time to exhaust their retries without prematurely reporting a timeout.

* **Tests**
  * Added coverage for startup synchronization when a TRV repeatedly rejects setpoint updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

Verified against the automated suite, not on a physical device. Device
behaviour is exercised through the fake-TRV fixtures under `tests/`, which
model the write contract of each supported integration.

HA Version: 2026.7.2 (the version `pytest-homeassistant-custom-component` pins)
Zigbee2MQTT Version: n/a — no hardware run
TRV Hardware: n/a — no hardware run

## New device mappings

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`
      (`climate.py` is changed; this is not a device-mapping PR)
