### PR TITLE
Re-record the forward-port gaps against both current lines

### DIFF
--- a/.forward-port-gaps.json
+++ b/.forward-port-gaps.json
@@ -1,3 +1,3 @@
 {
-  "9c7a0de083b066ffc32b0dba0feeb84d28bf8846": "The same defect is fixed on both lines in different places. The development line orders the degraded-mode annunciation ahead of the critical-entity check in every handler, and reaches the handlers through a state machine the maintenance line does not have, so the two test files share no line."
+  "1fbab97df0f62da4273afbaca133a4f146ab4ed7": "The same fix exists on both lines in different shapes. The development line owns its background tasks through _spawn_owned/_owned_tasks in climate.py; the maintenance-line commit wraps the same mechanism in handler docstrings and startup tests whose surroundings the development line's structure does not share, so those markers find no textual match."
 }


### PR DESCRIPTION
## Motivation:

The "Maintenance line carried forward" gate fails on the 2.0.0 release PR #2234: the acknowledgment for `9c7a0de0` is stale (the degraded-mode fix reached develop with #2282, so the script demands the entry be dropped), and the maintenance line's `1fbab97d` ("fix: let the entity cancel the background tasks it started", the 1.9 mirror of #2337) scores 42% because only its surroundings differ, and is recorded nowhere.

## Changes:

`.forward-port-gaps.json`: drop the carried-forward `9c7a0de0` entry, record `1fbab97d` with the reason it reads as behind — the mechanism (`_spawn_owned`/`_owned_tasks`) exists on develop, the misses are 1.9-specific handler docstrings and startup tests.

`uv run python scripts/forward_port_gaps.py check` passes on this branch: all 23 scored commits carried forward or recorded.

## Related issue (check one):

- [ ] fixes #<issue number goes here>
- [x] There is no related issue ticket

## Checklist (check one):

- [x] I did not change any code (e.g. documentation changes)
- [ ] The code change is tested and works locally.

## Test-Hardware list (for code changes)

Not applicable — bookkeeping file only.

## New device mappings

Not applicable.

- [x] I avoided any changes to other device mappings
- [x] There are no changes in `climate.py`

https://claude.ai/code/session_016LxyLuRspcsWXhRWj7CPeF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated forward-port tracking to reflect a fix for background-task ownership in climate functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->