### PR TITLE
test: run the async tests without a file-local anyio backend

### DIFF
--- a/tests/test_adapters_none_handling.py
+++ b/tests/test_adapters_none_handling.py
@@ -20,12 +20,6 @@ def _adapter_id(adapter):
 
 
 @pytest.fixture
-def anyio_backend():
-    """Configure anyio to use asyncio backend for async tests."""
-    return "asyncio"
-
-
-@pytest.fixture
 def mock_hass():
     """Create a mock Home Assistant instance."""
     hass = MagicMock()
@@ -51,7 +45,6 @@ def mock_bt_instance(mock_hass):
 class TestDeconzAdapter:
     """Tests for deCONZ adapter None handling."""
 
-    @pytest.mark.anyio
     async def test_get_info_returns_false_when_state_is_none(self, mock_bt_instance):
         """Test that get_info returns support_offset=False when state is None."""
         from custom_components.better_thermostat.adapters.deconz import get_info
@@ -62,7 +55,6 @@ class TestDeconzAdapter:
 
         assert result == {"support_offset": False, "support_valve": False}
 
-    @pytest.mark.anyio
     async def test_get_info_returns_true_when_offset_exists(self, mock_bt_instance):
         """Test that get_info returns support_offset=True when offset attribute exists."""
         from custom_components.better_thermostat.adapters.deconz import get_info
@@ -88,7 +80,6 @@ class TestBoundsOfAnEntityThatDeclaresNone:
     """
 
     @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS, ids=_adapter_id)
-    @pytest.mark.anyio
     async def test_step_of_a_stateless_entity(self, adapter, mock_bt_instance):
         """An entity that reports nothing publishes no granularity."""
         mock_bt_instance.hass.states.get.return_value = None
@@ -98,7 +89,6 @@ class TestBoundsOfAnEntityThatDeclaresNone:
         assert result == 1.0
 
     @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS, ids=_adapter_id)
-    @pytest.mark.anyio
     async def test_min_of_a_stateless_entity(self, adapter, mock_bt_instance):
         """An entity that reports nothing publishes no lower bound."""
         mock_bt_instance.hass.states.get.return_value = None
@@ -108,7 +98,6 @@ class TestBoundsOfAnEntityThatDeclaresNone:
         assert result == -10.0
 
     @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS, ids=_adapter_id)
-    @pytest.mark.anyio
     async def test_max_of_a_stateless_entity(self, adapter, mock_bt_instance):
         """An entity that reports nothing publishes no upper bound."""
         mock_bt_instance.hass.states.get.return_value = None
@@ -118,7 +107,6 @@ class TestBoundsOfAnEntityThatDeclaresNone:
         assert result == 10.0
 
     @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS, ids=_adapter_id)
-    @pytest.mark.anyio
     async def test_step_without_a_calibration_entity(self, adapter, mock_bt_instance):
         """A TRV discovery found no entity for gets the same answer."""
         mock_bt_instance.real_trvs = {
@@ -132,7 +120,6 @@ class TestBoundsOfAnEntityThatDeclaresNone:
         assert result == 1.0
 
     @pytest.mark.parametrize("adapter", ENTITY_ADAPTERS, ids=_adapter_id)
-    @pytest.mark.anyio
     async def test_step_comes_from_the_entity_when_it_publishes_one(
         self, adapter, mock_bt_instance
     ):

--- a/tests/test_battery_entity.py
+++ b/tests/test_battery_entity.py
@@ -16,12 +16,6 @@ import pytest
 
 
 @pytest.fixture
-def anyio_backend():
-    """Configure anyio to use asyncio backend for async tests."""
-    return "asyncio"
-
-
-@pytest.fixture
 def mock_hass():
     """Create a mock Home Assistant instance."""
     hass = MagicMock()
@@ -40,7 +34,6 @@ def mock_bt_instance(mock_hass):
 class TestFindBatteryEntity:
     """Tests for find_battery_entity function."""
 
-    @pytest.mark.anyio
     async def test_returns_none_for_unknown_entity(self, mock_bt_instance):
         """Test that None is returned when entity is not in registry."""
         from custom_components.better_thermostat.utils.helpers import (
@@ -59,7 +52,6 @@ class TestFindBatteryEntity:
             )
             assert result is None
 
-    @pytest.mark.anyio
     async def test_returns_battery_for_physical_device(self, mock_bt_instance):
         """Test that battery entity is found for physical device."""
         from custom_components.better_thermostat.utils.helpers import (
@@ -87,7 +79,6 @@ class TestFindBatteryEntity:
             result = await find_battery_entity(mock_bt_instance, "binary_sensor.window")
             assert result == "sensor.window_battery"
 
-    @pytest.mark.anyio
     async def test_returns_none_for_virtual_entity_without_group(
         self, mock_bt_instance
     ):
@@ -117,7 +108,6 @@ class TestFindBatteryEntity:
             )
             assert result is None
 
-    @pytest.mark.anyio
     async def test_returns_lowest_battery_for_group(self, mock_bt_instance):
         """Test that lowest battery is returned for a group of sensors."""
         from custom_components.better_thermostat.utils.helpers import (
@@ -198,7 +188,6 @@ class TestFindBatteryEntity:
             # Should return the battery with the lowest level (25%)
             assert result == "sensor.window2_battery"
 
-    @pytest.mark.anyio
     async def test_group_with_no_batteries_returns_none(self, mock_bt_instance):
         """Test that None is returned for group where no member has battery."""
         from custom_components.better_thermostat.utils.helpers import (

--- a/tests/test_helpers_valve.py
+++ b/tests/test_helpers_valve.py
@@ -1,17 +1,9 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from custom_components.better_thermostat.utils.helpers import (
     find_local_calibration_entity,
     find_valve_entity,
 )
-
-
-@pytest.fixture
-def anyio_backend():
-    """Return the async backend to use for tests."""
-    return "asyncio"
 
 
 def _make_entity(eid, uid, device_id, translation_key=None, original_name=None):
@@ -35,7 +27,6 @@ def _make_bt_instance():
     return bt
 
 
-@pytest.mark.anyio
 async def test_find_valve_entity_ignores_sensor_pi_heating_demand():
     """Test that find_valve_entity ignores sensor.pi_heating_demand but accepts number.pi_heating_demand."""
 
@@ -125,7 +116,6 @@ async def test_find_valve_entity_ignores_sensor_pi_heating_demand():
         assert result["writable"] is True
 
 
-@pytest.mark.anyio
 async def test_find_valve_entity_trvzb_valve_opening_degree_device_mismatch():
     """TRVZB-style valve entities may be registered under a different device_id.
 
