### PR TITLE
fix: observe a TRV switched back on at its own knob (1.9)

### DIFF
--- a/custom_components/better_thermostat/events/trv.py
+++ b/custom_components/better_thermostat/events/trv.py
@@ -37,6 +37,7 @@ from custom_components.better_thermostat.utils.helpers import (
     device_offers_mode,
     dual_role_entity_id,
     get_device_model,
+    get_hvac_bt_mode,
     group_all_members_off,
     is_reasonable_temperature,
     mode_remap,
@@ -270,7 +271,12 @@ async def trigger_trv_change(self, event):
                 and trv.last_hvac_mode != _org_trv_state.state
                 and (mapped_state != HVACMode.OFF or group_all_members_off(self))
             ):
-                self.bt_hvac_mode = mapped_state
+                # The decoded mode is the instance-level spelling of the
+                # device's demand; get_hvac_bt_mode() re-expresses it in the
+                # spelling this instance publishes, which is HEAT_COOL for a
+                # room with a cooler. The service path stores the mode the
+                # same way.
+                self.bt_hvac_mode = HVACMode(get_hvac_bt_mode(self, mapped_state))
 
     # The previous state only answers whether the TRV was publishing a setpoint
     # at all, so it is read without clamping or echo detection.

--- a/custom_components/better_thermostat/utils/helpers.py
+++ b/custom_components/better_thermostat/utils/helpers.py
@@ -527,11 +527,13 @@ def mode_remap(
         if inbound and hvac_mode == HVACMode.HEAT_COOL:
             return HVACMode.HEAT
     if not _offers_heat_cool and _offers_heat:
-        # entity only supports HEAT, but not HEAT_COOL - need to translate
+        # entity only supports HEAT, but not HEAT_COOL - need to translate.
+        # Only the outbound direction needs it: HEAT is already the
+        # instance-level spelling of the heating demand, which is what
+        # get_hvac_bt_mode() re-expresses as HEAT_COOL for a room with a
+        # cooler.
         if not inbound and hvac_mode == HVACMode.HEAT_COOL:
             return HVACMode.HEAT
-        if inbound and hvac_mode == HVACMode.HEAT:
-            return HVACMode.HEAT_COOL
 
     if hvac_mode == HVACMode.AUTO:
         # The mode is annunciated once per offered set, like the clamp does it,

--- a/tests/unit/test_helpers_mode_remap.py
+++ b/tests/unit/test_helpers_mode_remap.py
@@ -208,13 +208,19 @@ class TestModeRemapTranslationOnAReportedSpelling:
         assert _unsupported_records(caplog) == []
 
     @pytest.mark.parametrize("hvac_modes", HEAT_ONLY)
-    def test_inbound_heat_becomes_heat_cool(self, hvac_modes):
-        """A heat-only device's HEAT is decoded as HEAT_COOL."""
+    def test_inbound_heat_stays_heat(self, hvac_modes):
+        """A heat-only device's HEAT is the instance-level spelling already.
+
+        HEAT is what the instance stores for "the room wants heat", and it is
+        one of the two values convert_inbound_states() carries any further. A
+        room with a cooler re-expresses it as HEAT_COOL through
+        get_hvac_bt_mode() when it publishes its own mode.
+        """
         mock_bt = MockThermostat()
         mock_bt.add_trv("climate.test", hvac_modes=hvac_modes)
 
         result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT, inbound=True)
-        assert result == HVACMode.HEAT_COOL
+        assert result == HVACMode.HEAT
 
     @pytest.mark.parametrize("hvac_modes", HEAT_COOL_ONLY)
     def test_outbound_heat_becomes_heat_cool(self, hvac_modes, caplog):
@@ -236,6 +242,50 @@ class TestModeRemapTranslationOnAReportedSpelling:
 
         result = mode_remap(mock_bt, "climate.test", HVACMode.HEAT_COOL, inbound=True)
         assert result == HVACMode.HEAT
