### PR TITLE
fix: let the entity cancel the background tasks it started (1.9)

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -809,11 +809,21 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         name : str
             Task name Home Assistant records for diagnostics.
 
+        A removed entity starts nothing. ``async_will_remove_from_hass`` takes
+        one snapshot of ``_owned_tasks`` and cancels what is in it; a task
+        started afterwards is not in that snapshot and would keep writing to
+        TRVs. Callers reach here after awaiting, so their own removal checks
+        can be stale by the time they spawn, and the check belongs here.
+
         Returns
         -------
-        asyncio.Task
-            The running task, held in ``_owned_tasks`` until it finishes.
+        asyncio.Task or None
+            The running task, held in ``_owned_tasks`` until it finishes, or
+            ``None`` when the entity is already removed.
         """
+        if self.is_removed:
+            coro.close()
+            return None
         task = self.hass.async_create_background_task(coro, name=name)
         self._owned_tasks.add(task)
         task.add_done_callback(self._owned_tasks.discard)

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -7,6 +7,7 @@ import asyncio
 from collections import deque
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta
+from functools import partial
 import json
 import logging
 from random import randint
@@ -828,6 +829,31 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self._owned_tasks.add(task)
         task.add_done_callback(self._owned_tasks.discard)
         return task
+
+    @callback
+    def _start_owned_timer_work(self, coro_fn, name, now):
+        """Run one firing of a periodic timer as work this entity owns.
+
+        Handing an async callback to ``async_track_time_interval`` lets Home
+        Assistant run it in a task of its own. Unsubscribing the timer on
+        removal ends the next firing, not the one already running, and these
+        callbacks write setpoints, calibration offsets and the external
+        temperature. Spawning each firing through ``_spawn_owned`` puts it in
+        the set the removal cancels.
+
+        Registrations bind the first two parameters with ``partial``, which
+        Home Assistant unwraps when it classifies the job.
+
+        Parameters
+        ----------
+        coro_fn : collections.abc.Callable
+            The coroutine function this timer runs.
+        name : str
+            Task name prefix; the device name is appended.
+        now : datetime.datetime
+            The firing time Home Assistant passes in.
+        """
+        self._spawn_owned(coro_fn(now), name=f"{name}_{self.device_name}")
 
     async def async_added_to_hass(self):
         """Run when entity about to be added.
@@ -2194,7 +2220,17 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # Add listener
         if self.outdoor_sensor is not None:
             self.async_on_remove(
-                async_track_time_change(self.hass, self._trigger_time, 5, 0, 0)
+                async_track_time_change(
+                    self.hass,
+                    partial(
+                        self._start_owned_timer_work,
+                        self._trigger_time,
+                        "bt_outdoor_tick",
+                    ),
+                    5,
+                    0,
+                    0,
+                )
             )
 
         # Wait for optional sensors with increasing retry delays before
@@ -2228,7 +2264,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         )
         self.async_on_remove(
             async_track_time_interval(
-                self.hass, self._trigger_check_weather, timedelta(hours=1)
+                self.hass,
+                partial(
+                    self._start_owned_timer_work,
+                    self._trigger_check_weather,
+                    "bt_weather_tick",
+                ),
+                timedelta(hours=1),
             )
         )
 
