### PR TITLE
fix: apply temperature readings in the order they arrived

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -95,7 +95,11 @@ from .core.recorder import FlightRecorder
 from .device_binding import async_bind_trv_device, async_unbind_trv_device
 from .events.cooler import trigger_cooler_change
 from .events.door import door_queue, trigger_door_change
-from .events.temperature import _update_external_temp_ema, trigger_temperature_change
+from .events.temperature import (
+    _update_external_temp_ema,
+    temperature_filter_lock,
+    trigger_temperature_change,
+)
 from .events.trv import trigger_trv_change
 from .events.window import trigger_window_change, window_queue
 from .model_fixes.model_quirks import initial_tweak, load_model_quirks
@@ -1235,83 +1239,117 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 request_control_cycle(self)
 
     async def _trigger_temperature_change(self, event):
-        # The degradation ladder advances first: it must keep stepping (e.g.
-        # room sensor lost) even while an unavailable TRV aborts the trigger.
-        await check_and_update_degraded_mode(self)
-        _check = await check_critical_entities(self)
-        if _check is False:
-            return
-        self.async_set_context(event.context)
-        if (event.data.get("new_state")) is None:
-            return
+        """Hand one room-sensor reading to the temperature filter.
+
+        Home Assistant runs every state change in its own task, so the
+        order the readings are handed over in is the order they arrived in
+        only as long as this listener reaches the hand-over without
+        suspending. Anything awaited before it can take longer for one
+        reading than for the next and let a newer reading overtake an older
+        one, which would end with the room regulated on the older value.
+        The work each reading needs therefore happens on the far side of
+        the hand-over, down to deciding whether the event carries a reading
+        at all.
+        """
         self.hass.async_create_background_task(
-            trigger_temperature_change(self, event),
+            self._handle_temperature_reading(event),
             name=f"bt_trigger_temp_change_{self.device_name}",
         )
+
+    async def _handle_temperature_reading(self, event):
+        """Check the entities and filter one reading, in the order it arrived.
+
+        The turn is claimed before the checks and not after them. How long
+        the checks take depends on what they find: announcing a change of
+        degraded mode looks a translation up, while a settled pass waits
+        for nothing at all. A reading that ran them first could therefore
+        take its turn ahead of one that arrived earlier, and the room
+        would end up regulated on the older of the two.
+        """
+        async with temperature_filter_lock(self):
+            # The degradation ladder advances first: it must keep stepping (e.g.
+            # room sensor lost) even while an unavailable TRV aborts the trigger.
+            await check_and_update_degraded_mode(self)
+            _check = await check_critical_entities(self)
+            if _check is False:
+                return
+            self.async_set_context(event.context)
+            await trigger_temperature_change(self, event)
 
     async def _external_temperature_keepalive(self, event=None):
         """Re-send the external temperature regularly to the TRVs.
 
         Many devices expect an update at least every ~30 minutes.
+
+        The tick writes to the same devices as an incoming reading does, so
+        it takes the same turn. Writing across a reading that is being
+        applied would leave the TRVs the tick reaches after it on the value
+        the tick started with, while Better Thermostat itself already
+        regulates on the newer one. The tick waits for its turn instead of
+        skipping it, because a device that has forgotten the value has no
+        other way of getting it back, and it reads the temperature once the
+        turn is its own, so it re-sends the temperature the thermostat is
+        regulating on.
         """
         try:
