### PR TITLE
fix: refresh the cached TRV mode when a control cycle ends

### DIFF
--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -63,6 +63,10 @@ from custom_components.better_thermostat.utils.hvac_action import (
 )
 from custom_components.better_thermostat.utils.scheduler import request_control_cycle
 from custom_components.better_thermostat.utils.snapshot import build_snapshot
+from custom_components.better_thermostat.utils.watcher import (
+    UNAVAILABLE_STATES,
+    UNKNOWN_STATES,
+)
 
 if TYPE_CHECKING:
     from custom_components.better_thermostat.climate import BetterThermostat
@@ -662,6 +666,51 @@ def advance_hvac_action(self: BetterThermostat) -> None:
         )
 
 
+def refresh_cached_trv_modes(self: BetterThermostat) -> None:
+    """Re-read the mode every TRV reports into its own cache.
+
+    ``Trv.hvac_mode`` holds the raw state string a device publishes, and the
+    inbound event handler is its only other writer. That handler stands down
+    for the whole length of a control cycle, and a cycle runs for seconds
+    while the adapters wait for their writes to be confirmed. A device that
+    changes mode inside that window leaves behind a cache naming a mode it no
+    longer holds, and every setpoint the user presses on it afterwards is
+    turned away as coming from a device that is off.
+
+    The observational cache is the only thing that moves here. The mode of
+    the Better Thermostat entity stays where it is: a device mode reported
+    while the handler was standing down was not adopted as user intent, and
+    taking it into the entity at the end of the cycle would decide the room's
+    mode from a report nobody read.
+
+    A device that says nothing, one that is unavailable or unknown, and one
+    under a child lock keep the cache they have, which is how the event
+    handler reads all three.
+
+    Parameters
+    ----------
+    self : BetterThermostat
+        The Better Thermostat climate entity instance
+    """
+    for entity_id, trv in self.real_trvs.items():
+        state = self.hass.states.get(entity_id)
+        if state is None or state.state in UNAVAILABLE_STATES + UNKNOWN_STATES:
+            continue
+        if (trv.advanced or {}).get("child_lock"):
+            continue
+        if trv.hvac_mode == state.state:
+            continue
+        _LOGGER.debug(
+            "better_thermostat %s: TRV %s reports %s while its cached mode is "
+            "%s, taking the reported one",
+            self.device_name,
+            entity_id,
+            state.state,
+            trv.hvac_mode,
+        )
+        trv.hvac_mode = state.state
+
+
 async def control_queue(self: BetterThermostat) -> None:
     """Process control commands from the queue and coordinate TRV control.
 
@@ -810,6 +859,11 @@ async def control_queue(self: BetterThermostat) -> None:
                             request_control_cycle(self)
 
                         if not getattr(self, "in_maintenance", False):
+                            # The inbound handler stood down for the whole
+                            # cycle, so a mode a device reported meanwhile
+                            # never reached its cache. Read the reports back
+                            # before the window closes.
+                            refresh_cached_trv_modes(self)
                             self.ignore_states = False
 
                 finally:

--- a/custom_components/better_thermostat/utils/controlling.py
+++ b/custom_components/better_thermostat/utils/controlling.py
@@ -674,8 +674,10 @@ def refresh_cached_trv_modes(self: BetterThermostat) -> None:
     for the whole length of a control cycle, and a cycle runs for seconds
     while the adapters wait for their writes to be confirmed. A device that
     changes mode inside that window leaves behind a cache naming a mode it no
-    longer holds, and every setpoint the user presses on it afterwards is
-    turned away as coming from a device that is off.
+    longer holds, which would turn away every setpoint the user presses on it
+    as coming from a device that is off. The caller runs this at the end of
+    the cycle, before it releases ``ignore_states``, so the cache is out of
+    step only for as long as the handler is standing down.
 
     The observational cache is the only thing that moves here. The mode of
     the Better Thermostat entity stays where it is: a device mode reported

--- a/tests/unit/controlling/test_control_queue.py
+++ b/tests/unit/controlling/test_control_queue.py
@@ -7,7 +7,13 @@ import pytest
 
 from custom_components.better_thermostat.core.clock import FakeClock
 from custom_components.better_thermostat.core.decide import running_kernel_state
+from custom_components.better_thermostat.trv import Trv
 from custom_components.better_thermostat.utils.controlling import control_queue
+
+
+def _tracked_trv(entity_id: str) -> Trv:
+    """Build the record the entity keeps for one controlled TRV."""
+    return Trv.from_legacy_dict(entity_id, {})
 
 
 class TestControlQueue:
@@ -292,9 +298,8 @@ class TestControlQueue:
         mock_self.calculate_heating_power = AsyncMock()
         mock_self.cooler_entity_id = None
         mock_self.real_trvs = {
-            "climate.trv1": {},
-            "climate.trv2": {},
-            "climate.trv3": {},
+            entity_id: _tracked_trv(entity_id)
+            for entity_id in ("climate.trv1", "climate.trv2", "climate.trv3")
         }
 
         queue = asyncio.Queue()
@@ -332,7 +337,10 @@ class TestControlQueue:
         mock_self.calculate_heating_power = AsyncMock()
         mock_self.calculate_heat_loss = AsyncMock()
         mock_self.cooler_entity_id = None
-        mock_self.real_trvs = {"climate.trv1": {}, "climate.trv2": {}}
+        mock_self.real_trvs = {
+            entity_id: _tracked_trv(entity_id)
+            for entity_id in ("climate.trv1", "climate.trv2")
+        }
 
         queue = asyncio.Queue()
         mock_self.control_queue_task = queue
@@ -380,7 +388,7 @@ class TestControlQueue:
         mock_self.calculate_heating_power = AsyncMock()
         mock_self.calculate_heat_loss = AsyncMock()
         mock_self.cooler_entity_id = None
-        mock_self.real_trvs = {"climate.trv1": {}}
+        mock_self.real_trvs = {"climate.trv1": _tracked_trv("climate.trv1")}
 
         queue = asyncio.Queue(maxsize=10)
         mock_self.control_queue_task = queue
@@ -428,7 +436,7 @@ class TestControlQueue:
         mock_self.startup_running = False
         mock_self.calculate_heating_power = AsyncMock()
         mock_self.cooler_entity_id = None
-        mock_self.real_trvs = {"climate.trv1": {}}
+        mock_self.real_trvs = {"climate.trv1": _tracked_trv("climate.trv1")}
 
         # Create queue with maxsize=1
         queue = asyncio.Queue(maxsize=1)

--- a/tests/unit/controlling/test_trv_mode_cache_refresh.py
+++ b/tests/unit/controlling/test_trv_mode_cache_refresh.py
@@ -1,0 +1,257 @@
+"""What the per-TRV mode cache holds once a control cycle has ended.
+
+A control cycle is a window in which Better Thermostat drops inbound TRV
+events, and it stays open for seconds while the adapters wait for their writes
+to be confirmed. Each test here drives one cycle with a device that changes
+mode inside that window and states what the cache owes the user afterwards.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import STATE_UNAVAILABLE, UnitOfTemperature
+from homeassistant.core import State
+import pytest
+
+from custom_components.better_thermostat.climate import BetterThermostat
+from custom_components.better_thermostat.events.trv import trigger_trv_change
+from custom_components.better_thermostat.trv import Trv
+from custom_components.better_thermostat.utils.const import (
+    CONF_HOMEMATICIP,
+    CalibrationMode,
+    CalibrationType,
+)
+from custom_components.better_thermostat.utils.controlling import control_queue
+
+ENTITY_ID = "climate.test_trv"
+
+# The mode list of an ordinary radiator valve.
+OFFERED_MODES = [HVACMode.OFF, HVACMode.HEAT]
+
+
+def _reported_state(mode: str, setpoint: float = 19.0) -> State:
+    """Build the state one TRV publishes."""
+    return State(
+        ENTITY_ID,
+        mode,
+        attributes={
+            "current_temperature": 18.0,
+            "temperature": setpoint,
+            "hvac_modes": OFFERED_MODES,
+        },
+    )
+
+
+@pytest.fixture
+def reported_states() -> dict[str, State]:
+    """Hold what each device publishes, so a test can change it mid-cycle."""
+    return {ENTITY_ID: _reported_state("heat")}
+
+
+@pytest.fixture
+def thermostat(reported_states):
+    """Build a Better Thermostat driving one TRV that heats."""
+    bt = MagicMock()
+    bt.hass = MagicMock()
+    # Climate entities publish no unit attribute, so every temperature read off
+    # a TRV state resolves through the system unit.
+    bt.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
+    bt.hass.states.get.side_effect = reported_states.get
+    bt.device_name = "Test Thermostat"
+    bt.bt_hvac_mode = HVACMode.HEAT
+    bt.hvac_mode = HVACMode.HEAT
+    bt.bt_target_temp = 19.0
+    bt.bt_min_temp = 5.0
+    bt.bt_max_temp = 30.0
+    bt.bt_target_cooltemp = 25.0
+    bt.bt_target_temp_step = 0.5
+    bt.cur_temp = 18.0
+    bt.tolerance = 0.3
+    bt.window_open = False
+    bt.contact_open = False
+    bt.startup_running = False
+    bt.bt_update_lock = False
+    bt.in_maintenance = False
+    bt.ignore_states = False
+    bt.cooler_entity_id = None
+    bt.context = MagicMock()  # unique context so != event.context
+    bt.async_write_ha_state = MagicMock()
+    bt.calculate_heating_power = AsyncMock()
+    bt.calculate_heat_loss = AsyncMock()
+    bt.all_trvs = [{"advanced": {CONF_HOMEMATICIP: False}}]
+    bt._enforce_cool_above_heat = lambda **kwargs: (
+        BetterThermostat._enforce_cool_above_heat(bt, **kwargs)
+    )
+    bt._clamp_inbound_heat_target = lambda value: (
+        BetterThermostat._clamp_inbound_heat_target(bt, value)
+    )
+    bt.real_trvs = {
+        ENTITY_ID: Trv.from_legacy_dict(
+            ENTITY_ID,
+            {
+                "hvac_mode": "heat",
+                "hvac_modes": OFFERED_MODES,
+                "min_temp": 5.0,
+                "max_temp": 30.0,
+                "current_temperature": 18.0,
+                "temperature": 19.0,
+                "last_temperature": 19.0,
+                "last_hvac_mode": "heat",
+                "target_temp_received": True,
+                "system_mode_received": True,
+                "calibration_received": True,
+                "calibration": 1,
+                "last_calibration": 0.0,
+                "ignore_trv_states": False,
+                "model": "SomeModel",
+                "model_quirks": None,
+                "hvac_action": "heating",
+                "valve_position": 50,
+                "advanced": {
+                    "calibration": CalibrationType.LOCAL_BASED,
+                    "calibration_mode": CalibrationMode.DEFAULT,
+                    "no_off_system_mode": False,
+                    "heat_auto_swapped": False,
+                    "child_lock": False,
+                },
+            },
+        )
+    }
+    return bt
+
+
+async def _run_one_cycle(thermostat, reported_states, published_inside) -> None:
+    """Drive one control cycle, with the device publishing inside it.
+
+    ``published_inside`` is the state the TRV publishes while the cycle holds
+    it, which is the window in which an event from that TRV is dropped.
+    ``None`` stands for a device that publishes no state at all.
+    """
+    queue = asyncio.Queue()
+    thermostat.control_queue_task = queue
+    await queue.put(thermostat)
+
+    async def _control_trv(*args, **kwargs) -> bool:
+        assert thermostat.ignore_states is True
+        if published_inside is None:
+            reported_states.pop(ENTITY_ID)
+        else:
+            reported_states[ENTITY_ID] = published_inside
+        return True
+
+    with patch(
+        "custom_components.better_thermostat.utils.controlling.control_trv",
+        new=_control_trv,
+    ):
+        cycle = asyncio.create_task(control_queue(thermostat))
+        try:
+            await asyncio.wait_for(queue.join(), timeout=5)
+        finally:
+            cycle.cancel()
+            try:
+                await cycle
+            except asyncio.CancelledError:
+                pass
+
+
+def _press_setpoint(thermostat, reported_states, setpoint: float):
+    """Build the event a TRV sends when its knob was turned to ``setpoint``."""
+    old_state = reported_states[ENTITY_ID]
+    new_state = _reported_state(old_state.state, setpoint=setpoint)
+    reported_states[ENTITY_ID] = new_state
+
+    event = MagicMock()
+    event.data = {
+        "old_state": old_state,
+        "new_state": new_state,
+        "entity_id": ENTITY_ID,
+    }
+    event.context = MagicMock()  # differs from thermostat.context
+    return event
+
+
+class TestModeCacheAfterACycle:
+    """The cached mode a TRV reports, once the cycle that hid it has ended."""
+
+    @pytest.mark.asyncio
+    async def test_a_mode_reported_inside_the_cycle_reaches_the_cache(
+        self, thermostat, reported_states
+    ):
+        """A TRV that comes on during a cycle is cached as heating."""
+        thermostat.real_trvs[ENTITY_ID].hvac_mode = "off"
+        reported_states[ENTITY_ID] = _reported_state("off")
+
+        await _run_one_cycle(thermostat, reported_states, _reported_state("heat"))
+
+        assert thermostat.real_trvs[ENTITY_ID].hvac_mode == "heat"
+
+    @pytest.mark.asyncio
+    async def test_a_setpoint_pressed_after_the_cycle_is_adopted(
+        self, thermostat, reported_states
+    ):
+        """A knob turned after such a cycle moves the heating target.
+
+        This is the half the user feels: the setpoint guard turns away a press
+        from a device it holds as switched off, so a cache left behind by the
+        cycle silently drops the press.
+        """
+        thermostat.real_trvs[ENTITY_ID].hvac_mode = "off"
+        reported_states[ENTITY_ID] = _reported_state("off")
+
+        await _run_one_cycle(thermostat, reported_states, _reported_state("heat"))
+        await trigger_trv_change(
+            thermostat, _press_setpoint(thermostat, reported_states, 22.0)
+        )
+
+        assert thermostat.bt_target_temp == 22.0
+
+    @pytest.mark.asyncio
+    async def test_the_entity_keeps_the_mode_it_was_left_with(
+        self, thermostat, reported_states
+    ):
+        """Switching a TRV off during a cycle leaves the room heating.
+
+        The cache follows the device, the entity does not: a mode reported
+        while the handler stood down was not adopted as user intent, and the
+        end of the cycle is too late to read it as one.
+        """
+        await _run_one_cycle(thermostat, reported_states, _reported_state("off"))
+
+        assert thermostat.real_trvs[ENTITY_ID].hvac_mode == "off"
+        assert thermostat.bt_hvac_mode == HVACMode.HEAT
+
+    @pytest.mark.asyncio
+    async def test_an_unavailable_device_keeps_its_cached_mode(
+        self, thermostat, reported_states
+    ):
+        """A TRV that drops off the network keeps the mode it last reported."""
+        await _run_one_cycle(
+            thermostat, reported_states, State(ENTITY_ID, STATE_UNAVAILABLE)
+        )
+
+        assert thermostat.real_trvs[ENTITY_ID].hvac_mode == "heat"
+
+    @pytest.mark.asyncio
+    async def test_a_device_that_publishes_nothing_keeps_its_cached_mode(
+        self, thermostat, reported_states
+    ):
+        """A TRV with no state at all keeps the mode it last reported."""
+        await _run_one_cycle(thermostat, reported_states, None)
+
+        assert thermostat.real_trvs[ENTITY_ID].hvac_mode == "heat"
+
+    @pytest.mark.asyncio
+    async def test_a_child_locked_device_keeps_its_cached_mode(
+        self, thermostat, reported_states
+    ):
+        """A child lock holds the cache as firmly as it holds the handler.
+
+        The lock exists so that what happens at the device does not reach
+        Better Thermostat, and the end of a cycle is not a way around it.
+        """
+        thermostat.real_trvs[ENTITY_ID].advanced["child_lock"] = True
+
+        await _run_one_cycle(thermostat, reported_states, _reported_state("off"))
+
+        assert thermostat.real_trvs[ENTITY_ID].hvac_mode == "heat"


