### PR TITLE
fix: fail the coverage gate when a recorded floor leaves the report

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -360,6 +360,10 @@ which holds the level each module is at today. A change that leaves one of them
 less covered than it was fails the build; a module nobody has measured yet has
 nothing to fall below and passes.
 
+A recorded module the report does not cover fails the build as well. A floor
+nothing measures holds nothing back, so a module that was deleted or renamed
+has to be re-recorded rather than leave its floor behind unenforced.
+
 The floors are per module rather than one number for the project because a
 single project-wide threshold is bought back by adding tests where they are
 easiest to write, and every user-visible bug this project has had came from a

--- a/scripts/coverage_floors.py
+++ b/scripts/coverage_floors.py
@@ -15,8 +15,11 @@ Two modes:
 
 ``check``
     Compare a coverage JSON report against the stored floors and exit non-zero
-    when any module fell below its own. Modules with no floor yet are listed
-    and do not fail — a new module has nothing to regress against.
+    when any module fell below its own. A module that has a floor but is
+    missing from the report fails too: a floor nothing measures holds nothing
+    back, so leaving the report would otherwise retire a guard in silence.
+    Modules with no floor yet are listed and do not fail — a new module has
+    nothing to regress against.
 
 ``update``
     Rewrite the floors from a report. Run this after landing work that raises
@@ -80,7 +83,10 @@ def _load_floors() -> dict[str, float]:
 
 
 def check(report_path: Path) -> int:
-    """Report every module that fell below its floor. Return an exit code."""
+    """Report every module that fell below its floor or left the report.
+
+    Return an exit code.
+    """
     measured = _read_report(report_path)
     floors = _load_floors()
     if not floors:
@@ -96,21 +102,31 @@ def check(report_path: Path) -> int:
 
     for module in new:
         print(f"no floor yet: {module} at {measured[module]:.1f}%")
-    for module in gone:
-        print(f"not in the report: {module} (floor {floors[module]:.1f}%)")
 
-    if not regressions:
-        print(f"all {len(floors)} modules hold their floor")
-        return 0
+    if regressions:
+        print("\ncoverage dropped below the recorded floor:")
+        for module, floor, now in regressions:
+            print(f"  {module}: {now:.1f}% < {floor:.1f}%")
+        print(
+            "\nAdd tests for what the change left uncovered, or — if the drop is "
+            f"intended — re-record with '{Path(__file__).name} update'."
+        )
 
-    print("\ncoverage dropped below the recorded floor:")
-    for module, floor, now in regressions:
-        print(f"  {module}: {now:.1f}% < {floor:.1f}%")
-    print(
-        "\nAdd tests for what the change left uncovered, or — if the drop is "
-        f"intended — re-record with '{Path(__file__).name} update'."
-    )
-    return 1
+    if gone:
+        print("\nrecorded floors the report does not cover:")
+        for module in gone:
+            print(f"  {module} (floor {floors[module]:.1f}%)")
+        print(
+            "\nA floor nothing measures holds nothing back. Restore the module at "
+            "the recorded path, or re-record with "
+            f"'{Path(__file__).name} update' if it was deleted or renamed."
+        )
+
+    if regressions or gone:
+        return 1
+
+    print(f"all {len(floors)} modules hold their floor")
+    return 0
 
 
 def update(report_path: Path) -> int:

--- a/tests/unit/test_coverage_floors.py
+++ b/tests/unit/test_coverage_floors.py
@@ -1,9 +1,9 @@
 """Tests for the per-module coverage floors.
 
 The floors are the thing that notices when a change leaves code uncovered, so
-the check itself has to be right about three cases: a module that held its
-level passes, one that dropped fails, and one nobody has measured yet does not
-count as a regression.
+the check itself has to be right about four cases: a module that held its
+level passes, one that dropped fails, one that vanished from the report fails
+too, and one nobody has measured yet does not count as a regression.
 """
 
 import importlib.util
@@ -78,6 +78,69 @@ def test_check_fails_when_a_module_drops(floors, tmp_path, capsys):
     output = capsys.readouterr().out
     assert MODULE in output
     assert OTHER not in output.split("dropped below")[-1]
