### PR TITLE
fix: read MQTT offset bounds for a TRV without a calibration entity (1.9)

### DIFF
--- a/custom_components/better_thermostat/adapters/mqtt.py
+++ b/custom_components/better_thermostat/adapters/mqtt.py
@@ -177,9 +177,10 @@ async def get_current_offset(self, entity_id):
 
 async def get_offset_step(self, entity_id):
     """Get offset step."""
-    state = self.hass.states.get(
-        self.real_trvs[entity_id].local_temperature_calibration_entity
-    )
+    calibration_entity = self.real_trvs[entity_id].local_temperature_calibration_entity
+    if calibration_entity is None:
+        return 1.0
+    state = self.hass.states.get(calibration_entity)
     if state is None:
         return 1.0
     return float(str(state.attributes.get("step", 1)))
@@ -187,9 +188,10 @@ async def get_offset_step(self, entity_id):
 
 async def get_min_offset(self, entity_id):
     """Get min offset."""
-    state = self.hass.states.get(
-        self.real_trvs[entity_id].local_temperature_calibration_entity
-    )
+    calibration_entity = self.real_trvs[entity_id].local_temperature_calibration_entity
+    if calibration_entity is None:
+        return -10.0
+    state = self.hass.states.get(calibration_entity)
     if state is None:
         return -10.0
     return float(str(state.attributes.get("min", -10)))
@@ -197,9 +199,10 @@ async def get_min_offset(self, entity_id):
 
 async def get_max_offset(self, entity_id):
     """Get max offset."""
-    state = self.hass.states.get(
-        self.real_trvs[entity_id].local_temperature_calibration_entity
-    )
+    calibration_entity = self.real_trvs[entity_id].local_temperature_calibration_entity
+    if calibration_entity is None:
+        return 10.0
+    state = self.hass.states.get(calibration_entity)
     if state is None:
         return 10.0
     return float(str(state.attributes.get("max", 10)))

--- a/tests/test_adapters_none_handling.py
+++ b/tests/test_adapters_none_handling.py
@@ -39,6 +39,46 @@ def mock_bt_instance(mock_hass):
     return bt
 
 
+def _state_lookup_like_home_assistant(states):
+    """Look a state up the way Home Assistant's state machine does.
+
+    Parameters
+    ----------
+    states : dict
+        States to serve, keyed by entity ID.
+
+    Returns
+    -------
+    callable
+        Lookup that falls back to the lowercased entity ID, and therefore
+        raises ``AttributeError`` for ``None`` just as the state machine does.
+    """
+
+    def get(entity_id):
+        return states.get(entity_id) or states.get(entity_id.lower())
+
+    return get
+
+
+@pytest.fixture
+def mock_bt_instance_without_calibration_entity(mock_hass):
+    """Create a mock BetterThermostat whose TRV exposes no calibration entity.
+
+    Its state lookup mirrors Home Assistant's, so asking for the ``None``
+    entity ID raises instead of quietly answering ``None``.
+    """
+    bt = MagicMock()
+    bt.hass = mock_hass
+    bt.device_name = "Test Thermostat"
+    bt.real_trvs = {
+        "climate.test_trv": Trv(
+            entity_id="climate.test_trv", local_temperature_calibration_entity=None
+        )
+    }
+    bt.hass.states.get = MagicMock(side_effect=_state_lookup_like_home_assistant({}))
+    return bt
+
+
 class TestDeconzAdapter:
     """Tests for deCONZ adapter None handling."""
 
@@ -123,6 +163,45 @@ class TestMqttAdapter:
         result = await get_offset_step(mock_bt_instance, "climate.test_trv")
 
         assert result == 0.5