@@ -2266,7 +2308,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if active_balance_modes or active_calibration_modes:
             self.async_on_remove(
                 async_track_time_interval(
-                    self.hass, self._trigger_time, timedelta(minutes=5)
+                    self.hass,
+                    partial(
+                        self._start_owned_timer_work,
+                        self._trigger_time,
+                        "bt_periodic_tick",
+                    ),
+                    timedelta(minutes=5),
                 )
             )
             _LOGGER.debug(
@@ -2294,7 +2342,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             )
             self.async_on_remove(
                 async_track_time_interval(
-                    self.hass, self._maintenance_tick, timedelta(minutes=5)
+                    self.hass,
+                    partial(
+                        self._start_owned_timer_work,
+                        self._maintenance_tick,
+                        "bt_maintenance_tick",
+                    ),
+                    timedelta(minutes=5),
                 )
             )
             _LOGGER.debug(
@@ -2402,7 +2456,11 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.async_on_remove(
             async_track_time_interval(
                 self.hass,
-                self._external_temperature_keepalive,
+                partial(
+                    self._start_owned_timer_work,
+                    self._external_temperature_keepalive,
+                    "bt_ext_temp_keepalive",
+                ),
                 EXTERNAL_TEMPERATURE_KEEPALIVE_INTERVAL,
             )
         )
@@ -2410,7 +2468,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         _LOGGER.debug("better_thermostat %s: starting EMA timer...", self.device_name)
         self.async_on_remove(
             async_track_time_interval(
-                self.hass, self._async_update_ema_periodic, timedelta(minutes=1)
+                self.hass,
+                partial(
+                    self._start_owned_timer_work,
+                    self._async_update_ema_periodic,
+                    "bt_ema_tick",
+                ),
+                timedelta(minutes=1),
             )
         )
         _LOGGER.info("better_thermostat %s: startup completed.", self.device_name)

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -747,6 +747,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self._control_task = None
         self._window_task = None
         self._door_task = None
+        self._owned_tasks: set[asyncio.Task] = set()
         self.is_removed = False
         # Valve maintenance control
         self.in_maintenance = False
@@ -789,6 +790,34 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.last_sent_cooler_temp_ts: float | None = None
         self.last_sent_cooler_hvac_mode_ts: float | None = None
         self.last_cooler_mode_decided: str | None = None
+
+    def _spawn_owned(self, coro, *, name):
+        """Start a background task this entity cancels when it is removed.
+
+        Home Assistant cancels tasks made with ``async_create_background_task``
+        at core shutdown only. A task started for one entity therefore outlives
+        that entity's removal, and several of them go on writing to TRVs the
+        entity no longer drives. Keeping a handle in ``_owned_tasks`` gives
+        ``async_will_remove_from_hass`` something to cancel. The done callback
+        drops finished tasks again, so a long-lived entity does not accumulate
+        handles for work that is over.
+
+        Parameters
+        ----------
+        coro : collections.abc.Coroutine
+            The coroutine to run in the background.
+        name : str
+            Task name Home Assistant records for diagnostics.
+
+        Returns
+        -------
+        asyncio.Task
+            The running task, held in ``_owned_tasks`` until it finishes.
+        """
+        task = self.hass.async_create_background_task(coro, name=name)
+        self._owned_tasks.add(task)
+        task.add_done_callback(self._owned_tasks.discard)
+        return task
 
     async def async_added_to_hass(self):
         """Run when entity about to be added.
@@ -904,6 +933,9 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             if self.state_mgr is not None:
                 try:
                     self._record_thermal_to_state()
+                    # The last save is left to hass rather than owned: the
+                    # on_remove callbacks run before async_will_remove_from_hass,
+                    # so an owned task would be cancelled before it writes.
                     self.hass.async_create_background_task(
                         self.state_mgr.flush(),
                         name=f"bt_state_flush_{self.device_name}",
@@ -949,7 +981,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                     All parameters are piped.
             """
             self.context = Context()
-            self.hass.async_create_background_task(
+            self._spawn_owned(
                 self.startup(), name=f"better_thermostat_startup_{self.device_name}"
             )
 
@@ -1050,7 +1082,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         self.async_set_context(event.context)
         if (event.data.get("new_state")) is None:
             return
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             trigger_temperature_change(self, event),
             name=f"bt_trigger_temp_change_{self.device_name}",
         )
@@ -1165,7 +1197,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if (event.data.get("new_state")) is None:
             return
 
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             trigger_trv_change(self, event),
             name=f"bt_trigger_trv_change_{self.device_name}",
         )
@@ -1184,7 +1216,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
 
         # Only process contact changes if the sensor is available
         if is_entity_available(self.hass, contact_id):