+
+    @pytest.mark.parametrize(
+        ("hvac_modes", "reported"),
+        [
+            pytest.param(["off", "heat"], "heat", id="heat_only"),
+            pytest.param(["off", "heat", "auto"], "heat", id="heat_and_auto"),
+            pytest.param(["off", "heat", "heat_cool"], "heat", id="both_spellings"),
+            pytest.param(["off", "heat_cool"], "heat_cool", id="heat_cool_only"),
+        ],
+    )
+    def test_every_offered_set_decodes_a_heating_report_as_heat(
+        self, hvac_modes, reported
+    ):
+        """Whatever a device calls its heating mode arrives as HEAT.
+
+        The offered sets differ in which spelling the device publishes; the
+        instance stores one spelling for all of them, so the mode reaches
+        convert_inbound_states() as a mode that function carries on.
+        """
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=hvac_modes)
+
+        assert (
+            mode_remap(mock_bt, "climate.test", reported, inbound=True) == HVACMode.HEAT
+        )
+
+    @pytest.mark.parametrize(
+        "hvac_modes",
+        [
+            pytest.param(["off", "heat"], id="heat_only"),
+            pytest.param(["off", "heat", "auto"], id="heat_and_auto"),
+            pytest.param(["off", "heat", "heat_cool"], id="both_spellings"),
+            pytest.param(["off", "heat_cool"], id="heat_cool_only"),
+        ],
+    )
+    def test_every_offered_set_decodes_an_off_report_as_off(self, hvac_modes):
+        """OFF is spelled the same by every device and by the instance."""
+        mock_bt = MockThermostat()
+        mock_bt.add_trv("climate.test", hvac_modes=hvac_modes)
+
+        assert (
+            mode_remap(mock_bt, "climate.test", HVACMode.OFF, inbound=True)
+            == HVACMode.OFF
+        )
 
     def test_a_device_offering_both_is_not_translated(self):
         """Offering both spellings of the heating mode translates neither."""

--- a/tests/unit/test_trv_events.py
+++ b/tests/unit/test_trv_events.py
@@ -46,6 +46,9 @@ def mock_bt():
     bt.device_name = "Test Thermostat"
     bt.bt_hvac_mode = HVACMode.HEAT
     bt.hvac_mode = HVACMode.HEAT
+    # A room without a cooler spells its heat demand HEAT; ``_bind_cooler_hvac_mode``
+    # replaces this with HEAT_COOL for a room that has one.
+    bt.map_on_hvac_mode = HVACMode.HEAT
     bt.bt_target_temp = 19.0
     bt.bt_min_temp = 5.0
     bt.bt_max_temp = 30.0
@@ -166,6 +169,20 @@ def _add_homematicip_peer(bt):
 
     bt.hass.states.get.side_effect = _state_for
     return peer_state
+
+
+def _bind_cooler_hvac_mode(bt):
+    """Let ``bt.hvac_mode`` follow the real property of a cooler setup.
+
+    With a cooler configured the mode list carries HEAT_COOL in place of HEAT,
+    so the property reports HEAT_COOL for a ``bt_hvac_mode`` of HEAT. That
+    mapping decides whether the ordering check between the two targets applies,
+    so a handler that changes ``bt_hvac_mode`` needs the derived value, not a
+    fixed one.
+    """
+    bt._hvac_list = [HVACMode.OFF, HVACMode.HEAT_COOL]
+    bt.map_on_hvac_mode = HVACMode.HEAT_COOL
+    type(bt).hvac_mode = BetterThermostat.hvac_mode
 
 
 def _make_event(bt, new_state=None, old_state=None, entity_id=ENTITY_ID):
@@ -1050,6 +1067,84 @@ class TestHvacModeUpdate:
             outcomes.append((trv.hvac_mode, mock_bt.bt_hvac_mode))
 
         assert outcomes[0] == outcomes[1]
