### PR TITLE
fix: let the entity cancel the background tasks it started

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -8,6 +8,7 @@ from collections import deque
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import replace
 from datetime import datetime, timedelta
+from functools import partial
 import json
 import logging
 import math
@@ -1058,6 +1059,33 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self._owned_tasks.add(task)
         task.add_done_callback(self._owned_tasks.discard)
         return task
+
+    @callback
+    def _start_owned_timer_work(
+        self, coro_fn: Callable[[Any], Coroutine[Any, Any, Any]], name: str, now: Any
+    ) -> None:
+        """Run one firing of a periodic timer as work this entity owns.
+
+        Handing an async callback to ``async_track_time_interval`` lets Home
+        Assistant run it in a task of its own. Unsubscribing the timer on
+        removal ends the next firing, not the one already running, and these
+        callbacks write setpoints, calibration offsets and the external
+        temperature. Spawning each firing through ``_spawn_owned`` puts it in
+        the set the removal cancels.
+
+        Registrations bind the first two parameters with ``partial``, which
+        Home Assistant unwraps when it classifies the job.
+
+        Parameters
+        ----------
+        coro_fn : collections.abc.Callable
+            The coroutine function this timer runs.
+        name : str
+            Task name prefix; the device name is appended.
+        now : datetime.datetime
+            The firing time Home Assistant passes in.
+        """
+        self._spawn_owned(coro_fn(now), name=f"{name}_{self.device_name}")
 
     async def async_added_to_hass(self):
         """Run when entity about to be added.
@@ -2536,7 +2564,17 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # Add listener
         if self.outdoor_sensor is not None:
             self.async_on_remove(
-                async_track_time_change(self.hass, self._trigger_time, 5, 0, 0)
+                async_track_time_change(
+                    self.hass,
+                    partial(
+                        self._start_owned_timer_work,
+                        self._trigger_time,
+                        "bt_outdoor_tick",
+                    ),
+                    5,
+                    0,
+                    0,
+                )
             )
 
         # Wait for optional sensors with increasing retry delays before
@@ -2570,7 +2608,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         )
         self.async_on_remove(
             async_track_time_interval(
-                self.hass, self._trigger_check_weather, timedelta(hours=1)
+                self.hass,
+                partial(
+                    self._start_owned_timer_work,
+                    self._trigger_check_weather,
+                    "bt_weather_tick",
+                ),
+                timedelta(hours=1),
             )
         )
 
@@ -2614,7 +2658,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.async_on_remove(
             async_track_time_interval(
                 self.hass,
-                self._trigger_time if recomputes else self._availability_tick,
+                partial(
+                    self._start_owned_timer_work,
+                    self._trigger_time if recomputes else self._availability_tick,
+                    "bt_periodic_tick",
+                ),
                 timedelta(minutes=5),
             )
         )
@@ -2639,7 +2687,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             )
             self.async_on_remove(
                 async_track_time_interval(
-                    self.hass, self._maintenance_tick, timedelta(minutes=5)
+                    self.hass,
+                    partial(
+                        self._start_owned_timer_work,
+                        self._maintenance_tick,
+                        "bt_maintenance_tick",
+                    ),
+                    timedelta(minutes=5),
                 )
             )
             _LOGGER.debug(
@@ -2758,7 +2812,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.async_on_remove(
             async_track_time_interval(
                 self.hass,
-                self._external_temperature_keepalive,
+                partial(
+                    self._start_owned_timer_work,
+                    self._external_temperature_keepalive,
+                    "bt_ext_temp_keepalive",
+                ),
                 EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL,
             )
         )
@@ -2766,14 +2824,26 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         _LOGGER.debug("better_thermostat %s: starting EMA timer...", self.device_name)
         self.async_on_remove(
             async_track_time_interval(
-                self.hass, self._async_update_ema_periodic, timedelta(minutes=1)
+                self.hass,
+                partial(
+                    self._start_owned_timer_work,
+                    self._async_update_ema_periodic,
+                    "bt_ema_tick",
+                ),
+                timedelta(minutes=1),
             )
         )
         # Periodic reconciliation: heal lost writes by re-converging the
         # devices onto the kernel's intent.
         self.async_on_remove(
             async_track_time_interval(
-                self.hass, self._reconcile_tick, timedelta(minutes=5)
+                self.hass,
+                partial(
+                    self._start_owned_timer_work,
+                    self._reconcile_tick,
+                    "bt_reconcile_tick",
+                ),
+                timedelta(minutes=5),
             )
         )
         _LOGGER.info("better_thermostat %s: startup completed.", self.device_name)

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2537,6 +2537,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # DEBUG and the HA repair issue is deferred — slow cloud integrations
         # get time to come online before the user sees a warning.
         await await_optional_sensors(self)
+        # That wait can run for the better part of a minute and gives the
+        # entity up on its own once the removal starts, so the removal is
+        # read here rather than after the two steps below: a degraded-mode
+        # evaluation writes entity state, and the recheck outlives the call
+        # that starts it.
+        if self.is_removed:
+            return
         await check_and_update_degraded_mode(self)
 
         self._spawn_owned(

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -1023,7 +1023,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
     def _spawn_owned(
         self, coro: Coroutine[Any, Any, Any], *, name: str
-    ) -> asyncio.Task[Any]:
+    ) -> asyncio.Task[Any] | None:
         """Start a background task that ends when this entity is removed.
 
         Home Assistant cancels background tasks at core shutdown, not when a
