### PR TITLE
fix: leave the cooler out of the startup heating-member check

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -2110,8 +2110,17 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             # path applies, read through the same predicate so the two cannot
             # drift apart. A head that never reports "off" is off at its own
             # minimum setpoint, which is why the bare state is not enough.
+            # The list carries the cooler as well, because the temperature
+            # range is derived from it too. It is no head of this room, so it
+            # is not asked whether the room is heating: `member_counts_as_off`
+            # answers "heating" for anything it does not find among the TRVs,
+            # and a configured cooler would bring the room back up in HEAT
+            # after every restart that lost the mode.
             heating_members = [
-                x for x in states if not member_counts_as_off(self, x.entity_id, x)
+                state
+                for state in states
+                if state.entity_id in self.real_trvs
+                and not member_counts_as_off(self, state.entity_id, state)
             ]
             if heating_members:
                 self.bt_hvac_mode = HVACMode.HEAT

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -2063,6 +2063,7 @@ class TestValidateHvacMode:
         """
         bt.bt_hvac_mode = None
         bt.humidity_sensor_entity_id = None
+        bt.real_trvs = _two_heads()
         bt.cooler_entity_id = COOLER_ID
         states = [
             _make_trv_state(TRV_ID, state="off"),

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -1972,6 +1972,18 @@ class TestFinalizeStartupBatteryScan:
 # ---------------------------------------------------------------------------
 
 
+def _two_heads():
+    """Both TRVs the mode tests name, registered as heads of the room.
+
+    Only a state whose entity is among the room's heads speaks for it, so a
+    second head has to exist for a two-state case to say anything.
+    """
+    return {
+        entity_id: Trv(entity_id=entity_id, calibration=1)
+        for entity_id in (TRV_ID, TRV_ID_2)
+    }
+
+
 class TestValidateHvacMode:
     """Tests for _validate_hvac_mode."""
 
@@ -1995,6 +2007,7 @@ class TestValidateHvacMode:
         """A room whose heads all heat comes up heating."""
         bt.bt_hvac_mode = None
         bt.humidity_sensor_entity_id = None
+        bt.real_trvs = _two_heads()
         states = [
             _make_trv_state(TRV_ID, state="heat"),
             _make_trv_state(TRV_ID_2, state="heat"),
@@ -2010,6 +2023,7 @@ class TestValidateHvacMode:
         """
         bt.bt_hvac_mode = None
         bt.humidity_sensor_entity_id = None
+        bt.real_trvs = _two_heads()
         states = [
             _make_trv_state(TRV_ID, state="off"),
             _make_trv_state(TRV_ID_2, state="heat"),

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -2038,6 +2038,28 @@ class TestValidateHvacMode:
         BetterThermostat._validate_hvac_mode(bt, states)
         assert bt.bt_hvac_mode == HVACMode.OFF
 
+    def test_none_mode_a_cooler_is_not_a_head_of_the_room(self, bt):
+        """The cooler travels with the heads but does not vote on heating.
+
+        `_collect_trv_states` hands the same list to the temperature-range
+        calculation and to this check, and the cooler belongs in the first.
+        Counting it here brings a room whose every head is off back up in
+        HEAT after any restart that lost the mode — for as long as a cooler
+        stays configured.
+        """
+        bt.bt_hvac_mode = None
+        bt.humidity_sensor_entity_id = None
+        bt.cooler_entity_id = COOLER_ID
+        states = [
+            _make_trv_state(TRV_ID, state="off"),
+            _make_trv_state(TRV_ID_2, state="off"),
+            _make_cooler_state({ATTR_TEMPERATURE: 24.0}),
+        ]
+
+        BetterThermostat._validate_hvac_mode(bt, states)
+
+        assert bt.bt_hvac_mode == HVACMode.OFF
+
     def test_none_mode_one_head_above_its_minimum_sets_heat(self, bt):
         """One head lifted off its minimum brings the whole room up heating."""
         bt.bt_hvac_mode = None


### PR DESCRIPTION
## What

A thermostat with a cooler configured came back up in `HEAT` after any restart that lost its HVAC mode, however many of its heads were off.

`_collect_trv_states()` returns the TRV states **and the cooler state** — deliberately, because the temperature range is derived from all of them. `_validate_hvac_mode()` then judged that same list with `member_counts_as_off()`, which looks the entity up in `self.real_trvs` and answers "heating" for anything it does not find there. The cooler is never in `real_trvs`, so it counted as a heating head unconditionally, and one heating head is enough to bring the room up.

The check now considers only states whose entity is among the room's heads.

## Where it came from

I introduced it in #2284, which is merged. The code before that read `[x.state for x in states if x.state != HVACMode.OFF]`, so a cooler reporting `off` did not count and one reporting `cool` did. Switching to the shared predicate made it count always — worse, and only for installations with a cooler.

## Tests

`test_none_mode_a_cooler_is_not_a_head_of_the_room`: two heads off, a cooler in the list, expects `OFF`. It fails against the unfixed check.

Two neighbouring tests needed correcting rather than keeping. `test_none_mode_every_head_heating_sets_heat` and `test_none_mode_one_head_heating_sets_heat` both build a state for `TRV_ID_2`, which the fixture never registers in `real_trvs` — so they were passing *through the defect*: the unknown entity counted as heating. Both now register the second head, which is what they were always meant to be about, and a new `_two_heads()` helper says why.

Mirrored onto the maintenance line in #2285, which carries the same code and is not merged.

https://claude.ai/code/session_01U6NFDHBVHGP8TvB7b7x9tM

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [ ] I did not change any code (e.g. documentation changes)
- [x] The code change is tested and works locally.

## Test-Hardware list (for code changes)

Verified against the automated suite, not on a physical device. Device
behaviour is exercised through the fake-TRV fixtures under `tests/`, which
model the write contract of each supported integration.

HA Version: 2026.7.2 (the version `pytest-homeassistant-custom-component` pins)
Zigbee2MQTT Version: n/a — no hardware run
TRV Hardware: n/a — no hardware run

## New device mappings

- [x] I avoided any changes to other device mappings
- [ ] There are no changes in `climate.py`
      (`climate.py` is changed; this is not a device-mapping PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat startup mode restoration for multi-head heating configurations.
  * Parked heads now correctly restore to **Off**, while active heating heads restore to **Heat**.
  * Configured cooling devices are excluded from heating-mode decisions.
  * Improved handling for systems using `no_off_system_mode`.

* **Tests**
  * Added coverage for multi-head configurations and mixed heating/cooling setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->