### PR TITLE
fix: restore the temperature range a cooler publishes (1.9)

### DIFF
--- a/custom_components/better_thermostat/climate.py
+++ b/custom_components/better_thermostat/climate.py
@@ -173,6 +173,8 @@ from .utils.restore import (
     clamp_heating_power,
     mean_trv_target,
     restore_target_temperature,
+    saved_cooling_target,
+    saved_heating_target,
 )
 from .utils.state_manager import StateManager
 from .utils.telemetry import (
@@ -1650,7 +1652,7 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             )
             # Clamp the saved target, or fall back to the TRV mean.
             _restored_target = restore_target_temperature(
-                old_state.attributes.get(ATTR_TEMPERATURE),
+                saved_heating_target(old_state.attributes),
                 states,
                 self.bt_min_temp,
                 self.bt_max_temp,
@@ -1662,6 +1664,28 @@ class BetterThermostat(ClimateEntity, RestoreEntity, ABC):
             _LOGGER.debug(
                 "better_thermostat %s: target temperature restored", self.device_name
             )
+
+            # The cooling target is published as the upper bound of the range
+            # and comes back from it. It is read before the preset block below,
+            # which owns the pair of an active preset, and before
+            # `_seed_cool_target_from_cooler`, which fills a target that is
+            # still unknown from the cooler's own setpoint: a target the user
+            # chose outranks the one the device happens to sit on.
+            if self.cooler_entity_id is not None:
+                _restored_cool_target = convert_to_float_celsius(
+                    saved_cooling_target(old_state.attributes),
+                    self.device_name,
+                    "startup()",
+                    self.hass.config.units.temperature_unit,
+                )
+                if _restored_cool_target is not None:
+                    # The pair was ordered under the range that held when it
+                    # was saved. A narrower range can bound both targets onto
+                    # the same value, so the ordering is applied again here.
+                    self.bt_target_cooltemp = self._bound_target_to_range(
+                        _restored_cool_target
+                    )
+                    self._enforce_cool_above_heat(regardless_of_hvac_mode=True)
 
             _LOGGER.debug(
                 "better_thermostat %s: restoring preset mode...", self.device_name

--- a/custom_components/better_thermostat/utils/restore.py
+++ b/custom_components/better_thermostat/utils/restore.py
@@ -9,9 +9,15 @@ and assigns the results to entity attributes.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
 from statistics import mean
+from typing import Any
 
+from homeassistant.components.climate.const import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+)
 from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import State
 
@@ -44,6 +50,56 @@ def mean_trv_target(
         if celsius is not None:
             temps.append(celsius)
     return mean(temps) if temps else None
+
+
+def saved_heating_target(attributes: Mapping[str, Any]) -> Any:
+    """Read the heating target out of the attributes a thermostat published.
+
+    Which key carries it depends on what the entity advertised. Home Assistant
+    writes ``temperature`` for an entity that supports a single target, and
+    ``target_temp_low`` / ``target_temp_high`` for one that supports a range.
+    A thermostat with a cooler configured advertises the range, so its heating
+    target is published as ``target_temp_low`` and the state it saves holds no
+    ``temperature`` at all.
+
+    Both keys are read by presence rather than by truth, so a target of ``0.0``
+    counts as a value.
+
+    Parameters
+    ----------
+    attributes : Mapping[str, Any]
+            the attributes of the state the thermostat saved
+
+    Returns
+    -------
+    Any
+            the raw saved heating target, or ``None`` when neither key carries
+            one
+    """
+    saved = attributes.get(ATTR_TEMPERATURE)
+    if saved is not None:
+        return saved
+    return attributes.get(ATTR_TARGET_TEMP_LOW)
+
+
+def saved_cooling_target(attributes: Mapping[str, Any]) -> Any:
+    """Read the cooling target out of the attributes a thermostat published.
+
+    Only an entity advertising a temperature range publishes one, and Home
+    Assistant writes it as ``target_temp_high``.
+
+    Parameters
+    ----------
+    attributes : Mapping[str, Any]
+            the attributes of the state the thermostat saved
+
+    Returns
+    -------
+    Any
+            the raw saved cooling target, or ``None`` when the attributes carry
+            no such key
+    """
+    return attributes.get(ATTR_TARGET_TEMP_HIGH)
 
 
 def restore_target_temperature(

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -11,7 +11,12 @@ import json
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from homeassistant.components.climate.const import PRESET_NONE, HVACMode
+from homeassistant.components.climate.const import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+    PRESET_NONE,
+    HVACMode,
+)
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     STATE_UNAVAILABLE,
@@ -196,6 +201,16 @@ def _make_no_off_trv(entity_id):
 def _make_sensor_state(temp="21.5", state_val=None):
     """Build a sensor State."""
     return State(SENSOR_ID, state_val or temp)
+
+
+def _make_cooler_state(attrs, state="cool"):
+    """Build a cooler State with the given setpoint attributes."""
+    return State(COOLER_ID, state, attributes=attrs)
+
+
+def _install_states(bt, states):
+    """Route ``bt.hass.states.get`` to a per-entity mapping."""
+    bt.hass.states.get.side_effect = states.get
 
 
 # ---------------------------------------------------------------------------
@@ -1907,6 +1922,91 @@ class TestRestoreState:
 
         assert bt.bt_target_temp == 22.0
         assert bt.bt_target_cooltemp == 18.0
+
+    @pytest.mark.asyncio
+    async def test_a_saved_range_restores_both_targets(self, bt):
+        """A thermostat with a cooler comes back on the pair it published.
+
+        Home Assistant writes `temperature` for an entity offering a single
+        target and the two bounds of a range for one offering a range. A
+        thermostat with a cooler offers the range, so those two bounds are the
+        whole record of the pair the user set.
+        """
+        bt = self._cooling_bt(bt, 16.0, 30.0)
+        bt._preset_cool_temperatures = {"none": 24.0, "comfort": 24.0, "eco": 27.0}
+        bt.preset_mgr.temperatures = {}
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {ATTR_TARGET_TEMP_LOW: 20.0, ATTR_TARGET_TEMP_HIGH: 23.0}
+        bt.async_get_last_state = AsyncMock(return_value=old)
+
+        await BetterThermostat._restore_state(bt, [_make_trv_state()])
+
+        assert bt.bt_target_temp == 20.0
+        assert bt.bt_target_cooltemp == 23.0
+
+    @pytest.mark.asyncio
+    async def test_a_saved_single_target_restores_without_a_cooling_target(self, bt):
+        """A thermostat without a cooler reads the one key it published.
+
+        The heating target of a single-target thermostat sits in
+        `temperature`, and there is no cooling channel for a second one.
+        """
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {ATTR_TEMPERATURE: 22.5}
+        bt.async_get_last_state = AsyncMock(return_value=old)
+        bt.preset_mgr.temperatures = {}
+
+        await BetterThermostat._restore_state(bt, [_make_trv_state()])
+
+        assert bt.bt_target_temp == 22.5
+        assert bt.bt_target_cooltemp is None
+
+    @pytest.mark.asyncio
+    async def test_a_restored_cooling_target_survives_the_cooler_read(self, bt):
+        """The cooler's setpoint fills a cooling target that nothing else supplies.
+
+        The read off the device runs after the restore and is what a cooling
+        target comes from when the saved state holds none. A target the restore
+        did supply is the user's own choice and stays.
+        """
+        bt = self._cooling_bt(bt, 16.0, 30.0)
+        bt._preset_cool_temperatures = {"none": 24.0, "comfort": 24.0, "eco": 27.0}
+        bt.preset_mgr.temperatures = {}
+        _install_states(bt, {COOLER_ID: _make_cooler_state({ATTR_TEMPERATURE: 26.0})})
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {ATTR_TARGET_TEMP_LOW: 20.0, ATTR_TARGET_TEMP_HIGH: 23.0}
+        bt.async_get_last_state = AsyncMock(return_value=old)
+
+        await BetterThermostat._restore_state(bt, [_make_trv_state()])
+        seeded = BetterThermostat._seed_cool_target_from_cooler(bt, "startup()")
+
+        assert seeded is False
+        assert bt.bt_target_cooltemp == 23.0
+
+    @pytest.mark.asyncio
+    async def test_a_saved_range_below_the_minimum_is_bounded_and_ordered(self, bt):
+        """A pair bounded onto one value is pushed apart again.
+
+        Both targets are bounded into the configured range, so a pair saved
+        under a wider one can land on the same value. The pair is published as
+        a range and written to the devices from there, and two targets meeting
+        would run the cooler against the heads.
+        """
+        bt = self._cooling_bt(bt, 20.0, 30.0)
+        bt._preset_cool_temperatures = {"none": 24.0, "comfort": 24.0, "eco": 27.0}
+        bt.preset_mgr.temperatures = {}
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {ATTR_TARGET_TEMP_LOW: 9.0, ATTR_TARGET_TEMP_HIGH: 10.0}
+        bt.async_get_last_state = AsyncMock(return_value=old)
+
+        await BetterThermostat._restore_state(bt, [_make_trv_state()])
+
+        assert bt.bt_target_temp == 20.0
+        assert bt.bt_target_cooltemp == 20.5
 
     @pytest.mark.asyncio
     async def test_restores_heating_power_clamped(self, bt):

--- a/tests/unit/test_climate_startup.py
+++ b/tests/unit/test_climate_startup.py
@@ -2009,6 +2009,30 @@ class TestRestoreState:
         assert bt.bt_target_cooltemp == 20.5
 
     @pytest.mark.asyncio
+    async def test_a_saved_fahrenheit_range_restores_as_celsius(self, bt):
+        """A saved range is read in the unit Home Assistant wrote it in.
+
+        Better Thermostat reports its own targets in Celsius, and Home
+        Assistant converts an entity's targets into the system unit on the way
+        into the state it saves. On a Fahrenheit installation the pair comes
+        back as Fahrenheit, so reading it as Celsius would restore the room to
+        a target the configured range has to bound away.
+        """
+        bt = self._cooling_bt(bt, 16.0, 30.0)
+        bt.hass.config.units.temperature_unit = UnitOfTemperature.FAHRENHEIT
+        bt._preset_cool_temperatures = {"none": 24.0, "comfort": 24.0, "eco": 27.0}
+        bt.preset_mgr.temperatures = {}
+        old = MagicMock()
+        old.state = "heat"
+        old.attributes = {ATTR_TARGET_TEMP_LOW: 68.0, ATTR_TARGET_TEMP_HIGH: 73.4}
+        bt.async_get_last_state = AsyncMock(return_value=old)
+
+        await BetterThermostat._restore_state(bt, [_make_trv_state()])
+
+        assert bt.bt_target_temp == 20.0
+        assert bt.bt_target_cooltemp == 23.0
+
+    @pytest.mark.asyncio
     async def test_restores_heating_power_clamped(self, bt):
         """Test Restores heating power clamped."""
         old = MagicMock()

--- a/tests/unit/test_restore.py
+++ b/tests/unit/test_restore.py
@@ -1,5 +1,9 @@
 """Tests for the pure startup-restore helpers in utils/restore.py."""
 
+from homeassistant.components.climate.const import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+)
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import State
 import pytest
@@ -15,6 +19,8 @@ from custom_components.better_thermostat.utils.restore import (
     clamp_heating_power,
     mean_trv_target,
     restore_target_temperature,
+    saved_cooling_target,
+    saved_heating_target,
 )
 
 DEV = "Test BT"
@@ -92,6 +98,79 @@ class TestMeanTrvTarget:
             [_trv(20.0)], DEV, system_unit=UnitOfTemperature.CELSIUS
         )
         assert result == pytest.approx(20.0)
