### PR TITLE
fix: wait for the device before reporting an adopted TRV as tweaked (1.9)

### DIFF
--- a/custom_components/better_thermostat/model_fixes/default.py
+++ b/custom_components/better_thermostat/model_fixes/default.py
@@ -94,7 +94,11 @@ async def initial_tweak(self, entity_id):
                     cal_entity,
                 )
                 await self.hass.services.async_call(
-                    "number", "set_value", {"entity_id": cal_entity, "value": 0}
+                    "number",
+                    "set_value",
+                    {"entity_id": cal_entity, "value": 0},
+                    blocking=True,
+                    context=self.context,
                 )
             except Exception as e:
                 _LOGGER.warning(
@@ -127,7 +131,11 @@ async def initial_tweak(self, entity_id):
                             )
                             service = "turn_on" if child_lock_setting else "turn_off"
                             await self.hass.services.async_call(
-                                "switch", service, {"entity_id": cl_entity}
+                                "switch",
+                                service,
+                                {"entity_id": cl_entity},
+                                blocking=True,
+                                context=self.context,
                             )
                     elif domain == "lock":
                         target_lock = (
@@ -145,7 +153,11 @@ async def initial_tweak(self, entity_id):
                             )
                             service = "lock" if child_lock_setting else "unlock"
                             await self.hass.services.async_call(
-                                "lock", service, {"entity_id": cl_entity}
+                                "lock",
+                                service,
+                                {"entity_id": cl_entity},
+                                blocking=True,
+                                context=self.context,
                             )
                 except Exception as e:
                     _LOGGER.warning(
@@ -171,7 +183,11 @@ async def initial_tweak(self, entity_id):
                         win_entity,
                     )
                     await self.hass.services.async_call(
-                        "switch", "turn_off", {"entity_id": win_entity}
+                        "switch",
+                        "turn_off",
+                        {"entity_id": win_entity},
+                        blocking=True,
+                        context=self.context,
                     )
             except Exception as e:
                 _LOGGER.warning(
@@ -196,7 +212,11 @@ async def initial_tweak(self, entity_id):
                         away_entity,
                     )
                     await self.hass.services.async_call(
-                        "switch", "turn_off", {"entity_id": away_entity}
+                        "switch",
+                        "turn_off",
+                        {"entity_id": away_entity},
+                        blocking=True,
+                        context=self.context,
                     )
             except Exception as e:
                 _LOGGER.warning(

--- a/tests/unit/test_default_quirk.py
+++ b/tests/unit/test_default_quirk.py
@@ -469,3 +469,49 @@ class TestAdoptionRunsEveryStep:
             ("switch", "turn_off", {"entity_id": WINDOW_SWITCH}),
             ("switch", "turn_off", {"entity_id": AWAY_SWITCH}),
         ]
+
+    @pytest.mark.asyncio
+    async def test_every_step_waits_for_the_device_to_answer(self):
+        """A refusal only reaches the caller when the call blocks.
+
+        `ServiceRegistry.async_call` defaults to fire-and-forget and runs a
+        failing handler in a background task. Without `blocking=True` the
+        `except` around each step here can never see a device refuse, so the
+        warnings below it would never be reached and adoption would report a
+        device brought into a known state it never took.
+        """
+        thermostat = _thermostat(
+            child_lock=True,
+            states={
+                CHILD_LOCK_SWITCH: STATE_OFF,
+                WINDOW_SWITCH: STATE_ON,
+                AWAY_SWITCH: STATE_ON,
+            },
+        )
+
+        await _run_tweak(
+            thermostat,
+            calibration=CALIBRATION_ENTITY,
+            child_lock=CHILD_LOCK_SWITCH,
+            window=WINDOW_SWITCH,
+            away=AWAY_SWITCH,
+        )
+
+        waited = [
+            (call.kwargs.get("blocking"), call.kwargs.get("context"))
+            for call in thermostat.hass.services.async_call.await_args_list
+        ]
+        assert waited == [(True, thermostat.context)] * 4
+
+    @pytest.mark.asyncio
+    async def test_a_lock_step_waits_for_the_device_to_answer(self):
+        """The lock branch is the one step the equipped-device run does not take."""
+        thermostat = _thermostat(
+            child_lock=True, states={CHILD_LOCK_LOCK: LockState.UNLOCKED}
+        )
+
+        await _run_tweak(thermostat, child_lock=CHILD_LOCK_LOCK)
+
+        call = thermostat.hass.services.async_call.await_args_list[0]
+        assert call.kwargs["blocking"] is True
+        assert call.kwargs["context"] is thermostat.context


### PR DESCRIPTION
Maintenance-line counterpart of #2334.

## What

`initial_tweak()` in `model_fixes/default.py` puts a freshly adopted TRV into a known state: local calibration back to zero, child lock following the configuration, and the device's own window and away detection off. Each of the five service calls that does this omitted `blocking=True`.

`ServiceRegistry.async_call` defaults to `blocking: bool = False` and runs a failing handler in a background task, so a device refusing one of these writes never raised in `initial_tweak`. The `except Exception` around each step could not see it, and the `_LOGGER.warning` under each one was unreachable in production. Adoption reported a device brought into a known state it had never taken — its calibration still offset, its child lock in the wrong position, or its own window detection still fighting Better Thermostat's.

All five calls now pass `blocking=True, context=self.context`, which is what every other quirk module already does — `BTH-RM`, `BTH-RM230Z`, `TV02-Zigbee`, `TRVZB` and, since #2332, `SPZB0001`.

## How this was found

CodeRabbit flagged the same defect in `SPZB0001.check_operation_mode` on #2332. `default.py` carries it five more times and is outside that PR's scope, so it gets its own.

## Why the tests did not catch it

`test_a_failing_child_lock_write_does_not_stop_the_remaining_steps` and its two siblings set the mock's `side_effect` to raise, so the failure arrives whatever `blocking` says. They assert resilience against a failure that production could never deliver. The two new tests assert the call arguments instead — that every step is issued with `blocking=True` and the entity's context — and both fail against the unfixed source.

## Scope

The broad `except Exception` in each block stays: narrowing it would change which failures reach the startup path, and that is a separate concern.

https://claude.ai/code/session_01U6NFDHBVHGP8TvB7b7x9tM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thermostat setup actions now wait for device responses before continuing.
  * Calibration, child-lock, window detection, and away-mode updates provide clearer handling when the device refuses a command.

* **Tests**
  * Added coverage to verify setup actions wait for confirmation across supported thermostat configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->