@@ -190,7 +180,6 @@ async def test_find_valve_entity_trvzb_valve_opening_degree_device_mismatch():
         assert result["reason"] == "valve_opening_degree"
 
 
-@pytest.mark.anyio
 async def test_find_valve_entity_by_translation_key():
     """Test that find_valve_entity detects entities by translation_key without relying on string matching."""
 
@@ -240,7 +229,6 @@ async def test_find_valve_entity_by_translation_key():
         assert result["reason"] == "valve_position"
 
 
-@pytest.mark.anyio
 async def test_find_valve_entity_translation_key_preferred_over_string_match():
     """Test that translation_key match is preferred when both would match different entities."""
 
@@ -296,7 +284,6 @@ async def test_find_valve_entity_translation_key_preferred_over_string_match():
         assert result["reason"] == "valve_position"
 
 
-@pytest.mark.anyio
 async def test_find_valve_entity_by_translation_key_pi_heating_demand():
     """Test that translation_key='pi_heating_demand' is detected."""
 
@@ -342,7 +329,6 @@ async def test_find_valve_entity_by_translation_key_pi_heating_demand():
         assert result["reason"] == "pi_heating_demand"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_by_translation_key():
     """Test that find_local_calibration_entity detects entities by translation_key."""
 
@@ -379,7 +365,6 @@ async def test_find_local_calibration_entity_by_translation_key():
         assert result == "number.trv_opaque_calibration"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_by_translation_key_temperature_offset():
     """Test that translation_key='temperature_offset' is detected for calibration."""
 