+
+
+# ---------------------------------------------------------------------------
+# saved_heating_target / saved_cooling_target
+# ---------------------------------------------------------------------------
+
+
+class TestSavedHeatingTarget:
+    """saved_heating_target reads the key the thermostat published it under."""
+
+    def test_single_target_thermostat_publishes_temperature(self):
+        """A thermostat offering one target saves it as `temperature`."""
+        assert saved_heating_target({ATTR_TEMPERATURE: 21.5}) == 21.5
+
+    def test_range_publishing_thermostat_publishes_the_lower_bound(self):
+        """A thermostat offering a range saves the heating target as the lower bound.
+
+        Home Assistant writes `temperature` only for an entity that supports a
+        single target, so the attributes of a range-publishing one hold the
+        heating target under `target_temp_low` and no `temperature` at all.
+        """
+        assert (
+            saved_heating_target(
+                {ATTR_TARGET_TEMP_LOW: 20.0, ATTR_TARGET_TEMP_HIGH: 23.0}
+            )
+            == 20.0
+        )
+
+    def test_the_single_target_wins_over_a_lower_bound(self):
+        """With both keys present the single target is the one that was published."""
+        assert (
+            saved_heating_target({ATTR_TEMPERATURE: 21.5, ATTR_TARGET_TEMP_LOW: 18.0})
+            == 21.5
+        )
+
+    def test_a_zero_target_is_a_value(self):
+        """A saved 0.0 is read as a target rather than as a missing one."""
+        assert (
+            saved_heating_target({ATTR_TEMPERATURE: 0.0, ATTR_TARGET_TEMP_LOW: 18.0})
+            == 0.0
+        )
+
+    def test_an_empty_temperature_falls_through_to_the_lower_bound(self):
+        """A `temperature` present but unset leaves the lower bound to answer."""
+        assert (
+            saved_heating_target({ATTR_TEMPERATURE: None, ATTR_TARGET_TEMP_LOW: 20.0})
+            == 20.0
+        )
+
+    def test_neither_key_yields_none(self):
+        """Attributes carrying no target at all yield None."""
+        assert saved_heating_target({}) is None
+
+
+class TestSavedCoolingTarget:
+    """saved_cooling_target reads the upper bound of a published range."""
+
+    def test_range_publishing_thermostat_publishes_the_upper_bound(self):
+        """A thermostat offering a range saves the cooling target as the upper bound."""
+        assert (
+            saved_cooling_target(
+                {ATTR_TARGET_TEMP_LOW: 20.0, ATTR_TARGET_TEMP_HIGH: 23.0}
+            )
+            == 23.0
+        )
+
+    def test_a_single_target_thermostat_has_no_cooling_target(self):
+        """A thermostat offering one target publishes no upper bound."""
+        assert saved_cooling_target({ATTR_TEMPERATURE: 21.5}) is None
+
+    def test_a_zero_target_is_a_value(self):
+        """A saved 0.0 is read as a target rather than as a missing one."""
+        assert saved_cooling_target({ATTR_TARGET_TEMP_HIGH: 0.0}) == 0.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The 1.9 line of #2289. The develop counterpart is #2348; the production change
is byte-identical between the two.