@@ -1040,11 +1040,20 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         name : str
             The name Home Assistant labels the task with.
 
+        A removed entity starts nothing. ``async_will_remove_from_hass`` takes
+        one snapshot of ``_owned_tasks`` and cancels what is in it; a task
+        started afterwards is not in that snapshot and would keep writing to
+        TRVs. Callers reach here after awaiting, so their own removal checks
+        can be stale by the time they spawn, and the check belongs here.
+
         Returns
         -------
-        asyncio.Task
-            The started task.
+        asyncio.Task or None
+            The started task, or ``None`` when the entity is already removed.
         """
+        if self.is_removed:
+            coro.close()
+            return None
         task = self.hass.async_create_background_task(coro, name=name)
         self._owned_tasks.add(task)
         task.add_done_callback(self._owned_tasks.discard)

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC
 import asyncio
 from collections import deque
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import replace
 from datetime import datetime, timedelta
 import json
@@ -989,6 +989,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self._control_task = None
         self._window_task = None
         self._door_task = None
+        self._owned_tasks: set[asyncio.Task[Any]] = set()
         self.is_removed = False
         # Valve maintenance control
         # If control actions are requested during valve maintenance, defer them and
@@ -1019,6 +1020,35 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.accum_dir = 0
         self.pending_temp = None
         self.pending_since = None
+
+    def _spawn_owned(
+        self, coro: Coroutine[Any, Any, Any], *, name: str
+    ) -> asyncio.Task[Any]:
+        """Start a background task that ends when this entity is removed.
+
+        Home Assistant cancels background tasks at core shutdown, not when a
+        single entity goes away, so an untracked task outlives the thermostat
+        that started it. Several of them write to TRVs, which then follow a
+        thermostat that no longer exists. Keeping the handle lets
+        ``async_will_remove_from_hass`` stop the task, and the done callback
+        drops finished tasks so the set stays the size of the work in flight.
+
+        Parameters
+        ----------
+        coro : Coroutine
+            The coroutine to run in the background.
+        name : str
+            The name Home Assistant labels the task with.
+
+        Returns
+        -------
+        asyncio.Task
+            The started task.
+        """
+        task = self.hass.async_create_background_task(coro, name=name)
+        self._owned_tasks.add(task)
+        task.add_done_callback(self._owned_tasks.discard)
+        return task
 
     async def async_added_to_hass(self):
         """Run when entity about to be added.
@@ -1131,6 +1161,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             )
             # flush() saves immediately; the Store cancels its own
             # pending delayed write when async_save runs.
+            # This is the last write of the removal itself, so it is deliberately
+            # not one of the entity's owned tasks: cancelling it would drop the
+            # state the next start reads back.
             if self.state_mgr is not None:
                 try:
                     self._record_runtime_to_state()
@@ -1177,7 +1210,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     All parameters are piped.
             """
             self.context = Context()
-            self.hass.async_create_background_task(
+            self._spawn_owned(
                 self.startup(), name=f"better_thermostat_startup_{self.device_name}"
             )
 
@@ -1293,7 +1326,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         the hand-over, down to deciding whether the event carries a reading
         at all.
         """
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             self._handle_temperature_reading(event),
             name=f"bt_trigger_temp_change_{self.device_name}",
         )
