### PR TITLE
fix: write the deCONZ calibration offset in the units deCONZ reads (1.9)

### DIFF
--- a/custom_components/better_thermostat/adapters/deconz.py
+++ b/custom_components/better_thermostat/adapters/deconz.py
@@ -17,6 +17,12 @@ from .generic import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# deCONZ expresses a thermostat's ``config/offset`` in hundredths of a degree,
+# the same encoding it uses for ``heatsetpoint`` and the measured temperature:
+# the value 250 is 2.5 K. Every offset crossing this adapter is in Kelvin, so
+# the wire value is scaled on the way out and back on the way in.
+OFFSET_UNITS_PER_KELVIN = 100
+
 
 async def get_info(self, entity_id):
     """Get info from TRV."""
@@ -54,7 +60,7 @@ async def get_current_offset(self, entity_id):
     if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
         return 0.0
     try:
-        return float(str(state.attributes.get("offset", 0)))
+        return float(str(state.attributes.get("offset", 0))) / OFFSET_UNITS_PER_KELVIN
     except ValueError, TypeError:
         _LOGGER.warning(
             "better_thermostat %s: Could not convert calibration offset '%s' to float, using 0",
@@ -82,6 +88,9 @@ async def get_max_offset(self, entity_id):
 async def set_offset(self, entity_id, offset) -> bool:
     """Write a calibration offset through the deCONZ configure service.
 
+    The service passes its payload to the deCONZ REST API unaltered, so
+    what goes out is the requested offset in that API's own units.
+
     Parameters
     ----------
     self : BetterThermostat
@@ -100,7 +109,11 @@ async def set_offset(self, entity_id, offset) -> bool:
     await self.hass.services.async_call(
         "deconz",
         "configure",
-        {"entity": entity_id, "field": "/config", "data": {"offset": offset}},
+        {
+            "entity": entity_id,
+            "field": "/config",
+            "data": {"offset": round(offset * OFFSET_UNITS_PER_KELVIN)},
+        },
         blocking=True,
         context=self.context,
     )

--- a/custom_components/better_thermostat/adapters/deconz.py
+++ b/custom_components/better_thermostat/adapters/deconz.py
@@ -88,8 +88,9 @@ async def get_max_offset(self, entity_id):
 async def set_offset(self, entity_id, offset) -> bool:
     """Write a calibration offset through the deCONZ configure service.
 
-    The service passes its payload to the deCONZ REST API unaltered, so
-    what goes out is the requested offset in that API's own units.
+    deCONZ counts the offset in hundredths of a Kelvin, so the Kelvin value is
+    scaled by ``OFFSET_UNITS_PER_KELVIN`` here. The ``configure`` service
+    forwards that payload to the REST API unaltered.
 
     Parameters
     ----------

--- a/tests/unit/test_adapter_offset_contract.py
+++ b/tests/unit/test_adapter_offset_contract.py
@@ -197,3 +197,95 @@ class TestNoOffsetChannelReportsFalse:
         assert result is False
         mock_self.hass.services.async_call.assert_not_awaited()
         assert mock_self.real_trvs[ENTITY_ID].last_calibration is None
+
+
+def _deconz_thermostat(reported=0):
+    """Build a thermostat whose deCONZ TRV reports ``reported`` as its offset.
+
+    Parameters
+    ----------
+    reported : int
+        The value the deCONZ integration publishes on the climate entity,
+        which is the ``config/offset`` of the deCONZ resource itself.
+
+    Returns
+    -------
+    MagicMock
+        A stand-in for the Better Thermostat climate entity instance.
+    """
+    mock_self = _mock_self(calibration_entity=None)
+    mock_self.hass.states.get = lambda requested: State(
+        ENTITY_ID, "heat", {"offset": reported}
+    )
+    return mock_self
+
+
+def _written_config(mock_self):
+    """The payload the recorded deCONZ configure call carried."""
+    return mock_self.hass.services.async_call.await_args.args[2]["data"]
+
+
+class TestTheDeconzOffsetTravelsInHundredthsOfADegree:
+    """deCONZ carries a thermostat's offset in hundredths of a degree.
+
+    ``config/offset`` sits in the same resource as ``heatsetpoint`` and the
+    measured temperature and shares their encoding, so 250 is 2.5 K. The
+    configure service hands the payload to the REST API unaltered, and the
+    API scales it down to the 0.1 K steps the device itself takes; a plain
+    Kelvin float therefore arrives a hundred times too small and leaves the
+    device uncalibrated. The same scale governs the read, because the
+    attribute the integration publishes is that resource value.
+    """
+
+    @pytest.mark.parametrize(
+        ("kelvin", "expected"),
+        [(0.0, 0), (0.5, 50), (2.5, 250), (-2.5, -250), (-6.0, -600)],
+    )
+    @pytest.mark.asyncio
+    async def test_the_write_carries_the_offset_deconz_expects(self, kelvin, expected):
+        """What goes on the wire is the Kelvin request in deCONZ's units."""
+        mock_self = _mock_self()
+
+        await deconz.set_offset(mock_self, ENTITY_ID, kelvin)
+
+        assert _written_config(mock_self) == {"offset": expected}
+
+    @pytest.mark.asyncio
+    async def test_the_recorded_command_stays_in_kelvin(self):
+        """The scale belongs to the wire, not to the TRV record.
+
+        Every comparison the control cycle makes against ``last_calibration``
+        is in Kelvin, so the value stored there is the one that was asked for.
+        """
+        mock_self = _mock_self()
+
+        await deconz.set_offset(mock_self, ENTITY_ID, -2.0)
+
+        assert mock_self.real_trvs[ENTITY_ID].last_calibration == -2.0
+
+    @pytest.mark.parametrize(
+        ("reported", "expected"), [(0, 0.0), (250, 2.5), (-250, -2.5), (-600, -6.0)]
+    )
+    @pytest.mark.asyncio
+    async def test_the_read_answers_in_kelvin(self, reported, expected):
+        """A device resting at 2.5 K reports 250 and reads back as 2.5."""
+        assert (
+            await deconz.get_current_offset(_deconz_thermostat(reported), ENTITY_ID)
+            == expected
+        )
+
+    @pytest.mark.asyncio
+    async def test_the_write_and_the_read_share_one_scale(self):
+        """A device echoing the write back reports the offset that was sent.
+
+        The control cycle compares the two every run, so a read and a write
+        that disagreed on the scale would leave them permanently apart and
+        re-assert the offset for as long as the TRV is calibrated.
+        """
+        writing = _mock_self()
+        await deconz.set_offset(writing, ENTITY_ID, -2.0)
+        echoed = _written_config(writing)["offset"]
+
+        assert await deconz.get_current_offset(
+            _deconz_thermostat(echoed), ENTITY_ID
+        ) == pytest.approx(-2.0)


### PR DESCRIPTION
## Problem

deCONZ keeps a thermostat's calibration offset in `config/offset`, next to `heatsetpoint` and the measured temperature and in the same encoding: hundredths of a degree, so the value `250` is an offset of 2.5 K. The `deconz.configure` service passes its payload to the deCONZ REST API unaltered, and the API divides that value down to the 0.1 K steps the device itself accepts.

The adapter wrote a plain Kelvin float. Every offset Better Thermostat can command stays inside the range the adapter declares, so after the division it becomes zero. Measured against the adapter as it stands, for the whole declared range:

| request | value on the wire | what the device applies |
|---|---|---|
| 1.0 K | `1.0` | 0.0 K |
| 2.0 K | `2.0` | 0.0 K |
| -2.0 K | `-2.0` | 0.0 K |
| 6.0 K | `6.0` | 0.0 K |
| -6.0 K | `-6.0` | 0.0 K |

A deCONZ TRV configured for local calibration is therefore never calibrated at all, while `set_offset` returns `True` and records the command as sent. The read had the mirror error and took the raw resource value for Kelvin: a device resting at 2.5 K reports `250` and the adapter answered `250.0`, which then went into the offset controller as a 250 K offset.

Sources for the encoding:

- `thermostat.cpp` in the deCONZ REST plugin builds `config/offset` from the ZCL Local Temperature Calibration attribute as `attr.numericValue().s8 * 10`, and its own example resource shows `"heatsetpoint": 2200` alongside `"temperature": 2150`.
- `rest_sensors.cpp` handles a write with `data.integer = data.integer / 10` before clamping the result and writing the ZCL attribute.
- `pydeconz` exposes `Thermostat.offset` as the raw `config` value, with no `scaled_` counterpart of the kind it has for the temperature and the setpoint, and Home Assistant's deCONZ climate entity publishes it unchanged as the `offset` attribute.

## Change

`adapters/deconz.py` scales between the two units in one place. The write multiplies the requested Kelvin offset by 100 and rounds to the integer the resource holds; the read divides the reported value back. The command recorded on the TRV record stays in Kelvin, which is the unit the control cycle compares it in. The factor is a named constant carrying the reason.

The declared range and step are left as they are.

## What changes per device

The adapter declares a range of -6 to 6 K, and the control cycle clamps the offset it computes to that before the write. With the offset arriving in the right units, that range now reaches two kinds of device differently:

- **Tuya TRVs** reached through deCONZ (`Tuya_THD …` product ids): the REST plugin clamps them to ±6 °C, so the declared range and the device's own limit agree and the full range applies.
- **Plain ZCL thermostats** (`ZHAThermostat` on the standard path): the plugin clamps the ZCL write to ±25 steps of 0.1 K, so requests beyond ±2.5 K are silently reduced device-side. Better Thermostat cannot see that, because the resource keeps the value that was requested.

Both cases got nothing at all before this change. Matching the declared range to the device would need a per-device answer rather than one constant, so it is named here and not changed.

## Verification

Counter-check, each side of the conversion reverted on its own with the tests kept:

- write side only: 5 red, `test_the_write_carries_the_offset_deconz_expects` for 0.5, 2.5, -2.5 and -6.0 K, plus `test_the_write_and_the_read_share_one_scale`.
- read side only: 4 red, `test_the_read_answers_in_kelvin` for 250, -250 and -600, plus `test_the_write_and_the_read_share_one_scale`.

`pytest tests/unit`: 4498 passed, 1 skipped, against a baseline of 4487 passed, 1 skipped. `pytest tests`: 5132 passed, 1 skipped. `ruff check` and `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deCONZ thermostat offset handling for accurate temperature calibration.
  * Offset values are now correctly converted between Kelvin and hundredths of a degree when reading from or writing to devices.
  * Calibration values remain consistent when written and read back, preventing discrepancies between requested and reported settings.

* **Documentation**
  * Clarified the units used by the offset service and API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->