-            self.hass.async_create_background_task(
+            self._spawn_owned(
                 trigger_fn(self, event),
                 name=f"bt_trigger_{task_label}_change_{self.device_name}",
             )
@@ -1211,7 +1243,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if (event.data.get("new_state")) is None:
             return
 
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             trigger_cooler_change(self, event),
             name=f"bt_trigger_cooler_change_{self.device_name}",
         )
@@ -2087,7 +2119,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # ends, so a TRV that is still missing defers its repair issue. Re-run
         # the check once the grace window has elapsed; otherwise the issue
         # only appears when some later event happens to trigger a check.
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             self._post_grace_recheck(
                 self._critical_grace_until, check_critical_entities
             ),
@@ -2164,7 +2196,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         await await_optional_sensors(self)
         await check_and_update_degraded_mode(self)
 
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             self._post_grace_recheck(
                 self._degraded_grace_until, check_and_update_degraded_mode
             ),
@@ -2340,7 +2372,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             _LOGGER.debug(
                 "better_thermostat %s: creating keepalive task...", self.device_name
             )
-            self.hass.async_create_background_task(
+            self._spawn_owned(
                 self._external_temperature_keepalive(),
                 name=f"bt_ext_temp_keepalive_{self.device_name}",
             )
@@ -2429,7 +2461,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             return
 
         # Run maintenance asynchronously (don't block the tick)
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             self._run_valve_maintenance(trvs_to_service),
             name=f"bt_valve_maintenance_{self.device_name}",
         )
@@ -3726,7 +3758,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if self.hass is None:
             return
         # Schedule without waiting; state updates will propagate asynchronously.
