### PR TITLE
fix: let the naming gate accept newly added test files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,6 +295,12 @@ Sometimes a rejected spelling is the correct name anyway: `current_temperature` 
 the Home Assistant property this integration implements. `glossary.toml` records
 each such exception together with its reason.
 
+Under `tests/` a rejected spelling is charged only once production has stopped
+using it. A test has to name the attribute it asserts on, so that spelling is
+production's decision and not the test's, and a new test may write
+`world.cur_temp` for as long as the field is called `cur_temp`. Renaming the
+last production site is what makes its readers due, and they come out with it.
+
 New and touched code follows the convention. The spellings the codebase still
 carries come out in their own pull requests, so a rename you did not sign up for
 never lands in yours. `scripts/check_naming.py` tells you where you stand, and CI

--- a/scripts/check_naming.py
+++ b/scripts/check_naming.py
@@ -18,6 +18,14 @@ zone B and moves only with a migration, not with a rename. Where a rejected
 alias is the correct name after all, ``[[exception]]`` in `glossary.toml`
 records it together with the reason.
 
+Under `tests` a rejected spelling counts only once production has stopped using
+it. A test names the attribute it asserts on, so the spelling it carries is the
+production one and not a naming decision of its own; charging both files for
+one rename would make the backlog look larger than it is and would leave a new
+test file no room to name the field it covers. The coupling is what keeps the
+tests honest: the moment the last production site is renamed, every test still
+spelling the old name is over budget and has to follow.
+
 Three modes:
 
 ``check``
@@ -50,7 +58,9 @@ import tomllib
 REPO_ROOT = Path(__file__).resolve().parent.parent
 GLOSSARY_FILE = REPO_ROOT / "glossary.toml"
 BUDGET_FILE = REPO_ROOT / ".naming-budget.json"
-SCANNED = ("custom_components", "tests", "scripts")
+PRODUCTION_ROOT = "custom_components"
+TEST_ROOT = "tests"
+SCANNED = (PRODUCTION_ROOT, TEST_ROOT, "scripts")
 
 
 @dataclass(frozen=True)
@@ -147,19 +157,43 @@ def _identifiers(tree: ast.AST) -> list[tuple[str, int]]:
     return found
 
 
-def _scan(path: Path, glossary: Glossary) -> list[Finding]:
-    """Return every rejected alias used as an identifier in one file."""
+def _parse(path: Path) -> ast.Module:
+    """Return the parsed file, stopping on one the parser cannot read."""
     relative = path.relative_to(REPO_ROOT).as_posix()
     try:
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+        return ast.parse(path.read_text(encoding="utf-8"), filename=relative)
     except SyntaxError as err:
         sys.exit(f"{relative}: {err}")
 
+
+def _production_spellings(glossary: Glossary) -> frozenset[str]:
+    """Return the rejected aliases the production tree still spells.
+
+    These are the names a test cannot avoid: it has to say `world.cur_temp` to
+    assert on the field production calls `cur_temp`. Such a use is a reader of
+    a name someone else chose, so it is not counted while that name exists, and
+    it becomes a finding as soon as the production spelling is gone.
+    """
+    return frozenset(
+        name
+        for path in sorted((REPO_ROOT / PRODUCTION_ROOT).rglob("*.py"))
+        for name, _ in _identifiers(_parse(path))
+        if name in glossary.aliases
+    )
+
+
+def _scan(path: Path, glossary: Glossary, production: frozenset[str]) -> list[Finding]:
+    """Return every rejected alias used as an identifier in one file."""
+    relative = path.relative_to(REPO_ROOT).as_posix()
+    mirrors_production = relative.startswith(f"{TEST_ROOT}/")
+
     seen: set[tuple[str, int]] = set()
     findings = []
-    for name, line in _identifiers(tree):
+    for name, line in _identifiers(_parse(path)):
         targets = glossary.aliases.get(name)
         if targets is None or (name, line) in seen:
+            continue
+        if mirrors_production and name in production:
             continue
         if any(relative.startswith(p) for p in glossary.exceptions.get(name, ())):
             continue
@@ -186,8 +220,14 @@ def _sources(paths: list[Path] | None) -> list[Path]:
 
 
 def _findings(paths: list[Path] | None, glossary: Glossary) -> list[Finding]:
-    """Return every finding across the requested paths."""
-    return [f for path in _sources(paths) for f in _scan(path, glossary)]
+    """Return every finding across the requested paths.
+
+    Production is read in full whatever the requested paths are, because a file
+    under `tests` is judged against the spellings production still carries and
+    a partial reading of them would invent findings.
+    """
+    production = _production_spellings(glossary)
+    return [f for path in _sources(paths) for f in _scan(path, glossary, production)]
 
 
 def _load_budget() -> dict[str, int]:
@@ -203,7 +243,10 @@ def _load_budget() -> dict[str, int]:
 def check(paths: list[Path] | None) -> int:
     """Compare today's findings against the budget. Return an exit code."""
     glossary = _load_glossary()
-    counts = Counter(f.path for f in _findings(paths, glossary))
+    findings: dict[str, list[Finding]] = {}
+    for finding in _findings(paths, glossary):
+        findings.setdefault(finding.path, []).append(finding)
+    counts = Counter({path: len(found) for path, found in findings.items()})
     budget = _load_budget()
 
     over = sorted(
@@ -212,7 +255,7 @@ def check(paths: list[Path] | None) -> int:
         if count > budget.get(path, 0)
     )
     for path, count, allowed in over:
-        for finding in _scan(REPO_ROOT / path, glossary):
+        for finding in findings[path]:
             print(finding)
         print(f"over budget: {path} {count} rejected names, budget {allowed}\n")
 

--- a/tests/unit/test_check_naming.py
+++ b/tests/unit/test_check_naming.py
@@ -5,10 +5,13 @@ glossary replaced, so the check has to be right about a file that stayed level,
 a file that gained one, a file that fell, and a file nobody has budgeted, which
 fails on its first finding rather than on its second.
 
-The count underneath those cases has to be right about one more thing: it is
-taken from identifiers only. A rejected spelling inside a string, a comment or
+The count underneath those cases has to be right about two more things. It is
+taken from identifiers only: a rejected spelling inside a string, a comment or
 a docstring is a persisted key or a piece of prose, not a rename that is due,
-and counting it would make the budget demand edits that must not happen.
+and counting it would make the budget demand edits that must not happen. And a
+test that names the production attribute it asserts on carries no rename of its
+own, so it is charged for that spelling only once production has stopped using
+it.
 """
 
 import importlib.util
@@ -83,10 +86,14 @@ def checker(tmp_path, monkeypatch):
     script = _load_script()
     glossary = tmp_path / "glossary.toml"
     glossary.write_text(GLOSSARY, encoding="utf-8")
+    # Both scanned roots exist in the repository, and a root that does not is
+    # handed to the parser as if it were a file.
+    (tmp_path / "custom_components").mkdir()
+    (tmp_path / "tests").mkdir()
     monkeypatch.setattr(script, "REPO_ROOT", tmp_path)
     monkeypatch.setattr(script, "GLOSSARY_FILE", glossary)
     monkeypatch.setattr(script, "BUDGET_FILE", tmp_path / "budget.json")
-    monkeypatch.setattr(script, "SCANNED", ("custom_components",))
+    monkeypatch.setattr(script, "SCANNED", ("custom_components", "tests"))
     return script
 
 
@@ -132,6 +139,77 @@ def test_check_fails_on_the_first_name_in_an_unbudgeted_file(checker, capsys):
     _budget(checker)
     assert checker.check(None) == 1
     assert "budget 0" in capsys.readouterr().out
+
+
+# A field production spells the way the glossary rejects, and a test that has
+# to say that spelling out loud to assert on the field.
+PRODUCTION_FIELD = textwrap.dedent(
+    '''
+    """A module whose field carries a rejected spelling."""
+
+
+    class Entry:
+        """Hold the field a test has to name in order to read it."""
+
+        def __init__(self, cfg):
+            self.cfg = cfg
+    '''
+)
+
+COVERS_THE_FIELD = textwrap.dedent(
+    '''
+    """A test that reads the field under the name production gives it."""
+
+
+    def test_entry_keeps_its_field(entry):
+        """Read the field by its production name."""
+        assert entry.cfg == {"mode": "heat"}
+    '''
+)
+
+
+def test_a_new_test_file_may_name_a_spelling_production_still_carries(checker):
+    """A test file nobody budgeted may name the attribute it asserts on."""
+    _write(checker, "custom_components/entry.py", PRODUCTION_FIELD)
+    _write(checker, "tests/unit/test_entry.py", COVERS_THE_FIELD)
+    _budget(checker, **{"custom_components/entry.py": 2})
+    assert checker.check(None) == 0
+
+
+def test_a_test_file_is_charged_for_a_spelling_it_invents(checker, capsys):
+    """A name no production site carries is the test's own naming decision."""
+    _write(checker, "custom_components/entry.py", PRODUCTION_FIELD)
+    _write(checker, "tests/unit/test_entry.py", "def test_read(val):\n    return val\n")
+    _budget(checker, **{"custom_components/entry.py": 2})
+    assert checker.check(None) == 1
+    assert "`val` is rejected, use `value`" in capsys.readouterr().out
+
+
+def test_a_test_file_is_charged_once_production_drops_the_spelling(checker, capsys):
+    """Renaming the last production site is what makes its readers due."""
+    _write(checker, "custom_components/entry.py", '"""Renamed already."""\n')
+    _write(checker, "tests/unit/test_entry.py", COVERS_THE_FIELD)
+    _budget(checker)
+    assert checker.check(None) == 1
+    assert "tests/unit/test_entry.py:7: `cfg` is rejected" in capsys.readouterr().out
+
+
+def test_production_is_charged_for_the_spelling_it_carries(checker):
+    """The allowance is for readers of a name, not for the name's own tree."""
+    _write(checker, "custom_components/entry.py", PRODUCTION_FIELD)
+    _budget(checker)
+    assert checker.check(None) == 1
+
+
+def test_update_records_no_entry_for_a_test_file_that_only_mirrors(checker):
+    """Nothing is due in it, so it carries no budget to hold."""
+    _write(checker, "custom_components/entry.py", PRODUCTION_FIELD)
+    _write(checker, "tests/unit/test_entry.py", COVERS_THE_FIELD)
+    _budget(checker, **{"custom_components/entry.py": 2})
+    assert checker.update(allow_raise=False) == 0
+    assert json.loads(checker.BUDGET_FILE.read_text()) == {
+        "custom_components/entry.py": 2
+    }
 
 
 def test_check_passes_when_a_count_falls(checker):