## What the user sees

A Better Thermostat with a cooler configured loses both of its target
temperatures across a Home Assistant restart. The reporter sets 20 °C and
23 °C on a Sonoff TRVZB paired with a Daikin split AC; after the restart the
values are, in their words, "all over the place".

## Mechanism

With a cooler configured the entity advertises
`ClimateEntityFeature.TARGET_TEMPERATURE_RANGE` instead of
`TARGET_TEMPERATURE`, and Home Assistant's `ClimateEntity.state_attributes`
writes the `temperature` attribute only for an entity that advertises the
single-target feature (verified against homeassistant 2026.7.2,
`components/climate/__init__.py:375`). The state such an entity saves
therefore carries `target_temp_low` and `target_temp_high` and no
`temperature` at all, while the startup restore read `temperature` alone; with
nothing there, `restore_target_temperature` falls back to the mean of the
TRVs' current setpoints, which is the number the user sees. The cooling target
was not read from the saved state at all — it was re-derived from whatever
setpoint the cooler happened to report, which is the right answer only for as
long as the device still carries the value.

## The change

`utils/restore.py` gains the two attribute-selection rules, next to
`restore_target_temperature` where the concern already lives and is unit
tested. `saved_heating_target` prefers `temperature` and falls back to
`target_temp_low`; `saved_cooling_target` reads `target_temp_high`. Both read
by presence rather than by truth, so a target of 0.0 is a value.