-        self.hass.async_create_background_task(
+        self._spawn_owned(
             self.async_set_preset_mode(preset_mode),
             name=f"bt_set_preset_{self.device_name}",
         )
@@ -3954,6 +3986,15 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         if self.plateau_timer_cancel is not None:
             self.plateau_timer_cancel()
             self.plateau_timer_cancel = None
+        # The owned tasks are cancelled before anything is awaited, for the same
+        # reason: several of them write to TRVs, and awaiting the workers below
+        # hands the loop back long enough for a ready one to take its turn. The
+        # set is copied and emptied first, because the done callbacks discard
+        # from it as the cancellations land.
+        owned = list(self._owned_tasks)
+        self._owned_tasks.clear()
+        for task in owned:
+            task.cancel()
         if self._control_task:
             self._control_task.cancel()
             try:
@@ -3972,4 +4013,6 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
                 await self._door_task
             except asyncio.CancelledError:
                 pass
+        if owned:
+            await asyncio.gather(*owned, return_exceptions=True)
         await super().async_will_remove_from_hass()

--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2194,6 +2194,13 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
         # integrations get time to come online before the user sees a warning.
         self._degraded_grace_until = dt_util.now() + STARTUP_DEGRADED_GRACE_PERIOD
         await await_optional_sensors(self)
+        # That wait can run for the better part of a minute and gives the
+        # entity up on its own once the removal starts, so the removal is
+        # read here rather than after the two steps below: a degraded-mode
+        # evaluation writes entity state, and the recheck outlives the call
+        # that starts it.
+        if self.is_removed:
+            return
         await check_and_update_degraded_mode(self)
 
         self._spawn_owned(

--- a/tests/integration/test_entry_lifecycle.py
+++ b/tests/integration/test_entry_lifecycle.py
@@ -6,11 +6,16 @@ real entry is set up against a simulated TRV and the assertions are the
 service calls that arrive at the device.
 """
 
+import asyncio
+from unittest.mock import patch
+
 from homeassistant.components.climate.const import ATTR_HVAC_ACTION
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import State
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import mock_restore_cache
+
+from custom_components.better_thermostat.utils.state_manager import StateManager
 
 from .conftest import (
     DOMAIN,
@@ -114,6 +119,37 @@ async def test_unload_and_reload_the_entry(hass, fake_trv):
         blocking=True,
     )
     assert await wait_for(hass, lambda: fake_trv.set_temperature_calls)
+
+
+async def test_the_last_state_save_survives_the_unload(hass, fake_trv):
+    """The save the entity dispatches while unloading has to reach the store.
+
+    It is dispatched from an on-remove callback, which Home Assistant runs
+    before ``async_will_remove_from_hass``, so it is already in flight while
+    the entity ends its background work. Losing it discards the thermal
+    model and the preset temperatures the user last had.
+    """
+    _room_sensor(hass)
+    entry = make_entry()
+    await setup_entry(hass, entry)
+    await wait_for_startup(hass, entry)
+
+    saved = asyncio.Event()
+    let_the_write_land = asyncio.Event()
+    write_the_store = StateManager.save_if_dirty
+
+    async def report_the_save(self):
+        # A real save hands the loop back for the executor round trip, so it
+        # is still pending while the entity finishes letting go.
+        await let_the_write_land.wait()
+        await write_the_store(self)
+        saved.set()
+
+    with patch.object(StateManager, "save_if_dirty", report_the_save):
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+        let_the_write_land.set()
+        assert await wait_for(hass, saved.is_set)
 
 
 async def test_climate_entity_id_follows_device_name_after_rename(hass, fake_trv):

--- a/tests/unit/test_climate_maintenance.py
+++ b/tests/unit/test_climate_maintenance.py
@@ -30,7 +30,7 @@ def bt():
     mock.bt_hvac_mode = HVACMode.HEAT
     mock.real_trvs = {"climate.trv": {}}
     mock.hass = MagicMock()
-    mock.hass.async_create_background_task = MagicMock()
+    mock._spawn_owned = MagicMock()
     return mock
 
 
@@ -57,7 +57,7 @@ async def test_one_unreadable_head_does_not_cost_the_others_their_exercise(bt):
 
     # Still consulted, so the repair issues it raises and clears stay current.
     critical.assert_awaited_once_with(bt)
-    bt.hass.async_create_background_task.assert_called_once()
+    bt._spawn_owned.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -68,7 +68,7 @@ async def test_availability_check_exception_returns(bt):
         AsyncMock(side_effect=RuntimeError("boom")),
     ):
         await BetterThermostat._maintenance_tick(bt)
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -82,7 +82,7 @@ async def test_already_in_maintenance_returns(bt):
     ):
         dt.now.return_value = _NOW
         await BetterThermostat._maintenance_tick(bt)
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -96,7 +96,7 @@ async def test_not_due_yet_returns(bt):
     ):
         dt.now.return_value = _NOW
         await BetterThermostat._maintenance_tick(bt)
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -112,7 +112,7 @@ async def test_window_open_postpones_one_hour(bt):
         dt.now.return_value = _NOW
         await BetterThermostat._maintenance_tick(bt)
     assert bt.next_valve_maintenance == _NOW + timedelta(hours=1)
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -131,7 +131,7 @@ async def test_hvac_off_still_runs_maintenance(bt, mode_attr):
     ):
         dt.now.return_value = _NOW
         await BetterThermostat._maintenance_tick(bt)
-    bt.hass.async_create_background_task.assert_called_once()
+    bt._spawn_owned.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -147,7 +147,7 @@ async def test_window_open_still_postpones_while_off(bt):
         dt.now.return_value = _NOW
         await BetterThermostat._maintenance_tick(bt)
     assert bt.next_valve_maintenance == _NOW + timedelta(hours=1)
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -162,7 +162,7 @@ async def test_no_enabled_trvs_schedules_far_future(bt):
         dt.now.return_value = _NOW
         await BetterThermostat._maintenance_tick(bt)
     assert bt.next_valve_maintenance == _NOW + timedelta(days=7)
-    bt.hass.async_create_background_task.assert_not_called()
+    bt._spawn_owned.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -179,4 +179,4 @@ async def test_due_and_enabled_dispatches_maintenance(bt):
     ):
         dt.now.return_value = _NOW
         await BetterThermostat._maintenance_tick(bt)
-    bt.hass.async_create_background_task.assert_called_once()
+    bt._spawn_owned.assert_called_once()

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -406,6 +406,7 @@ def owned_bt(plateau_bt):
     owned tasks is filled the way it is at runtime, while the rest of the
     entity stays mocked.
     """
+    plateau_bt.is_removed = False
     plateau_bt._spawn_owned = lambda coro, *, name: BetterThermostat._spawn_owned(
         plateau_bt, coro, name=name
     )
@@ -441,6 +442,92 @@ class TestOwnedBackgroundTasks:
         await BetterThermostat.async_will_remove_from_hass(owned_bt)
 
         assert cancelled.is_set()
+        assert owned_bt._owned_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_work_handed_over_after_the_removal_began_never_starts(
+        self, hass, owned_bt
+    ):
+        """A task started after the removal is not in the set the removal cancels.
+
+        The removal reads ``_owned_tasks`` once and cancels what it finds.
+        Anything added afterwards is invisible to it and goes on writing to
+        TRVs the entity has already let go of.
+        """
+        started = False
+
+        async def write_to_a_trv():
+            nonlocal started
+            started = True
+
+        # Home Assistant runs the on-remove callbacks, which set the flag,
+        # before it awaits async_will_remove_from_hass.
+        owned_bt.is_removed = True
+        await BetterThermostat.async_will_remove_from_hass(owned_bt)
+
+        task = BetterThermostat._spawn_owned(
+            owned_bt, write_to_a_trv(), name="bt_late_write"
+        )
+        await hass.async_block_till_done()
+
+        assert task is None
+        assert started is False
+        assert owned_bt._owned_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_a_dispatcher_suspended_across_the_removal_starts_nothing(
+        self, hass, owned_bt
+    ):
+        """A dispatcher that was mid-await when the removal ran spawns nothing.
+
+        Every dispatcher checks the entity, awaits its watcher checks and only
+        then hands work over. The removal fits in that gap, which makes the
+        dispatcher's own check stale by the time it spawns.
+        """
+        handled = []
+        in_the_watcher_check = asyncio.Event()
+        release_the_watcher_check = asyncio.Event()
+
+        async def suspend_until_released(entity):
+            in_the_watcher_check.set()
+            await release_the_watcher_check.wait()
+
+        async def handle_the_contact_change(entity, event):
+            handled.append(event)
+
+        with (
+            patch(
+                "custom_components.better_thermostat.climate.check_and_update_degraded_mode",
+                side_effect=suspend_until_released,
+            ),
+            patch(
+                "custom_components.better_thermostat.climate.check_critical_entities",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "custom_components.better_thermostat.climate.is_entity_available",
+                return_value=True,
+            ),
+        ):
+            dispatch = hass.async_create_task(
+                BetterThermostat._trigger_contact_change(
+                    owned_bt,
+                    MagicMock(),
+                    "binary_sensor.window",
+                    handle_the_contact_change,
+                    "window",
+                )
+            )
+            await in_the_watcher_check.wait()
+
+            owned_bt.is_removed = True
+            await BetterThermostat.async_will_remove_from_hass(owned_bt)
+
+            release_the_watcher_check.set()
+            await dispatch
+            await hass.async_block_till_done()
+
+        assert handled == []
         assert owned_bt._owned_tasks == set()
 
     @pytest.mark.asyncio

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -531,6 +531,36 @@ class TestOwnedBackgroundTasks:
         assert owned_bt._owned_tasks == set()
 
     @pytest.mark.asyncio
+    async def test_a_timer_firing_in_flight_is_cancelled_by_the_removal(
+        self, hass, owned_bt
+    ):
+        """A periodic tick already running when the entity goes must be stopped.
+
+        Unsubscribing an interval ends the next firing, not the one already
+        running. These ticks re-send setpoints and the external temperature,
+        so one that outlives the unload drives TRVs the entity has let go of.
+        """
+        reached_the_trv = False
+        writing = asyncio.Event()
+
+        async def keeps_writing(now):
+            writing.set()
+            await asyncio.sleep(0)
+            nonlocal reached_the_trv
+            reached_the_trv = True
+
+        BetterThermostat._start_owned_timer_work(
+            owned_bt, keeps_writing, "bt_test_tick", dt_util.utcnow()
+        )
+        await writing.wait()
+
+        await BetterThermostat.async_will_remove_from_hass(owned_bt)
+        await hass.async_block_till_done()
+
+        assert reached_the_trv is False
+        assert owned_bt._owned_tasks == set()
+
+    @pytest.mark.asyncio
     async def test_a_finished_task_stops_being_held(self, hass, owned_bt):
         """Every sensor reading starts one of these, so held handles must be released.
 

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -1139,6 +1139,54 @@ async def _run_finalize_startup(bt):
         await BetterThermostat._finalize_startup(bt)
 
 
+class TestStartupStopsOnceTheEntityIsGone:
+    """A startup interrupted by removal must not go on setting the room up.
+
+    Waiting for the optional sensors can run for the better part of a
+    minute, and the entity can be removed inside that window. Everything
+    after it belongs to a thermostat the user still has.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_removal_during_the_sensor_wait_ends_the_startup(self):
+        """The degraded evaluation writes state, so it may not run after it.
+
+        `await_optional_sensors` gives up on its own once the removal
+        starts, and returns normally. Reading the removal only after the
+        steps below it lets a torn-down entity publish a degraded mode and
+        start a recheck that outlives the call.
+        """
+        climate = "custom_components.better_thermostat.climate"
+
+        async def removed_during_the_wait(_self):
+            _self.is_removed = True
+            return []
+
+        degraded = AsyncMock()
+        bt = _make_finalize_bt()
+        bt.is_removed = False
+        bt._spawn_owned = MagicMock()
+        with (
+            patch(f"{climate}.await_critical_entities", AsyncMock()),
+            patch(f"{climate}.check_critical_entities", AsyncMock(return_value=True)),
+            patch(f"{climate}.await_optional_sensors", removed_during_the_wait),
+            patch(f"{climate}.check_and_update_degraded_mode", degraded),
+            patch(f"{climate}.asyncio.sleep", AsyncMock()),
+            patch(f"{climate}.async_track_time_interval"),
+            patch(f"{climate}.async_track_state_change_event"),
+            patch(f"{climate}.async_track_time_change"),
+        ):
+            await BetterThermostat._finalize_startup(bt)
+
+        degraded.assert_not_awaited()
+        # The critical-entity recheck is started before the wait; only the
+        # degraded one belongs to the steps this guard now covers.
+        started = [
+            call.kwargs.get("name", "") for call in bt._spawn_owned.call_args_list
+        ]
+        assert not any("post_grace_degraded" in name for name in started)
+
+
 class TestFinalizeStartupCoolerReread:
     """The cooler setpoint is re-read once the cooler listener is live."""
 

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -121,6 +121,7 @@ def bt():
     mock.preset_modes = ["none", "comfort", "eco"]
     mock.version = "1.0.0"
     mock.startup_running = True
+    mock._owned_tasks = set()
     mock._bound_target_to_range = lambda value: BetterThermostat._bound_target_to_range(
         mock, value
     )
@@ -390,6 +391,140 @@ class TestPlateauTimerOnRemoval:
         await BetterThermostat.async_will_remove_from_hass(plateau_bt)
 
         assert order == ["timer", "worker"]
+
+
+# ---------------------------------------------------------------------------
+# 0c. the background tasks the entity owns
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def owned_bt(plateau_bt):
+    """A thermostat that spawns its background work on a real event loop.
+
+    ``_spawn_owned`` is bound to the production implementation so the set of
+    owned tasks is filled the way it is at runtime, while the rest of the
+    entity stays mocked.
+    """
+    plateau_bt._spawn_owned = lambda coro, *, name: BetterThermostat._spawn_owned(
+        plateau_bt, coro, name=name
+    )
+    return plateau_bt
+
+
+class TestOwnedBackgroundTasks:
+    """Work the entity starts in the background must not outlive the entity.
+
+    Home Assistant ends a background task at core shutdown, not when one
+    entity is removed. Several of these tasks write setpoints, calibration
+    offsets and the external temperature, so one that survives an unload
+    drives devices that now belong to nobody.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_spawned_task_is_cancelled_by_removal(self, hass, owned_bt):
+        """Removal has to end the work, not merely stop starting new work."""
+        running = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def keeps_writing():
+            running.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        owned_bt._spawn_owned(keeps_writing(), name="bt_test_owned_task")
+        await running.wait()
+
+        await BetterThermostat.async_will_remove_from_hass(owned_bt)
+
+        assert cancelled.is_set()
+        assert owned_bt._owned_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_a_finished_task_stops_being_held(self, hass, owned_bt):
+        """Every sensor reading starts one of these, so held handles must be released.
+
+        A thermostat runs for months between restarts. A set that only grew
+        would keep a handle for every event the entity ever handled, and with
+        it the result and traceback each task carries.
+        """
+
+        async def returns_at_once():
+            return None
+
+        task = owned_bt._spawn_owned(returns_at_once(), name="bt_test_finished_task")
+        assert task in owned_bt._owned_tasks
+
+        await task
+        await asyncio.sleep(0)
+
+        assert owned_bt._owned_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_the_removal_time_save_runs_to_completion(self, hass, owned_bt):
+        """The last save of the persisted state has to survive the unload.
+
+        Home Assistant runs the entity's on-remove callbacks before
+        ``async_will_remove_from_hass``, so that save is already in flight
+        when the owned tasks are cancelled. Ending it would throw away the
+        thermal model and the preset temperatures the user last had.
+        """
+        saved = asyncio.Event()
+        release = asyncio.Event()
+
+        async def flush():
+            await release.wait()
+            saved.set()
+
+        save_task = hass.async_create_background_task(
+            flush(), name=f"bt_state_flush_{owned_bt.device_name}"
+        )
+
+        await BetterThermostat.async_will_remove_from_hass(owned_bt)
+
+        release.set()
+        await save_task
+        assert saved.is_set()
+
+    @pytest.mark.asyncio
+    async def test_the_reading_handler_is_a_task_the_entity_owns(self, hass, owned_bt):
+        """The busiest device-writing handler has to be one the entity can end.
+
+        Every external sensor update starts one, and it pushes the reading
+        into each TRV. Started outside the entity's own set it keeps writing
+        to valves the entity no longer drives.
+        """
+        reached_the_trv = asyncio.Event()
+
+        async def write_that_never_returns(*_args):
+            reached_the_trv.set()
+            await asyncio.Event().wait()
+
+        _external_temperature_writes(owned_bt).side_effect = write_that_never_returns
+
+        event = MagicMock()
+        event.data = {"new_state": State(SENSOR_ID, "20.0")}
+        with (
+            patch(
+                "custom_components.better_thermostat.climate.check_and_update_degraded_mode",
+                new=AsyncMock(),
+            ),
+            patch(
+                "custom_components.better_thermostat.climate.check_critical_entities",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            await BetterThermostat._trigger_temperature_change(owned_bt, event)
+        await reached_the_trv.wait()
+        spawned = list(owned_bt._owned_tasks)
+
+        await BetterThermostat.async_will_remove_from_hass(owned_bt)
+
+        assert spawned, "the reading handler was not started as an owned task"
+        assert all(task.cancelled() for task in spawned)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_climate_tick_registration.py
+++ b/tests/unit/test_climate_tick_registration.py
@@ -63,9 +63,19 @@ async def _run_finalize_startup(bt):
     return track_interval
 
 
+def _timer_target(registered):
+    """The coroutine function a registered timer callback runs.
+
+    Each tick reaches the tracker through a dispatcher that spawns the firing
+    as work the entity owns, bound with ``partial``, so the callable handed to
+    the tracker is that dispatcher rather than the tick itself.
+    """
+    return registered.args[0]
+
+
 def _registered_callbacks(track_interval, bt):
     """Extract the callbacks registered via async_track_time_interval."""
-    return [call.args[1] for call in track_interval.call_args_list]
+    return [_timer_target(call.args[1]) for call in track_interval.call_args_list]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_external_temperature_keepalive.py
+++ b/tests/unit/test_external_temperature_keepalive.py
@@ -60,7 +60,20 @@ async def _registered_intervals(bt):
         patch(f"{_CLIMATE}.async_track_time_change"),
     ):
         await BetterThermostat._finalize_startup(bt)
-    return [(call.args[1], call.args[2]) for call in track_interval.call_args_list]
+    return [
+        (_timer_target(call.args[1]), call.args[2])
+        for call in track_interval.call_args_list
+    ]
+
+
+def _timer_target(registered):
+    """The coroutine function a registered timer callback runs.
+
+    Each tick reaches the tracker through a dispatcher that spawns the firing
+    as work the entity owns, bound with ``partial``, so the callable handed to
+    the tracker is that dispatcher rather than the tick itself.
+    """
+    return registered.args[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Maintenance-line counterpart of #2337.

## What

`BetterThermostat` started ten background tasks through `hass.async_create_background_task` and dropped every handle. Home Assistant cancels those at **core shutdown**, not when a single entity is removed, and `async_will_remove_from_hass` knew only about `_control_task`, `_window_task`, `_door_task` and the plateau timer.

So a task still in flight when the entry is unloaded or the thermostat reconfigured kept running — and several of them write to devices: `trigger_temperature_change`, `_external_temperature_keepalive`, `_run_valve_maintenance`, `trigger_trv_change`, `trigger_cooler_change`. The valve exercise is the worst of them: it drives valves to their extremes and restores them afterwards, so a run cut loose from its entity leaves a valve parked at an extreme.

The entity now keeps the handles in `_owned_tasks` and cancels them on removal.

## Ordering

The cancellations happen **before** any worker is awaited, alongside the plateau timer and for the same reason the comment there already gives: awaiting `_control_task` hands the loop back, which is long enough for a ready task to take its turn and write.

## The one deliberate exception

`state_mgr.flush()` in the `on_remove` callback stays unowned. Home Assistant's `Entity.__async_remove_impl` calls `_call_on_remove_callbacks()` *before* `async_will_remove_from_hass()`, so that save is already in flight when the owned tasks are cancelled — owning it would cancel the last state write. There is a comment at the call site saying so, and an integration test that catches the mistake: routing the flush through the helper makes it fail while the rest of the suite stays green.

## How this was found

CodeRabbit raised the temperature-reading case as an outside-diff finding on the develop line. Counting the rest of `climate.py` turned one instance into ten, so this closes the class rather than the instance. Same failure shape as the plateau timer in #2298.

## Tests

`TestOwnedBackgroundTasks` in `tests/unit/test_climate_startup.py` plus one integration test for the removal-time save. Three fail against the unfixed source; the two flush tests cannot, and are not meant to — they guard against the wrong fix rather than the absent one.

https://claude.ai/code/session_01U6NFDHBVHGP8TvB7b7x9tM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat cleanup when entities are removed by cancelling and completing active background operations.
  * Prevented startup, maintenance, and timer actions from continuing after an entity is gone.
  * Ensured the final pending state save completes during configuration unload.
  * Improved handling of temperature changes and delayed startup checks during removal.

* **Tests**
  * Added coverage for task cancellation, cleanup, timer handling, and final state persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

Verified against the automated suite, not on a physical device. Device
behaviour is exercised through the fake-TRV fixtures under `tests/`, which
model the write contract of each supported integration.

HA Version: 2026.7.2 (the version `pytest-homeassistant-custom-component` pins)
Zigbee2MQTT Version: n/a — no hardware run
TRV Hardware: n/a — no hardware run

## New device mappings

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`
      (`climate.py` is changed; this is not a device-mapping PR)