@@ -1439,7 +1472,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if (event.data.get("new_state")) is None:
             return
 
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             trigger_trv_change(self, event),
             name=f"bt_trigger_trv_change_{self.device_name}",
         )
@@ -1458,7 +1491,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # The window/door handler interprets unknown/unavailable readings
         # itself (a lost sensor counts as closed so heating resumes), so
         # events are dispatched regardless of sensor availability.
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             trigger_fn(self, event),
             name=f"bt_trigger_{task_label}_change_{self.device_name}",
         )
@@ -1480,7 +1513,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if (event.data.get("new_state")) is None:
             return
 
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             trigger_cooler_change(self, event),
             name=f"bt_trigger_cooler_change_{self.device_name}",
         )
@@ -2399,7 +2432,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # ends, so a TRV that is still missing defers its repair issue. Re-run
         # the check once the grace window has elapsed; otherwise the issue
         # only appears when some later event happens to trigger a check.
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             self._post_grace_recheck(
                 self._critical_grace_until, check_critical_entities
             ),
@@ -2490,7 +2523,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         await await_optional_sensors(self)
         await check_and_update_degraded_mode(self)
 
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             self._post_grace_recheck(
                 self._degraded_grace_until, check_and_update_degraded_mode
             ),
@@ -2680,7 +2713,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             _LOGGER.debug(
                 "better_thermostat %s: creating keepalive task...", self.device_name
             )
-            self.hass.async_create_background_task(
+            self._spawn_owned(
                 self._external_temperature_keepalive(),
                 name=f"bt_ext_temp_keepalive_{self.device_name}",
             )
@@ -2777,7 +2810,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             return
 
         # Run maintenance asynchronously (don't block the tick)
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             self._run_valve_maintenance(trvs_to_service),
             name=f"bt_valve_maintenance_{self.device_name}",
         )
@@ -4156,7 +4189,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if self.hass is None:
             return
         # Schedule without waiting; state updates will propagate asynchronously.
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             self.async_set_preset_mode(preset_mode),
             name=f"bt_set_preset_{self.device_name}",
         )
@@ -4384,6 +4417,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if self.plateau_timer_cancel is not None:
             self.plateau_timer_cancel()
             self.plateau_timer_cancel = None
+        # The owned tasks are cancelled before anything is awaited, for the same
+        # reason: several of them write to TRVs, and awaiting the workers below
+        # hands the loop back long enough for a ready one to take its turn.
+        owned_tasks = list(self._owned_tasks)
+        self._owned_tasks.clear()
+        for owned_task in owned_tasks:
+            owned_task.cancel()
         if self._control_task:
             self._control_task.cancel()
             try:
@@ -4402,6 +4442,8 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 await self._door_task
             except asyncio.CancelledError:
                 pass
+        if owned_tasks:
+            await asyncio.gather(*owned_tasks, return_exceptions=True)
         await super().async_will_remove_from_hass()
 
 

--- a/tests/integration/test_entry_lifecycle.py
+++ b/tests/integration/test_entry_lifecycle.py
@@ -13,6 +13,7 @@ that depends on the device is derived from the profile it was built from.
 from contextlib import contextmanager
 from dataclasses import replace
 from datetime import timedelta
+from functools import partial
 from unittest.mock import patch
 
 from homeassistant.components.climate import HVACMode
@@ -250,7 +251,11 @@ def _recording_intervals(registered):
     real = climate_module.async_track_time_interval
 
     def _record(hass, action, interval, *args, **kwargs):
-        registered.append((getattr(action, "__name__", repr(action)), interval))
+        # Each tick reaches the tracker through a dispatcher that spawns the
+        # firing as work the entity owns, bound with ``partial``. What is on
+        # the interval is the tick that dispatcher runs.
+        tick = action.args[0] if isinstance(action, partial) else action
+        registered.append((getattr(tick, "__name__", repr(tick)), interval))
         return real(hass, action, interval, *args, **kwargs)
 
     with patch.object(climate_module, "async_track_time_interval", _record):

--- a/tests/unit/test_climate_maintenance.py
+++ b/tests/unit/test_climate_maintenance.py
@@ -39,7 +39,7 @@ def bt():
     mock.bt_hvac_mode = HVACMode.HEAT
     mock.real_trvs = {"climate.trv": {}}
     mock.hass = MagicMock()
