### PR TITLE
test: run the async tests without a file-local anyio backend (1.9)

### DIFF
--- a/tests/test_adapters_none_handling.py
+++ b/tests/test_adapters_none_handling.py
@@ -11,12 +11,6 @@ from custom_components.better_thermostat.trv import Trv
 
 
 @pytest.fixture
-def anyio_backend():
-    """Configure anyio to use asyncio backend for async tests."""
-    return "asyncio"
-
-
-@pytest.fixture
 def mock_hass():
     """Create a mock Home Assistant instance."""
     hass = MagicMock()
@@ -42,7 +36,6 @@ def mock_bt_instance(mock_hass):
 class TestDeconzAdapter:
     """Tests for deCONZ adapter None handling."""
 
-    @pytest.mark.anyio
     async def test_get_info_returns_false_when_state_is_none(self, mock_bt_instance):
         """Test that get_info returns support_offset=False when state is None."""
         from custom_components.better_thermostat.adapters.deconz import get_info
@@ -53,7 +46,6 @@ class TestDeconzAdapter:
 
         assert result == {"support_offset": False, "support_valve": False}
 
-    @pytest.mark.anyio
     async def test_get_info_returns_true_when_offset_exists(self, mock_bt_instance):
         """Test that get_info returns support_offset=True when offset attribute exists."""
         from custom_components.better_thermostat.adapters.deconz import get_info
@@ -70,7 +62,6 @@ class TestDeconzAdapter:
 class TestMqttAdapter:
     """Tests for MQTT adapter None handling."""
 
-    @pytest.mark.anyio
     async def test_get_offset_step_returns_default_when_state_is_none(
         self, mock_bt_instance
     ):
@@ -83,7 +74,6 @@ class TestMqttAdapter:
 
         assert result == 1.0
 
-    @pytest.mark.anyio
     async def test_get_min_offset_returns_default_when_state_is_none(
         self, mock_bt_instance
     ):
@@ -96,7 +86,6 @@ class TestMqttAdapter:
 
         assert result == -10.0
 
-    @pytest.mark.anyio
     async def test_get_max_offset_returns_default_when_state_is_none(
         self, mock_bt_instance
     ):
@@ -109,7 +98,6 @@ class TestMqttAdapter:
 
         assert result == 10.0
 
-    @pytest.mark.anyio
     async def test_get_offset_step_returns_attribute_when_state_exists(
         self, mock_bt_instance
     ):
@@ -128,7 +116,6 @@ class TestMqttAdapter:
 class TestGenericAdapter:
     """Tests for generic adapter None handling."""
 
-    @pytest.mark.anyio
     async def test_get_offset_step_returns_none_when_state_is_none(
         self, mock_bt_instance
     ):
@@ -141,7 +128,6 @@ class TestGenericAdapter:
 
         assert result is None
 
-    @pytest.mark.anyio
     async def test_get_min_offset_returns_default_when_state_is_none(
         self, mock_bt_instance
     ):
@@ -154,7 +140,6 @@ class TestGenericAdapter:
 
         assert result == -6.0
 
-    @pytest.mark.anyio
     async def test_get_max_offset_returns_default_when_state_is_none(
         self, mock_bt_instance
     ):
@@ -167,7 +152,6 @@ class TestGenericAdapter:
 
         assert result == 6.0
 
-    @pytest.mark.anyio
     async def test_get_offset_step_returns_none_when_no_calibration_entity(
         self, mock_bt_instance
     ):

--- a/tests/test_battery_entity.py
+++ b/tests/test_battery_entity.py
@@ -16,12 +16,6 @@ import pytest
 
 
 @pytest.fixture
-def anyio_backend():
-    """Configure anyio to use asyncio backend for async tests."""
-    return "asyncio"
-
-
-@pytest.fixture
 def mock_hass():
     """Create a mock Home Assistant instance."""
     hass = MagicMock()
@@ -40,7 +34,6 @@ def mock_bt_instance(mock_hass):
 class TestFindBatteryEntity:
     """Tests for find_battery_entity function."""
 