+
+
+def test_check_fails_when_a_recorded_module_is_missing_from_the_report(
+    floors, tmp_path, capsys
+):
+    """A floor nothing measures is not being held, so its absence has to fail.
+
+    Passing here would retire a module's floor the moment the module stopped
+    being measured, and the run would still report that every floor holds.
+    """
+    floors.update(_report(tmp_path, **{MODULE: 88.7, OTHER: 93.0}))
+
+    assert floors.check(_report(tmp_path, **{MODULE: 88.7})) == 1
+
+    output = capsys.readouterr().out
+    assert OTHER in output
+    assert "hold their floor" not in output
+
+
+def test_the_missing_module_failure_names_the_re_record_path(floors, tmp_path, capsys):
+    """Re-recording is the only legitimate exit, so the failure has to name it.
+
+    A module that really was deleted or renamed has to leave the floors file
+    somehow; a reader who is not told which command does that will edit the
+    file by hand or stop trusting the gate.
+    """
+    floors.update(_report(tmp_path, **{MODULE: 88.7, OTHER: 93.0}))
+
+    floors.check(_report(tmp_path, **{MODULE: 88.7}))
+
+    assert "coverage_floors.py update" in capsys.readouterr().out
+
+
+def test_check_counts_every_recorded_floor_when_it_reports_success(
+    floors, tmp_path, capsys
+):
+    """The success line may only be claimed once every recorded floor was measured.
+
+    Its count is the number a reader takes as the size of the guarded set, so
+    a run that compared fewer modules than it names is worse than no report.
+    """
+    floors.update(_report(tmp_path, **{MODULE: 88.7, OTHER: 93.0}))
+
+    assert floors.check(_report(tmp_path, **{MODULE: 90.0, OTHER: 93.0})) == 0
+
+    assert "all 2 modules hold their floor" in capsys.readouterr().out
+
+
+def test_update_drops_the_floor_of_a_module_the_report_no_longer_covers(
+    floors, tmp_path
+):
+    """Re-recording has to accept the very report the check rejects.
+
+    Both modes read the same report, so a missing module must stay a finding
+    of the check alone — if update refused it too, a deleted module would
+    leave the floors file unfixable by the tool that owns it.
+    """
+    floors.update(_report(tmp_path, **{MODULE: 88.7, OTHER: 93.0}))
+
+    assert floors.update(_report(tmp_path, **{MODULE: 88.7})) == 0
+
+    recorded = json.loads(floors.FLOORS_FILE.read_text(encoding="utf-8"))
+    assert recorded == {MODULE: 88.7}
 
 
 def test_a_module_without_a_floor_is_not_a_regression(floors, tmp_path, capsys):


### PR DESCRIPTION
## What

`scripts/coverage_floors.py check` collected the modules that have a recorded floor but no entry in the coverage report, printed one line each, and then returned `0` whenever no module had regressed. A floor therefore stopped being enforced the moment its module dropped out of the report — deleted, renamed, or simply no longer imported by any test — while the gate went on printing `all N modules hold their floor` with an N that was quietly smaller than the recorded set.

A guard that can be bypassed without anyone noticing is worse than no guard: it reports assurance it is not providing. `check` now fails on those modules too, in a block of its own so the output says which of the two problems it is, and the message names the one legitimate way out — restore the module, or re-record with `coverage_floors.py update` if it really was deleted or renamed.

`update` is untouched; only `check` gained the failure.

## How this was found

CodeRabbit raised it as an outside-diff finding on #2308, whose subject is repair-issue lifecycle. It belongs here rather than there.

## Why it cannot fire spuriously

`[tool.coverage.run] source` points at the package, so coverage.py emits an entry for every file under `custom_components/better_thermostat` even when no test imports it. There are 100 recorded floors and 100 `.py` files under that path, and `check` passes on this branch. The new failure is reachable only by a real delete or rename — which is exactly the case that should stop the build until the floors are re-recorded.

## Tests

Four cases in `tests/unit/test_coverage_floors.py`: a recorded module missing from the report fails; the failure names the re-record path; a report covering every recorded module still passes; `update` is unaffected.

The first two fail against the unfixed script — verified by stashing it and re-running. The other two cannot fail against it and are not meant to: they pin that the change did not over-reach, so a red result from either would mean the healthy path had broken.

`CONTRIBUTING.md` gains a paragraph, because the section describing this gate no longer described all of it.

## Scope

develop only — the maintenance line carries no `scripts/coverage_floors.py`.

https://claude.ai/code/session_01U6NFDHBVHGP8TvB7b7x9tM

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

Verified against the automated suite, not on a physical device. Device
behaviour is exercised through the fake-TRV fixtures under `tests/`, which
model the write contract of each supported integration.

HA Version: 2026.7.2 (the version `pytest-homeassistant-custom-component` pins)
Zigbee2MQTT Version: n/a — no hardware run
TRV Hardware: n/a — no hardware run

## New device mappings

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Coverage validation now fails when a previously recorded module is missing from the coverage report.
  * Failure messages identify missing modules and explain how to re-record coverage floors.
  * Successful checks are reported only when all recorded modules are covered and meet their required floors.
  * Coverage-floor updates now remove entries for modules no longer included in reports.

* **Documentation**
  * Contributor guidance now explains how missing, deleted, or renamed modules affect coverage checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->