-            cur = self.cur_temp
-            if cur is None:
-                _LOGGER.debug(
-                    "better_thermostat %s: external_temperature keepalive skipped (cur_temp is None)",
-                    self.device_name,
-                )
-                return
-
-            # Use the known TRV entity IDs (keys in real_trvs)
-            trv_ids = list(self.real_trvs.keys())
-            # Fallback (normally should not be needed)
-            if not trv_ids and hasattr(self, "entity_ids"):
-                trv_ids = list(self.entity_ids or [])
-            if not trv_ids:
-                _LOGGER.debug(
-                    "better_thermostat %s: external_temperature keepalive: no TRVs found",
-                    self.device_name,
-                )
-                return
-            else:
-                _LOGGER.debug(
-                    "better_thermostat %s: external_temperature keepalive: %d TRV(s) found",
-                    self.device_name,
-                    len(trv_ids),
-                )
-
-            for trv_id in trv_ids:
-                try:
-                    _mq_trv = (
-                        self.real_trvs.get(trv_id)
-                        if hasattr(self, "real_trvs")
-                        else None
-                    )
-                    quirks = _mq_trv.model_quirks if _mq_trv is not None else None
-                    if quirks and hasattr(quirks, "maybe_set_external_temperature"):
-                        ok = await quirks.maybe_set_external_temperature(
-                            self, trv_id, cur
-                        )
-                        _LOGGER.debug(
-                            "better_thermostat %s: external_temperature keepalive sent to %s (ok=%s, value=%s)",
-                            self.device_name,
-                            trv_id,
-                            ok,
-                            cur,
-                        )
-                    else:
-                        _LOGGER.debug(
-                            "better_thermostat %s: no quirks with maybe_set_external_temperature for %s",
-                            self.device_name,
-                            trv_id,
-                        )
-                except OSError, RuntimeError, AttributeError, TypeError:
+            async with temperature_filter_lock(self):
+                cur = self.cur_temp
+                if cur is None:
                     _LOGGER.debug(
-                        "better_thermostat %s: external_temperature keepalive write failed for %s (non critical)",
+                        "better_thermostat %s: external_temperature keepalive skipped (cur_temp is None)",
                         self.device_name,
-                        trv_id,
                     )