### PR DESCRIPTION
## What the user sees

After an external `climate.set_hvac_mode` call on the Better Thermostat entity, every
temperature change the user then makes on the TRV itself is silently dropped. Both the
TRV and the Better Thermostat entity show `heat` in the UI, and the debug log names the
reason:

```
better_thermostat <room>: TRV climate.<trv> setpoint change 19.0 -> 22.0 NOT adopted
(echo=False child_lock=None target_temp_received=True system_mode_received=True
 hvac_mode=off window_open=False ...)
```

Only reloading the config entry gets the device working again. Reported in #2317.

## Mechanism

`real_trvs[...].hvac_mode` caches the raw state string a TRV reports, and at runtime its
only writer is the inbound event handler in `events/trv.py`, which sits behind an
unconditional `if self.ignore_states: return`. `ignore_states` is held for the whole
length of a control cycle, and a cycle runs for seconds. The MQTT adapter alone sleeps
3 s inside `set_hvac_mode`, and the setpoint and system-mode confirmation loops poll for
several more. The TRV's `off` → `heat` transition therefore lands inside that blind
window and is dropped whole, and nothing corrects the cache afterwards: Better
Thermostat's own write path updates `last_hvac_mode` but not `hvac_mode`, and it writes
`heat` to a device that already reports `heat`, which produces no further state change.
Downstream, `_accept_user_setpoint` requires `trv.hvac_mode != HVACMode.OFF`, which is
why every later press on that TRV is refused.