+
+
+class TestKnobOperatedMode:
+    """A user turning the device off and on again at its own knob."""
+
+    @staticmethod
+    async def _report(bt, mode):
+        """Route one reported device mode through the event handler.
+
+        The remap is not patched out here: the decoding of the device's own
+        spelling is what these tests are about.
+        """
+        previous = bt.real_trvs[ENTITY_ID].hvac_mode
+        trv_state = _make_state(state_str=mode)
+        bt.hass.states.get.return_value = trv_state
+        event = _make_event(
+            bt, new_state=trv_state, old_state=_make_state(state_str=previous)
+        )
+        await trigger_trv_change(bt, event)
+
+    @staticmethod
+    def _stamp_written_mode(bt, mode):
+        """Record the mode a control cycle put on the wire.
+
+        ``last_hvac_mode`` is written by the control cycle, and the handler
+        reads it to tell a device echoing Better Thermostat's own command
+        from a device a user has just operated.
+        """
+        bt.real_trvs[ENTITY_ID].last_hvac_mode = mode
+
+    @pytest.mark.asyncio
+    async def test_a_heat_only_device_switched_off_and_on_ends_on_heat(self, mock_bt):
+        """Both directions of the knob reach the cache and the entity.
+
+        The device offers off and heat only, the overwhelmingly common shape.
+        """
+        trv = mock_bt.real_trvs[ENTITY_ID]
+        assert trv.hvac_modes == [HVACMode.OFF, HVACMode.HEAT]
+        trv.hvac_mode = "heat"
+        self._stamp_written_mode(mock_bt, "heat")
+
+        await self._report(mock_bt, "off")
+
+        assert trv.hvac_mode == "off"
+        assert mock_bt.bt_hvac_mode == HVACMode.OFF
+
+        self._stamp_written_mode(mock_bt, "off")
+
+        await self._report(mock_bt, "heat")
+
+        assert trv.hvac_mode == "heat"
+        assert mock_bt.bt_hvac_mode == HVACMode.HEAT
+
+    @pytest.mark.asyncio
+    async def test_a_room_with_a_cooler_follows_the_knob_as_heat_cool(self, mock_bt):
+        """The entity of a room with a cooler spells the adopted mode HEAT_COOL.
+
+        The device names the same demand heat; the instance publishes the mode
+        its own list carries.
+        """
+        _bind_cooler_hvac_mode(mock_bt)
+        mock_bt.cooler_entity_id = "climate.cooler"
+        trv = mock_bt.real_trvs[ENTITY_ID]
+        trv.hvac_mode = "heat"
+        self._stamp_written_mode(mock_bt, "heat")
+
+        await self._report(mock_bt, "off")
+
+        assert mock_bt.bt_hvac_mode == HVACMode.OFF
+        assert mock_bt.hvac_mode == HVACMode.OFF
+
+        self._stamp_written_mode(mock_bt, "off")
+
+        await self._report(mock_bt, "heat")
+
+        assert trv.hvac_mode == "heat"
+        assert mock_bt.bt_hvac_mode == HVACMode.HEAT_COOL
+        assert mock_bt.hvac_mode == HVACMode.HEAT_COOL
 
 
 # ---------------------------------------------------------------------------
@@ -1962,6 +2057,57 @@ class TestConvertInboundStates:
             result = convert_inbound_states(mock_bt, ENTITY_ID, state)
         assert result == HVACMode.HEAT
 
+    @pytest.mark.parametrize(
+        ("hvac_modes", "reported"),
+        [
+            pytest.param([HVACMode.OFF, HVACMode.HEAT], "heat", id="heat_only"),
+            pytest.param(
+                [HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO], "heat", id="heat_and_auto"
+            ),
+            pytest.param(
+                [HVACMode.OFF, HVACMode.HEAT, HVACMode.HEAT_COOL],
+                "heat",
+                id="both_spellings",
+            ),
+            pytest.param(
+                [HVACMode.OFF, HVACMode.HEAT_COOL], "heat_cool", id="heat_cool_only"
+            ),
+        ],
+    )
+    def test_a_reported_heating_mode_is_carried_through(
+        self, mock_bt, hvac_modes, reported
+    ):
+        """A device reporting that it heats yields HEAT, not nothing.
+
+        The remap runs for real here: its result is the only thing this
+        function judges, and a value it does not carry on leaves the whole
+        mode adoption downstream without an input.
+        """
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = list(hvac_modes)
+        state = _make_state(state_str=reported)
+
+        assert convert_inbound_states(mock_bt, ENTITY_ID, state) == HVACMode.HEAT
+
+    @pytest.mark.parametrize(
+        "hvac_modes",
+        [
+            pytest.param([HVACMode.OFF, HVACMode.HEAT], id="heat_only"),
+            pytest.param(
+                [HVACMode.OFF, HVACMode.HEAT, HVACMode.AUTO], id="heat_and_auto"
+            ),
+            pytest.param(
+                [HVACMode.OFF, HVACMode.HEAT, HVACMode.HEAT_COOL], id="both_spellings"
+            ),
+            pytest.param([HVACMode.OFF, HVACMode.HEAT_COOL], id="heat_cool_only"),
+        ],
+    )
+    def test_a_reported_off_is_carried_through(self, mock_bt, hvac_modes):
+        """The off direction reaches the entity for every offered set."""
+        mock_bt.real_trvs[ENTITY_ID].hvac_modes = list(hvac_modes)
+        state = _make_state(state_str="off")
+
+        assert convert_inbound_states(mock_bt, ENTITY_ID, state) == HVACMode.OFF
+
     def test_unsupported_mode_returns_none(self, mock_bt):
         """Return None for unsupported HVAC modes like COOL."""
         state = _make_state(state_str="cool")