+                    return
+
+                # Use the known TRV entity IDs (keys in real_trvs)
+                trv_ids = list(self.real_trvs.keys())
+                # Fallback (normally should not be needed)
+                if not trv_ids and hasattr(self, "entity_ids"):
+                    trv_ids = list(self.entity_ids or [])
+                if not trv_ids:
+                    _LOGGER.debug(
+                        "better_thermostat %s: external_temperature keepalive: no TRVs found",
+                        self.device_name,
+                    )
+                    return
+                else:
+                    _LOGGER.debug(
+                        "better_thermostat %s: external_temperature keepalive: %d TRV(s) found",
+                        self.device_name,
+                        len(trv_ids),
+                    )
+
+                for trv_id in trv_ids:
+                    try:
+                        _mq_trv = (
+                            self.real_trvs.get(trv_id)
+                            if hasattr(self, "real_trvs")
+                            else None
+                        )
+                        quirks = _mq_trv.model_quirks if _mq_trv is not None else None
+                        if quirks and hasattr(quirks, "maybe_set_external_temperature"):
+                            ok = await quirks.maybe_set_external_temperature(
+                                self, trv_id, cur
+                            )
+                            _LOGGER.debug(
+                                "better_thermostat %s: external_temperature keepalive sent to %s (ok=%s, value=%s)",
+                                self.device_name,
+                                trv_id,
+                                ok,
+                                cur,
+                            )
+                        else:
+                            _LOGGER.debug(
+                                "better_thermostat %s: no quirks with maybe_set_external_temperature for %s",
+                                self.device_name,
+                                trv_id,
+                            )
+                    except OSError, RuntimeError, AttributeError, TypeError:
+                        _LOGGER.debug(
+                            "better_thermostat %s: external_temperature keepalive write failed for %s (non critical)",
+                            self.device_name,
+                            trv_id,
+                        )
         except OSError, RuntimeError, AttributeError, TypeError:
             _LOGGER.debug(
                 "better_thermostat %s: external_temperature keepalive encountered an error",

--- a/custom_components/better_thermostat/events/temperature.py
+++ b/custom_components/better_thermostat/events/temperature.py
@@ -75,7 +75,7 @@ def _update_external_temp_ema(self, temp_q: float) -> float:
     return float(ema)
 
 
-def _filter_lock(self) -> asyncio.Lock:
+def temperature_filter_lock(self) -> asyncio.Lock:
     """Return the lock that serialises this entity's temperature filter.
 
     The filter carries state from one reading to the next: the accumulated
@@ -85,6 +85,9 @@ def _filter_lock(self) -> asyncio.Lock:
     arrives during such a write is decided against, and committed on top of,
     a half-applied predecessor. The lock is created on first use and lives
     on the entity, so each Better Thermostat only queues behind itself.
+
+    Everything that writes the room temperature to the TRVs takes this
+    lock: the sensor readings, the plateau timer and the keepalive tick.
     """
     lock = getattr(self, "_temperature_filter_lock", None)
     if lock is None:
@@ -95,7 +98,7 @@ def _filter_lock(self) -> asyncio.Lock:
 
 async def _apply_temperature_update(self, new_temp):
     """Apply the new external temperature once the filter is free."""
-    async with _filter_lock(self):
+    async with temperature_filter_lock(self):
         await _commit_temperature_update(self, new_temp)
 
 
@@ -189,9 +192,14 @@ async def _commit_temperature_update(self, new_temp):
 async def trigger_temperature_change(self, event):
     """Handle temperature changes.
 
-    Readings are handled one at a time; a reading that arrives while an
-    earlier one is still being applied waits its turn instead of being
-    dropped, so it is judged against the state the earlier one left behind.
+    Decides whether one external temperature reading is applied. Readings
+    are handled one at a time, so a reading that arrives while an earlier
+    one is still being applied waits its turn instead of being dropped and
+    is then judged against the state the earlier one left behind.
+
+    Callers hold the filter lock (see :func:`temperature_filter_lock`);
+    the decision reads and rewrites filter state that must not be shared
+    with a second reading.
 
     Parameters
     ----------
@@ -203,15 +211,6 @@ async def trigger_temperature_change(self, event):
     Returns
     -------
     None
-    """
-    async with _filter_lock(self):
-        await _evaluate_temperature_reading(self, event)
-
-
-async def _evaluate_temperature_reading(self, event):
-    """Decide whether one external temperature reading is applied.
-
-    Callers hold the filter lock.
     """
     if self.startup_running:
         return

--- a/custom_components/better_thermostat/events/temperature.py
+++ b/custom_components/better_thermostat/events/temperature.py
@@ -8,6 +8,7 @@ propagated to the target devices.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 import math
@@ -74,10 +75,37 @@ def _update_external_temp_ema(self, temp_q: float) -> float:
     return float(ema)
 
 
+def _filter_lock(self) -> asyncio.Lock:
+    """Return the lock that serialises this entity's temperature filter.
+
+    The filter carries state from one reading to the next: the accumulated
+    delta, the pending plateau value and its timer. Home Assistant handles
+    every sensor update in its own task, and applying a reading suspends
+    while the value is written to the TRVs. Without the lock a reading that
+    arrives during such a write is decided against, and committed on top of,
+    a half-applied predecessor. The lock is created on first use and lives
+    on the entity, so each Better Thermostat only queues behind itself.
+    """
+    lock = getattr(self, "_temperature_filter_lock", None)
+    if lock is None:
+        lock = asyncio.Lock()
+        self._temperature_filter_lock = lock
+    return lock
+
+
 async def _apply_temperature_update(self, new_temp):
-    """Apply the new external temperature and trigger updates."""
+    """Apply the new external temperature once the filter is free."""
+    async with _filter_lock(self):
+        await _commit_temperature_update(self, new_temp)
+
+
+async def _commit_temperature_update(self, new_temp):
+    """Apply the new external temperature and trigger updates.
+
+    Callers hold the filter lock.
+    """
     _LOGGER.debug(
-        "better_thermostat %s: _apply_temperature_update called with %.2f",
+        "better_thermostat %s: _commit_temperature_update called with %.2f",
         self.device_name,
         new_temp,
     )
@@ -154,12 +182,16 @@ async def _apply_temperature_update(self, new_temp):
         else:
             request_control_cycle(self)
     _LOGGER.debug(
-        "better_thermostat %s: _apply_temperature_update finished", self.device_name
+        "better_thermostat %s: _commit_temperature_update finished", self.device_name
     )
 
 
 async def trigger_temperature_change(self, event):
     """Handle temperature changes.
+
+    Readings are handled one at a time; a reading that arrives while an
+    earlier one is still being applied waits its turn instead of being
+    dropped, so it is judged against the state the earlier one left behind.
 
     Parameters
     ----------
@@ -171,6 +203,15 @@ async def trigger_temperature_change(self, event):
     Returns
     -------
     None
+    """
+    async with _filter_lock(self):
+        await _evaluate_temperature_reading(self, event)
+
+
+async def _evaluate_temperature_reading(self, event):
+    """Decide whether one external temperature reading is applied.
+
+    Callers hold the filter lock.
     """
     if self.startup_running:
         return
@@ -354,7 +395,7 @@ async def trigger_temperature_change(self, event):
             (self.accum_delta if _cur_q is not None else 0.0),
             ("+" if self.accum_dir > 0 else ("-" if self.accum_dir < 0 else "0")),
         )
