### PR TITLE
fix: offer direct valve control where the model's quirk drives the valve (1.9)

### DIFF
--- a/custom_components/better_thermostat/config_flow.py
+++ b/custom_components/better_thermostat/config_flow.py
@@ -27,6 +27,7 @@ import voluptuous as vol
 
 from . import DOMAIN  # pylint: disable=unused-import
 from .adapters.delegate import load_adapter
+from .model_fixes.model_quirks import load_model_quirks, quirk_writes_valve
 from .utils.const import (
     CONF_CALIBRATION,
     CONF_CALIBRATION_MODE,
@@ -256,29 +257,70 @@ def _as_bool(value: bool | str | int | None, default: bool = False) -> bool:
     return bool(value)
 
 
+async def _quirk_valve_support(
+    flow: config_entries.ConfigFlow | config_entries.OptionsFlow, entity_id: str
+) -> bool:
+    """Answer whether this TRV's model quirk drives its valve.
+
+    The model comes from the device registry and its quirk is loaded the way
+    the running thermostat loads it, so the calibration strategies the flow
+    offers are the ones the write path can carry out.
+
+    Parameters
+    ----------
+    flow : config_entries.ConfigFlow | config_entries.OptionsFlow
+        The flow the probe runs in, supplying Home Assistant access.
+    entity_id : str
+        Entity ID of the TRV to probe.
+
+    Returns
+    -------
+    bool
+        True when the TRV's model has a quirk of its own that writes the
+        valve, False when it has none and when the model cannot be read.
+    """
+    try:
+        model = await get_device_model(flow, entity_id)
+        quirks = await load_model_quirks(flow, model, entity_id)
+    except RuntimeError, ValueError, TypeError, AttributeError, ImportError:
+        _LOGGER.debug("model quirk probe failed", exc_info=True)
+        return False
+    return quirk_writes_valve(quirks)
+
+
 async def _load_adapter_info(
     flow: config_entries.ConfigFlow | config_entries.OptionsFlow,
     integration: str | None,
-    trv_id: str | None,
+    entity_id: str | None,
     *,
     existing_adapter: Any | None = None,
 ) -> tuple[Any | None, dict[str, Any]]:
     adapter = existing_adapter
     info: dict[str, Any] = {}
 
-    if integration and trv_id:
+    if integration and entity_id:
         if adapter is None:
             try:
-                adapter = await load_adapter(flow, integration, trv_id)
+                adapter = await load_adapter(flow, integration, entity_id)
             except RuntimeError, ValueError, TypeError:  # pragma: no cover - defensive
                 _LOGGER.debug("load_adapter failed", exc_info=True)
 
         if adapter is not None and hasattr(adapter, "get_info"):
             try:
                 # type: ignore[attr-defined]
-                info = await adapter.get_info(flow, trv_id)
+                info = await adapter.get_info(flow, entity_id)
             except RuntimeError, ValueError, TypeError, AttributeError:
                 _LOGGER.debug("adapter get_info failed", exc_info=True)
+
+    # A model quirk owns the valve of the devices it covers, whichever adapter
+    # serves the ecosystem they are paired through, so the adapter's answer is
+    # not the whole of the valve surface.
+    if (
+        entity_id
+        and not info.get("support_valve", False)
+        and await _quirk_valve_support(flow, entity_id)
+    ):
+        info = info | {"support_valve": True}
 
     return adapter, info
 

--- a/custom_components/better_thermostat/model_fixes/model_quirks.py
+++ b/custom_components/better_thermostat/model_fixes/model_quirks.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import re
+from types import ModuleType
 
 from homeassistant.helpers.importlib import async_import_module
 
@@ -113,6 +114,28 @@ async def load_model_quirks(self, model, entity_id):
             raise
 
     return self.model_quirks
+
+
+def quirk_writes_valve(model_quirks: ModuleType | None) -> bool:
+    """Answer whether a model's own quirk drives that model's valve.
+
+    A quirk module carrying ``override_set_valve`` reaches the valve through
+    the entities its device family exposes, which is a channel of the model
+    and not of the ecosystem the device happens to be paired through. So the
+    answer holds for every adapter, including the generic one a device
+    without an adapter of its own falls back to.
+
+    Parameters
+    ----------
+    model_quirks : ModuleType | None
+        Quirk module loaded for a TRV, or None where none is loaded.
+
+    Returns
+    -------
+    bool
+        True when the module carries a callable ``override_set_valve``.
+    """
+    return callable(getattr(model_quirks, "override_set_valve", None))
 
 
 def trv_state_unknown_as_available(self, entity_id):

--- a/tests/unit/test_config_flow_offered_modes.py
+++ b/tests/unit/test_config_flow_offered_modes.py
@@ -1,18 +1,34 @@
-"""Tests for the config flow's reads of a device's offered HVAC modes.
+"""Tests for the config flow's reads of what a device can be driven by.
 
 A climate entity publishes its capability list in its own spelling, so both
 the AUTO probe and the OFF gate must compare normalized. A device naming its
 modes ``HVACMode.OFF`` offers OFF just as one naming them ``off`` does.
+
+The calibration strategies the advanced step offers are the second such read,
+and the one that goes past the entity: they follow from the write channels
+behind it. A valve the device's own model quirk drives is such a channel, and
+the adapter serving the ecosystem it is paired through reports none.
 """
 
+import contextlib
+import importlib
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.climate.const import HVACMode
+from homeassistant.const import CONF_NAME
+from homeassistant.core import State
 import pytest
 
 from custom_components.better_thermostat.config_flow import (
     ConfigFlow,
+    OptionsFlowHandler,
     _trv_supports_auto,
+)
+from custom_components.better_thermostat.utils.const import (
+    CONF_CALIBRATION,
+    CONF_HEATER,
+    CalibrationType,
 )
 
 
@@ -112,3 +128,149 @@ def test_hvac_mode_enum_members_are_recognized():
     assert _trv_supports_auto(
         _flow_with_modes([HVACMode.OFF, HVACMode.AUTO]), "climate.trv"
     )
+
+
+TRV_ID = "climate.trv"
+
+# A model whose quirk module drives the valve itself, and one that is served
+# by the default quirk module, which drives nothing.
+QUIRK_BACKED_MODEL = "TRVZB"
+UNQUIRKED_MODEL = "Generic"
+
+
+def _adapter_without_a_valve_channel():
+    """Build the capability answer an ecosystem without a valve gives.
+
+    Every adapter that reads its channels off the entity answers this way for
+    a device whose valve it cannot see, the generic one included.
+    """
+    adapter = MagicMock()
+    adapter.get_info = AsyncMock(
+        return_value={"support_offset": True, "support_valve": False}
+    )
+    return adapter
+
+
+@contextlib.contextmanager
+def _a_device_of_model(model):
+    """Run the body against a Home Assistant holding one device of ``model``.
+
+    The device registry reports the model, the quirk loader imports the
+    modules that ship with the package, and the TRV is served by an adapter
+    that publishes no valve channel.
+    """
+    entity_registry = MagicMock()
+    entity_registry.async_get.return_value = SimpleNamespace(device_id="device")
+    device_registry = MagicMock()
+    device_registry.async_get.return_value = SimpleNamespace(
+        manufacturer="Vendor",
+        model=model,
+        model_id=model,
+        name=model,
+        identifiers=set(),
+    )
+    with (
+        patch(
+            "custom_components.better_thermostat.utils.helpers.er.async_get",
+            return_value=entity_registry,
+        ),
+        patch(
+            "custom_components.better_thermostat.utils.helpers.dr.async_get",
+            return_value=device_registry,
+        ),
+        patch(
+            "custom_components.better_thermostat.model_fixes.model_quirks"
+            ".async_import_module",
+            new=AsyncMock(
+                side_effect=lambda _hass, path: importlib.import_module(path)
+            ),
+        ),
+        patch(
+            "custom_components.better_thermostat.config_flow.load_adapter",
+            autospec=True,
+            return_value=_adapter_without_a_valve_channel(),
+        ),
+    ):
+        yield
+
+
+def _trv_bundle_entry(model):
+    """Return the one device bundle a config entry carries for ``model``."""
+    return {"trv": TRV_ID, "integration": "zha", "model": model, "advanced": {}}
+
+
+def _hass_holding_the_trv():
+    """Return a Home Assistant whose only entity is the TRV under test."""
+    hass = MagicMock()
+    hass.states.get.return_value = State(
+        TRV_ID, "heat", {"hvac_modes": ["heat", "off"]}
+    )
+    return hass
+
+
+def _offered_calibrations(form):
+    """Return the calibration strategies an advanced form publishes."""
+    schema = form["data_schema"].schema
+    for marker in schema:
+        if marker == CONF_CALIBRATION:
+            return list(schema[marker].config["options"])
+    raise AssertionError("the advanced step publishes no calibration field")
+
+
+async def _create_flow_advanced_form(model):
+    """Render the advanced step a new entry is configured through."""
+    flow = ConfigFlow()
+    flow.hass = _hass_holding_the_trv()
+    flow.trv_bundle = [_trv_bundle_entry(model)]
+    flow.i = 0
+    with _a_device_of_model(model):
+        return await flow.async_step_advanced(None, flow.trv_bundle[0])
+
+
+async def _options_flow_advanced_form(model):
+    """Render the advanced step an existing entry is reconfigured through."""
+    entry = MagicMock()
+    entry.data = {CONF_NAME: "Living Room", CONF_HEATER: [_trv_bundle_entry(model)]}
+    flow = OptionsFlowHandler(entry)
+    flow.hass = _hass_holding_the_trv()
+    flow.trv_bundle = [_trv_bundle_entry(model)]
+    flow.updated_config = dict(entry.data)
+    with _a_device_of_model(model):
+        return await flow.async_step_advanced(None, flow.trv_bundle[0], entry.data)
+
+
+ADVANCED_FORMS = {
+    "create": _create_flow_advanced_form,
+    "options": _options_flow_advanced_form,
+}
+
+
+class TestOfferedCalibrationStrategies:
+    """Direct valve control is offered where a valve can be written."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("render", ADVANCED_FORMS.values(), ids=ADVANCED_FORMS)
+    async def test_a_quirk_driven_valve_is_offered(self, render):
+        """A device whose model quirk drives the valve can be calibrated on it.
+
+        The quirk reaches the valve through the entities the device's model
+        carries, so it works under whichever adapter serves the ecosystem the
+        device is paired through — including the generic fallback, which
+        reports no valve channel of its own.
+        """
+        form = await render(QUIRK_BACKED_MODEL)
+
+        assert CalibrationType.DIRECT_VALVE_BASED in _offered_calibrations(form)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("render", ADVANCED_FORMS.values(), ids=ADVANCED_FORMS)
+    async def test_a_device_with_nothing_to_write_to_is_not_offered_it(self, render):
+        """A device with neither channel is left off direct valve control.
+
+        Its adapter has no valve to write to and its model has no quirk that
+        would, so a thermostat put on the strategy would command positions
+        that reach nothing.
+        """
+        form = await render(UNQUIRKED_MODEL)
+
+        assert CalibrationType.DIRECT_VALVE_BASED not in _offered_calibrations(form)

--- a/tests/unit/test_model_quirk_surface.py
+++ b/tests/unit/test_model_quirk_surface.py
@@ -190,9 +190,9 @@ def _is_a_quirk_module(node, holders=frozenset()):
 
     Only the wrappers the shell actually puts around one are unwrapped:
     an ``await``, a guard against a missing TRV, a fallback chain. What
-    a quirk function *returns* is not a quirk module, so a call only
-    counts when it is the loader, and a bare name only when it was bound
-    from one of these in the first place.
+    a quirk function *returns* is not a quirk module, so a call counts
+    only when it is the loader or the attribute lookup itself, and a bare
+    name only when it was bound from one of these in the first place.
     """
     if isinstance(node, ast.Await):
         return _is_a_quirk_module(node.value, holders)
@@ -213,7 +213,18 @@ def _is_a_quirk_module(node, holders=frozenset()):
             if isinstance(called, ast.Attribute)
             else getattr(called, "id", None)
         )
-        return name == QUIRK_LOADER
+        if name == QUIRK_LOADER:
+            return True
+        # ``getattr(trv, "model_quirks", None)`` reaches the same attribute as
+        # ``trv.model_quirks``; the shell spells it that way wherever the
+        # record it reads from may be absent, and the dispatch that writes the
+        # valve is one of those places.
+        return (
+            name == "getattr"
+            and len(node.args) > 1
+            and isinstance(node.args[1], ast.Constant)
+            and node.args[1].value == QUIRK_ATTRIBUTE
+        )
     return False
 
 


### PR DESCRIPTION
The 1.9 line of #2288. The develop counterpart is #2353; the change carries the same shape.

## What the user sees

A Sonoff TRVZB paired through ZHA is offered only "Offset Based" and "Target Temperature Based" in the config flow. "Direct Valve Control" never appears, although the documentation lists the TRVZB as supporting it "via Zigbee2MQTT or ZHA", and the same head paired through Zigbee2MQTT does get the option. The report is against 1.9.2.

## Mechanism

The advanced step asks the adapter alone what a device can be calibrated on: `_load_adapter_info` calls the adapter's `get_info`, and both flows gate the calibration dropdown on the `support_valve` flag it returns. There is no `adapters/zha.py`, so a ZHA head falls back to `adapters/generic.py`, whose `get_info` returns a hard-coded `"support_valve": False`. The write path never went through that adapter in the first place: `model_fixes/TRVZB.py` provides `override_set_valve`, `adapters/delegate.py` dispatches to it before any adapter valve write, and the override finds the device's `valve_opening_degree` / `valve_closing_degree` number entities by walking the entity registry from the climate entity's device — which is ecosystem-agnostic and works exactly the same under ZHA. The reporter's diagnostics confirm both halves: the device registry model is `TRVZB`, and ZHA publishes the two number entities with the translation keys the override matches on. `utils/valve_maintenance.py` and `calibration.py` already read the quirk's override as a valve channel, so the config flow was the one place that did not.

The capability probe now states the same rule: the adapter's declared `support_valve` unioned with "this TRV's model quirk exposes a callable `override_set_valve`". It sits in `_load_adapter_info`, the single place both flows assemble `info` from, so the create flow and the options flow are covered by one change. The rule itself lives once, in `model_fixes/model_quirks.quirk_writes_valve`.

## Why the widening stops at quirk-backed models

`generic.get_info` deliberately keeps reporting no valve, rather than deriving one from `find_valve_entity`. `generic.set_valve` is a `return  # Not supported`, so a generic-adapter device that happens to publish a writable valve entity but has no quirk behind it would be offered a strategy whose commands silently reach nothing. Restricting the union to devices whose model quirk really drives the valve keeps the offer honest — today that is `TRVZB` and `ZWA021`/`Spirit`.

## Measured coverage

The mutation is "the config flow ignores the model quirk", i.e. the union removed from `_load_adapter_info`.

| | red tests |
|---|---|
| before the fix (5362 passed) | **0** |
| after the fix (5366 passed) | **2** — one per config-flow call site |

## Tests

`tests/unit/test_config_flow_offered_modes.py` renders the advanced step of both `ConfigFlow` and `OptionsFlowHandler` against a device whose model has a quirk and one whose model has none, with the adapter answering "no valve channel" in both cases. The test text is identical to the develop branch's, which additionally drives the same rule through the device-profile integration harness that only exists there.

`tests/unit/test_model_quirk_surface.py` carries the same mirrored correction as develop: the scan that proves every surface entry is really dispatched reads `getattr(trv, "model_quirks", None)` as the quirk module it is. It previously saw only the attribute spelling, so the dispatch in `adapters/delegate.py` — the one that actually writes the valve — did not count.

Full suite green, `ruff check` and `ruff format --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved thermostat setup detection for devices whose model-specific behavior provides valve control.
  - Direct-valve calibration is now offered when supported by either the adapter or the device model.

- **Bug Fixes**
  - Prevented incorrect omission of valve calibration for compatible thermostat models.
  - Improved handling of normalized HVAC mode names, including AUTO and OFF.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->