### PR DESCRIPTION
## Problem

The naming gate refuses a newly added test file. A file with no entry in
`.naming-budget.json` gets an allowance of zero, and `update` refuses to raise
one, so a test that names a production attribute such as `cur_temp`, `trv_id` or
`last_temperature` fails `check_naming.py check` the moment the file is
created:

```
tests/unit/test_climate_removal.py:9: `cur_temp` is rejected, use `room_temperature`
over budget: tests/unit/test_climate_removal.py 4 rejected names, budget 0
```

New tests can therefore only be written into files that already carry a budget,
and a file sitting exactly on its recorded number cannot take another one at
all. A tool meant to protect the codebase ends up steering where tests are
allowed to live.

The count underneath it is wrong: a test has to name the attribute it asserts
on. That spelling is production's naming decision, not the test's. Charging it
a second time bills two files for one rename, and makes the backlog look larger
than it is.

## Change

Under `tests/` a rejected spelling counts only once production has stopped
using it. The production tree is read for the rejected aliases it still spells,
and a use of one of those under `tests/` is not a finding.

Everything else is unchanged. Production files are charged exactly as before, a
test that invents a rejected spelling production does not use is charged, and no
file may exceed its recorded budget. The coupling is what keeps the tests
honest: renaming the last production site is what makes its readers due, and
they have to come out with it.

Across the tree this moves the count from 2385 to 956. Of the 1468 findings
under `tests/`, 1429 were spellings production still carries. The 39 that remain
are `valve_pct` in the benchmark tree, where production has already completed
the rename, which is precisely the case the rule keeps visible.

`.naming-budget.json` is deliberately not touched here. After this merges, one
`check_naming.py update` collapses it from 137 entries / 2385 names to 62 / 956.
Until then `check` stays green and reports the slack, so that re-record can run
last, after the other pull requests that rewrite the same file.

## Verification

Counterfactual with the script change reverted and the tests kept:
`test_a_new_test_file_may_name_a_spelling_production_still_carries` and
`test_update_records_no_entry_for_a_test_file_that_only_mirrors` fail; both pass
with it.

A second mutation, exempting the whole tree instead of `tests/` only, turns
`test_production_is_charged_for_the_spelling_it_carries` red, so the allowance
cannot silently spread to production.

- `tests/unit/test_check_naming.py`: 29 passed
- `tests/unit`: 6619 passed, 1 skipped
- `check_naming.py check`: green, 956 rejected names across 62 files
- ruff check + format, pyrefly: clean



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified vocabulary and naming expectations for tests in the contributor guidance.

- **Bug Fixes**
  - Updated naming checks so test files are evaluated consistently with the spellings still used in production.
  - Prevented mirrored production spellings in tests from being incorrectly flagged or counted against naming budgets.
  - Improved reporting of naming findings by file.

- **Tests**
  - Added coverage for production-coupled spellings, renamed attributes, and test-only spellings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->