-        await _apply_temperature_update(self, _incoming_temperature_q)
+        await _commit_temperature_update(self, _incoming_temperature_q)
     else:
         _LOGGER.debug(
             "better_thermostat %s: external_temperature ignored (old=%.2f new=%.2f diff=%s "

--- a/tests/unit/test_temperature_events.py
+++ b/tests/unit/test_temperature_events.py
@@ -1,7 +1,8 @@
 """Tests for events/temperature.py – external temperature event handlers.
 
 Covers EMA calculation, temperature application, guard clauses, debounce
-acceptance logic, accumulation tracking, and plateau acceptance.
+acceptance logic, accumulation tracking, plateau acceptance, and the order
+in which overlapping readings and the keepalive tick reach the TRVs.
 """
 
 import asyncio
@@ -12,9 +13,13 @@ from homeassistant.core import State
 from homeassistant.util import dt as dt_util
 import pytest
 
+from custom_components.better_thermostat.climate import BetterThermostat
+from custom_components.better_thermostat.core.clock import FakeClock
+from custom_components.better_thermostat.core.decide import KernelState
 from custom_components.better_thermostat.events.temperature import (
     _apply_temperature_update,
     _update_external_temp_ema,
+    temperature_filter_lock,
     trigger_temperature_change,
 )
 from custom_components.better_thermostat.trv import Trv
@@ -822,13 +827,22 @@ class _RecordingQuirks:
         self.in_flight = 0
         self.max_in_flight = 0
         self.gate: asyncio.Event | None = None
+        # How many writes wait for ``gate``; None holds up every one of
+        # them. A budget of one leaves a caller standing between two TRVs
+        # while another one runs its own round to the end.
+        self.gated_writes: int | None = None
+        self.started = 0
 
     async def maybe_set_external_temperature(self, entity, entity_id, temperature):
         """Record one write, yielding long enough for another task to run."""
+        self.started += 1
+        gated = self.gate is not None and (
+            self.gated_writes is None or self.started <= self.gated_writes
+        )
         self.in_flight += 1
         self.max_in_flight = max(self.max_in_flight, self.in_flight)
         try:
-            if self.gate is not None:
+            if gated:
                 await self.gate.wait()
             else:
                 for _ in range(3):
@@ -867,6 +881,12 @@ class TestConcurrentReadings:
             for entity_id in entity_ids
         }
 