## The change

`refresh_cached_trv_modes()` reads each TRV's reported mode back into its cache at the
end of a completed control cycle, immediately before `ignore_states` is released. It runs
on every cycle rather than only on one in which a mode was written: a TRV that changed
mode while Better Thermostat wrote nothing to it fails in exactly the same way.

**The refresh heals the cache and adopts no mode.** `bt_hvac_mode` is left exactly where
it was. A device mode reported while the inbound handler was standing down was not
adopted as user intent before this change either, and taking it into the entity at the
end of the cycle would decide the room's mode from a report nobody read. A TRV that
publishes no state, one that is unavailable or unknown, and one under a child lock keep
the cache they have, which is how the inbound handler reads all three.

## Measured

The defect stated as a mutation is the scenario itself: a TRV reports `off`, a control
cycle starts, the TRV flips to `heat` while `ignore_states` is `True`, the cycle ends.
What does `real_trvs[...].hvac_mode` hold?

- **Before: 0 red.** Nothing in the suite describes the blind window; the whole suite is
  green with the defect in place (7980 passed, 1 xfailed).
- **After: 3 of the 6 new tests turn red** when the refresh call is removed again: the
  cached mode, the setpoint press that follows it, and the entity mode that has to stay
  put. The remaining three are restraint tests (unavailable, no state at all, child lock)
  and hold under the mutation by design.