-    mock.hass.async_create_background_task = MagicMock()
+    mock._spawn_owned = MagicMock()
     mock.clock = MagicMock()
     mock.clock.now.return_value = _NOW
     mock.clock.monotonic.return_value = 1000.0
@@ -56,7 +56,7 @@ async def test_critical_entities_unavailable_returns_early(bt):
     ):
         await BetterThermostat._maintenance_tick(bt)
     assert bt.next_valve_maintenance is None
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -70,7 +70,7 @@ async def test_availability_check_exception_returns(bt):
         patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
     ):
         await BetterThermostat._maintenance_tick(bt)
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -82,7 +82,7 @@ async def test_already_in_maintenance_returns(bt):
         patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
     ):
         await BetterThermostat._maintenance_tick(bt)
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -94,7 +94,7 @@ async def test_not_due_yet_returns(bt):
         patch(f"{_CLIMATE}.check_and_update_degraded_mode", AsyncMock()),
     ):
         await BetterThermostat._maintenance_tick(bt)
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -108,7 +108,7 @@ async def test_window_open_postpones_one_hour(bt):
     ):
         await BetterThermostat._maintenance_tick(bt)
     assert bt.next_valve_maintenance == _NOW + timedelta(hours=1)
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -125,7 +125,7 @@ async def test_hvac_off_still_runs_maintenance(bt, mode_attr):
         ),
     ):
         await BetterThermostat._maintenance_tick(bt)
-    bt.hass.async_create_background_task.assert_called_once()
+    bt._spawn_owned.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -139,7 +139,7 @@ async def test_window_open_still_postpones_while_off(bt):
     ):
         await BetterThermostat._maintenance_tick(bt)
     assert bt.next_valve_maintenance == _NOW + timedelta(hours=1)
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -152,7 +152,7 @@ async def test_no_enabled_trvs_schedules_far_future(bt):
     ):
         await BetterThermostat._maintenance_tick(bt)
     assert bt.next_valve_maintenance == _NOW + timedelta(days=7)
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -201,7 +201,7 @@ async def test_due_and_enabled_dispatches_maintenance(bt):
         ),
     ):
         await BetterThermostat._maintenance_tick(bt)
-    bt.hass.async_create_background_task.assert_called_once()
+    bt._spawn_owned.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -179,6 +179,7 @@ def plateau_bt(bt, hass):
     bt.pending_temp = None
     bt.pending_since = None
     bt.plateau_timer_cancel = None
+    bt._owned_tasks = set()
     bt.all_trvs = [{"advanced": {CONF_HOMEMATICIP: False}}]
     trv = MagicMock()
     trv.model_quirks = MagicMock()
@@ -309,6 +310,7 @@ class TestStartupUnloadBailout:
         bt._window_task = None
         bt._door_task = None
         bt.plateau_timer_cancel = None
+        bt._owned_tasks = set()
 
         await BetterThermostat.async_will_remove_from_hass(bt)
 
@@ -426,6 +428,151 @@ class TestPlateauTimerOnRemoval:
         await BetterThermostat.async_will_remove_from_hass(plateau_bt)
 
         assert order == ["timer", "worker"]