+    @staticmethod
+    async def _take_turn_and_read(mock_bt, state):
+        """Hand one reading to the filter the way the thermostat does."""
+        async with temperature_filter_lock(mock_bt):
+            await trigger_temperature_change(mock_bt, _make_event(state))
+
     @pytest.mark.asyncio
     async def test_overlapping_readings_reach_every_trv_in_order(self, mock_bt):
         """Hand both accepted readings to every TRV, oldest first."""
@@ -880,12 +900,8 @@ class TestConcurrentReadings:
             _AdvancingClock(start),
         ):
             await asyncio.gather(
-                trigger_temperature_change(
-                    mock_bt, _make_event(State(SENSOR_ID, "21.0"))
-                ),
-                trigger_temperature_change(
-                    mock_bt, _make_event(State(SENSOR_ID, "22.0"))
-                ),
+                self._take_turn_and_read(mock_bt, State(SENSOR_ID, "21.0")),
+                self._take_turn_and_read(mock_bt, State(SENSOR_ID, "22.0")),
             )
 
         assert quirks.max_in_flight == 1
@@ -933,4 +949,147 @@ class TestConcurrentReadings:
         await queued
 
         assert quirks.writes == [("climate.trv1", 22.0)]
+        assert mock_bt.last_known_external_temp == 22.0
+
+
+async def _suspending_translations(*args, **kwargs):
+    """Stand in for a translation lookup that has to read its files.
+
+    Home Assistant serves a cached language from memory without ever
+    giving up control, and reads it through the executor when the cache
+    does not hold it yet. Announcing a change of degraded mode is the only
+    part of the entity checks that looks a translation up, so the checks
+    take longer for the reading that announces one than for the next
+    reading, which is the difference the ordering has to survive.
+    """
+    await asyncio.sleep(0)
+    return {}
+
+
+class TestArrivalOrder:
+    """Readings are applied in the order the room sensor sent them."""
+
+    @staticmethod
+    def _make_thermostat_checkable(mock_bt):
+        """Give the thermostat what the entity checks read.
+
+        The checks look at the sensors the thermostat was configured with
+        and at the control-mode record; a bare mock answers every one of
+        those with a new mock and the checks cannot run against it.
+        """
+        mock_bt.hass.states.get = lambda entity_id: State(entity_id, "21.0")
+        mock_bt.window_id = None
+        mock_bt.door_id = None
+        mock_bt.cooler_entity_id = None
+        mock_bt.humidity_sensor_entity_id = None
+        mock_bt.outdoor_sensor = None
+        mock_bt.weather_entity = None
+        mock_bt.devices_errors = []
+        mock_bt.devices_states = {}
+        mock_bt.unavailable_sensors = []
+        mock_bt._critical_grace_until = None
+        mock_bt.kernel_state = KernelState()
+        mock_bt.clock = FakeClock()
+        # The first of the two readings announces that degraded mode has
+        # ended, which is the pass whose checks have to wait.
+        mock_bt._degraded_warning_emitted = True
+
+    @staticmethod
+    def _collect_handlers(mock_bt, handlers):
+        """Build the handler coroutines the listener hands over.
+
+        The thermostat is a mock, so the coroutine it would hand to Home
+        Assistant has to be built from the real method.
+        """
+        mock_bt._handle_temperature_reading = lambda event: (
+            BetterThermostat._handle_temperature_reading(mock_bt, event)
+        )
+        mock_bt.hass.async_create_background_task = lambda coro, name=None: (
+            handlers.append(asyncio.ensure_future(coro))
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_older_of_two_readings_is_applied_first(self, mock_bt):
+        """Two readings dispatched together keep the order they arrived in.
+
+        Home Assistant handles each state change in its own task. The
+        checks that run for a reading wait on the pass that announces a
+        change of degraded mode and on no other, so the second reading can
+        overtake the first one and leave the room regulated on the older
+        value.
+        """
+        self._make_thermostat_checkable(mock_bt)
+        quirks = _RecordingQuirks()
+        mock_bt.real_trvs = {
+            "climate.trv1": Trv.from_legacy_dict(
+                "climate.trv1", {"model_quirks": quirks}
+            )
+        }
+        start = dt_util.now()
+        mock_bt.last_external_sensor_change = start
+        handlers = []
+        self._collect_handlers(mock_bt, handlers)
+
+        with (
+            patch(
+                "custom_components.better_thermostat.utils.helpers.translation."
+                "async_get_translations",
+                _suspending_translations,
+            ),
+            patch(
+                "custom_components.better_thermostat.events.temperature.dt_util",
+                _AdvancingClock(start),
+            ),
+        ):
+            await asyncio.gather(
+                BetterThermostat._trigger_temperature_change(
+                    mock_bt, _make_event(State(SENSOR_ID, "21.0"))
+                ),
+                BetterThermostat._trigger_temperature_change(
+                    mock_bt, _make_event(State(SENSOR_ID, "22.0"))
+                ),
+            )
+            await asyncio.gather(*handlers)
+
+        assert quirks.writes == [("climate.trv1", 21.0), ("climate.trv1", 22.0)]
+        assert mock_bt.last_known_external_temp == 22.0
+
+
+class TestKeepaliveTick:
+    """The periodic re-send shares its turn with the readings."""
+
+    @pytest.mark.asyncio
+    async def test_the_tick_does_not_write_over_a_reading_it_overlapped(self, mock_bt):
+        """A tick left standing between two TRVs must not undo an update.
+
+        The tick reads the room temperature once and writes it to every
+        TRV in turn. An update landing while it is between two of them
+        would leave the TRVs it has yet to reach on the value it started
+        with, while Better Thermostat regulates on the newer one.
+        """
+        quirks = _RecordingQuirks()
+        quirks.gate = asyncio.Event()
+        quirks.gated_writes = 1
+        mock_bt.real_trvs = {
+            entity_id: Trv.from_legacy_dict(entity_id, {"model_quirks": quirks})
+            for entity_id in ("climate.trv1", "climate.trv2")
+        }
+
+        tick = asyncio.create_task(
+            BetterThermostat._external_temperature_keepalive(mock_bt)
+        )
+        await asyncio.sleep(0)
+        reading = asyncio.create_task(_apply_temperature_update(mock_bt, 22.0))
+        for _ in range(4):
+            await asyncio.sleep(0)
+        quirks.gate.set()
+        await asyncio.gather(tick, reading)
+
+        assert quirks.max_in_flight == 1
+        assert quirks.writes == [
+            ("climate.trv1", 20.0),
+            ("climate.trv2", 20.0),
+            ("climate.trv1", 22.0),
+            ("climate.trv2", 22.0),
+        ]
         assert mock_bt.last_known_external_temp == 22.0

--- a/tests/unit/test_temperature_events.py
+++ b/tests/unit/test_temperature_events.py
@@ -4,6 +4,7 @@ Covers EMA calculation, temperature application, guard clauses, debounce
 acceptance logic, accumulation tracking, and plateau acceptance.
 """
 
+import asyncio
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -57,6 +58,9 @@ def mock_bt():
     bt.pending_temp = None
     bt.pending_since = None
     bt.plateau_timer_cancel = None
+
+    # Serialisation of concurrent readings
+    bt._temperature_filter_lock = None
 
     # Anti-flicker state
     bt.flicker_candidate = None
@@ -803,3 +807,130 @@ class TestEdgeCasesAndRobustness:
 
         # 30s < 600s → rejected because one TRV is HomematicIP
         assert mock_bt.cur_temp == 20.0
+
+
+# ---------------------------------------------------------------------------
+# 8. Concurrent readings
+# ---------------------------------------------------------------------------
+
+
+class _RecordingQuirks:
+    """Model quirks that record external-temperature writes and overlap."""
+
+    def __init__(self):
+        self.writes: list[tuple[str, float]] = []
+        self.in_flight = 0
+        self.max_in_flight = 0
+        self.gate: asyncio.Event | None = None
+
+    async def maybe_set_external_temperature(self, entity, entity_id, temperature):
+        """Record one write, yielding long enough for another task to run."""
+        self.in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self.in_flight)
+        try:
+            if self.gate is not None:
+                await self.gate.wait()
+            else:
+                for _ in range(3):
+                    await asyncio.sleep(0)
+            self.writes.append((entity_id, temperature))
+        finally:
+            self.in_flight -= 1
+
+
+class _AdvancingClock:
+    """Hand out timestamps that move forward on every read.
+
+    Each reading is debounced against the previous one, so a clock that
+    stood still would reject the second of two readings long before the
+    handlers could overlap.
+    """
+
+    def __init__(self, start, step_seconds=10):
+        self._current = start
+        self._step = timedelta(seconds=step_seconds)
+
+    def now(self):
+        """Return a timestamp ``step_seconds`` after the previous one."""
+        self._current += self._step
+        return self._current
+
+
+class TestConcurrentReadings:
+    """Two readings handled at the same time must not interleave."""
+
+    @staticmethod
+    def _attach_trvs(mock_bt, quirks, entity_ids):
+        """Give the thermostat TRVs that all share one quirks recorder."""
+        mock_bt.real_trvs = {
+            entity_id: Trv.from_legacy_dict(entity_id, {"model_quirks": quirks})
+            for entity_id in entity_ids
+        }
+
+    @pytest.mark.asyncio
+    async def test_overlapping_readings_reach_every_trv_in_order(self, mock_bt):
+        """Hand both accepted readings to every TRV, oldest first."""
+        quirks = _RecordingQuirks()
+        self._attach_trvs(mock_bt, quirks, ("climate.trv1", "climate.trv2"))
+        start = dt_util.now()
+        mock_bt.last_external_sensor_change = start
+
+        with patch(
+            "custom_components.better_thermostat.events.temperature.dt_util",
+            _AdvancingClock(start),
+        ):
+            await asyncio.gather(
+                trigger_temperature_change(
+                    mock_bt, _make_event(State(SENSOR_ID, "21.0"))
+                ),
+                trigger_temperature_change(
+                    mock_bt, _make_event(State(SENSOR_ID, "22.0"))
+                ),
+            )
+
+        assert quirks.max_in_flight == 1
+        assert quirks.writes == [
+            ("climate.trv1", 21.0),
+            ("climate.trv2", 21.0),
+            ("climate.trv1", 22.0),
+            ("climate.trv2", 22.0),
+        ]
+        assert mock_bt.last_known_external_temp == 22.0
+        assert mock_bt.accum_delta == 0.0
+        assert mock_bt.pending_temp is None
+
+    @pytest.mark.asyncio
+    async def test_overlapping_applies_do_not_share_the_write_loop(self, mock_bt):
+        """Serialise updates that skip the debounce, such as the plateau timer."""
+        quirks = _RecordingQuirks()
+        self._attach_trvs(mock_bt, quirks, ("climate.trv1",))
+
+        await asyncio.gather(
+            _apply_temperature_update(mock_bt, 21.0),
+            _apply_temperature_update(mock_bt, 22.0),
+        )
+
+        assert quirks.max_in_flight == 1
+        assert quirks.writes == [("climate.trv1", 21.0), ("climate.trv1", 22.0)]
+        assert mock_bt.last_known_external_temp == 22.0
+
+    @pytest.mark.asyncio
+    async def test_cancelled_update_lets_the_next_one_through(self, mock_bt):
+        """Release the serialisation when a pending update is cancelled."""
+        quirks = _RecordingQuirks()
+        quirks.gate = asyncio.Event()
+        self._attach_trvs(mock_bt, quirks, ("climate.trv1",))
+
+        cancelled = asyncio.create_task(_apply_temperature_update(mock_bt, 21.0))
+        await asyncio.sleep(0)
+        queued = asyncio.create_task(_apply_temperature_update(mock_bt, 22.0))
+        await asyncio.sleep(0)
+
+        cancelled.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled
+        quirks.gate.set()
+        await queued
+
+        assert quirks.writes == [("climate.trv1", 22.0)]
+        assert mock_bt.last_known_external_temp == 22.0


### PR DESCRIPTION
Builds on #2305; that pull request's commit shows up here because its branch is the base of this one.

## Problem

Two defects leave a TRV holding a room temperature that Better Thermostat no longer believes.

**Readings can be applied out of order.** Home Assistant handles every room-sensor update in its own task. The listener for those updates ran the entity checks before it handed the reading to the temperature filter, and how long those checks take depends on what they find: announcing a change of degraded mode looks a translation up, while a settled pass waits for nothing at all. Of two readings dispatched close together the second can therefore reach the filter first. The filter serves readings in the order it received them, so the older one is applied last, written to the TRVs last, and regulated on until the next update arrives.

**The keepalive tick wrote across an update in flight.** It reads the room temperature once and writes it to each TRV in sequence, from its own timer and without taking the filter's turn. An update landing while the tick stood between two TRVs left the ones it had yet to reach on the value it started with, while Better Thermostat already regulated on the newer one. With two TRVs both of them ended up on the stale value.

## Change

The listener hands the reading over before it awaits anything, so the order of the hand-over is the order the readings arrived in. The work each reading needs, the degradation ladder and the critical-entity check included, now runs on the far side of that hand-over, inside the turn the reading holds. Nothing is dropped; the readings are only ordered. The filter itself is unchanged and now documents that its callers hold the lock.

The keepalive tick takes the same turn and reads the room temperature once it holds it, so it re-sends the temperature the thermostat is regulating on. It waits for its turn rather than skipping it, because a device that has forgotten the value has no other way of getting it back.

One trade-off worth naming: the degradation ladder's temperature-driven pass now waits behind a TRV write that is already running. The five-minute tick and the four other listeners still drive the ladder, so it cannot stall.

## Verification

Both defects were reproduced against the real production code before the fix.

For the ordering, two readings (21.0 then 22.0) are dispatched together while the first pass leaves degraded mode. The only stand-in is Home Assistant's translation lookup, patched to give up control once, which is what it does on a cache miss. Without the fix the TRV is written 22.0 and then 21.0, and the thermostat settles on the older reading; with it, 21.0 then 22.0.

For the keepalive, a tick is left standing on its first TRV while an update of 22.0 completes. Without the fix both TRVs end on the tick's stale 20.0 and two writes to the same entity are in flight at once; with it the tick finishes its round and the update follows, leaving both TRVs on 22.0.

Counter-checks were run per defect by putting each one back on its own:

- `TestArrivalOrder::test_the_older_of_two_readings_is_applied_first` goes red when the checks move back ahead of the hand-over.
- `TestKeepaliveTick::test_the_tick_does_not_write_over_a_reading_it_overlapped` goes red when the tick stops taking the turn.

`tests/unit/test_temperature_events.py::TestConcurrentReadings::test_overlapping_readings_reach_every_trv_in_order` was carried along: it drove the filter directly and now takes the lock the way the thermostat does.

Full suite: 7359 passed, 1 skipped. All 99 coverage floors hold (climate.py 89.7% against a floor of 88.7%). `ruff check`, `ruff format --check`, `pyrefly`, the naming budget and the blind-except budget are all clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temperature handling so overlapping sensor readings are processed one at a time and in arrival order.
  * Prevented stale keepalive updates from overwriting newer temperature readings.
  * Improved reliability when temperature updates are cancelled or delayed.
* **Tests**
  * Added coverage for concurrent readings, arrival ordering, cancellation, and keepalive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->