### PR TITLE
fix: report refused device writes in the model quirks (1.9)

### DIFF
--- a/custom_components/better_thermostat/model_fixes/BTH-RM.py
+++ b/custom_components/better_thermostat/model_fixes/BTH-RM.py
@@ -38,12 +38,25 @@ def fix_target_temperature_calibration(self, entity_id, temperature):
 async def _write_setpoint(self, entity_id, payload):
     """Put one setpoint payload on the wire.
 
-    Returns True once the device took the write. A device that is asleep or
-    out of reach, an integration reloading its config entry, and an entity
-    that declares no support for the attributes in the payload all answer a
-    blocking service call with an error; that is reported as a refused write
-    so the caller can fall back to the generic adapter, which carries the
-    retry handling.
+    A device that is asleep or out of reach, an integration reloading its
+    config entry, and an entity that declares no support for the attributes
+    in the payload all answer a blocking service call with an error; that is
+    reported as a refused write so the caller can fall back to the generic
+    adapter, which carries the retry handling.
+
+    Parameters
+    ----------
+    self :
+        self instance of better_thermostat
+    entity_id : str
+        Entity ID of the TRV the payload is addressed to
+    payload : dict
+        Service data for ``climate.set_temperature``
+
+    Returns
+    -------
+    bool
+        True once the device took the write, False when it refused
     """
     try:
         await self.hass.services.async_call(

--- a/custom_components/better_thermostat/model_fixes/BTH-RM.py
+++ b/custom_components/better_thermostat/model_fixes/BTH-RM.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import logging
 
+from homeassistant.exceptions import HomeAssistantError
+
 from custom_components.better_thermostat.utils.helpers import (
     celsius_to_system_temperature,
     supports_temperature_range,
@@ -31,6 +33,31 @@ def fix_target_temperature_calibration(self, entity_id, temperature):
     For the BTH-RM this is currently a no-op.
     """
     return temperature
+
+
+async def _write_setpoint(self, entity_id, payload):
+    """Put one setpoint payload on the wire.
+
+    Returns True once the device took the write. A device that is asleep or
+    out of reach, an integration reloading its config entry, and an entity
+    that declares no support for the attributes in the payload all answer a
+    blocking service call with an error; that is reported as a refused write
+    so the caller can fall back to the generic adapter, which carries the
+    retry handling.
+    """
+    try:
+        await self.hass.services.async_call(
+            "climate", "set_temperature", payload, blocking=True, context=self.context
+        )
+    except (HomeAssistantError, OSError) as ex:
+        _LOGGER.warning(
+            "better_thermostat %s: BTH-RM setpoint write for %s failed: %s",
+            self.device_name,
+            entity_id,
+            ex,
+        )
+        return False
+    return True
 
 
 async def override_set_hvac_mode(self, entity_id, hvac_mode):
@@ -61,11 +88,12 @@ async def override_set_temperature(self, entity_id, temperature):
     Returns
     -------
     bool
-            True, always: the quirk issues a service call for every
-            input (a plain temperature write when the entity has no
-            current state or no range support, a range write
-            otherwise), so the caller never needs the generic
-            adapter fallback.
+            True once the setpoint write went out, so the caller does not
+            need the generic adapter fallback (a plain temperature write
+            when the entity has no current state or no range support, a
+            range write otherwise). False when the device refused it: the
+            adapter write then carries the setpoint instead, with its own
+            step rounding and retry handling.
     """
     temperature = celsius_to_system_temperature(self.hass, temperature)
     state = self.hass.states.get(entity_id)
@@ -76,14 +104,9 @@ async def override_set_temperature(self, entity_id, temperature):
             self.device_name,
             entity_id,
         )
-        await self.hass.services.async_call(
-            "climate",
-            "set_temperature",
-            {"entity_id": entity_id, "temperature": temperature},
-            blocking=True,
-            context=self.context,
+        return await _write_setpoint(
+            self, entity_id, {"entity_id": entity_id, "temperature": temperature}
         )
-        return True
 
     _supports_range = supports_temperature_range(state)
 
@@ -97,23 +120,15 @@ async def override_set_temperature(self, entity_id, temperature):
     )
 
     if _supports_range:
-        await self.hass.services.async_call(
-            "climate",
-            "set_temperature",
+        return await _write_setpoint(
+            self,
+            entity_id,
             {
                 "entity_id": entity_id,
                 "target_temp_high": temperature,
                 "target_temp_low": temperature,
             },
-            blocking=True,
-            context=self.context,
         )
-    else:
-        await self.hass.services.async_call(
-            "climate",
-            "set_temperature",
-            {"entity_id": entity_id, "temperature": temperature},
-            blocking=True,
-            context=self.context,
-        )
-    return True
+    return await _write_setpoint(
+        self, entity_id, {"entity_id": entity_id, "temperature": temperature}
+    )

--- a/custom_components/better_thermostat/model_fixes/BTH-RM230Z.py
+++ b/custom_components/better_thermostat/model_fixes/BTH-RM230Z.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import logging
 
+from homeassistant.exceptions import HomeAssistantError
+
 from custom_components.better_thermostat.utils.helpers import (
     celsius_to_system_temperature,
     supports_temperature_range,
@@ -30,6 +32,31 @@ def fix_target_temperature_calibration(self, entity_id, temperature):
     Currently a passthrough, but provided for future adjustments.
     """
     return temperature
+
+
+async def _write_setpoint(self, entity_id, payload):
+    """Put one setpoint payload on the wire.
+
+    Returns True once the device took the write. A device that is asleep or
+    out of reach, an integration reloading its config entry, and an entity
+    that declares no support for the attributes in the payload all answer a
+    blocking service call with an error; that is reported as a refused write
+    so the caller can fall back to the generic adapter, which carries the
+    retry handling.
+    """
+    try:
+        await self.hass.services.async_call(
+            "climate", "set_temperature", payload, blocking=True, context=self.context
+        )
+    except (HomeAssistantError, OSError) as ex:
+        _LOGGER.warning(
+            "better_thermostat %s: BTH-RM230Z setpoint write for %s failed: %s",
+            self.device_name,
+            entity_id,
+            ex,
+        )
+        return False
+    return True
 
 
 async def override_set_hvac_mode(self, entity_id, hvac_mode):
@@ -64,11 +91,12 @@ async def override_set_temperature(self, entity_id, temperature):
     Returns
     -------
     bool
-            True, always: the quirk issues a service call for every
-            input (a plain temperature write when the entity has no
-            current state or no range support, a range write
-            otherwise), so the caller never needs the generic
-            adapter fallback.
+            True once the setpoint write went out, so the caller does not
+            need the generic adapter fallback (a plain temperature write
+            when the entity has no current state or no range support, a
+            range write otherwise). False when the device refused it: the
+            adapter write then carries the setpoint instead, with its own
+            step rounding and retry handling.
     """
     temperature = celsius_to_system_temperature(self.hass, temperature)
     state = self.hass.states.get(entity_id)
@@ -79,14 +107,9 @@ async def override_set_temperature(self, entity_id, temperature):
             self.device_name,
             entity_id,
         )
-        await self.hass.services.async_call(
-            "climate",
-            "set_temperature",
-            {"entity_id": entity_id, "temperature": temperature},
-            blocking=True,
-            context=self.context,
+        return await _write_setpoint(
+            self, entity_id, {"entity_id": entity_id, "temperature": temperature}
         )
-        return True
 
     _supports_range = supports_temperature_range(state)
 
@@ -100,23 +123,15 @@ async def override_set_temperature(self, entity_id, temperature):
     )
 
     if _supports_range:
-        await self.hass.services.async_call(
-            "climate",
-            "set_temperature",
+        return await _write_setpoint(
+            self,
+            entity_id,
             {
                 "entity_id": entity_id,
                 "target_temp_high": temperature,
                 "target_temp_low": temperature,
             },
-            blocking=True,
-            context=self.context,
         )
-    else:
-        await self.hass.services.async_call(
-            "climate",
-            "set_temperature",
-            {"entity_id": entity_id, "temperature": temperature},
-            blocking=True,
-            context=self.context,
-        )
-    return True
+    return await _write_setpoint(
+        self, entity_id, {"entity_id": entity_id, "temperature": temperature}
+    )

--- a/custom_components/better_thermostat/model_fixes/BTH-RM230Z.py
+++ b/custom_components/better_thermostat/model_fixes/BTH-RM230Z.py
@@ -37,12 +37,25 @@ def fix_target_temperature_calibration(self, entity_id, temperature):
 async def _write_setpoint(self, entity_id, payload):
     """Put one setpoint payload on the wire.
 
-    Returns True once the device took the write. A device that is asleep or
-    out of reach, an integration reloading its config entry, and an entity
-    that declares no support for the attributes in the payload all answer a
-    blocking service call with an error; that is reported as a refused write
-    so the caller can fall back to the generic adapter, which carries the
-    retry handling.
+    A device that is asleep or out of reach, an integration reloading its
+    config entry, and an entity that declares no support for the attributes
+    in the payload all answer a blocking service call with an error; that is
+    reported as a refused write so the caller can fall back to the generic
+    adapter, which carries the retry handling.
+
+    Parameters
+    ----------
+    self :
+        self instance of better_thermostat
+    entity_id : str
+        Entity ID of the TRV the payload is addressed to
+    payload : dict
+        Service data for ``climate.set_temperature``
+
+    Returns
+    -------
+    bool
+        True once the device took the write, False when it refused
     """
     try:
         await self.hass.services.async_call(

--- a/custom_components/better_thermostat/model_fixes/SPZB0001.py
+++ b/custom_components/better_thermostat/model_fixes/SPZB0001.py
@@ -29,10 +29,25 @@ async def check_operation_mode(self, entity_id, goal: str = "1"):
     """Put the device's TRV mode select onto ``goal``.
 
     Finds the ``select`` entity carrying the TRV mode on the same device as
-    ``entity_id`` and selects ``goal`` when it reads anything else. Returns
-    True once the mode reads ``goal`` or the switch to it has been requested,
-    and False when the registry entry, the mode select or its state is
-    missing, or when the device refused the option.
+    ``entity_id`` and selects ``goal`` when it reads anything else. Direct
+    valve control depends on that mode, so a refused option is reported
+    rather than assumed to have taken effect.
+
+    Parameters
+    ----------
+    self :
+        self instance of better_thermostat
+    entity_id : str
+        Entity ID of the climate entity identifying the device
+    goal : str
+        Option the TRV mode select is to carry
+
+    Returns
+    -------
+    bool
+        True once the mode reads ``goal`` or the switch to it went through.
+        False when the registry entry, the mode select or its state is
+        missing, or when the device refused the option.
     """
 
     entity_registry = er.async_get(self.hass)
@@ -74,7 +89,11 @@ async def check_operation_mode(self, entity_id, goal: str = "1"):
         )
         try:
             await self.hass.services.async_call(
-                "select", "select_option", {"entity_id": target_entity, "option": goal}
+                "select",
+                "select_option",
+                {"entity_id": target_entity, "option": goal},
+                blocking=True,
+                context=self.context,
             )
         except (HomeAssistantError, OSError) as ex:
             # A device whose mode select does not carry this option, or

--- a/custom_components/better_thermostat/model_fixes/SPZB0001.py
+++ b/custom_components/better_thermostat/model_fixes/SPZB0001.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from ..utils.const import CalibrationType
@@ -25,9 +26,13 @@ def fix_local_calibration(self, entity_id, offset):
 
 
 async def check_operation_mode(self, entity_id, goal: str = "1"):
-    """Return a possibly adjusted valve calibration for SPZB0001.
+    """Put the device's TRV mode select onto ``goal``.
 
-    Currently a no-op.
+    Finds the ``select`` entity carrying the TRV mode on the same device as
+    ``entity_id`` and selects ``goal`` when it reads anything else. Returns
+    True once the mode reads ``goal`` or the switch to it has been requested,
+    and False when the registry entry, the mode select or its state is
+    missing, or when the device refused the option.
     """
 
     entity_registry = er.async_get(self.hass)
@@ -67,9 +72,22 @@ async def check_operation_mode(self, entity_id, goal: str = "1"):
             goal,
             val.state,
         )
-        await self.hass.services.async_call(
-            "select", "select_option", {"entity_id": target_entity, "option": goal}
-        )
+        try:
+            await self.hass.services.async_call(
+                "select", "select_option", {"entity_id": target_entity, "option": goal}
+            )
+        except (HomeAssistantError, OSError) as ex:
+            # A device whose mode select does not carry this option, or
+            # that is out of reach, keeps the mode it has. Direct valve
+            # control depends on that mode, so the caller is told the
+            # switch did not happen instead of assuming it did.
+            _LOGGER.warning(
+                "better_thermostat %s: SPZB0001 TRV mode write to %s failed: %s",
+                self.device_name,
+                target_entity,
+                ex,
+            )
+            return False
 
     return True
 

--- a/custom_components/better_thermostat/model_fixes/TV02-Zigbee.py
+++ b/custom_components/better_thermostat/model_fixes/TV02-Zigbee.py
@@ -29,8 +29,15 @@ async def _select_manual_preset(self, entity_id):
 
     A device that refuses the preset keeps running its own schedule and
     overwrites whatever Better Thermostat sends it, so the refusal is
-    reported. It does not decide the command the caller asked for: that one
+    logged. It does not decide the command the caller asked for: that one
     still has to reach the device, and it is written either way.
+
+    Parameters
+    ----------
+    self :
+        self instance of better_thermostat
+    entity_id : str
+        Entity ID of the TRV to take off its schedule
     """
     try:
         await self.hass.services.async_call(

--- a/custom_components/better_thermostat/model_fixes/TV02-Zigbee.py
+++ b/custom_components/better_thermostat/model_fixes/TV02-Zigbee.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.better_thermostat.utils.helpers import (
     celsius_to_system_temperature,
@@ -23,6 +24,32 @@ def fix_target_temperature_calibration(self, entity_id, temperature):
     return temperature
 
 
+async def _select_manual_preset(self, entity_id):
+    """Take the TRV off its internal schedule.
+
+    A device that refuses the preset keeps running its own schedule and
+    overwrites whatever Better Thermostat sends it, so the refusal is
+    reported. It does not decide the command the caller asked for: that one
+    still has to reach the device, and it is written either way.
+    """
+    try:
+        await self.hass.services.async_call(
+            "climate",
+            "set_preset_mode",
+            {"entity_id": entity_id, "preset_mode": "manual"},
+            blocking=True,
+            context=self.context,
+        )
+    except (HomeAssistantError, OSError) as ex:
+        _LOGGER.warning(
+            "better_thermostat %s: TV02-Zigbee manual preset for %s failed, "
+            "the device stays on its own schedule: %s",
+            self.device_name,
+            entity_id,
+            ex,
+        )
+
+
 async def override_set_hvac_mode(self, entity_id, hvac_mode):
     """Enable device quirks while setting HVAC mode.
 
@@ -38,16 +65,27 @@ async def override_set_hvac_mode(self, entity_id, hvac_mode):
     Returns
     -------
     bool
-        True, always: the quirk issues the mode write itself, so the
-        caller never needs the generic adapter fallback.
+        True once the mode write went out, so the caller does not need the
+        generic adapter fallback. False when the device refused it: the
+        adapter write then carries the mode instead, with its own retry
+        handling.
     """
-    await self.hass.services.async_call(
-        "climate",
-        "set_hvac_mode",
-        {"entity_id": entity_id, "hvac_mode": hvac_mode},
-        blocking=True,
-        context=self.context,
-    )
+    try:
+        await self.hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {"entity_id": entity_id, "hvac_mode": hvac_mode},
+            blocking=True,
+            context=self.context,
+        )
+    except (HomeAssistantError, OSError) as ex:
+        _LOGGER.warning(
+            "better_thermostat %s: TV02-Zigbee mode write for %s failed: %s",
+            self.device_name,
+            entity_id,
+            ex,
+        )
+        return False
     model = self.real_trvs[entity_id].model
     if model == "TV02-Zigbee" and hvac_mode != HVACMode.OFF:
         _LOGGER.debug(
@@ -55,13 +93,7 @@ async def override_set_hvac_mode(self, entity_id, hvac_mode):
             self.device_name,
             entity_id,
         )
-        await self.hass.services.async_call(
-            "climate",
-            "set_preset_mode",
-            {"entity_id": entity_id, "preset_mode": "manual"},
-            blocking=True,
-            context=self.context,
-        )
+        await _select_manual_preset(self, entity_id)
     return True
 
 
@@ -84,8 +116,10 @@ async def override_set_temperature(self, entity_id, temperature):
     Returns
     -------
     bool
-        True, always: the quirk issues the setpoint write itself, so
-        the caller never needs the generic adapter fallback.
+        True once the setpoint write went out, so the caller does not need
+        the generic adapter fallback. False when the device refused it: the
+        adapter write then carries the setpoint instead, with its own step
+        rounding and retry handling.
     """
     model = self.real_trvs[entity_id].model
     if model == "TV02-Zigbee":
@@ -94,22 +128,25 @@ async def override_set_temperature(self, entity_id, temperature):
             self.device_name,
             entity_id,
         )
+        await _select_manual_preset(self, entity_id)
+
+    try:
         await self.hass.services.async_call(
             "climate",
-            "set_preset_mode",
-            {"entity_id": entity_id, "preset_mode": "manual"},
+            "set_temperature",
+            {
+                "entity_id": entity_id,
+                "temperature": celsius_to_system_temperature(self.hass, temperature),
+            },
             blocking=True,
             context=self.context,
         )
-
-    await self.hass.services.async_call(
-        "climate",
-        "set_temperature",
-        {
-            "entity_id": entity_id,
-            "temperature": celsius_to_system_temperature(self.hass, temperature),
-        },
-        blocking=True,
-        context=self.context,
-    )
+    except (HomeAssistantError, OSError) as ex:
+        _LOGGER.warning(
+            "better_thermostat %s: TV02-Zigbee setpoint write for %s failed: %s",
+            self.device_name,
+            entity_id,
+            ex,
+        )
+        return False
     return True

--- a/custom_components/better_thermostat/model_fixes/ZWA021.py
+++ b/custom_components/better_thermostat/model_fixes/ZWA021.py
@@ -11,6 +11,7 @@ mode the module is inert and the device is driven through the standard
 import logging
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.exceptions import HomeAssistantError
 
 from ..utils.const import CalibrationType
 
@@ -87,9 +88,10 @@ async def override_set_hvac_mode(self, entity_id, hvac_mode):
     """Engage the manufacturer-specific mode for direct valve control.
 
     Only active when the TRV is configured for direct valve control and the
-    requested mode is not OFF. In all other cases this returns ``False`` so the
-    caller falls back to the standard ``climate.set_hvac_mode`` service, leaving
-    behaviour identical to a device without this quirk.
+    requested mode is not OFF. In all other cases, and when the device refuses
+    the mode write, this returns ``False`` so the caller falls back to the
+    standard ``climate.set_hvac_mode`` service, leaving behaviour identical to
+    a device without this quirk.
     """
     if not _is_direct_valve(self, entity_id):
         return False
@@ -102,18 +104,31 @@ async def override_set_hvac_mode(self, entity_id, hvac_mode):
         self.device_name,
         entity_id,
     )
-    await self.hass.services.async_call(
-        _ZWAVE_JS_DOMAIN,
-        _ZWAVE_JS_SET_VALUE,
-        {
-            "entity_id": entity_id,
-            "command_class": _THERMOSTAT_MODE_COMMAND_CLASS,
-            "property": "mode",
-            "value": _MANUFACTURER_SPECIFIC_MODE,
-        },
-        blocking=True,
-        context=self.context,
-    )
+    try:
+        await self.hass.services.async_call(
+            _ZWAVE_JS_DOMAIN,
+            _ZWAVE_JS_SET_VALUE,
+            {
+                "entity_id": entity_id,
+                "command_class": _THERMOSTAT_MODE_COMMAND_CLASS,
+                "property": "mode",
+                "value": _MANUFACTURER_SPECIFIC_MODE,
+            },
+            blocking=True,
+            context=self.context,
+        )
+    except (HomeAssistantError, OSError) as ex:
+        # No Z-Wave JS to reach, a node that is asleep or out of range, or a
+        # firmware that rejects the undocumented mode: the device is not in
+        # valve mode, so the standard climate service is the one that can
+        # still make it heat.
+        _LOGGER.warning(
+            "better_thermostat %s: Spirit/ZWA021 valve mode write for %s failed: %s",
+            self.device_name,
+            entity_id,
+            ex,
+        )
+        return False
     return True
 
 
@@ -125,10 +140,11 @@ async def override_set_temperature(self, entity_id, temperature):
 async def override_set_valve(self, entity_id, percent):
     """Drive the valve directly via the Multilevel Switch command class.
 
-    Active only in direct valve control; otherwise returns ``False`` so the
-    generic valve handling applies. The device is expected to already be in
-    manufacturer-specific mode (see :func:`override_set_hvac_mode`). The
-    requested 0-100 % opening is mapped onto the device's 0-99 range.
+    Active only in direct valve control; otherwise, and when the device
+    refuses the write, returns ``False`` so the generic valve handling
+    applies. The device is expected to already be in manufacturer-specific
+    mode (see :func:`override_set_hvac_mode`). The requested 0-100 % opening
+    is mapped onto the device's 0-99 range.
     """
     if not _is_direct_valve(self, entity_id):
         return False
@@ -145,16 +161,28 @@ async def override_set_valve(self, entity_id, percent):
         value,
         _VALVE_MAX,
     )
-    await self.hass.services.async_call(
-        _ZWAVE_JS_DOMAIN,
-        _ZWAVE_JS_SET_VALUE,
-        {
-            "entity_id": entity_id,
-            "command_class": _MULTILEVEL_SWITCH_COMMAND_CLASS,
-            "property": "targetValue",
-            "value": value,
-        },
-        blocking=True,
-        context=self.context,
-    )
+    try:
+        await self.hass.services.async_call(
+            _ZWAVE_JS_DOMAIN,
+            _ZWAVE_JS_SET_VALUE,
+            {
+                "entity_id": entity_id,
+                "command_class": _MULTILEVEL_SWITCH_COMMAND_CLASS,
+                "property": "targetValue",
+                "value": value,
+            },
+            blocking=True,
+            context=self.context,
+        )
+    except (HomeAssistantError, OSError) as ex:
+        # Reporting the refused write as a declined one keeps the caller from
+        # recording a position the valve never reached, and leaves it free to
+        # try the generic valve channel.
+        _LOGGER.warning(
+            "better_thermostat %s: Spirit/ZWA021 valve write for %s failed: %s",
+            self.device_name,
+            entity_id,
+            ex,
+        )
+        return False
     return True

--- a/tests/unit/test_quirk_refused_writes.py
+++ b/tests/unit/test_quirk_refused_writes.py
@@ -270,6 +270,33 @@ class TestTheEurotronicModeSelectReportsARefusedOption:
 
         assert answered is False
 
+    @pytest.mark.asyncio
+    async def test_the_option_is_written_and_waited_for(self):
+        """A refusal only reaches the caller when the call blocks.
+
+        `ServiceRegistry.async_call` defaults to fire-and-forget and runs a
+        failing handler in a background task, so without `blocking=True` the
+        device's refusal never raises here and the mode reads as switched
+        when it is not.
+        """
+        host = _host(state=State("select.trv_trv_mode", "2"), model="SPZB0001")
+        host.hass.services.async_call = AsyncMock(return_value=None)
+
+        with patch.object(
+            spzb0001_quirk.er,
+            "async_get",
+            lambda hass: self._registry_holding_a_mode_select(),
+        ):
+            assert await spzb0001_quirk.check_operation_mode(host, ENTITY_ID, "1")
+
+        host.hass.services.async_call.assert_awaited_once_with(
+            "select",
+            "select_option",
+            {"entity_id": "select.trv_trv_mode", "option": "1"},
+            blocking=True,
+            context=host.context,
+        )
+
     @pytest.mark.parametrize("refusal", REFUSALS, ids=REFUSAL_IDS)
     @pytest.mark.asyncio
     async def test_a_refused_option_does_not_end_the_startup_tweak(self, refusal):

--- a/tests/unit/test_quirk_refused_writes.py
+++ b/tests/unit/test_quirk_refused_writes.py
@@ -1,0 +1,358 @@
+"""What a quirk answers when the device turns its write down.
+
+Every command a quirk issues is a blocking service call, and Home Assistant
+answers one with an exception whenever the device cannot take it: a battery
+device that is asleep, a node out of range, an integration reloading its
+config entry, a missing service, or an entity that does not carry the
+option or the attribute the payload names.
+
+The quirks sit deep inside one control cycle, and they hold the lock that
+serialises every TRV of the instance while they run. An error escaping one
+ends that cycle for the TRV before its calibration and its setpoint are
+written and before the confirmation watchdogs are armed, and the control
+queue re-queues the failed cycle immediately, with nothing between the
+attempts. A device that refuses one write on every cycle therefore turns the
+loop into a spin. The generic adapter, which is what drives a TRV without a
+quirk, does not behave that way: it reports a refusal and leaves the caller
+to decide.
+
+So each of these functions reports a refused write through its return
+value. ``False`` says no command reached the device, which is what routes
+the caller to the standard adapter path and its retry handling; ``True``
+stays reserved for a command that went out. A supplementary device setting
+is the one exception: it is reported in the log, but it does not decide
+whether the command the caller asked for is written.
+"""
+
+from importlib import import_module
+import inspect
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.climate.const import ClimateEntityFeature
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import State
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+import pytest
+
+from custom_components.better_thermostat.model_fixes import (
+    SPZB0001 as spzb0001_quirk,
+    ZWA021 as zwa021_quirk,
+)
+from custom_components.better_thermostat.trv import Trv
+from custom_components.better_thermostat.utils.const import CalibrationType
+
+# The device name carries a hyphen, so the module is reached by name.
+TV02 = import_module("custom_components.better_thermostat.model_fixes.TV02-Zigbee")
+BTH_RM = import_module("custom_components.better_thermostat.model_fixes.BTH-RM")
+BTH_RM230Z = import_module("custom_components.better_thermostat.model_fixes.BTH-RM230Z")
+
+ENTITY_ID = "climate.trv"
+RANGE_BIT = int(ClimateEntityFeature.TARGET_TEMPERATURE_RANGE)
+
+# One instance per way a device says no. ``ServiceValidationError`` is what
+# Home Assistant itself raises for an unsupported mode, an unsupported
+# option and a service nobody registered, and it derives from
+# ``HomeAssistantError``, so catching the base class covers all three.
+# ``OSError`` is the transport underneath giving out.
+REFUSALS = [
+    HomeAssistantError("device did not answer"),
+    ServiceValidationError("the entity does not carry that option"),
+    OSError("connection reset"),
+]
+REFUSAL_IDS = ["unreachable", "unsupported", "transport"]
+
+
+def _host(state=None, model=None, advanced=None):
+    """A Better Thermostat stand-in whose every service call is refused."""
+    host = MagicMock()
+    host.device_name = "Test BT"
+    host.context = None
+    host.hass = MagicMock()
+    host.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+    host.hass.states.get.return_value = state
+    host.hass.services.async_call = AsyncMock()
+    trv = Trv(entity_id=ENTITY_ID)
+    trv.model = model
+    if advanced is not None:
+        trv.advanced = advanced
+    host.real_trvs = {ENTITY_ID: trv}
+    return host
+
+
+def _climate_state(supported_features):
+    """A live climate state declaring the given feature bitmask."""
+    return State(
+        ENTITY_ID, "heat", {"supported_features": supported_features, "temperature": 20}
+    )
+
+
+class TestTheBoschRoomThermostatsDeclineARefusedSetpoint:
+    """Both Bosch modules write the setpoint themselves, on three branches.
+
+    Which attributes go out depends on what the entity declares, and any of
+    the three payloads can come back refused. The range write is the
+    likeliest of the three, because it is the one naming attributes an
+    entity may not support at the moment it is asked.
+    """
+
+    @pytest.fixture(params=[BTH_RM, BTH_RM230Z], ids=["BTH-RM", "BTH-RM230Z"])
+    def quirk(self, request):
+        """Each Bosch room-thermostat quirk module in turn."""
+        return request.param
+
+    @pytest.mark.parametrize(
+        "state",
+        [None, _climate_state(RANGE_BIT), _climate_state(0)],
+        ids=["no_state", "range_write", "plain_write"],
+    )
+    @pytest.mark.parametrize("refusal", REFUSALS, ids=REFUSAL_IDS)
+    @pytest.mark.asyncio
+    async def test_a_refused_setpoint_is_declined_on_every_branch(
+        self, quirk, state, refusal
+    ):
+        """Whichever payload the entity earns, a refusal answers False."""
+        host = _host(state=state)
+        host.hass.services.async_call = AsyncMock(side_effect=refusal)
+
+        assert await quirk.override_set_temperature(host, ENTITY_ID, 21.0) is False
+        host.hass.services.async_call.assert_awaited_once()
+
+
+class TestTheTuyaValveDeclinesARefusedCommand:
+    """TV02-Zigbee writes the mode and the setpoint itself.
+
+    It also puts the device on its manual preset, so the TRV does not fall
+    back to its own schedule and overwrite what it was just told. That
+    preset is a device setting, not the command the caller asked for.
+    """
+
+    @pytest.mark.parametrize("refusal", REFUSALS, ids=REFUSAL_IDS)
+    @pytest.mark.asyncio
+    async def test_a_refused_mode_write_is_declined(self, refusal):
+        """No mode reached the device, so the adapter write has to carry it."""
+        host = _host(model="TV02-Zigbee")
+        host.hass.services.async_call = AsyncMock(side_effect=refusal)
+
+        assert await TV02.override_set_hvac_mode(host, ENTITY_ID, "heat") is False
+
+    @pytest.mark.parametrize("refusal", REFUSALS, ids=REFUSAL_IDS)
+    @pytest.mark.asyncio
+    async def test_a_refused_setpoint_write_is_declined(self, refusal):
+        """The setpoint is the command, so its refusal decides the answer."""
+        host = _host(model="TV02-Zigbee")
+
+        async def _refuse_the_setpoint(_domain, service, _data, **_kwargs):
+            if service == "set_temperature":
+                raise refusal
+
+        host.hass.services.async_call = AsyncMock(side_effect=_refuse_the_setpoint)
+
+        assert await TV02.override_set_temperature(host, ENTITY_ID, 21.0) is False
+
+    @pytest.mark.parametrize("refusal", REFUSALS, ids=REFUSAL_IDS)
+    @pytest.mark.asyncio
+    async def test_a_refused_preset_still_lets_the_setpoint_through(self, refusal):
+        """A firmware without the manual preset refuses it on every cycle.
+
+        The preset write comes first, so letting its refusal end the call
+        would leave that device without a setpoint for as long as it runs.
+        """
+        host = _host(model="TV02-Zigbee")
+
+        async def _refuse_the_preset(_domain, service, _data, **_kwargs):
+            if service == "set_preset_mode":
+                raise refusal
+
+        host.hass.services.async_call = AsyncMock(side_effect=_refuse_the_preset)
+
+        assert await TV02.override_set_temperature(host, ENTITY_ID, 21.0) is True
+        assert [
+            call.args[1] for call in host.hass.services.async_call.await_args_list
+        ] == ["set_preset_mode", "set_temperature"]
+
+    @pytest.mark.parametrize("refusal", REFUSALS, ids=REFUSAL_IDS)
+    @pytest.mark.asyncio
+    async def test_a_refused_preset_does_not_undo_the_mode_that_went_out(self, refusal):
+        """The mode is already on the wire, so the caller must not repeat it."""
+        host = _host(model="TV02-Zigbee")
+
+        async def _refuse_the_preset(_domain, service, _data, **_kwargs):
+            if service == "set_preset_mode":
+                raise refusal
+
+        host.hass.services.async_call = AsyncMock(side_effect=_refuse_the_preset)
+
+        assert await TV02.override_set_hvac_mode(host, ENTITY_ID, "heat") is True
+
+
+class TestTheZWaveValveDeclinesARefusedCommand:
+    """ZWA021 drives the valve through two Z-Wave JS command classes.
+
+    Both writes go to ``zwave_js.set_value``, which is missing outright on
+    an installation that reaches the device through some other integration,
+    and which a sleeping node answers with an error. Declining lets the
+    caller do what it does for a TRV without this quirk: put the device on
+    the standard climate service, and try the generic valve channel.
+    """
+
+    @staticmethod
+    def _direct_valve_host():
+        """A ZWA021 configured for direct valve control."""
+        return _host(
+            model="ZWA021", advanced={"calibration": CalibrationType.DIRECT_VALVE_BASED}
+        )
+
+    @pytest.mark.parametrize("refusal", REFUSALS, ids=REFUSAL_IDS)
+    @pytest.mark.asyncio
+    async def test_a_refused_valve_mode_write_is_declined(self, refusal):
+        """Without the mode the valve writes are ignored anyway."""
+        host = self._direct_valve_host()
+        host.hass.services.async_call = AsyncMock(side_effect=refusal)
+
+        answered = await zwa021_quirk.override_set_hvac_mode(host, ENTITY_ID, "heat")
+
+        assert answered is False
+
+    @pytest.mark.parametrize("refusal", REFUSALS, ids=REFUSAL_IDS)
+    @pytest.mark.asyncio
+    async def test_a_refused_valve_write_is_declined(self, refusal):
+        """A position that never reached the valve is not one to record."""
+        host = self._direct_valve_host()
+        host.hass.services.async_call = AsyncMock(side_effect=refusal)
+
+        assert await zwa021_quirk.override_set_valve(host, ENTITY_ID, 50) is False
+
+
+class TestTheEurotronicModeSelectReportsARefusedOption:
+    """SPZB0001 puts the device's TRV mode select on the mode it needs.
+
+    The select is what decides whether the device takes external valve
+    positions at all, and the write runs during startup, where the rest of
+    the TRV's initialisation follows it.
+    """
+
+    @staticmethod
+    def _registry_holding_a_mode_select():
+        """An entity registry whose device carries a TRV mode select."""
+        climate_entry = MagicMock(
+            entity_id=ENTITY_ID,
+            domain="climate",
+            device_id="device1",
+            unique_id="0x1234_climate",
+            original_name="TRV",
+        )
+        select_entry = MagicMock(
+            entity_id="select.trv_trv_mode",
+            domain="select",
+            device_id="device1",
+            unique_id="0x1234_trv_mode",
+            original_name="Trv mode",
+        )
+        registry = MagicMock()
+        registry.async_get.return_value = climate_entry
+        registry.entities.values.return_value = [climate_entry, select_entry]
+        return registry
+
+    @pytest.mark.parametrize("refusal", REFUSALS, ids=REFUSAL_IDS)
+    @pytest.mark.asyncio
+    async def test_a_refused_option_is_reported(self, refusal):
+        """The device keeps the mode it has, and says so."""
+        host = _host(state=State("select.trv_trv_mode", "2"), model="SPZB0001")
+        host.hass.services.async_call = AsyncMock(side_effect=refusal)
+
+        with patch.object(
+            spzb0001_quirk.er,
+            "async_get",
+            lambda hass: self._registry_holding_a_mode_select(),
+        ):
+            answered = await spzb0001_quirk.check_operation_mode(host, ENTITY_ID, "1")
+
+        assert answered is False
+
+    @pytest.mark.parametrize("refusal", REFUSALS, ids=REFUSAL_IDS)
+    @pytest.mark.asyncio
+    async def test_a_refused_option_does_not_end_the_startup_tweak(self, refusal):
+        """The startup path runs this write among others."""
+        host = _host(
+            state=State("select.trv_trv_mode", "2"),
+            model="SPZB0001",
+            advanced={"calibration": CalibrationType.DIRECT_VALVE_BASED},
+        )
+        host.hass.services.async_call = AsyncMock(side_effect=refusal)
+
+        with patch.object(
+            spzb0001_quirk.er,
+            "async_get",
+            lambda hass: self._registry_holding_a_mode_select(),
+        ):
+            assert await spzb0001_quirk.initial_tweak(host, ENTITY_ID) is None
+
+
+# Everything a quirk module may define that puts a command on a device,
+# together with the answer its contract owes the caller.
+WRITING_SURFACE = {
+    "override_set_hvac_mode": (("heat",), bool),
+    "override_set_temperature": ((21.0,), bool),
+    "override_set_valve": ((50,), bool),
+    "initial_tweak": ((), type(None)),
+}
+QUIRK_PACKAGE = "custom_components.better_thermostat.model_fixes"
+QUIRKS_DIR = Path(spzb0001_quirk.__file__).parent
+NOT_A_MODEL = {"__init__", "model_quirks", "types"}
+
+
+def _writing_pairs():
+    """Every (module, write function) pair the quirk package defines."""
+    pairs = []
+    for path in sorted(QUIRKS_DIR.glob("*.py")):
+        if path.stem in NOT_A_MODEL:
+            continue
+        module = import_module(f"{QUIRK_PACKAGE}.{path.stem}")
+        pairs.extend(
+            (module, path.stem, name)
+            for name in WRITING_SURFACE
+            if hasattr(module, name)
+        )
+    return pairs
+
+
+WRITING_PAIRS = _writing_pairs()
+WRITING_IDS = [f"{model}-{name}" for _module, model, name in WRITING_PAIRS]
+
+
+class TestNoQuirkLetsARefusalEscape:
+    """The same promise, held against every module at once.
+
+    Twelve modules extend Better Thermostat for one device family each, and
+    the control cycle reaches them through a duck-typed dispatch that puts
+    nothing between them and the loop. A module added later inherits the
+    same exposure, so the promise is stated for the whole package rather
+    than only for the modules that carry a write today.
+    """
+
+    @pytest.mark.parametrize(
+        ("module", "model", "name"), WRITING_PAIRS, ids=WRITING_IDS
+    )
+    @pytest.mark.parametrize("refusal", REFUSALS, ids=REFUSAL_IDS)
+    @pytest.mark.asyncio
+    async def test_it_answers_its_contract_instead_of_raising(
+        self, module, model, name, refusal
+    ):
+        """Called against a host that refuses everything, it still answers."""
+        arguments, expected = WRITING_SURFACE[name]
+        host = _host(
+            state=_climate_state(RANGE_BIT),
+            model=model,
+            advanced={"calibration": CalibrationType.DIRECT_VALVE_BASED},
+        )
+        host.hass.services.async_call = AsyncMock(side_effect=refusal)
+
+        answer = getattr(module, name)(host, ENTITY_ID, *arguments)
+        if inspect.iscoroutine(answer):
+            answer = await answer
+
+        if expected is type(None):
+            assert answer is None
+        else:
+            assert isinstance(answer, expected)


### PR DESCRIPTION
## Problem

Five quirk modules issue blocking service calls with nothing catching them:
`TV02-Zigbee.py` (44, 58, 97, 105), `BTH-RM.py` (79, 100, 112), `BTH-RM230Z.py`
(82, 103, 115), `ZWA021.py` (105, 148) and `SPZB0001.py` (70).

Home Assistant answers a blocking service call with an exception whenever the
device cannot take the write: a battery device that is asleep, a node out of
range, an integration reloading its config entry, a service that is not
registered at all, or an entity that does not carry the option or the attribute
the payload names. All of those are `HomeAssistantError` (`ServiceValidationError`
included); the transport underneath adds `OSError`. Driving each of the seven
call sites against a host that refuses the write confirms all seven raise today.

The exception escapes the quirk into `control_trv`, whose only handler is a
`finally`. The cycle ends there for that TRV: the calibration offset and the
setpoint are never written and the confirmation watchdogs are never armed.
`control_queue` gathers the task with `return_exceptions=True`, logs
`ERROR controlling TRV`, and re-queues the failed cycle with `put_nowait` and
nothing in between. `control_trv` holds `self._temp_lock`, one lock per Better
Thermostat instance, so the other TRVs of the same room wait through every
attempt.

Two cases where this is a permanent loss of function rather than a bad minute:

- A TV02-Zigbee whose firmware does not offer the `manual` preset gets a
  `ServiceValidationError` from `climate.set_preset_mode`. That write comes
  *before* the setpoint write in `override_set_temperature`, so the device never
  receives a setpoint at all, on every cycle, for as long as it runs.
- A ZWA021 on an installation that does not have Z-Wave JS loaded gets
  `ServiceNotFound` from `zwave_js.set_value`, which ends the cycle before the
  mode, the offset and the setpoint are written.

The generic adapter, which is what drives a TRV without a quirk, does not behave
this way: `set_hvac_mode` catches and logs, and the quirk-less setpoint path
carries a retry budget. The quirk modules were the only writers that let a
refusal reach the loop.

## Change

Each of the seven affected writes now catches `(HomeAssistantError, OSError)`,
logs a WARNING carrying the Better Thermostat name, the entity id and the
exception text, and reports the refusal through the function's return value.

`False` says no command reached the device. That is what the boolean already
means everywhere else in `model_fixes/`: it routes the caller to the standard
adapter path, which owns the retry handling. So a refused write now answers
`False` from `TV02-Zigbee.override_set_hvac_mode` and `override_set_temperature`,
from both Bosch modules' `override_set_temperature` (on all three of its
branches), and from `ZWA021.override_set_hvac_mode` and `override_set_valve` -
in the ZWA021 cases matching what those docstrings already promised for the
declined path. `SPZB0001.check_operation_mode` answers `False` alongside the
other reasons it already had for not having switched the mode; its summary line
described a different function entirely and now describes this one.

`True` stays reserved for a command that went out. TV02-Zigbee's `manual` preset
is the one supplementary device setting here: it keeps the TRV off its internal
schedule but is not the command the caller asked for, so its refusal is logged
and the mode or setpoint write still happens. It moved into a small module-local
writer shared by both call sites; the two Bosch modules got the same treatment
for their three identical setpoint calls.

The docstrings that said "True, always" were describing a contract the code no
longer has, and now say when each answer comes back.

## The cost this carries, and why the answer is still `False`

On the setpoint path a `False` hands the write to `delegate.set_temperature`,
which is `@async_retry(retries=5)`: six attempts with 1+2+4+8+16 s of backoff,
roughly 31 s, with `self._temp_lock` held throughout. For a device that refuses
permanently that is about 31 s per cycle where the cycle fails at once today.
Three measurements decided that this is worth taking:

- The startup path is bounded here exactly as on the development line:
  `climate.py:2003` runs `control_trv` under `asyncio.wait_for(..., timeout=10)`.
  The steady-state path carries no deadline on either line.
- The lock is a single `asyncio.Lock` per instance on both lines
  (`climate.py:679` here), so serialisation costs the same on both.
- The one real asymmetry runs the *other* way. A failed cycle is re-queued here
  with no delay, where the development line sleeps 2 s first. With `control_trv`
  raising every time, the loop turns over 6135 times in 0.30 s in a harness that
  replaces `control_trv` with an immediate raise. In the real system the rate is
  bounded by service dispatch rather than by that figure, but nothing in the path
  is a deliberate throttle.

Today every one of these seven refusals lands in that spin. After the change the
common case has no exception at all: the mode path answers `False`, the generic
adapter swallows the refusal, and the cycle completes normally. Where an
exception does survive - the setpoint path, whose generic adapter does not catch -
the adapter's backoff is the first throttle anywhere in the path. The 31 s buys
a throttle this line does not otherwise have.

Swallowing the refusal and answering `True` was the alternative, and it is worse
here than it would be on the development line: there is no reconciler on this
branch to notice afterwards that the device never took the value.

## Verification

New file `tests/unit/test_quirk_refused_writes.py`, 135 cases: every affected
function is driven against a host that refuses the write with each of
`HomeAssistantError`, `ServiceValidationError` and `OSError`, plus a systematic
case that holds the same promise against every module in the package, so a
module added later inherits the check.

Counterfactual, one module at a time (original file restored from HEAD, suite
re-run, fix put back):

| reverted module | failures |
|---|---|
| `TV02-Zigbee.py` | 18 |
| `BTH-RM.py` | 12 |
| `BTH-RM230Z.py` | 12 |
| `ZWA021.py` | 12 |
| `SPZB0001.py` | 6 |

Suite: 4622 passed, 1 skipped (baseline on `1.9` 4487 passed, 1 skipped; the 135
new cases are the difference, no existing test changed). `ruff check` and
`ruff format --check` clean.

Same change as #2331 on `develop`, with the helper extractions adapted to the
untyped modules on this line and the return semantics measured here rather than
carried over.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of refused thermostat, valve, and mode-setting commands.
  * Failed device writes now safely trigger standard retry and fallback behavior instead of causing errors.
  * Added clearer warnings when devices reject temperature, HVAC mode, valve, or preset changes.
  * Improved reliability when switching operating modes and applying temperature presets.

* **Tests**
  * Added comprehensive coverage for refused device commands across supported thermostat and valve models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->