+
+
+# ---------------------------------------------------------------------------
+# 0c. background tasks the entity owns
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def owned_task_bt(bt, hass):
+    """A thermostat whose background tasks run on a real event loop.
+
+    Spawning and teardown are both under test here, so the helper that
+    starts a task runs for real while staying observable, and no queue
+    worker is started, leaving the teardown only the spawned work to
+    answer for.
+    """
+    bt.hass = hass
+    bt._control_task = None
+    bt._window_task = None
+    bt._door_task = None
+    bt.plateau_timer_cancel = None
+    bt._owned_tasks = set()
+    bt._spawn_owned = lambda coro, *, name: BetterThermostat._spawn_owned(
+        bt, coro, name=name
+    )
+    return bt
+
+
+def _record_readings_into(entity, readings):
+    """Make the reading handler append to ``readings`` after one loop turn.
+
+    The turn matters: the handler has to be suspended, not finished, when
+    the removal starts, or there is nothing left for the removal to stop.
+    """
+
+    async def handle(event):
+        await asyncio.sleep(0)
+        readings.append(event)
+
+    entity._handle_temperature_reading = AsyncMock(side_effect=handle)
+
+
+class TestOwnedBackgroundTasks:
+    """Work the entity started must end when the entity is removed.
+
+    Home Assistant cancels background tasks when the core shuts down, not
+    when a single entity goes away, so an entity that unloads on its own
+    leaves them running. Several of them write to TRVs, and a write that
+    lands after the unload comes from a thermostat the user no longer has.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_dispatched_reading_reaches_the_handler(self, hass, owned_task_bt):
+        """A reading dispatched by a live entity is handled."""
+        readings = []
+        _record_readings_into(owned_task_bt, readings)
+        event = MagicMock()
+
+        await BetterThermostat._trigger_temperature_change(owned_task_bt, event)
+        await hass.async_block_till_done()
+
+        assert readings == [event]
+
+    @pytest.mark.asyncio
+    async def test_removal_drops_a_reading_still_in_flight(self, hass, owned_task_bt):
+        """A reading dispatched before the removal must not be handled after it.
+
+        Handling it writes the room temperature to TRVs the entity has
+        already let go of, so the reading has to die with its entity.
+        """
+        readings = []
+        _record_readings_into(owned_task_bt, readings)
+
+        await BetterThermostat._trigger_temperature_change(owned_task_bt, MagicMock())
+        assert readings == []
+
+        await BetterThermostat.async_will_remove_from_hass(owned_task_bt)
+        await hass.async_block_till_done()
+
+        assert readings == []
+
+    @pytest.mark.asyncio
+    async def test_a_finished_task_stops_being_tracked(self, hass, owned_task_bt):
+        """Tracking must end when the work does.
+
+        A thermostat handles a reading every few seconds for months on end.
+        Holding on to every task it ever started would grow without bound
+        for the sake of a teardown that has nothing left to cancel.
+        """
+        readings = []
+        _record_readings_into(owned_task_bt, readings)
+
+        await BetterThermostat._trigger_temperature_change(owned_task_bt, MagicMock())
+        assert len(owned_task_bt._owned_tasks) == 1
+
+        await hass.async_block_till_done()
+        # The task drops itself from a callback the loop runs after it ends.
+        await asyncio.sleep(0)
+
+        assert owned_task_bt._owned_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_removal_keeps_the_last_state_write(self, hass, owned_task_bt):
+        """The save the removal itself performs must not be cancelled with the rest.
+
+        It is the only record the next start has of the learned thermal
+        model and the target the user last set; dropping it silently resets
+        the thermostat to its defaults on the next restart.
+        """
+        state_mgr = MagicMock()
+        state_mgr.load = AsyncMock()
+        state_mgr.flush = AsyncMock()
+        owned_task_bt.all_trvs = []
+        owned_task_bt._unique_id = "uid"
+        owned_task_bt._config_entry_id = "entry"
+        owned_task_bt.entity_id = "climate.bt_test"
+
+        async def idle_worker(_entity):
+            await asyncio.Event().wait()
+
+        module = "custom_components.better_thermostat.climate"
+        with (
+            patch(f"{module}.control_queue", side_effect=idle_worker),
+            patch(f"{module}.StateManager", return_value=state_mgr),
+            patch(f"{module}.migrate_v0_stores", new=AsyncMock()),
+        ):
+            await BetterThermostat.async_added_to_hass(owned_task_bt)
+
+        save_on_removal = next(
+            call.args[0]
+            for call in owned_task_bt.async_on_remove.call_args_list
+            if getattr(call.args[0], "__name__", "") == "on_remove"
+        )
+        readings = []
+        _record_readings_into(owned_task_bt, readings)
+        await BetterThermostat._trigger_temperature_change(owned_task_bt, MagicMock())
+
+        # Home Assistant runs the registered removal callbacks after the
+        # entity's own teardown, so the save is written last.
+        await BetterThermostat.async_will_remove_from_hass(owned_task_bt)
+        save_on_removal()
+        await hass.async_block_till_done()
+
+        assert readings == []
+        state_mgr.flush.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -1760,6 +1760,58 @@ async def _run_finalize_startup(bt):
         await BetterThermostat._finalize_startup(bt)
 
 
+class TestStartupStopsOnceTheEntityIsGone:
+    """A startup interrupted by removal must not go on setting the room up.
+
+    Waiting for the optional sensors can run for the better part of a
+    minute, and the entity can be removed inside that window. Everything
+    after it belongs to a thermostat the user still has.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_removal_during_the_sensor_wait_ends_the_startup(self, bt):
+        """The degraded evaluation writes state, so it may not run after it.
+
+        `await_optional_sensors` gives up on its own once the removal
+        starts, and returns normally. Reading the removal only after the
+        steps below it lets a torn-down entity publish a degraded mode and
+        start a recheck that outlives the call.
+        """
+
+        async def removed_during_the_wait(_self):
+            _self.is_removed = True
+            return []
+
+        degraded = AsyncMock()
+        bt.is_removed = False
+        bt.all_trvs = None
+        bt.entity_ids = [TRV_ID]
+        bt._async_unsub_state_changed = None
+        bt._post_grace_recheck = MagicMock()
+        bt._external_temperature_keepalive = MagicMock()
+        bt._spawn_owned = MagicMock()
+        bt.control_queue_task = asyncio.Queue(maxsize=1)
+        with (
+            patch(f"{_CLIMATE}.await_critical_entities", AsyncMock()),
+            patch(f"{_CLIMATE}.check_critical_entities", AsyncMock()),
+            patch(f"{_CLIMATE}.await_optional_sensors", removed_during_the_wait),
+            patch(f"{_CLIMATE}.check_and_update_degraded_mode", degraded),
+            patch(f"{_CLIMATE}.async_track_state_change_event", MagicMock()),
+            patch(f"{_CLIMATE}.async_track_time_interval", MagicMock()),
+            patch(f"{_CLIMATE}.async_track_time_change", MagicMock()),
+            patch(f"{_CLIMATE}.asyncio.sleep", AsyncMock()),
+        ):
+            await BetterThermostat._finalize_startup(bt)
+
+        degraded.assert_not_awaited()
+        # The critical-entity recheck is started before the wait; only the
+        # degraded one belongs to the steps this guard now covers.
+        started = [
+            call.kwargs.get("name", "") for call in bt._spawn_owned.call_args_list
+        ]
+        assert not any("post_grace_degraded" in name for name in started)
+
+
 class TestCoolerTargetReadAtListenerRegistration:
     """The cool target is re-read once the cooler subscription is live.
 

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -589,6 +589,36 @@ class TestOwnedBackgroundTasks:
         assert owned_task_bt._owned_tasks == set()
 
     @pytest.mark.asyncio
+    async def test_a_timer_firing_in_flight_is_cancelled_by_the_removal(
+        self, hass, owned_task_bt
+    ):
+        """A periodic tick already running when the entity goes must be stopped.
+
+        Unsubscribing an interval ends the next firing, not the one already
+        running. These ticks re-send setpoints and the external temperature,
+        so one that outlives the unload drives TRVs the entity has let go of.
+        """
+        reached_the_trv = False
+        writing = asyncio.Event()
+
+        async def keeps_writing(now):
+            writing.set()
+            await asyncio.sleep(0)
+            nonlocal reached_the_trv
+            reached_the_trv = True
+
+        BetterThermostat._start_owned_timer_work(
+            owned_task_bt, keeps_writing, "bt_test_tick", dt_util.utcnow()
+        )
+        await writing.wait()
+
+        await BetterThermostat.async_will_remove_from_hass(owned_task_bt)
+        await hass.async_block_till_done()
+
+        assert reached_the_trv is False
+        assert owned_task_bt._owned_tasks == set()
+
+    @pytest.mark.asyncio
     async def test_a_finished_task_stops_being_tracked(self, hass, owned_task_bt):
         """Tracking must end when the work does.
 

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -449,6 +449,7 @@ def owned_task_bt(bt, hass):
     bt._window_task = None
     bt._door_task = None
     bt.plateau_timer_cancel = None