Three existing `control_queue` tests held plain dicts in `real_trvs` where production
holds a `Trv` record, so the first attribute the refresh reads off one of them raised.
They now carry the production type.

Suite after the change: 7986 passed, 1 xfailed. `ruff check` and `ruff format --check` clean. Coverage floors, naming, blind-except and restated-contract gates green.

## A related finding, deliberately not fixed here

For a device whose mode list is `["off", "heat"]`, which is an ordinary radiator valve, an
inbound `heat` is translated to `heat_cool` by `mode_remap()`, and `convert_inbound_states()`
returns `None` for anything outside `(off, heat)`. The mode-cache block in the inbound
handler is therefore skipped for a `heat` report from such a device: the cache can move to
`off` but has no way back to `heat` through the event path at all. That is a second reason
the stale `off` survives, and it is why the refresh takes the reported state directly
rather than reusing the inbound decoder. Fixing the translation would change which reports
reach `bt_hvac_mode`, so it belongs in its own change.

The issue also carries a second complaint: a genuine setpoint press that happens to equal
the last value Better Thermostat wrote is discarded as an echo, because
`resolve_inbound_setpoint()` compares values with no time bound and no one-shot
consumption. That is a design trade-off rather than a stale-state bug and is not touched
here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat mode tracking after control cycles by refreshing cached TRV modes from device-reported states.
  * Handles unavailable or unknown device states safely.
  * Preserves correct behavior for child-locked TRVs and distinguishes device mode from the thermostat’s selected mode.
  * Keeps mode information synchronized after device state changes.

* **Tests**
  * Added coverage for mode updates, state changes, unavailable devices, child-lock behavior, and setpoint changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->