@@ -415,7 +400,6 @@ async def test_find_local_calibration_entity_by_translation_key_temperature_offs
         assert result == "number.trv_generic_entity"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_fallback_string_match():
     """Test that find_local_calibration_entity falls back to string matching when no translation_key."""
 
@@ -452,7 +436,6 @@ async def test_find_local_calibration_entity_fallback_string_match():
         assert result == "number.trv_temperature_calibration"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_translation_key_preferred_over_string():
     """Test that translation_key match is found first, even with a string-matchable entity."""
 
@@ -497,7 +480,6 @@ async def test_find_local_calibration_translation_key_preferred_over_string():
         assert result == "number.trv_tk_entity"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_prefers_number_over_sensor():
     """Test that the number calibration entity wins over a read-only sensor.
 
@@ -544,7 +526,6 @@ async def test_find_local_calibration_entity_prefers_number_over_sensor():
         assert result == "number.trv_local_temperature_calibration"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_first_writable_match_wins():
     """Test that the fallback pass stops at the first writable match.
 
@@ -590,7 +571,6 @@ async def test_find_local_calibration_entity_first_writable_match_wins():
         assert result == "number.trv_local_temperature_calibration"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_translation_key_ignores_sensor_domain():
     """Test that the translation_key pass skips non-writable domains.
 
@@ -636,7 +616,6 @@ async def test_find_local_calibration_translation_key_ignores_sensor_domain():
         assert result == "number.trv_calibration"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_sensor_only_returns_none():
     """Test that a device exposing only the read-only sensor yields no match."""
 
@@ -672,7 +651,6 @@ async def test_find_local_calibration_entity_sensor_only_returns_none():
         assert result is None
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_accepts_select_domain():
     """Test that a select calibration entity is accepted as writable target."""
 

--- a/tests/test_model_detection.py
+++ b/tests/test_model_detection.py
@@ -85,12 +85,6 @@ class TestModelDetectionFromString:
         assert result == "Model (v2) Pro"
 
 
-@pytest.fixture
-def anyio_backend() -> str:
-    """Configure anyio to use asyncio backend."""
-    return "asyncio"
-
-
 class TestGetDeviceModelFunction:
     """Integration tests for the get_device_model function."""
 
@@ -103,7 +97,6 @@ class TestGetDeviceModelFunction:
         mock.model = "configured_model"
         return mock
 
-    @pytest.mark.anyio
     async def test_get_device_model_z2m_format(self, mock_self):
         """Test get_device_model with Z2M format device.model."""
         from custom_components.better_thermostat.utils.helpers import get_device_model
@@ -142,7 +135,6 @@ class TestGetDeviceModelFunction:
                     f"Expected 'TS0601 _TZE284_cvub6xbb' but got '{result}'"
                 )
 
-    @pytest.mark.anyio
     async def test_get_device_model_with_model_id(self, mock_self):
         """Test that model_id takes priority over model string."""
         from custom_components.better_thermostat.utils.helpers import get_device_model
@@ -176,7 +168,6 @@ class TestGetDeviceModelFunction:
                 # model_id should take priority
                 assert result == "TS0601"
 
-    @pytest.mark.anyio
     async def test_get_device_model_plain_string(self, mock_self):
         """Test model detection with plain string (no parentheses)."""
         from custom_components.better_thermostat.utils.helpers import get_device_model

--- a/tests/test_window_no_off_mode.py
+++ b/tests/test_window_no_off_mode.py
@@ -189,7 +189,6 @@ class TestTrvStateUpdateBug:
 class TestControlTrvWithNoOffMode:
     """Tests for the full control_trv flow with no_off_system_mode."""
 
-    @pytest.mark.anyio
     async def test_control_trv_restores_temp_after_window_close(self, mock_bt_instance):
         """Test that control_trv properly restores temperature after window closes.
 

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -2535,7 +2535,6 @@ class TestGroupedTrvCalibration:
     flag can get stuck at False, blocking future calibration updates.
     """
 
-    @pytest.mark.anyio
     async def test_confirmed_command_releases_the_gate_and_writes_the_new_intent(
         self, mock_bt_grouped
     ):
@@ -2581,7 +2580,6 @@ class TestGroupedTrvCalibration:
             mock_set_offset.assert_awaited_once_with(mock_bt_grouped, entity_id, 3.0)
             assert mock_bt_grouped.real_trvs[entity_id].calibration_received is False
 
-    @pytest.mark.anyio
     async def test_calibration_sent_when_received_true_and_differs(
         self, mock_bt_grouped
     ):
@@ -2621,7 +2619,6 @@ class TestGroupedTrvCalibration:
             mock_set_offset.assert_called_once_with(mock_bt_grouped, entity_id, 3.0)
             assert mock_bt_grouped.real_trvs[entity_id].calibration_received is False
 
-    @pytest.mark.anyio
     async def test_missing_reference_calibration_skips_offset_write(
         self, mock_bt_grouped
     ):
@@ -2672,7 +2669,6 @@ class TestGroupedTrvCalibration:
             mock_set_offset.assert_not_called()
             mock_set_temp.assert_awaited_once_with(mock_bt_grouped, entity_id, 21.0)
 
-    @pytest.mark.anyio
     @pytest.mark.parametrize(
         ("step", "reported", "released"),
         [(0.5, 2.2, True), (0.5, 2.3, False), (1.0, 2.5, True)],
@@ -2719,7 +2715,6 @@ class TestGroupedTrvCalibration:
 
             assert mock_bt_grouped.real_trvs[entity_id].calibration_received is released
 
-    @pytest.mark.anyio
     async def test_calibration_tolerance_outside_half_degree(self, mock_bt_grouped):
         """Test that calibration outside 0.5 degree tolerance is not matching."""
         entity_id = "climate.trv_3"


### PR DESCRIPTION
## What breaks today

Running any one of these test files on its own ends in `ERROR at setup` instead of a
result. The same tests pass in a full-suite run, so CI is green and nothing reports the
breakage — but the tests are unreproducible per file, and a `-k`/`-m` selection cannot
reach them either.

```
$ uv run pytest tests/test_adapters_none_handling.py -q
17 errors in 0.05s

ScopeMismatch: You tried to access the function scoped fixture anyio_backend
with a session scoped request object. Requesting fixture stack:
  .venv/.../anyio/pytest_plugin.py:104:  def wrapper(anyio_backend, request, **kwargs)
Requested fixture:
  tests/test_battery_entity.py:18:  def anyio_backend()
```

## Mechanism

anyio's pytest plugin wraps every async fixture whose test node also requests
`anyio_backend`; `pytest-homeassistant-custom-component` contributes a session-scoped
async fixture (`mock_zeroconf_resolver`), and when that one is first created during an
`@pytest.mark.anyio` test, its wrapper asks a session-scoped request for a
narrower-scoped `anyio_backend` and pytest refuses.

A full run creates `mock_zeroconf_resolver` earlier, during an unmarked test, so the
wrapper is never installed and the error never appears.

## Shape

`asyncio_mode = "auto"` already hands every unmarked async test to pytest-asyncio, so
the file-local `anyio_backend` fixtures and the `@pytest.mark.anyio` markers both go.
`tests/unit/test_watcher.py` already carries that shape; the remaining files now match
it. Nothing here needs a backend anyio provides and pytest-asyncio does not: trio is not
installed, and no test imports `anyio`.

Two of the six files carry markers without a file-local fixture
(`tests/test_window_no_off_mode.py`, `tests/unit/controlling/test_control_trv.py`).
anyio's own `anyio_backend` fixture is **module** scoped, which is still narrower than
session, so those two hit the identical `ScopeMismatch` as soon as a selection reaches a
marked test first. They are part of the same change.

## Files touched

- `tests/test_adapters_none_handling.py`
- `tests/test_battery_entity.py`
- `tests/test_helpers_valve.py` (its `import pytest` goes with the fixture)
- `tests/test_model_detection.py`
- `tests/test_window_no_off_mode.py`
- `tests/unit/controlling/test_control_trv.py`

## Numbers

Per-file selection, `uv run pytest <file> -q`:

| file | before | after |
| --- | --- | --- |
| `tests/test_adapters_none_handling.py` | 17 errors | 17 passed |
| `tests/test_battery_entity.py` | 5 errors | 5 passed |
| `tests/test_helpers_valve.py` | 14 errors | 14 passed |
| `tests/test_model_detection.py` | 8 passed | 8 passed |
| `tests/test_window_no_off_mode.py` | 5 passed | 5 passed |
| `tests/unit/controlling/test_control_trv.py` | 71 passed | 71 passed |

The last three look healthy only because a sync test in the same file happens to be
collected first and creates the session fixture before any marked test does. Narrowing
the selection to the marked tests, `uv run pytest <file> -q -m anyio`:

| file | before | after |
| --- | --- | --- |
| `tests/test_adapters_none_handling.py` | 17 errors | 17 deselected |
| `tests/test_battery_entity.py` | 5 errors | 5 deselected |
| `tests/test_helpers_valve.py` | 14 errors | 14 deselected |
| `tests/test_model_detection.py` | 5 deselected, 3 errors | 8 deselected |
| `tests/test_window_no_off_mode.py` | 4 deselected, 1 error | 5 deselected |
| `tests/unit/controlling/test_control_trv.py` | 64 deselected, 7 errors | 71 deselected |

Full suite, `uv run pytest tests/ -q -p no:randomly`:

| | before | after |
| --- | --- | --- |
| total | **7980 passed, 1 xfailed** | **7980 passed, 1 xfailed** |

The totals are identical, and every per-file item count above is unchanged, so nothing
was de-collected. The only visible difference is in test ids: the marked tests lose the
`[asyncio]` suffix that anyio's parametrized backend fixture used to add.

## Each converted file still fails when it should

One assertion per file was inverted, the single test run, and the file restored:

| file | test | mutation | result |
| --- | --- | --- | --- |
| `test_adapters_none_handling.py` | `TestDeconzAdapter::test_get_info_returns_false_when_state_is_none` | `support_offset`/`support_valve` `False` → `True` | 1 failed |
| `test_battery_entity.py` | `TestFindBatteryEntity::test_returns_battery_for_physical_device` | `sensor.window_battery` → `sensor.wrong_battery` | 1 failed |
| `test_helpers_valve.py` | `test_find_local_calibration_entity_accepts_select_domain` | `select.trv_temperature_offset` → `select.trv_wrong_entity` | 1 failed |
| `test_model_detection.py` | `TestGetDeviceModelFunction::test_get_device_model_with_model_id` | `TS0601` → `TS9999` | 1 failed |
| `test_window_no_off_mode.py` | `TestControlTrvWithNoOffMode::test_control_trv_restores_temp_after_window_close` | `bt_target_temp == 21.0` → `== 99.0` | 1 failed |
| `test_control_trv.py` | `TestGroupedTrvCalibration::test_calibration_tolerance_outside_half_degree` | final `calibration_received is False` → `is True` | 1 failed |

## Gates

| gate | result |
| --- | --- |
| `uv run pytest tests/` | 7980 passed, 1 xfailed |
| `uvx ruff@0.15.15 check` | All checks passed |
| `uvx ruff@0.15.15 format --check` | 344 files already formatted |
| `uv run python scripts/coverage_floors.py check` | all 101 modules hold their floor |
| `uv run python scripts/check_naming.py check` | 832 rejected names across 58 files, all within budget (exit 0) |
| `uv run python scripts/blind_except_budget.py check` | all 18 files stay within their budget (exit 0) |
| `uv run pytest tests/unit/test_restated_contracts.py` | 28 passed |
| `uv run pyrefly check` | 0 errors |

https://claude.ai/code/session_01PDK4Ae8guxGD9Jp2bkxkNv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for thermostat behavior when windows open or close, including heating and off modes.
  - Added regression checks for correct temperature handling and mode preservation in affected scenarios.
  - Simplified asynchronous test execution by relying on the default asyncio backend.
  - Removed redundant test markers and fixtures while keeping existing test logic intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->