+    bt.is_removed = False
     bt._owned_tasks = set()
     bt._spawn_owned = lambda coro, *, name: BetterThermostat._spawn_owned(
         bt, coro, name=name
@@ -508,6 +509,84 @@ class TestOwnedBackgroundTasks:
         await hass.async_block_till_done()
 
         assert readings == []
+
+    @pytest.mark.asyncio
+    async def test_work_handed_over_after_the_removal_began_never_starts(
+        self, hass, owned_task_bt
+    ):
+        """A task started after the removal is not in the set the removal cancels.
+
+        The removal reads ``_owned_tasks`` once and cancels what it finds.
+        Anything added afterwards is invisible to it and goes on writing to
+        TRVs the entity has already let go of.
+        """
+        started = False
+
+        async def write_to_a_trv():
+            nonlocal started
+            started = True
+
+        # Home Assistant runs the on-remove callbacks, which set the flag,
+        # before it awaits async_will_remove_from_hass.
+        owned_task_bt.is_removed = True
+        await BetterThermostat.async_will_remove_from_hass(owned_task_bt)
+
+        task = BetterThermostat._spawn_owned(
+            owned_task_bt, write_to_a_trv(), name="bt_late_write"
+        )
+        await hass.async_block_till_done()
+
+        assert task is None
+        assert started is False
+        assert owned_task_bt._owned_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_a_dispatcher_suspended_across_the_removal_starts_nothing(
+        self, hass, owned_task_bt
+    ):
+        """A dispatcher that was mid-await when the removal ran spawns nothing.
+
+        Every dispatcher checks the entity, awaits its watcher checks and only
+        then hands work over. The removal fits in that gap, which makes the
+        dispatcher's own check stale by the time it spawns.
+        """
+        handled = []
+        in_the_watcher_check = asyncio.Event()
+        release_the_watcher_check = asyncio.Event()
+
+        async def suspend_until_released(entity):
+            in_the_watcher_check.set()
+            await release_the_watcher_check.wait()
+
+        async def handle_the_contact_change(entity, event):
+            handled.append(event)
+
+        with (
+            patch(
+                "custom_components.better_thermostat.climate.check_and_update_degraded_mode",
+                side_effect=suspend_until_released,
+            ),
+            patch(
+                "custom_components.better_thermostat.climate.check_critical_entities",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            dispatch = hass.async_create_task(
+                BetterThermostat._trigger_contact_change(
+                    owned_task_bt, MagicMock(), handle_the_contact_change, "window"
+                )
+            )
+            await in_the_watcher_check.wait()
+
+            owned_task_bt.is_removed = True
+            await BetterThermostat.async_will_remove_from_hass(owned_task_bt)
+
+            release_the_watcher_check.set()
+            await dispatch
+            await hass.async_block_till_done()
+
+        assert handled == []
+        assert owned_task_bt._owned_tasks == set()
 
     @pytest.mark.asyncio
     async def test_a_finished_task_stops_being_tracked(self, hass, owned_task_bt):

--- a/tests/unit/test_climate_startup_registration.py
+++ b/tests/unit/test_climate_startup_registration.py
@@ -82,18 +82,32 @@ def _startup_bt(**overrides):
     return mock
 
 
+def _timer_target(registered):
+    """The coroutine function a registered timer callback runs.
+
+    Each tick goes to the tracker through a dispatcher that spawns the firing
+    as work the entity owns, bound with ``partial``, so the callable handed to
+    the tracker is that dispatcher rather than the tick itself. The set under
+    test is which tick runs on which interval, so the binding is unwrapped
+    here.
+    """
+    return registered.args[0]
+
+
 class _Registrations:
     """What one ``_finalize_startup`` run handed to the event helpers."""
 
     def __init__(self, intervals, state_changes, time_changes):
         self.intervals = Counter(
-            (call.args[1], call.args[2]) for call in intervals.call_args_list
+            (_timer_target(call.args[1]), call.args[2])
+            for call in intervals.call_args_list
         )
         self.state_changes = Counter(
             (tuple(call.args[1]), call.args[2]) for call in state_changes.call_args_list
         )
         self.time_changes = Counter(
-            (call.args[1], call.args[2:]) for call in time_changes.call_args_list
+            (_timer_target(call.args[1]), call.args[2:])
+            for call in time_changes.call_args_list
         )
 
 

--- a/tests/unit/test_climate_window_dispatch.py
+++ b/tests/unit/test_climate_window_dispatch.py
@@ -26,6 +26,7 @@ def _make_self():
         window_id="binary_sensor.window",
         hass=MagicMock(),
         async_set_context=MagicMock(),
+        _spawn_owned=MagicMock(),
     )
     # ``_trigger_window_change`` delegates to the shared contact dispatcher;
     # bind it so the stand-in resolves the method call.
@@ -61,7 +62,7 @@ async def test_window_event_is_dispatched_regardless_of_availability(reading):
     with _patch_checks():
         await BetterThermostat._trigger_window_change(bt, _event(reading))
 
-    bt.hass.async_create_background_task.assert_called_once()
+    bt._spawn_owned.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -74,4 +75,4 @@ async def test_event_without_new_state_is_dropped():
     with _patch_checks():
         await BetterThermostat._trigger_window_change(bt, event)
 
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()

--- a/tests/unit/test_temperature_events.py
+++ b/tests/unit/test_temperature_events.py
@@ -1003,8 +1003,8 @@ class TestArrivalOrder:
         mock_bt._handle_temperature_reading = lambda event: (
             BetterThermostat._handle_temperature_reading(mock_bt, event)
         )
-        mock_bt.hass.async_create_background_task = lambda coro, name=None: (
-            handlers.append(asyncio.ensure_future(coro))
+        mock_bt._spawn_owned = lambda coro, *, name: handlers.append(
+            asyncio.ensure_future(coro)
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What

`BetterThermostat` started ten background tasks through `hass.async_create_background_task` and dropped every handle. Home Assistant cancels those at **core shutdown**, not when a single entity is removed, and `async_will_remove_from_hass` knew only about `_control_task`, `_window_task`, `_door_task` and the plateau timer.

So a task still in flight when the entry is unloaded or the thermostat reconfigured kept running — and several of them write to devices: `_handle_temperature_reading`, `_external_temperature_keepalive`, `_run_valve_maintenance`, `trigger_trv_change`, `trigger_cooler_change`, `async_set_preset_mode`. The valve exercise is the worst of them: it drives valves to their extremes and restores them afterwards, so a run cut loose from its entity leaves a valve parked at an extreme.

The entity now keeps the handles in `_owned_tasks` and cancels them on removal.

## Ordering

The cancellations happen **before** any worker is awaited, alongside the plateau timer and for the same reason the comment there already gives: awaiting `_control_task` hands the loop back, which is long enough for a ready task to take its turn and write.

## The one deliberate exception

`state_mgr.flush()` in the `on_remove` callback stays unowned. Home Assistant's `Entity.__async_remove_impl` calls `_call_on_remove_callbacks()` *before* `async_will_remove_from_hass()`, so that save is already in flight when the owned tasks are cancelled — owning it would cancel the last state write. There is a comment at the call site saying so, and a test.

## How this was found

CodeRabbit raised the `_handle_temperature_reading` case as an outside-diff finding on #2306. Counting the rest of `climate.py` turned one instance into ten, so this closes the class rather than the instance. Same failure shape as the plateau timer in #2294.

## Tests

`TestOwnedBackgroundTasks` in `tests/unit/test_climate_startup.py`: a spawned task is cancelled by removal, a finished task stops being tracked, a reading still in flight is dropped, and the last state write is not. Three of the four fail against the unfixed source; the fourth is the control that pins the handler still runs while the entity lives, so the others cannot pass by breaking dispatch.

Nine pre-existing tests observed the dispatch at `hass.async_create_background_task` and now observe it at `_spawn_owned`. No test intent changed.

Mirrored onto the maintenance line in the 1.9 counterpart.

## Known, not fixed here

`utils/controlling.py` (`TaskManager` and three spawns), `sensor.py`, `model_fixes/TRVZB.py` and `utils/watcher.py` start untracked background tasks too. They are outside `climate.py` and get their own change.

https://claude.ai/code/session_01U6NFDHBVHGP8TvB7b7x9tM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat reliability during startup, event handling, maintenance, preset updates, and scheduled checks.
  * Ensured background work stops cleanly when a thermostat is removed.
  * Prevented tasks from starting or continuing after removal.
  * Preserved the final state update during removal.
  * Prevented completed background work from lingering.
  * Avoided unnecessary degraded-mode checks when startup is interrupted.
  * Improved cancellation of scheduled timers and stale event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

Verified against the automated suite, not on a physical device. Device
behaviour is exercised through the fake-TRV fixtures under `tests/`, which
model the write contract of each supported integration.

HA Version: 2026.7.2 (the version `pytest-homeassistant-custom-component` pins)
Zigbee2MQTT Version: n/a — no hardware run
TRV Hardware: n/a — no hardware run

## New device mappings

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`
      (`climate.py` is changed; this is not a device-mapping PR)