+
+    async def test_get_offset_step_returns_default_without_calibration_entity(
+        self, mock_bt_instance_without_calibration_entity
+    ):
+        """A TRV without a calibration entity reads the default step."""
+        from custom_components.better_thermostat.adapters.mqtt import get_offset_step
+
+        result = await get_offset_step(
+            mock_bt_instance_without_calibration_entity, "climate.test_trv"
+        )
+
+        assert result == 1.0
+        mock_bt_instance_without_calibration_entity.hass.states.get.assert_not_called()
+
+    async def test_get_min_offset_returns_default_without_calibration_entity(
+        self, mock_bt_instance_without_calibration_entity
+    ):
+        """A TRV without a calibration entity reads the default lower bound."""
+        from custom_components.better_thermostat.adapters.mqtt import get_min_offset
+
+        result = await get_min_offset(
+            mock_bt_instance_without_calibration_entity, "climate.test_trv"
+        )
+
+        assert result == -10.0
+        mock_bt_instance_without_calibration_entity.hass.states.get.assert_not_called()
+
+    async def test_get_max_offset_returns_default_without_calibration_entity(
+        self, mock_bt_instance_without_calibration_entity
+    ):
+        """A TRV without a calibration entity reads the default upper bound."""
+        from custom_components.better_thermostat.adapters.mqtt import get_max_offset
+
+        result = await get_max_offset(
+            mock_bt_instance_without_calibration_entity, "climate.test_trv"
+        )
+
+        assert result == 10.0
+        mock_bt_instance_without_calibration_entity.hass.states.get.assert_not_called()
 
 
 class TestGenericAdapter:


### PR DESCRIPTION
## What breaks, and for whom

Every Home Assistant start, for anyone running an MQTT/Zigbee2MQTT TRV that exposes no `local_temperature_calibration` entity — a Danfoss Ally, for example. The climate entity logs six failed retries per offset read, then `Timeout getting offsets for TRV ...`, and stays unavailable for roughly 35 seconds per config entry. With eleven such TRVs, that is the whole startup. Reported as #2341.

## Mechanism

When device discovery finds no calibration entity, `real_trvs[entity_id].local_temperature_calibration_entity` stays `None`. The MQTT adapter's `get_offset_step`, `get_min_offset` and `get_max_offset` passed that unset id straight into `hass.states.get`, which resolves a lookup as `states.get(entity_id) or states.get(entity_id.lower())` — so it raises `AttributeError: 'NoneType' object has no attribute 'lower'` before the `if state is None` line below it can act. That check guards a missing *state*, never a missing *entity id*. Each read is wrapped in `@async_retry(retries=5)` in `adapters/delegate.py` and the three run inside an `asyncio.timeout(10)` in `climate.py`, which turns one unset id into six retries per read and then the timeout. The write counterpart `set_offset` already returns early on `None`; only the reads were missing the guard.

Each read now resolves the calibration entity into a local first and answers with the default it already had when the TRV has none. The existing defaults (`1.0`, `-10.0`, `10.0`) are deliberately kept rather than redirecting to the generic adapter, whose defaults differ (`None`, `-6.0`, `6.0`) and which additionally infers bounds from a select entity's options — a behaviour change this maintenance branch should not take.

## Measured mutation numbers

The existing MQTT tests set `hass.states.get.return_value = None`, so their mock never performs the lowercase fallback and the crash cannot surface. The three new tests use a lookup that resolves an id the way Home Assistant's state machine does, and assert both that the call returns its default and that `hass.states.get` was never reached.

- Guard absent (unfixed code, new tests present): **3 failed, 5362 passed** — failing at `mqtt.py:180/190/200` with the production `AttributeError: 'NoneType' object has no attribute 'lower'`.
- Guard present: **5365 passed**.
- Guard removed again from the fixed tree: **3 failed, 5362 passed** — exactly the three new tests, nothing else.

Also green: `ruff check`, `ruff format --check` (0.15.15, as CI pins), and `pyrefly check` (0 errors).

## Scope

`1.9` only. On `develop` all four offset reads already delegate to `adapters/generic.py`, which holds the guard, so nothing there needs changing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat calibration handling when no local calibration entity is configured.
  * Applied default calibration limits and step values in this situation, preventing errors and ensuring consistent thermostat behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->