The startup restore uses them. The cooling target is read before the preset
block and before `_seed_cool_target_from_cooler`, so a restored preset keeps
the precedence it has today and the read off the device keeps its "only fill a
target that is genuinely unknown" contract.

### Why the restored pair is ordered

`_enforce_cool_above_heat(regardless_of_hvac_mode=True)` runs on the restored
pair. It earns its place rather than decorating: both targets are bounded into
the configured range, and a range narrower than the one the pair was saved
under can bound both onto the same value — a pair saved as 9.0 / 10.0 and
restored under a minimum of 20.0 lands on 20.0 / 20.0, and two targets meeting
runs the cooler against the heads. It is the same call, with the same
argument, that the preset branch below already makes for the same reason, and
`test_a_saved_range_below_the_minimum_is_bounded_and_ordered` pins it.

## Measured

- **Mutation before**: with the defect in place and no new tests,
  `uv run pytest tests/` is **5362 passed, 0 failed**. Nothing in the suite
  objected to it.
- **Mutation after**: with the defect re-applied under the new tests,
  **3 failed, 5372 passed**:
  - `TestRestoreState::test_a_saved_range_restores_both_targets`
  - `TestRestoreState::test_a_restored_cooling_target_survives_the_cooler_read`
  - `TestRestoreState::test_a_saved_range_below_the_minimum_is_bounded_and_ordered`
- **With the fix**: **5375 passed, 0 failed**. `ruff check`,
  `ruff format --check` and `pyrefly check` are green.

## Where this differs from #2348

Only in the tests, and only because of the harness. On develop the round trip
is also pinned end to end, through the integration matrix in
`tests/integration/test_setting_round_trips.py` and one dedicated case that
moves the cooler off the value before the restart. This branch's integration
harness has a single fake TRV and a `make_entry` with no cooler key at all, so
that proof would mean porting the device profiles, the simulated cooler and
the role scenarios into a maintenance branch. The unit tests here drive the
real `_restore_state` together with the real `_bound_target_to_range`,
`_enforce_cool_above_heat` and `_seed_cool_target_from_cooler`, which is what
the mutation numbers above are measured against.

https://claude.ai/code/session_01PDK4Ae8guxGD9Jp2bkxkNv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat state restoration for heating and cooling targets.
  * Restores temperature ranges correctly for compatible thermostats.
  * Converts restored Fahrenheit ranges to Celsius when needed.
  * Preserves valid zero-valued targets and applies configured limits.
  * Maintains the correct ordering between heating and cooling temperatures.
  * Correctly restores saved targets when no cooler is configured.

* **Tests**
  * Expanded coverage for single-target, range-based, missing, zero-valued, converted, and boundary temperature values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->