@@ -2293,6 +2439,7 @@ def _make_group_bt(entity_ids, *, no_off=False, bt_hvac_mode=HVACMode.HEAT):
     bt.hass.config.units.temperature_unit = UnitOfTemperature.CELSIUS
     bt.device_name = "Grouped Thermostat"
     bt.bt_hvac_mode = bt_hvac_mode
+    bt.map_on_hvac_mode = HVACMode.HEAT
     bt.bt_target_temp = 19.0
     bt.bt_min_temp = 5.0
     bt.bt_max_temp = 30.0


### PR DESCRIPTION
## What a user sees

A TRV that offers `["off", "heat"]`, the shape almost every Zigbee valve has, can be
switched off at its own knob and Better Thermostat notices. Switch it back on and
Better Thermostat does not. The per-TRV mode cache is a one-way ratchet: it reaches
`off` and has no path back to `heat`.

The cache is what the setpoint guard reads, so the next temperature the user presses
on the device is turned away as coming from a valve that is off. That is the
`hvac_mode=off` in the `NOT adopted` log line of #2317, printed while both the TRV and
the Better Thermostat entity show `heat` in the UI. The reporter of that issue built an
automation mirroring the TRV's mode onto the Better Thermostat entity because "BT
doesn't sync hvac_mode from the physical TRV natively". This is why it did not.

## The chain, measured

`mode_remap()` and `convert_inbound_states()` called against a real `Trv` on
`origin/1.9`:

```
modes=['off', 'heat']              inbound 'heat' -> mode_remap=heat_cool  convert_inbound_states=None
modes=['off', 'heat', 'auto']      inbound 'heat' -> mode_remap=heat_cool  convert_inbound_states=None
modes=['off', 'heat', 'heat_cool'] inbound 'heat' -> mode_remap=heat       convert_inbound_states=heat
modes=['off', 'heat']              inbound 'off'  -> mode_remap=off        convert_inbound_states=off
```

1. `mode_remap()`'s `not offers_heat_cool and offers_heat` branch translated an inbound
   `heat` into `heat_cool`.
2. Its only inbound caller is `convert_inbound_states()`, whose next statement is
   `if remapped_state not in (HVACMode.OFF, HVACMode.HEAT): return None`. The
   translation's single consumer discards it.
3. `mapped_state` is then `None` in `trigger_trv_change()`, so the
   `if mapped_state in (OFF, HEAT):` block never runs. That block is the only runtime
   writer of `real_trvs[...].hvac_mode` and the only place that adopts a device mode
   into `self.bt_hvac_mode`.

`off` survives the remap untouched, which is why only one direction was observable.

## The change

**Drop the inbound leg** of that branch. Its sibling branch
(`not offers_heat and offers_heat_cool`) already normalises an inbound `heat_cool` to
`HEAT`; this one pushed a device-level reading up into an entity-level spelling
instead. Both branches now normalise a reported heating demand to `HEAT`, the value the
instance stores. The outbound legs are untouched: a device offering `heat_cool` without
`heat` still receives `heat_cool`, which is what the comment in
`controlling.py` relies on. That comment describes the outbound direction only; the
probe confirms `mode_remap(HEAT, inbound=False) == heat_cool` before and after.

**Route the adopted mode through `get_hvac_bt_mode()`.** `trigger_trv_change()` assigned
`self.bt_hvac_mode = mapped_state` raw. The service path already stores
`HVACMode(get_hvac_bt_mode(self, hvac_mode_norm))`, and the state restore reads back the
published mode, which is `HEAT_COOL` for a room with a cooler. Without this the same
room would carry `HEAT` when the mode arrived from the device and `HEAT_COOL` when it
arrived from a service call or a restart. The `hvac_mode` property normalises on the way
out either way, so this does not change what the entity publishes; it makes the stored
value one value.

After the change, all four offered sets decode an inbound heating report to `heat` and
`convert_inbound_states()` carries it:

```
modes=['off', 'heat']              inbound 'heat' -> mode_remap=heat  convert_inbound_states=heat
modes=['off', 'heat', 'auto']      inbound 'heat' -> mode_remap=heat  convert_inbound_states=heat
modes=['off', 'heat', 'heat_cool'] inbound 'heat' -> mode_remap=heat  convert_inbound_states=heat
modes=['off', 'heat_cool']         inbound 'heat_cool' -> mode_remap=heat  convert_inbound_states=heat
```

## The test that pinned the old behaviour

`tests/unit/test_helpers_mode_remap.py::test_inbound_heat_becomes_heat_cool` asserted
`mode_remap(HEAT, inbound=True) == HEAT_COOL`. It holds the defect in place rather than
documenting an intention, and the same file says so:

- Its docstring, "A heat-only device's HEAT is decoded as HEAT_COOL", restates the code
  and gives no reason.
- `test_inbound_auto_becomes_heat_for_a_cooler_room_too` in the same file states the
  intended inbound contract in full: "HEAT is what the instance stores for 'the room
  wants heat' whether or not a cooler is configured; a room with one re-expresses it as
  HEAT_COOL when it publishes its own mode." It asserts
  `get_hvac_bt_mode(adopted) == HEAT_COOL` for exactly that reason. The
  `heat_auto_swapped` branch already follows that contract; the branch repaired here did
  not.
- The value it pinned had no consumer. `convert_inbound_states()` is the only inbound
  caller and drops `HEAT_COOL` on the next line.

It is rewritten as `test_inbound_heat_stays_heat` with the contract spelled out.

## Tests

New, all red before the change:

- `test_inbound_heat_stays_heat`, `test_every_offered_set_decodes_a_heating_report_as_heat`
  and `test_every_offered_set_decodes_an_off_report_as_off` in
  `tests/unit/test_helpers_mode_remap.py`, over `['off','heat']`, `['off','heat','auto']`,
  `['off','heat','heat_cool']` and `['off','heat_cool']`.
- `TestConvertInboundStates::test_a_reported_heating_mode_is_carried_through` and
  `test_a_reported_off_is_carried_through`. Not one pre-existing test in that class ever
  ran the chain this bug lives in: four of them patch `mode_remap` out and hand the
  function a fixed answer, the other three raise before reaching it. These call the real
  remap.
- `TestKnobOperatedMode::test_a_heat_only_device_switched_off_and_on_ends_on_heat`, end to
  end through `trigger_trv_change()`: off, then on again, asserting
  `real_trvs[...].hvac_mode == "heat"` and `bt_hvac_mode == HEAT`.
- `TestKnobOperatedMode::test_a_room_with_a_cooler_follows_the_knob_as_heat_cool`, the
  same sequence for a room with a cooler, asserting `HEAT_COOL` at the entity.

Three pre-existing tests failed on the first run for a reason unrelated to the fix: the
`mock_bt` and `_make_group_bt` fixtures never set `map_on_hvac_mode`, so
`get_hvac_bt_mode()` received a `MagicMock`. Both fixtures now carry the production
default.

### Numbers

Full suite, `uv run pytest tests/`:

| state | result |
| --- | --- |
| `origin/1.9`, before any edit | 5362 passed |
| with the fix and the new tests | 5380 passed |
| new tests present, both halves of the fix reverted | **8 failed**, 5372 passed |
| new tests present, only the `mode_remap` half reverted | **8 failed**, 5372 passed |
| new tests present, only the `get_hvac_bt_mode` half reverted | **1 failed**, 5379 passed |

Each half is pinned on its own. Reverting the `mode_remap` half fails all eight, because
nothing downstream ever sees a decoded mode. Reverting the `get_hvac_bt_mode` half fails
one, the cooler test, which is the only place the stored spelling is observable.

`grep` over `tests/` for `heat_cool` found no further test asserting the old inbound
behaviour, and the full suite agrees.

### Gates

`uvx ruff@0.15.15 check` and `format --check` clean, `pyrefly check` 0 errors. This
branch has no coverage-floor, naming, blind-except or restated-contract gate; the
`develop` twin runs all four and they hold there.

## Relation to #2347

#2347 refreshes `Trv.hvac_mode` from the reported states at the end of a control cycle,
covering the window in which the inbound handler stands down. This PR repairs the
handler itself, which is what runs outside that window. They compose: #2347 deliberately
leaves `bt_hvac_mode` alone, because a report nobody read is not user intent, while this
change is about the reports the handler does read. This branch is based on
`origin/1.9`, not on #2347, and the two touch different files.

Together they close both routes into the stuck `hvac_mode=off` of #2317. Merged onto
one tree the two branches conflict nowhere and the suite stays green: 5386 passed.

Refs #2317

## Same shape as the develop twin

The production diff is byte-identical to the `develop` PR. The only difference in the
whole change is the `_bind_cooler_hvac_mode` test helper, which already exists on
`develop` and is added here verbatim so the two test files carry the same text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermostat mode handling for rooms with cooling support, ensuring reported modes use the correct room-specific spelling.
  * Heat-only devices now preserve reported HEAT mode correctly instead of converting it to HEAT_COOL.
  * Improved handling of OFF and heating states across different thermostat mode configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->