-    @pytest.mark.anyio
     async def test_returns_none_for_unknown_entity(self, mock_bt_instance):
         """Test that None is returned when entity is not in registry."""
         from custom_components.better_thermostat.utils.helpers import (
@@ -59,7 +52,6 @@ class TestFindBatteryEntity:
             )
             assert result is None
 
-    @pytest.mark.anyio
     async def test_returns_battery_for_physical_device(self, mock_bt_instance):
         """Test that battery entity is found for physical device."""
         from custom_components.better_thermostat.utils.helpers import (
@@ -87,7 +79,6 @@ class TestFindBatteryEntity:
             result = await find_battery_entity(mock_bt_instance, "binary_sensor.window")
             assert result == "sensor.window_battery"
 
-    @pytest.mark.anyio
     async def test_returns_none_for_virtual_entity_without_group(
         self, mock_bt_instance
     ):
@@ -117,7 +108,6 @@ class TestFindBatteryEntity:
             )
             assert result is None
 
-    @pytest.mark.anyio
     async def test_returns_lowest_battery_for_group(self, mock_bt_instance):
         """Test that lowest battery is returned for a group of sensors."""
         from custom_components.better_thermostat.utils.helpers import (
@@ -198,7 +188,6 @@ class TestFindBatteryEntity:
             # Should return the battery with the lowest level (25%)
             assert result == "sensor.window2_battery"
 
-    @pytest.mark.anyio
     async def test_group_with_no_batteries_returns_none(self, mock_bt_instance):
         """Test that None is returned for group where no member has battery."""
         from custom_components.better_thermostat.utils.helpers import (

--- a/tests/test_helpers_valve.py
+++ b/tests/test_helpers_valve.py
@@ -1,17 +1,9 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from custom_components.better_thermostat.utils.helpers import (
     find_local_calibration_entity,
     find_valve_entity,
 )
-
-
-@pytest.fixture
-def anyio_backend():
-    """Return the async backend to use for tests."""
-    return "asyncio"
 
 
 def _make_entity(eid, uid, device_id, translation_key=None, original_name=None):
@@ -35,7 +27,6 @@ def _make_bt_instance():
     return bt
 
 
-@pytest.mark.anyio
 async def test_find_valve_entity_ignores_sensor_pi_heating_demand():
     """Test that find_valve_entity ignores sensor.pi_heating_demand but accepts number.pi_heating_demand."""
 
@@ -125,7 +116,6 @@ async def test_find_valve_entity_ignores_sensor_pi_heating_demand():
         assert result["writable"] is True
 
 
-@pytest.mark.anyio
 async def test_find_valve_entity_trvzb_valve_opening_degree_device_mismatch():
     """TRVZB-style valve entities may be registered under a different device_id.
 
@@ -190,7 +180,6 @@ async def test_find_valve_entity_trvzb_valve_opening_degree_device_mismatch():
         assert result["reason"] == "valve_opening_degree"
 
 
-@pytest.mark.anyio
 async def test_find_valve_entity_by_translation_key():
     """Test that find_valve_entity detects entities by translation_key without relying on string matching."""
 
@@ -240,7 +229,6 @@ async def test_find_valve_entity_by_translation_key():
         assert result["reason"] == "valve_position"
 
 
-@pytest.mark.anyio
 async def test_find_valve_entity_translation_key_preferred_over_string_match():
     """Test that translation_key match is preferred when both would match different entities."""
 
@@ -296,7 +284,6 @@ async def test_find_valve_entity_translation_key_preferred_over_string_match():
         assert result["reason"] == "valve_position"
 
 
-@pytest.mark.anyio
 async def test_find_valve_entity_by_translation_key_pi_heating_demand():
     """Test that translation_key='pi_heating_demand' is detected."""
 
@@ -342,7 +329,6 @@ async def test_find_valve_entity_by_translation_key_pi_heating_demand():
         assert result["reason"] == "pi_heating_demand"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_by_translation_key():
     """Test that find_local_calibration_entity detects entities by translation_key."""
 
@@ -379,7 +365,6 @@ async def test_find_local_calibration_entity_by_translation_key():
         assert result == "number.trv_opaque_calibration"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_by_translation_key_temperature_offset():
     """Test that translation_key='temperature_offset' is detected for calibration."""
 
@@ -415,7 +400,6 @@ async def test_find_local_calibration_entity_by_translation_key_temperature_offs
         assert result == "number.trv_generic_entity"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_fallback_string_match():
     """Test that find_local_calibration_entity falls back to string matching when no translation_key."""
 
@@ -452,7 +436,6 @@ async def test_find_local_calibration_entity_fallback_string_match():
         assert result == "number.trv_temperature_calibration"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_translation_key_preferred_over_string():
     """Test that translation_key match is found first, even with a string-matchable entity."""
 
@@ -497,7 +480,6 @@ async def test_find_local_calibration_translation_key_preferred_over_string():
         assert result == "number.trv_tk_entity"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_prefers_number_over_sensor():
     """Test that the number calibration entity wins over a read-only sensor.
 
@@ -544,7 +526,6 @@ async def test_find_local_calibration_entity_prefers_number_over_sensor():
         assert result == "number.trv_local_temperature_calibration"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_first_writable_match_wins():
     """Test that the fallback pass stops at the first writable match.
 
@@ -590,7 +571,6 @@ async def test_find_local_calibration_entity_first_writable_match_wins():
         assert result == "number.trv_local_temperature_calibration"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_translation_key_ignores_sensor_domain():
     """Test that the translation_key pass skips non-writable domains.
 
@@ -636,7 +616,6 @@ async def test_find_local_calibration_translation_key_ignores_sensor_domain():
         assert result == "number.trv_calibration"
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_sensor_only_returns_none():
     """Test that a device exposing only the read-only sensor yields no match."""
 
@@ -672,7 +651,6 @@ async def test_find_local_calibration_entity_sensor_only_returns_none():
         assert result is None
 
 
-@pytest.mark.anyio
 async def test_find_local_calibration_entity_accepts_select_domain():
     """Test that a select calibration entity is accepted as writable target."""
 

--- a/tests/test_model_detection.py
+++ b/tests/test_model_detection.py
@@ -85,12 +85,6 @@ class TestModelDetectionFromString:
         assert result == "Model (v2) Pro"
 
 
-@pytest.fixture
-def anyio_backend() -> str:
-    """Configure anyio to use asyncio backend."""
-    return "asyncio"
-
-
 class TestGetDeviceModelFunction:
     """Integration tests for the get_device_model function."""
 
@@ -103,7 +97,6 @@ class TestGetDeviceModelFunction:
         mock.model = "configured_model"
         return mock
 
-    @pytest.mark.anyio
     async def test_get_device_model_z2m_format(self, mock_self):
         """Test get_device_model with Z2M format device.model."""
         from custom_components.better_thermostat.utils.helpers import get_device_model
@@ -142,7 +135,6 @@ class TestGetDeviceModelFunction:
                     f"Expected 'TS0601 _TZE284_cvub6xbb' but got '{result}'"
                 )
 
-    @pytest.mark.anyio
     async def test_get_device_model_with_model_id(self, mock_self):
         """Test that model_id takes priority over model string."""
         from custom_components.better_thermostat.utils.helpers import get_device_model
@@ -176,7 +168,6 @@ class TestGetDeviceModelFunction:
                 # model_id should take priority
                 assert result == "TS0601"
 
-    @pytest.mark.anyio
     async def test_get_device_model_plain_string(self, mock_self):
         """Test model detection with plain string (no parentheses)."""
         from custom_components.better_thermostat.utils.helpers import get_device_model

--- a/tests/test_window_no_off_mode.py
+++ b/tests/test_window_no_off_mode.py
@@ -189,7 +189,6 @@ class TestTrvStateUpdateBug:
 class TestControlTrvWithNoOffMode:
     """Tests for the full control_trv flow with no_off_system_mode."""
 
-    @pytest.mark.anyio
     async def test_control_trv_restores_temp_after_window_close(self, mock_bt_instance):
         """Test that control_trv properly restores temperature after window closes.
 

--- a/tests/unit/controlling/test_control_trv.py
+++ b/tests/unit/controlling/test_control_trv.py
@@ -1836,7 +1836,6 @@ class TestGroupedTrvCalibration:
     flag can get stuck at False, blocking future calibration updates.
     """
 
-    @pytest.mark.anyio
     async def test_confirmed_command_releases_flag_and_writes_new_intent(
         self, mock_bt_grouped
     ):
@@ -1880,7 +1879,6 @@ class TestGroupedTrvCalibration:
             mock_set_offset.assert_awaited_once_with(mock_bt_grouped, entity_id, 3.0)
             assert mock_bt_grouped.real_trvs[entity_id].calibration_received is False
 
-    @pytest.mark.anyio
     async def test_calibration_sent_when_received_true_and_differs(
         self, mock_bt_grouped
     ):
@@ -1918,7 +1916,6 @@ class TestGroupedTrvCalibration:
             mock_set_offset.assert_called_once_with(mock_bt_grouped, entity_id, 3.0)
             assert mock_bt_grouped.real_trvs[entity_id].calibration_received is False
 
-    @pytest.mark.anyio
     @pytest.mark.parametrize(
         "step,reported,released",
         [(0.5, 2.2, True), (0.5, 2.3, False), (1.0, 2.5, True)],
@@ -1965,7 +1962,6 @@ class TestGroupedTrvCalibration:
 
             assert mock_bt_grouped.real_trvs[entity_id].calibration_received is released
 
-    @pytest.mark.anyio
     async def test_calibration_tolerance_outside_half_degree(self, mock_bt_grouped):
         """Test that calibration outside 0.5 degree tolerance is not matching."""
         entity_id = "climate.trv_3"

--- a/tests/unit/test_watcher.py
+++ b/tests/unit/test_watcher.py
@@ -18,12 +18,6 @@ def _close_coro(coro, *args, **kwargs):
 
 
 @pytest.fixture
-def anyio_backend():
-    """Configure anyio to use asyncio backend for async tests."""
-    return "asyncio"
-
-
-@pytest.fixture
 def mock_hass():
     """Create a mock Home Assistant instance."""
     hass = MagicMock()
@@ -339,7 +333,6 @@ class TestGetCriticalEntities:
 class TestCheckCriticalEntities:
     """Tests for check_critical_entities function."""
 
-    @pytest.mark.anyio
     async def test_returns_true_when_all_trvs_available(self, mock_bt_instance):
         """Test that True is returned when all TRVs are available."""
         from custom_components.better_thermostat.utils.watcher import (
@@ -355,7 +348,6 @@ class TestCheckCriticalEntities:
 
         assert result is True
 
-    @pytest.mark.anyio
     async def test_returns_false_when_trv_unavailable(self, mock_bt_instance):
         """Test that False is returned when a TRV is unavailable."""
         from custom_components.better_thermostat.utils.watcher import (
@@ -372,7 +364,6 @@ class TestCheckCriticalEntities:
         assert result is False
         assert len(mock_bt_instance.devices_errors) > 0
 
-    @pytest.mark.anyio
     async def test_no_issue_during_grace_period(self, mock_bt_instance):
         """Unavailable TRV during startup grace does not raise a repair issue."""
         from datetime import timedelta
@@ -395,7 +386,6 @@ class TestCheckCriticalEntities:
         assert len(mock_bt_instance.devices_errors) == 0
         assert not mock_ir.async_create_issue.called
 
-    @pytest.mark.anyio
     async def test_issue_after_grace_expires(self, mock_bt_instance):
         """Unavailable TRV after grace expiry raises a repair issue."""
         from datetime import timedelta
@@ -419,7 +409,6 @@ class TestCheckCriticalEntities:
         assert len(mock_bt_instance.devices_errors) > 0
         assert mock_ir.async_create_issue.called
 
-    @pytest.mark.anyio
     async def test_warns_once_while_a_trv_stays_unavailable(
         self, mock_bt_instance, caplog
     ):
@@ -458,7 +447,6 @@ class TestCheckCriticalEntities:
         assert len(announced) == len(set(announced)) == trv_count
         assert mock_ir.async_create_issue.call_count == trv_count
 
-    @pytest.mark.anyio
     async def test_auto_clear_issue_on_recovery(self, mock_bt_instance):
         """Issue is cleared when a previously-unavailable TRV becomes available."""
         from custom_components.better_thermostat.utils.watcher import (
@@ -479,7 +467,6 @@ class TestCheckCriticalEntities:
         # Issue must be deleted for each recovered TRV
         assert mock_ir.async_delete_issue.call_count == 2
 
-    @pytest.mark.anyio
     async def test_clears_stale_issue_even_without_devices_errors(
         self, mock_bt_instance
     ):
@@ -500,7 +487,6 @@ class TestCheckCriticalEntities:
         # delete is called idempotently for every available entity
         assert mock_ir.async_delete_issue.call_count == 2
 
-    @pytest.mark.anyio
     async def test_partial_unavailability_clears_available(self, mock_bt_instance):
         """Available TRVs are processed even when another TRV is unavailable."""
         from datetime import timedelta
@@ -548,7 +534,6 @@ class TestCheckCriticalEntitiesBattery:
         mock_bt_instance.devices_errors = []
         return mock_bt_instance
 
-    @pytest.mark.anyio
     async def test_no_task_when_battery_already_populated(self, mock_bt_instance):
         """Steady state: populated battery values spawn no background task."""
         from custom_components.better_thermostat.utils.watcher import (
@@ -565,7 +550,6 @@ class TestCheckCriticalEntitiesBattery:
 
         assert bt.hass.async_create_background_task.call_count == 0
 
-    @pytest.mark.anyio
     async def test_task_on_initial_unpopulated_battery(self, mock_bt_instance):
         """First pass: an unpopulated battery spawns one task per TRV."""
         from custom_components.better_thermostat.utils.watcher import (
@@ -582,7 +566,6 @@ class TestCheckCriticalEntitiesBattery:
 
         assert bt.hass.async_create_background_task.call_count == 2
 
-    @pytest.mark.anyio
     async def test_task_on_recovery_even_if_populated(self, mock_bt_instance):
         """A recovering TRV refreshes battery even if a value already exists."""
         from custom_components.better_thermostat.utils.watcher import (
@@ -600,7 +583,6 @@ class TestCheckCriticalEntitiesBattery:
 
         assert bt.hass.async_create_background_task.call_count == 2
 
-    @pytest.mark.anyio
     async def test_no_task_when_entity_has_no_battery(self, mock_bt_instance):
         """Entities without a battery id never spawn a refresh in steady state."""
         from custom_components.better_thermostat.utils.watcher import (
@@ -621,7 +603,6 @@ class TestCheckCriticalEntitiesBattery:
 class TestCheckAndUpdateDegradedMode:
     """Tests for check_and_update_degraded_mode function."""
 
-    @pytest.mark.anyio
     async def test_sets_degraded_mode_when_optional_sensor_unavailable(
         self, mock_bt_instance
     ):
@@ -647,7 +628,6 @@ class TestCheckAndUpdateDegradedMode:
         assert mock_bt_instance.degraded_mode is True
         assert "binary_sensor.window" in mock_bt_instance.unavailable_sensors
 
-    @pytest.mark.anyio
     async def test_sets_degraded_mode_when_door_sensor_unavailable(
         self, mock_bt_instance
     ):
@@ -673,7 +653,6 @@ class TestCheckAndUpdateDegradedMode:
         assert "binary_sensor.door" in mock_bt_instance.unavailable_sensors
         assert mock_ir.async_create_issue.called
 
-    @pytest.mark.anyio
     async def test_no_degraded_mode_when_door_sensor_not_configured(
         self, mock_bt_instance
     ):
@@ -693,7 +672,6 @@ class TestCheckAndUpdateDegradedMode:
         assert result is False
         assert mock_bt_instance.unavailable_sensors == []
 
-    @pytest.mark.anyio
     async def test_no_degraded_mode_when_all_sensors_available(self, mock_bt_instance):
         """Test that degraded_mode is False when all sensors are available."""
         from custom_components.better_thermostat.utils.watcher import (
@@ -711,7 +689,6 @@ class TestCheckAndUpdateDegradedMode:
         assert mock_bt_instance.degraded_mode is False
         assert mock_bt_instance.unavailable_sensors == []
 
-    @pytest.mark.anyio
     async def test_includes_room_sensor_in_unavailable_list(self, mock_bt_instance):
         """Test that room temperature sensor is added to unavailable list when unavailable."""
         from custom_components.better_thermostat.utils.watcher import (
@@ -836,7 +813,6 @@ class TestDegradedModeGracePeriod:
 
         return mock_get
 
-    @pytest.mark.anyio
     async def test_warning_and_issue_when_grace_inactive(
         self, mock_bt_instance, caplog
     ):
@@ -858,7 +834,6 @@ class TestDegradedModeGracePeriod:
         assert mock_ir.async_create_issue.called
         assert mock_bt_instance._degraded_warning_emitted is True
 
-    @pytest.mark.anyio
     async def test_silent_during_grace_period(self, mock_bt_instance, caplog):
         """Grace active → degraded transition logs DEBUG, no issue, no WARNING."""
         from datetime import timedelta
@@ -883,7 +858,6 @@ class TestDegradedModeGracePeriod:
         assert not mock_ir.async_create_issue.called
         assert mock_bt_instance._degraded_warning_emitted is False
 
-    @pytest.mark.anyio
     async def test_warns_after_grace_expires(self, mock_bt_instance, caplog):
         """Grace passed → still-degraded re-check logs WARNING and raises issue."""
         from datetime import timedelta
@@ -910,7 +884,6 @@ class TestDegradedModeGracePeriod:
         assert mock_ir.async_create_issue.called
         assert mock_bt_instance._degraded_warning_emitted is True
 
-    @pytest.mark.anyio
     async def test_silent_recovery_during_grace(self, mock_bt_instance, caplog):
         """Recover during grace → no INFO log, no issue deleted (none was created)."""
         from datetime import timedelta
@@ -938,7 +911,6 @@ class TestDegradedModeGracePeriod:
         assert not any("Exiting degraded mode" in r.message for r in caplog.records)
         assert not mock_ir.async_delete_issue.called
 
-    @pytest.mark.anyio
     async def test_info_on_recovery_after_warned(self, mock_bt_instance, caplog):
         """Recover after we'd warned → INFO log + issue deleted."""
         from custom_components.better_thermostat.utils.watcher import (
@@ -960,7 +932,6 @@ class TestDegradedModeGracePeriod:
         assert mock_ir.async_delete_issue.called
         assert mock_bt_instance._degraded_warning_emitted is False
 
-    @pytest.mark.anyio
     async def test_no_double_warning(self, mock_bt_instance, caplog):
         """Subsequent check while already-warned → no second WARNING."""
         from custom_components.better_thermostat.utils.watcher import (
@@ -1110,15 +1081,11 @@ class TestCoolerDegradedMode:
 
 
 class TestAwaitOptionalSensors:
-    """Tests for await_optional_sensors retry logic.
-
-    Uses asyncio.run() to avoid the HA event-loop-policy issue that
-    affects @pytest.mark.anyio tests in this project.
-    """
+    """Tests for await_optional_sensors retry logic."""
 
     @staticmethod
     def _run(coro):
-        """Run a coroutine in a fresh event loop (avoids HA plugin issues)."""
+        """Run a coroutine to completion on a fresh event loop."""
         import asyncio
 
         loop = asyncio.new_event_loop()
@@ -1483,7 +1450,7 @@ class TestAwaitCriticalEntities:
 
     @staticmethod
     def _run(coro):
-        """Run a coroutine in a fresh event loop (avoids HA plugin issues)."""
+        """Run a coroutine to completion on a fresh event loop."""
         import asyncio
 
         loop = asyncio.new_event_loop()
@@ -1725,7 +1692,6 @@ class TestAwaitCriticalEntities:
 class TestBatteryStatusCalls:
     """Tests for battery status updates in entity checks."""
 
-    @pytest.mark.anyio
     async def test_check_critical_entities_calls_battery_status(self, mock_bt_instance):
         """check_critical_entities fetches battery for available TRVs on first pass."""
         from custom_components.better_thermostat.utils.watcher import (
@@ -1753,7 +1719,6 @@ class TestBatteryStatusCalls:
                     mock_bt_instance.hass.async_create_background_task.call_count == 2
                 )
 
-    @pytest.mark.anyio
     async def test_check_critical_entities_no_battery_call_when_unavailable(
         self, mock_bt_instance
     ):


### PR DESCRIPTION
## What breaks today

Running any one of these test files on its own ends in `ERROR at setup` instead of a
result. The same tests pass in a full-suite run, so CI is green and nothing reports the
breakage — but the tests are unreproducible per file, and a `-k`/`-m` selection cannot
reach them either.

```
$ uv run pytest tests/test_adapters_none_handling.py -q
10 errors in 0.03s

ScopeMismatch: You tried to access the function scoped fixture anyio_backend
with a session scoped request object. Requesting fixture stack:
  .venv/.../anyio/pytest_plugin.py:104:  def wrapper(anyio_backend, request, **kwargs)
Requested fixture:
  tests/test_battery_entity.py:18:  def anyio_backend()
```

## Mechanism

anyio's pytest plugin wraps every async fixture whose test node also requests
`anyio_backend`; `pytest-homeassistant-custom-component` contributes a session-scoped
async fixture (`mock_zeroconf_resolver`), and when that one is first created during an
`@pytest.mark.anyio` test, its wrapper asks a session-scoped request for a
narrower-scoped `anyio_backend` and pytest refuses.

A full run creates `mock_zeroconf_resolver` earlier, during an unmarked test, so the
wrapper is never installed and the error never appears.

## Shape

`asyncio_mode = "auto"` already hands every unmarked async test to pytest-asyncio, so
the file-local `anyio_backend` fixtures and the `@pytest.mark.anyio` markers both go.
Nothing here needs a backend anyio provides and pytest-asyncio does not: trio is not
installed, and no test imports `anyio`.

Two of the seven files carry markers without a file-local fixture
(`tests/test_window_no_off_mode.py`, `tests/unit/controlling/test_control_trv.py`).
anyio's own `anyio_backend` fixture is **module** scoped, which is still narrower than
session, so those two hit the identical `ScopeMismatch` as soon as a selection reaches a
marked test first. They are part of the same change.

`tests/_test_watcher.py` keeps its fixture and markers. Its leading underscore does not
match pytest's default `python_files` patterns (`test_*.py`, `*_test.py`), so it is not
part of the suite: `uv run pytest tests/ --collect-only -q | grep -c _test_watcher`
returns `0`, while naming the path explicitly collects 19 tests. Nothing runs it, so it
stays as it is.

## Files touched

- `tests/test_adapters_none_handling.py`
- `tests/test_battery_entity.py`
- `tests/test_helpers_valve.py` (its `import pytest` goes with the fixture)
- `tests/test_model_detection.py`
- `tests/test_window_no_off_mode.py`
- `tests/unit/controlling/test_control_trv.py`
- `tests/unit/test_watcher.py` (two docstrings there described the marker as the reason
  for a hand-rolled event loop; they now describe what the helper does)

## Numbers

Per-file selection, `uv run pytest <file> -q`:

| file | before | after |
| --- | --- | --- |
| `tests/test_adapters_none_handling.py` | 10 errors | 10 passed |
| `tests/test_battery_entity.py` | 5 errors | 5 passed |
| `tests/test_helpers_valve.py` | 14 errors | 14 passed |
| `tests/test_model_detection.py` | 8 passed | 8 passed |
| `tests/test_window_no_off_mode.py` | 5 passed | 5 passed |
| `tests/unit/controlling/test_control_trv.py` | 60 passed | 60 passed |
| `tests/unit/test_watcher.py` | 69 passed | 69 passed |

The last four look healthy only because a sync test in the same file happens to be
collected first and creates the session fixture before any marked test does. Narrowing
the selection to the marked tests, `uv run pytest <file> -q -m anyio`:

| file | before | after |
| --- | --- | --- |
| `tests/test_adapters_none_handling.py` | 10 errors | 10 deselected |
| `tests/test_battery_entity.py` | 5 errors | 5 deselected |
| `tests/test_helpers_valve.py` | 14 errors | 14 deselected |
| `tests/test_model_detection.py` | 5 deselected, 3 errors | 8 deselected |
| `tests/test_window_no_off_mode.py` | 4 deselected, 1 error | 5 deselected |
| `tests/unit/controlling/test_control_trv.py` | 54 deselected, 6 errors | 60 deselected |
| `tests/unit/test_watcher.py` | 44 deselected, 25 errors | 69 deselected |

Full suite, `uv run pytest tests/ -q -p no:randomly`:

| | before | after |
| --- | --- | --- |
| total | **5362 passed** | **5362 passed** |

The totals are identical, and every per-file item count above is unchanged, so nothing
was de-collected. The only visible difference is in test ids: the marked tests lose the
`[asyncio]` suffix that anyio's parametrized backend fixture used to add.

## Each converted file still fails when it should

One assertion per file was inverted, the single test run, and the file restored:

| file | test | mutation | result |
| --- | --- | --- | --- |
| `test_adapters_none_handling.py` | `TestDeconzAdapter::test_get_info_returns_false_when_state_is_none` | `support_offset`/`support_valve` `False` → `True` | 1 failed |
| `test_battery_entity.py` | `TestFindBatteryEntity::test_returns_battery_for_physical_device` | `sensor.window_battery` → `sensor.wrong_battery` | 1 failed |
| `test_helpers_valve.py` | `test_find_local_calibration_entity_accepts_select_domain` | `select.trv_temperature_offset` → `select.trv_wrong_entity` | 1 failed |
| `test_model_detection.py` | `TestGetDeviceModelFunction::test_get_device_model_with_model_id` | `TS0601` → `TS9999` | 1 failed |
| `test_window_no_off_mode.py` | `TestControlTrvWithNoOffMode::test_control_trv_restores_temp_after_window_close` | `bt_target_temp == 21.0` → `== 99.0` | 1 failed |
| `test_control_trv.py` | `TestGroupedTrvCalibration::test_calibration_tolerance_outside_half_degree` | final `calibration_received is False` → `is True` | 1 failed |
| `unit/test_watcher.py` | `TestCheckCriticalEntities::test_returns_true_when_all_trvs_available` | `result is True` → `is False` | 1 failed |

## Gates

This branch has no `scripts/` gates; the workflows here are ruff, pyrefly and the suite.

| gate | result |
| --- | --- |
| `uv run pytest tests/` | 5362 passed |
| `uvx ruff@0.15.15 check` | All checks passed |
| `uvx ruff@0.15.15 format --check` | 254 files already formatted |
| `uv run pyrefly check` | 0 errors (3 suppressed) |

https://claude.ai/code/session_01PDK4Ae8guxGD9Jp2bkxkNv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of device model names with trailing descriptions in parentheses.
  - Fixed battery entity detection for physical devices and device groups.
  - Corrected TRV behavior when a heating window closes, preventing incorrect OFF mode and low temperature states.

- **Tests**
  - Expanded coverage for battery detection, model parsing, valve behavior, window handling, and adapter edge cases.
  - Simplified asynchronous test execution across the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->